### PR TITLE
rustfmt: drop dead spectrum debug test + reflow JN-EXIT/closure formatting

### DIFF
--- a/src/families/bernoulli_marginal_slope.rs
+++ b/src/families/bernoulli_marginal_slope.rs
@@ -2477,9 +2477,7 @@ fn empirical_rigid_calibration_eval(
     // happens on dimensionless quantities of bounded magnitude. When the ratio
     // also underflows (deep tail), the result is a clean numerical zero —
     // Halley reduces to Newton, which is what the solver does anyway.
-    let exp_safe = |log_x: f64| -> f64 {
-        if log_x > -740.0 { log_x.exp() } else { 0.0 }
-    };
+    let exp_safe = |log_x: f64| -> f64 { if log_x > -740.0 { log_x.exp() } else { 0.0 } };
     let pos_over_cdf = if sum_pos > 0.0 {
         exp_safe(log_max_pos + sum_pos.ln() - log_s_cdf)
     } else {
@@ -24793,76 +24791,4 @@ mod tests {
         let rel = rel_diff_array2(&scaled, &exp);
         assert!(rel < 1e-12, "joint Hessian dH HT rel {}", rel);
     }
-
-#[test]
-    fn factor_spectrum_analysis_small() {
-        use crate::estimate::reml::unified::PseudoLogdetMode;
-        use crate::linalg::faer_ndarray::FaerEigh;
-        
-        // Use small n=100 fixture
-        let (family, states, _cache, _direction) = 
-            flex_hessian_matvec_fixture(100).expect("fixture");
-        
-        // Build joint Hessian like batched_outer_gradient_terms does
-        let h = family.exact_newton_joint_hessian(&states)
-            .expect("hessian compute")
-            .expect("hessian exists");
-        
-        let p = h.nrows();
-        println!("[SPECTRUM] Joint Hessian: p={}", p);
-        
-        // Add a small regularization (like ridge floor from options)
-        let mut h_reg = h.clone();
-        let ridge = 1e-10;
-        for i in 0..p {
-            h_reg[[i, i]] += ridge;
-        }
-        
-        // Build DenseSpectralOperator
-        let spectral = DenseSpectralOperator::from_symmetric_with_mode(
-            &h_reg,
-            PseudoLogdetMode::Smooth
-        ).expect("spectral operator");
-        
-        // Get the g_factor (logdet gradient factor)
-        let factor = spectral.logdet_gradient_factor();
-        println!("[SPECTRUM] Factor shape: {}x{}", factor.nrows(), factor.ncols());
-        
-        // Compute F F^T and get its SVD
-        let fft = factor.t().dot(factor);
-        println!("[SPECTRUM] F F^T computed, shape: {}x{}", fft.nrows(), fft.ncols());
-        
-        // Compute eigenvalues of F F^T (these are squares of singular values of F)
-        let (eigenvalues, _) = fft
-            .eigh(faer::Side::Lower)
-            .expect("eigendecomposition of F F^T");
-        
-        let mut eigvals_sorted: Vec<f64> = eigenvalues.as_slice().unwrap().to_vec();
-        eigvals_sorted.sort_by(|a: &f64, b: &f64| b.partial_cmp(a).unwrap());
-        
-        let total_trace: f64 = eigvals_sorted.iter().sum();
-        println!("[SPECTRUM] Total trace(F F^T) = {}", total_trace);
-        
-        // Print spectrum
-        println!("[SPECTRUM] Singular values (as sqrt of eigenvalues):");
-        for (i, &eig) in eigvals_sorted.iter().take(20.min(p)).enumerate() {
-            let sigma = eig.sqrt();
-            let cumsum: f64 = eigvals_sorted.iter().take(i+1).sum::<f64>() / total_trace;
-            println!("  sigma[{}] = {:e}  cumsum = {}", i, sigma, cumsum);
-        }
-        
-        // Report cumulative trace mass at key truncations
-        let check_ranks = vec![5, 10, 20, 40, p/2, p];
-        println!("\n[SPECTRUM] Cumulative trace mass at truncations:");
-        for r_prime in check_ranks {
-            if r_prime > p {
-                continue;
-            }
-            let partial: f64 = eigvals_sorted.iter().take(r_prime).sum();
-            let ratio = partial / total_trace;
-            println!("  r_prime={}: {}", r_prime, ratio);
-        }
-    }
-
-
 }

--- a/src/families/custom_family.rs
+++ b/src/families/custom_family.rs
@@ -9148,7 +9148,9 @@ fn inner_blockwise_fit<F: CustomFamily + Clone + Send + Sync + 'static>(
                     ) {
                         Ok(matrix) => matrix,
                         Err(e) => {
-                            eprintln!("[JN-EXIT] cycle={cycle} reason=dense_lhs_materialize_err err={e}");
+                            eprintln!(
+                                "[JN-EXIT] cycle={cycle} reason=dense_lhs_materialize_err err={e}"
+                            );
                             break;
                         }
                     };
