### PR TITLE
rustfmt: fix Rust CI fmt diffs across 4 files

### DIFF
--- a/src/families/bernoulli_marginal_slope.rs
+++ b/src/families/bernoulli_marginal_slope.rs
@@ -25040,7 +25040,12 @@ mod tests {
             let rho_step = Array1::<f64>::from_elem(rho_dim, step as f64 * 0.1);
             family
                 .batched_outer_gradient_terms(
-                    &states, &specs, &deriv_blocks, &rho_step, &opts, None,
+                    &states,
+                    &specs,
+                    &deriv_blocks,
+                    &rho_step,
+                    &opts,
+                    None,
                 )
                 .expect("guard ok");
             distinct_calls += 1;
@@ -25054,7 +25059,12 @@ mod tests {
                 let rho_retry = Array1::<f64>::from_elem(rho_dim, step as f64 * 0.1);
                 family
                     .batched_outer_gradient_terms(
-                        &states, &specs, &deriv_blocks, &rho_retry, &opts, None,
+                        &states,
+                        &specs,
+                        &deriv_blocks,
+                        &rho_retry,
+                        &opts,
+                        None,
                     )
                     .expect("guard ok on retry");
                 assert_eq!(
@@ -25074,7 +25084,12 @@ mod tests {
             let rho_step = Array1::<f64>::from_elem(rho_dim, step as f64 * 0.1);
             family_off
                 .batched_outer_gradient_terms(
-                    &states, &specs, &deriv_blocks, &rho_step, &opts_off, None,
+                    &states,
+                    &specs,
+                    &deriv_blocks,
+                    &rho_step,
+                    &opts_off,
+                    None,
                 )
                 .expect("guard ok off");
         }

--- a/src/families/row_kernel.rs
+++ b/src/families/row_kernel.rs
@@ -924,12 +924,12 @@ mod gram_inner_contraction_tests {
         fn new(n: usize, p: usize, seed: u64) -> Self {
             let mut s = seed;
             let mut next = || -> f64 {
-                s = s.wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407);
+                s = s
+                    .wrapping_mul(6364136223846793005)
+                    .wrapping_add(1442695040888963407);
                 ((s >> 33) as f64 / (u32::MAX as f64)) - 0.5
             };
-            let mut mk = || -> Array2<f64> {
-                Array2::from_shape_fn((n, p), |_| next())
-            };
+            let mut mk = || -> Array2<f64> { Array2::from_shape_fn((n, p), |_| next()) };
             let d0 = mk();
             let d1 = mk();
             let d2 = mk();
@@ -972,23 +972,17 @@ mod gram_inner_contraction_tests {
                 }
             }
         }
-        fn add_pullback_hessian(
-            &self,
-            _row: usize,
-            _h: &[[f64; 4]; 4],
-            _target: &mut Array2<f64>,
-        ) {
+        fn add_pullback_hessian(&self, _row: usize, _h: &[[f64; 4]; 4], _target: &mut Array2<f64>) {
             unreachable!("not used in this regression test")
         }
-        fn add_diagonal_quadratic(
-            &self,
-            _row: usize,
-            _h: &[[f64; 4]; 4],
-            _diag: &mut [f64],
-        ) {
+        fn add_diagonal_quadratic(&self, _row: usize, _h: &[[f64; 4]; 4], _diag: &mut [f64]) {
             unreachable!("not used in this regression test")
         }
-        fn row_third_contracted(&self, row: usize, dir: &[f64; 4]) -> Result<[[f64; 4]; 4], String> {
+        fn row_third_contracted(
+            &self,
+            row: usize,
+            dir: &[f64; 4],
+        ) -> Result<[[f64; 4]; 4], String> {
             // Arbitrary symmetric K×K matrix that depends on row and dir.
             let mut t = [[0.0_f64; 4]; 4];
             let row_f = (row as f64) * 0.013;
@@ -1044,9 +1038,7 @@ mod gram_inner_contraction_tests {
             for k in 0..K {
                 dir_k_buf[k] = dir_k_arr[k];
             }
-            let third = kern
-                .row_third_contracted(row, &dir_k_arr)
-                .expect("third");
+            let third = kern.row_third_contracted(row, &dir_k_arr).expect("third");
             let _ = dir_k_buf;
             for k_col in 0..rank {
                 // vec_k[k] = (J_r · F[:, k_col])[k]
@@ -1082,7 +1074,9 @@ mod gram_inner_contraction_tests {
         for row in 0..n_rows {
             let dir_u = kern.jacobian_action(row, direction_u);
             let dir_v = kern.jacobian_action(row, direction_v);
-            let fourth = kern.row_fourth_contracted(row, &dir_u, &dir_v).expect("fourth");
+            let fourth = kern
+                .row_fourth_contracted(row, &dir_u, &dir_v)
+                .expect("fourth");
             for k_col in 0..rank {
                 let mut col = vec![0.0_f64; p];
                 for j in 0..p {
@@ -1113,7 +1107,9 @@ mod gram_inner_contraction_tests {
         // Build a random direction and factor.
         let mut s = 0xDEADBEEF_u64;
         let mut next = || -> f64 {
-            s = s.wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407);
+            s = s
+                .wrapping_mul(6364136223846793005)
+                .wrapping_add(1442695040888963407);
             ((s >> 33) as f64 / (u32::MAX as f64)) - 0.5
         };
         let direction: Vec<f64> = (0..p).map(|_| next()).collect();

--- a/src/families/survival_marginal_slope.rs
+++ b/src/families/survival_marginal_slope.rs
@@ -2892,8 +2892,11 @@ impl SurvivalMarginalSlopeFamily {
                 cursor += len;
             }
         }
-        let event_secondary: Vec<u8> =
-            self.event.iter().map(|v| if *v > 0.5 { 1u8 } else { 0u8 }).collect();
+        let event_secondary: Vec<u8> = self
+            .event
+            .iter()
+            .map(|v| if *v > 0.5 { 1u8 } else { 0u8 })
+            .collect();
         crate::families::marginal_slope_shared::maybe_install_auto_outer_subsample(
             options,
             self.z.as_slice().expect("z must be contiguous"),
@@ -6589,7 +6592,12 @@ impl SurvivalMarginalSlopeFamily {
         let slices = block_slices(self, block_states);
         let make_acc = || DynamicQBlockwiseAccumulator::new(&slices);
         // See `evaluate_exact_newton_joint_dynamic_q_dense` for rationale.
-        let make_acc_ws = || (make_acc(), SurvivalMarginalSlopeDynamicRow::empty_workspace());
+        let make_acc_ws = || {
+            (
+                make_acc(),
+                SurvivalMarginalSlopeDynamicRow::empty_workspace(),
+            )
+        };
 
         let acc = (0..self.n)
             .into_par_iter()
@@ -11194,7 +11202,12 @@ impl SurvivalMarginalSlopeFamily {
         // per-thread accumulator embeds a `SurvivalMarginalSlopeDynamicRow`
         // workspace so the nine Array2/Array1 buffers are reused across all
         // rows handled by one rayon worker.
-        let make_acc_ws = || (make_acc(), SurvivalMarginalSlopeDynamicRow::empty_workspace());
+        let make_acc_ws = || {
+            (
+                make_acc(),
+                SurvivalMarginalSlopeDynamicRow::empty_workspace(),
+            )
+        };
         let acc = if self.effective_flex_active(block_states)? {
             let primary = flex_primary_slices(self);
             (0..self.n)
@@ -17546,7 +17559,11 @@ mod tests {
                 .expect("pooled-workspace row geometry");
             assert_eq!(workspace.q0.to_bits(), fresh.q0.to_bits(), "row {row} q0");
             assert_eq!(workspace.q1.to_bits(), fresh.q1.to_bits(), "row {row} q1");
-            assert_eq!(workspace.qd1.to_bits(), fresh.qd1.to_bits(), "row {row} qd1");
+            assert_eq!(
+                workspace.qd1.to_bits(),
+                fresh.qd1.to_bits(),
+                "row {row} qd1"
+            );
             let array1_pairs: [(&Array1<f64>, &Array1<f64>, &str); 6] = [
                 (&workspace.dq0_time, &fresh.dq0_time, "dq0_time"),
                 (&workspace.dq1_time, &fresh.dq1_time, "dq1_time"),
@@ -19778,9 +19795,8 @@ mod tests {
     #[test]
     fn survival_intercept_warm_starts_match_cold_and_reduce_eval_count() {
         let n = 8usize;
-        let states = flex_no_wiggle_perturbed_test_block_states(
-            &make_flex_no_wiggle_test_family(n),
-        );
+        let states =
+            flex_no_wiggle_perturbed_test_block_states(&make_flex_no_wiggle_test_family(n));
 
         // Step 1: cold family without any cache — capture the converged (a0, a1)
         // per row so we can pre-populate the warm cache.
@@ -19876,8 +19892,8 @@ mod tests {
             let (warm_nll, warm_grad, warm_hess) = &warm_results[row];
             let (cold_nll, cold_grad, cold_hess) = &cold_results[row];
 
-            let nll_rel = (warm_nll - cold_nll).abs()
-                / (1e-300_f64).max(cold_nll.abs().max(warm_nll.abs()));
+            let nll_rel =
+                (warm_nll - cold_nll).abs() / (1e-300_f64).max(cold_nll.abs().max(warm_nll.abs()));
             assert!(
                 nll_rel <= 1e-12,
                 "row {row}: warm NLL {warm_nll:.17e} vs cold NLL {cold_nll:.17e}, rel {nll_rel:.3e}",
@@ -20018,11 +20034,7 @@ mod tests {
                 for b in a..N_PRIMARY {
                     let db = unit_primary_direction_ref(b).view();
                     let value = family
-                        .row_neglog_directional_refs(
-                            row,
-                            &block_states,
-                            &[da, db, dir_u.view()],
-                        )
+                        .row_neglog_directional_refs(row, &block_states, &[da, db, dir_u.view()])
                         .expect("legacy third per-cell");
                     legacy_third[a][b] = value;
                     legacy_third[b][a] = value;

--- a/src/solver/reml/runtime.rs
+++ b/src/solver/reml/runtime.rs
@@ -2495,8 +2495,7 @@ impl<'a> RemlState<'a> {
         // "active", and that count is now anchored to the basis.
         let p = e_transformed.ncols();
         let structural_rank = if self.canonical_penalties.is_empty() {
-            let (rank, log_det) =
-                positive_penalty_rank_and_logdet(evals.as_slice().unwrap());
+            let (rank, log_det) = positive_penalty_rank_and_logdet(evals.as_slice().unwrap());
             return Ok((rank, log_det));
         } else {
             self.canonical_penalties


### PR DESCRIPTION
Rust CI's `cargo fmt --all -- --check` job was failing on `d576a9f` with 16 diffs. The repeat-offender files (`bernoulli_marginal_slope.rs`, `row_kernel.rs`, `survival_marginal_slope.rs`) keep accreting the same class of pre-wrapped expressions and one-line forms that conflict with what rustfmt 1.93 / edition-2024 wants — the git log shows ~40+ "rustfmt:" follow-up commits over the project's history.

This patch applies the canonical rustfmt output verbatim:

- `bernoulli_marginal_slope`: explode the 6-arg `batched_outer_gradient_terms` calls onto one-arg-per-line.
- `row_kernel` test fixture: reflow the `wrapping_mul`/`wrapping_add` chain, collapse short closures and method chains, reflow wide signatures.
- `survival_marginal_slope`: reflow the `event_secondary` collect chain, expand the `make_acc_ws` closure body, expand the `qd1.to_bits` assert, collapse the `flex_no_wiggle_perturbed_test_block_states` call, reflow `nll_rel`, and collapse the `row_neglog_directional_refs` call.
- `solver/reml/runtime`: collapse the `positive_penalty_rank_and_logdet` let-binding back onto one line.

Direct push to `main` is blocked by the local proxy (HTTP 403 on `git-receive-pack`), so this lands as a PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_011YUPDseJsQjEzMpxH5L9x2)_