### PR TITLE
Deterministic coreset subsampling for large bernoulli marginal‑slope fits and embed block refactor

### DIFF
--- a/src/families/custom_family.rs
+++ b/src/families/custom_family.rs
@@ -2284,14 +2284,22 @@ pub(crate) fn build_block_spatial_psi_derivatives(
                     psi_dim,
                     design_operator.is_some(),
                 );
+            let embed_design = |local: &Array2<f64>| -> Array2<f64> {
+                if local.ncols() == 0 || local.nrows() == 0 {
+                    return Array2::<f64>::zeros((local.nrows(), info.total_p));
+                }
+                EmbeddedColumnBlock::new(local, info.global_range.clone(), info.total_p).materialize()
+            };
             let x_full = if materialize_dense_design {
-                EmbeddedColumnBlock::new(&info.x_psi_local, info.global_range.clone(), info.total_p)
-                    .materialize()
+                embed_design(&info.x_psi_local)
             } else {
                 Array2::<f64>::zeros((0, 0))
             };
             let penalty_indices = info.penalty_indices.clone();
             let embed_penalty = |local: &Array2<f64>| -> Array2<f64> {
+                if local.nrows() == 0 || local.ncols() == 0 {
+                    return Array2::<f64>::zeros((info.total_p, info.total_p));
+                }
                 EmbeddedSquareBlock::new(local, info.global_range.clone(), info.total_p)
                     .materialize()
             };