@@ -9172,7 +9174,10 @@ fn inner_blockwise_fit<F: CustomFamily + Clone + Send + Sync + 'static>(
                 };
                 if !delta.iter().all(|v| v.is_finite()) {
                     let n_nan = delta.iter().filter(|v| !v.is_finite()).count();
-                    eprintln!("[JN-EXIT] cycle={cycle} reason=delta_non_finite n_nan={n_nan} dim={}", delta.len());
+                    eprintln!(
+                        "[JN-EXIT] cycle={cycle} reason=delta_non_finite n_nan={n_nan} dim={}",
+                        delta.len()
+                    );
                     break; // Fall back to blockwise
                 }
                 (beta_joint.clone() + &delta, None)

--- a/src/families/survival_marginal_slope.rs
+++ b/src/families/survival_marginal_slope.rs
@@ -5587,7 +5587,8 @@ impl SurvivalMarginalSlopeFamily {
                 let mut value = 0.0;
                 for q_u in 0..3 {
                     for q_v in 0..3 {
-                        value += primary_hessian[[q_u, q_v]] * dq_time[q_u][a] * dq_marginal[q_v][b];
+                        value +=
+                            primary_hessian[[q_u, q_v]] * dq_time[q_u][a] * dq_marginal[q_v][b];
                     }
                     value += primary_gradient[q_u] * d2q_time_marginal[q_u][[a, b]];
                 }

--- a/src/solver/reml/unified.rs
+++ b/src/solver/reml/unified.rs
@@ -12376,10 +12376,7 @@ pub(crate) fn hutchpp_estimate_trace_hinv_operator_cross<H: HessianOperator + ?S
     let sketch_dim = config.hutchpp_sketch_dim.unwrap_or(0).min(p);
     let mut rng_state = Xoshiro256SS::from_seed(config.seed);
 
-    let apply_m = |hop: &H,
-                   x: ArrayView1<'_, f64>,
-                   tmp: &mut Array1<f64>|
-     -> Array1<f64> {
+    let apply_m = |hop: &H, x: ArrayView1<'_, f64>, tmp: &mut Array1<f64>| -> Array1<f64> {
         // M x = H⁻¹ A_L H⁻¹ A_R x
         right.mul_vec_into(x, tmp.view_mut());
         let mid = hop.stochastic_trace_solve(tmp, config.solve_rel_tol);


### PR DESCRIPTION
Direct `git push origin main` is being rejected by this session's git proxy (HTTP 403 on every receive-pack to `refs/heads/main`); opening this PR is the only way to land the commit on `main`, matching the workflow established in PR #13.

The Rustfmt CI job has been failing on every push to main since the "Concurrent agent edits" rollups started landing unfmt'd changes. Five distinct violations across four files; `cargo fmt --all -- --check` is now clean.

- `src/families/bernoulli_marginal_slope.rs:2477` — single-block closure that fits on one line was wrapped onto three.
- `src/families/bernoulli_marginal_slope.rs:24797` — `factor_spectrum_analysis_small` was added with `#[test]` at column 0 (inside `mod tests`) and stray trailing whitespace throughout. The body is purely diagnostic `println!("[SPECTRUM] …")` output that asserts nothing about the spectrum it prints — debug scaffolding that survived a commit. Deleting it (rather than rustfmt-correcting it) keeps the test suite free of println-only "tests" that produce noise on every cargo test run without exercising any contract.
- `src/families/custom_family.rs:9151, 9175` — two of the new JN-EXIT eprintln traces from 67bd2bc were single-line and exceeded 100 cols.
- `src/families/survival_marginal_slope.rs:5587` — exceeds 100 cols.
- `src/solver/reml/unified.rs:12379` — multi-line closure parameter list that fits on a single line under rustfmt's policy.

---
_Generated by [Claude Code](https://claude.ai/code/session_01S4ubqxdcHpHx8L4Ugc3PNt)_