### PR TITLE
clippy: reattach orphan build_outer_score_subsample docstring

### DIFF
--- a/src/families/marginal_slope_shared.rs
+++ b/src/families/marginal_slope_shared.rs
@@ -786,23 +786,6 @@ fn splitmix64(state: &mut u64) -> u64 {
     z ^ (z >> 31)
 }
 
-/// Build a deterministic stratified row subsample of size ≥ `k` from
-/// `(z, stratum_secondary)`.
-///
-/// Stratification: 100 z-deciles × distinct values of `stratum_secondary`
-/// (typically the {0,1} event/outcome indicator, giving ≤ 200 strata).
-/// Each non-empty stratum contributes `ceil(k * stratum_size / n)` rows
-/// drawn via a splitmix64-keyed Fisher-Yates partial shuffle so the result
-/// is reproducible from `(seed, stratum_id)`.
-///
-/// The returned mask is sorted, deduplicated, and never empty when `n > 0`.
-/// Per-row weights `w_i = N_h / k_h` (Horvitz-Thompson inverse-inclusion
-/// weights for the stratum the row came from) are assigned to
-/// `OuterScoreSubsample::rows`, and `weight_scale` is reported as the mean
-/// of those weights for diagnostics only.
-///
-/// Panics if `z.len() != stratum_secondary.len()`.
-
 /// Configuration for the automatic outer-score subsampler.
 ///
 /// At biobank scale (n ≥ tens of thousands) the marginal-slope outer
@@ -1002,6 +985,22 @@ pub fn maybe_install_auto_outer_subsample(
     Some(cloned)
 }
 
+/// Build a deterministic stratified row subsample of size ≥ `k` from
+/// `(z, stratum_secondary)`.
+///
+/// Stratification: 100 z-deciles × distinct values of `stratum_secondary`
+/// (typically the {0,1} event/outcome indicator, giving ≤ 200 strata).
+/// Each non-empty stratum contributes `ceil(k * stratum_size / n)` rows
+/// drawn via a splitmix64-keyed Fisher-Yates partial shuffle so the result
+/// is reproducible from `(seed, stratum_id)`.
+///
+/// The returned mask is sorted, deduplicated, and never empty when `n > 0`.
+/// Per-row weights `w_i = N_h / k_h` (Horvitz-Thompson inverse-inclusion
+/// weights for the stratum the row came from) are assigned to
+/// `OuterScoreSubsample::rows`, and `weight_scale` is reported as the mean
+/// of those weights for diagnostics only.
+///
+/// Panics if `z.len() != stratum_secondary.len()`.
 pub fn build_outer_score_subsample(
     z: &[f64],
     stratum_secondary: &[u8],


### PR DESCRIPTION
Direct `git push origin main` is rejected by this session's git proxy (HTTP 403 on receive-pack to `refs/heads/main`; non-default branches accept pushes), matching the pattern from PRs #12, #13, #14, #15. Opening this PR is the only way to land the commit on `main`.

## Root cause

The Clippy CI job has been failing on every push to `main` since the Hutch++ / auto-subsample rollup with:

```
error: empty line after doc comment
   --> src/families/marginal_slope_shared.rs:804:1
    |
804 | / /// Panics if `z.len() != stratum_secondary.len()`.
805 | |
    | |_^
...
835 |   pub struct AutoOuterSubsampleOptions {
    |   ------------------------------------ the comment documents this struct
    = note: `-D clippy::empty-line-after-doc-comments` implied by `-D clippy::suspicious`
```

The orphan docstring block at `marginal_slope_shared.rs:789-804` (starts "Build a deterministic stratified row subsample of size ≥ `k`", ends "Panics if `z.len() != stratum_secondary.len()`") describes `build_outer_score_subsample` (signature `(z: &[f64], stratum_secondary: &[u8], k: usize, seed: u64) -> OuterScoreSubsample` at line 1005, with `assert_eq!(z.len(), stratum_secondary.len(), ...)` matching the documented panic). The function had no doc comment; the docstring was somehow stranded ~200 lines above its function with a blank line separator.

Rust's item-attribute rules tied the orphan docstring to the next item (`AutoOuterSubsampleOptions`), but the content describes neither that struct nor any other intervening item. `clippy::suspicious -> empty_line_after_doc_comments` correctly identifies this as a defect: the doc comment is attached to the wrong item.

## Fix

Reattach the docstring to its rightful function. `build_outer_score_subsample` now carries the API documentation that describes its actual behavior; `AutoOuterSubsampleOptions` keeps its existing (and unrelated) docstring. Pure relocation — no behavior changes.

Verified locally:
```
cargo clippy --all-targets --all-features -- -A warnings -D clippy::correctness -D clippy::suspicious
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.89s
cargo fmt --all -- --check
(clean)
```

## Other CI signals investigated this iteration (NOT addressed here)

- **Test job** (`cargo test --all-features --lib`): 1596 passed / 1 failed. The single failure is `families::gamlss::tests::binomial_location_scalewiggle_exact_newton_spatial_joint_hyper_returns_fullhessian` panicking at `gamlss.rs:24014` because `evaluate_custom_family_joint_hyper` returns `outer_hessian: HessianResult::Unavailable` (set by `nonconverged_outer_eval_result` at `custom_family.rs:4927` when `inner_blockwise_fit` flags `!inner.converged`). PR #13 noted this as pre-existing wiggle-family inner-Newton non-convergence on the small (n=14) probit + 2D Matérn + 4-knot degree-2 wiggle spatial fixture. A root-cause fix requires investigating the wiggle blockwise PIRLS step proposal on this fixture; that's a deeper numerical project and is **not** attempted in this PR. No bandaid (no test weakening, no `Unavailable → bail` workaround) added.
- **Fuzz vs mgcv**: cannot be reproduced in this environment (no R / mgcv installed). The fix in 92b4600 (REML penalty-rank cliff at fuzz seed=92) was a substantive correctness fix targeting one of the four failing seeds; the remaining failing seeds (small-n outlier blow-up, gamlss complexity, binomial separation per the 92b4600 commit body) need separate investigation against fresh fuzz output.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JDfxJqVpgRus1T7mSsR8X7)_