@@ -2308,23 +2316,13 @@ pub(crate) fn build_block_spatial_psi_derivatives(
             let x_psi_psi_rows = if materialize_dense_design {
                 let mut rows =
                     vec![Array2::<f64>::zeros((x_full.nrows(), x_full.ncols())); psi_dim];
-                rows[psi_idx] = EmbeddedColumnBlock::new(
-                    &info.x_psi_psi_local,
-                    info.global_range.clone(),
-                    info.total_p,
-                )
-                .materialize();
+                rows[psi_idx] = embed_design(&info.x_psi_psi_local);
                 if let (Some(gid), Some(cross_designs)) =
                     (info.aniso_group_id, info.aniso_cross_designs.as_ref())
                 {
                     for (axis_j, local) in cross_designs {
                         if let Some(&global_j) = axis_lookup.get(&(gid, *axis_j)) {
-                            rows[global_j] = EmbeddedColumnBlock::new(
-                                local,
-                                info.global_range.clone(),
-                                info.total_p,
-                            )
-                            .materialize();
+                            rows[global_j] = embed_design(local);
                         }
                     }
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -558,6 +558,33 @@ fn validate_cli_firth_configuration(ctx: CliFirthValidation<'_>) -> Result<(), S
 const FAMILY_GAUSSIAN_LOCATION_SCALE: &str = "gaussian-location-scale";
 const FAMILY_BINOMIAL_LOCATION_SCALE: &str = "binomial-location-scale";
 const FAMILY_BERNOULLI_MARGINAL_SLOPE: &str = "bernoulli-marginal-slope";
+const LARGE_FIT_SUBSAMPLE_THRESHOLD: usize = 180_000;
+const LARGE_FIT_SUBSAMPLE_TARGET: usize = 120_000;
+
+fn deterministic_fit_subsample_indices(n: usize, target: usize) -> Vec<usize> {
+    if target >= n {
+        return (0..n).collect();
+    }
+    let stride = n as f64 / target as f64;
+    let mut idx = Vec::with_capacity(target);
+    for i in 0..target {
+        let raw = (i as f64 * stride).floor() as usize;
+        idx.push(raw.min(n - 1));
+    }
+    idx.sort_unstable();
+    idx.dedup();
+    if idx.len() < target {
+        let mut cursor = 0usize;
+        while idx.len() < target && cursor < n {
+            if idx.binary_search(&cursor).is_err() {
+                idx.push(cursor);
+            }
+            cursor += 1;
+        }
+        idx.sort_unstable();
+    }
+    idx
+}
 const FAMILY_TRANSFORMATION_NORMAL: &str = "transformation-normal";
 
 fn main() {
@@ -1359,10 +1386,33 @@ fn run_fit_bernoulli_marginal_slope(
     let z_col = *col_map
         .get(z_column)
         .ok_or_else(|| format!("z column '{z_column}' not found"))?;
-    let z = ds.values.column(z_col).to_owned();
-    let weights = resolve_weight_column(ds, col_map, args.weights_column.as_deref())?;
-    let marginal_offset = resolve_offset_column(ds, col_map, args.offset_column.as_deref())?;
-    let logslope_offset = resolve_offset_column(ds, col_map, args.noise_offset_column.as_deref())?;
+    let mut z = ds.values.column(z_col).to_owned();
+    let mut weights = resolve_weight_column(ds, col_map, args.weights_column.as_deref())?;
+    let mut marginal_offset = resolve_offset_column(ds, col_map, args.offset_column.as_deref())?;
+    let mut logslope_offset =
+        resolve_offset_column(ds, col_map, args.noise_offset_column.as_deref())?;
+    let mut y_fit = y.clone();
+    let mut fit_data_owned: Option<Array2<f64>> = None;
+    let n_rows = ds.values.nrows();
+    if n_rows > LARGE_FIT_SUBSAMPLE_THRESHOLD {
+        let target = LARGE_FIT_SUBSAMPLE_TARGET.min(n_rows);
+        let idx = deterministic_fit_subsample_indices(n_rows, target);
+        fit_data_owned = Some(ds.values.select(Axis(0), &idx));
+        y_fit = y.select(Axis(0), &idx);
+        z = z.select(Axis(0), &idx);
+        weights = weights.select(Axis(0), &idx);
+        marginal_offset = marginal_offset.select(Axis(0), &idx);
+        logslope_offset = logslope_offset.select(Axis(0), &idx);
+        inference_notes.push(format!(
+            "biobank-scale safety mode: optimized bernoulli marginal-slope on deterministic coreset ({}/{}) to avoid OOM while preserving coverage of the full cohort",
+            idx.len(),
+            n_rows
+        ));
+    }
+    let fit_data = fit_data_owned
+        .as_ref()
+        .map(|arr| arr.view())
+        .unwrap_or_else(|| ds.values.view());
     let frailty = fixed_gaussian_shift_frailty_from_spec(
         &fit_frailty_spec_from_args(args, "bernoulli marginal-slope")?,
         "bernoulli marginal-slope",
@@ -1425,9 +1475,9 @@ fn run_fit_bernoulli_marginal_slope(
     progress.set_stage("fit", "optimizing bernoulli marginal-slope model");
     let solved = match fit_model(FitRequest::BernoulliMarginalSlope(
         BernoulliMarginalSlopeFitRequest {
-            data: ds.values.view(),
+            data: fit_data,
             spec: BernoulliMarginalSlopeTermSpec {
-                y: y.clone(),
+                y: y_fit,
                 weights,
                 z,
                 base_link: base_link.clone(),


### PR DESCRIPTION
### Motivation
- Prevent OOMs and speed up optimization on very large cohorts by running bernoulli marginal‑slope fitting on a deterministic coreset when the input is huge. 
- Reduce duplication and correctly handle empty local blocks when materializing embedded design/penalty blocks in the custom family spatial code.

### Description
- Add `LARGE_FIT_SUBSAMPLE_THRESHOLD` and `LARGE_FIT_SUBSAMPLE_TARGET` constants and implement `deterministic_fit_subsample_indices` which selects a deterministic, evenly spaced index coreset with deduplication. 
- In `run_fit_bernoulli_marginal_slope` slice the training data (`y`, `z`, `weights`, offsets`, and `ds.values`) to the coreset when `n_rows > LARGE_FIT_SUBSAMPLE_THRESHOLD`, set `fit_data`/`y_fit` accordingly, and attach an inference note about the coreset. 
- Update the `fit_model` call to use the coreset view (`fit_data`) and the adjusted response vector (`y_fit`) when subsampling is activated. 
- Refactor `src/families/custom_family.rs` to introduce `embed_design` and `embed_penalty` closures to centralize embedded block materialization, and add guards that return correctly sized zero matrices for empty local inputs.

### Testing
- Built the project with `cargo build --release` which completed successfully. 
- Ran the full test suite with `cargo test` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c47d4e11c0832ebe45704ba87aa05d)