### PR TITLE
Add GPU dispatch scaffold for dense PIRLS

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,7 +43,7 @@ pub use resource::{
     ByteLruCache, DerivativeStorageMode, MaterializationPolicy, MatrixMaterializationError,
     ProblemHints, ResidentBytes, ResourcePolicy,
 };
-pub use solver::{estimate, mixture_link, pirls, seeding, visualizer};
+pub use solver::{estimate, gpu, mixture_link, pirls, seeding, visualizer};
 pub use terms::{basis, construction, hull, layout, smooth, term_builder};
 
 pub use families::bernoulli_marginal_slope;

--- a/src/solver/gpu.rs
+++ b/src/solver/gpu.rs
@@ -1,0 +1,212 @@
+//! GPU dispatch policy and instrumentation scaffolding for device-resident fits.
+//!
+//! The numerical fitting code is intentionally conservative: production builds
+//! without a compiled CUDA/HIP/Metal backend must never pretend to be GPU
+//! accelerated.  This module centralizes the `auto | off | force` policy so hot
+//! P-IRLS/REML sites can make an explicit decision, log CPU fallback reasons in
+//! `auto`, and fail loudly in `force`.
+
+use std::fmt;
+use std::sync::Once;
+use std::time::{Duration, Instant};
+
+/// Runtime GPU routing policy.
+///
+/// Configure with `GAM_GPU=auto|off|force` (case-insensitive).  `auto` is the
+/// default: supported large workloads may use a compiled backend, unsupported
+/// ones fall back to CPU with an explanatory log.  `force` converts unsupported
+/// dispatch into an error so benchmark and deployment jobs do not silently run
+/// on the CPU.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub enum GpuPolicy {
+    #[default]
+    Auto,
+    Off,
+    Force,
+}
+
+impl GpuPolicy {
+    /// Parse a policy token.
+    pub fn parse(value: &str) -> Option<Self> {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "auto" | "" => Some(Self::Auto),
+            "off" | "false" | "0" | "cpu" => Some(Self::Off),
+            "force" | "on" | "true" | "1" | "gpu" => Some(Self::Force),
+            _ => None,
+        }
+    }
+
+    /// Resolve the current process policy from `GAM_GPU`.
+    pub fn from_env() -> Self {
+        match std::env::var("GAM_GPU") {
+            Ok(value) => Self::parse(&value).unwrap_or_else(|| {
+                log::warn!("unrecognized GAM_GPU={value:?}; expected auto|off|force, using auto");
+                Self::Auto
+            }),
+            Err(_) => Self::Auto,
+        }
+    }
+
+    /// Whether unsupported GPU dispatch should be returned as a hard error.
+    #[inline]
+    pub fn is_force(self) -> bool {
+        matches!(self, Self::Force)
+    }
+}
+
+impl fmt::Display for GpuPolicy {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Auto => f.write_str("auto"),
+            Self::Off => f.write_str("off"),
+            Self::Force => f.write_str("force"),
+        }
+    }
+}
+
+/// High-level operation classes used by GPU dispatch and timing logs.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum GpuOperation {
+    DensePirlsXtWX,
+    DensePirlsMatvec,
+    DensePirlsTransposeMatvec,
+    CandidateScreen,
+    MatrixFreePcg,
+    SparseOuterProduct,
+    SpatialKernelOperator,
+    MarginalSlopeRowKernel,
+    RemlTrace,
+    FinalInference,
+}
+
+impl GpuOperation {
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::DensePirlsXtWX => "dense-pirls-xtwx",
+            Self::DensePirlsMatvec => "dense-pirls-xbeta",
+            Self::DensePirlsTransposeMatvec => "dense-pirls-xtvec",
+            Self::CandidateScreen => "lm-candidate-screen",
+            Self::MatrixFreePcg => "matrix-free-pcg",
+            Self::SparseOuterProduct => "sparse-row-outer-product",
+            Self::SpatialKernelOperator => "spatial-kernel-operator",
+            Self::MarginalSlopeRowKernel => "marginal-slope-row-kernel",
+            Self::RemlTrace => "reml-trace",
+            Self::FinalInference => "final-inference",
+        }
+    }
+}
+
+/// Result of a GPU dispatch decision.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum GpuDispatch {
+    UseDevice,
+    UseCpu { reason: String },
+}
+
+/// Decide whether a dense P-IRLS sweep primitive can run on the GPU in this
+/// build.  Today this is a strict capability gate; vendor backends should plug
+/// in here rather than adding ad-hoc checks at numerical call sites.
+pub fn dense_pirls_dispatch(
+    operation: GpuOperation,
+    rows: usize,
+    cols: usize,
+    signed_weights: bool,
+) -> Result<GpuDispatch, String> {
+    let policy = GpuPolicy::from_env();
+    if matches!(policy, GpuPolicy::Off) {
+        return Ok(GpuDispatch::UseCpu {
+            reason: "GAM_GPU=off".to_string(),
+        });
+    }
+
+    let reason = format!(
+        "{} requires a compiled device backend; this build has no CUDA/HIP/Metal backend registered (n={rows}, p={cols}, signed_weights={signed_weights})",
+        operation.label()
+    );
+    if policy.is_force() {
+        Err(format!("GAM_GPU=force requested but {reason}"))
+    } else {
+        log_auto_fallback_once(operation, &reason);
+        Ok(GpuDispatch::UseCpu { reason })
+    }
+}
+
+fn log_auto_fallback_once(operation: GpuOperation, reason: &str) {
+    static DENSE_XTWX: Once = Once::new();
+    static DENSE_XBETA: Once = Once::new();
+    static DENSE_XTVEC: Once = Once::new();
+    static CANDIDATE: Once = Once::new();
+    static PCG: Once = Once::new();
+    static SPARSE: Once = Once::new();
+    static SPATIAL: Once = Once::new();
+    static MARGSLOPE: Once = Once::new();
+    static REML: Once = Once::new();
+    static INFERENCE: Once = Once::new();
+
+    let once = match operation {
+        GpuOperation::DensePirlsXtWX => &DENSE_XTWX,
+        GpuOperation::DensePirlsMatvec => &DENSE_XBETA,
+        GpuOperation::DensePirlsTransposeMatvec => &DENSE_XTVEC,
+        GpuOperation::CandidateScreen => &CANDIDATE,
+        GpuOperation::MatrixFreePcg => &PCG,
+        GpuOperation::SparseOuterProduct => &SPARSE,
+        GpuOperation::SpatialKernelOperator => &SPATIAL,
+        GpuOperation::MarginalSlopeRowKernel => &MARGSLOPE,
+        GpuOperation::RemlTrace => &REML,
+        GpuOperation::FinalInference => &INFERENCE,
+    };
+    once.call_once(|| log::info!("GPU auto fallback for {}: {reason}", operation.label()));
+}
+
+/// Lightweight event timer for hot-path instrumentation.  It logs only when
+/// `GAM_GPU_TIMING=1|true|on`, keeping the default path allocation-free except
+/// for the `Instant` captured by callers that opt into timing.
+pub struct GpuStageTimer {
+    label: &'static str,
+    start: Instant,
+    enabled: bool,
+}
+
+impl GpuStageTimer {
+    pub fn start(label: &'static str) -> Self {
+        let enabled = std::env::var("GAM_GPU_TIMING")
+            .ok()
+            .and_then(|v| GpuPolicy::parse(&v))
+            .is_some_and(|p| !matches!(p, GpuPolicy::Off));
+        Self {
+            label,
+            start: Instant::now(),
+            enabled,
+        }
+    }
+
+    pub fn elapsed(&self) -> Duration {
+        self.start.elapsed()
+    }
+}
+
+impl Drop for GpuStageTimer {
+    fn drop(&mut self) {
+        if self.enabled {
+            log::info!(
+                "[gpu-timing] {} {:.3} ms",
+                self.label,
+                self.elapsed().as_secs_f64() * 1e3
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn gpu_policy_parser_accepts_documented_values() {
+        assert_eq!(GpuPolicy::parse("auto"), Some(GpuPolicy::Auto));
+        assert_eq!(GpuPolicy::parse("OFF"), Some(GpuPolicy::Off));
+        assert_eq!(GpuPolicy::parse("force"), Some(GpuPolicy::Force));
+        assert_eq!(GpuPolicy::parse("gpu"), Some(GpuPolicy::Force));
+        assert_eq!(GpuPolicy::parse("nonsense"), None);
+    }
+}

--- a/src/solver/mod.rs
+++ b/src/solver/mod.rs
@@ -1,5 +1,6 @@
 pub(crate) mod active_set;
 pub mod estimate;
+pub mod gpu;
 pub mod mixture_link;
 pub mod outer_strategy;
 pub mod pirls;

--- a/src/solver/pirls.rs
+++ b/src/solver/pirls.rs
@@ -915,14 +915,22 @@ impl PirlsWorkspace {
         (TARGET_BYTES / bytes_perrow).clamp(MIN_ROWS, MAX_ROWS)
     }
 
-    fn add_dense_xtwx_streaming_from_sqrt<S>(
-        sqrtw: &Array1<f64>,
+    /// Add `Xᵀ diag(weights) X` to `out` using bounded dense chunks.
+    ///
+    /// This is deliberately sign-preserving: observed-information curvature can
+    /// produce negative row weights, so a `sqrt(max(0, w))` Gram formulation is
+    /// mathematically wrong for this path.  The layout mirrors the future GPU
+    /// resident path (`WX` then `Xᵀ(WX)`) and keeps peak scratch bounded by one
+    /// row chunk plus one p×p accumulator per worker.
+    fn add_dense_xtwx_streaming_signed<S, W>(
+        weights: &ArrayBase<W, Ix1>,
         weighted_x_chunk: &mut Array2<f64>,
         x: &ArrayBase<S, Ix2>,
         out: &mut Array2<f64>,
         par: Par,
     ) where
         S: Data<Elem = f64> + Sync,
+        W: Data<Elem = f64> + Sync,
     {
         let n = x.nrows();
         let p = x.ncols();
@@ -930,9 +938,9 @@ impl PirlsWorkspace {
             return;
         }
         debug_assert_eq!(
-            sqrtw.len(),
+            weights.len(),
             n,
-            "sqrtw length must match row count for streamed XtWX"
+            "weight length must match row count for streamed XtWX"
         );
         let chunkrows = Self::dense_xtwx_chunkrows(p).min(n);
 
@@ -940,9 +948,10 @@ impl PirlsWorkspace {
         let use_parallel = num_chunks >= 4 && (n as u64) * (p as u64) >= 200_000;
 
         if use_parallel {
-            // Parallel: use fold/reduce so each thread reuses one chunk buffer
-            // and one p×p accumulator. This reduces allocations from num_chunks×p²
-            // to num_threads×p² (e.g., 8 instead of 400 at biobank scale).
+            // Parallel: use fold/reduce so each thread reuses one WX chunk
+            // and one p×p accumulator. This is the CPU analogue of the GPU
+            // tall-skinny reduction plan: scale rows, then accumulate Xᵀ(WX)
+            // without ever clipping negative observed-curvature weights.
             let combined = (0..num_chunks)
                 .into_par_iter()
                 .fold(
@@ -958,8 +967,7 @@ impl PirlsWorkspace {
                         {
                             let mut chunk = chunk_buf.slice_mut(s![0..rows, ..]);
                             let x_slice = x.slice(s![start..start + rows, ..]);
-                            let w_slice = sqrtw.slice(s![start..start + rows]);
-                            // Parallel per-row sqrt-weight scaling.
+                            let w_slice = weights.slice(s![start..start + rows]);
                             Zip::from(chunk.rows_mut())
                                 .and(x_slice.rows())
                                 .and(&w_slice)
@@ -967,14 +975,16 @@ impl PirlsWorkspace {
                                     Zip::from(&mut dst).and(&src).for_each(|d, &s| *d = s * w);
                                 });
                         }
-                        let chunkrowsview = chunk_buf.slice(s![0..rows, ..]);
-                        let chunkview = FaerArrayView::new(&chunkrowsview);
+                        let x_slice = x.slice(s![start..start + rows, ..]);
+                        let wx_slice = chunk_buf.slice(s![0..rows, ..]);
+                        let x_view = FaerArrayView::new(&x_slice);
+                        let wx_view = FaerArrayView::new(&wx_slice);
                         let mut accview = array2_to_matmut(&mut acc);
                         matmul(
                             accview.as_mut(),
                             Accum::Add,
-                            chunkview.as_ref().transpose(),
-                            chunkview.as_ref(),
+                            x_view.as_ref().transpose(),
+                            wx_view.as_ref(),
                             1.0,
                             Par::Seq,
                         );
@@ -995,7 +1005,7 @@ impl PirlsWorkspace {
                 );
             *out += &combined.1;
         } else {
-            // Sequential: reuse workspace chunk buffer
+            // Sequential: reuse workspace chunk buffer.
             if weighted_x_chunk.ncols() != p || weighted_x_chunk.nrows() != chunkrows {
                 *weighted_x_chunk = Array2::zeros((chunkrows, p).f());
             }
@@ -1005,9 +1015,7 @@ impl PirlsWorkspace {
                 {
                     let mut chunk = weighted_x_chunk.slice_mut(s![0..rows, ..]);
                     let x_slice = x.slice(s![start..start + rows, ..]);
-                    let w_slice = sqrtw.slice(s![start..start + rows]);
-                    // Parallel over chunk rows; the inner per-row column
-                    // copy stays sequential (small p).
+                    let w_slice = weights.slice(s![start..start + rows]);
                     Zip::from(chunk.rows_mut())
                         .and(x_slice.rows())
                         .and(&w_slice)
@@ -1015,31 +1023,20 @@ impl PirlsWorkspace {
                             Zip::from(&mut dst).and(&src).for_each(|d, &s| *d = s * w);
                         });
                 }
-                let chunkrowsview = weighted_x_chunk.slice(s![0..rows, ..]);
-                let chunkview = FaerArrayView::new(&chunkrowsview);
+                let x_slice = x.slice(s![start..start + rows, ..]);
+                let wx_slice = weighted_x_chunk.slice(s![0..rows, ..]);
+                let x_view = FaerArrayView::new(&x_slice);
+                let wx_view = FaerArrayView::new(&wx_slice);
                 matmul(
                     outview.as_mut(),
                     Accum::Add,
-                    chunkview.as_ref().transpose(),
-                    chunkview.as_ref(),
+                    x_view.as_ref().transpose(),
+                    wx_view.as_ref(),
                     1.0,
                     par,
                 );
             }
         }
-    }
-
-    #[inline]
-    fn fill_sqrtweights<S>(&mut self, weights: &ArrayBase<S, Ix1>)
-    where
-        S: Data<Elem = f64>,
-    {
-        if self.sqrtw.len() != weights.len() {
-            self.sqrtw = Array1::zeros(weights.len());
-        }
-        Zip::from(&mut self.sqrtw)
-            .and(weights)
-            .par_for_each(|sqrtw, &w| *sqrtw = w.max(0.0).sqrt());
     }
 
     /// Ensure the sparse penalty cache is populated and consistent with `x` and `s_lambda`.
@@ -1607,16 +1604,29 @@ impl<'a> GamWorkingModel<'a> {
             // cannot be densified; fall through to the operator XᵀWX path.
             DesignMatrix::Dense(x) if x.is_materialized_dense() => {
                 let p = x.ncols();
+                match crate::solver::gpu::dense_pirls_dispatch(
+                    crate::solver::gpu::GpuOperation::DensePirlsXtWX,
+                    x.nrows(),
+                    p,
+                    true,
+                ) {
+                    Ok(crate::solver::gpu::GpuDispatch::UseDevice) => unreachable!(
+                        "dense_pirls_dispatch cannot select a device without a registered backend"
+                    ),
+                    Ok(crate::solver::gpu::GpuDispatch::UseCpu { .. }) => {}
+                    Err(msg) => return Err(EstimationError::InvalidInput(msg)),
+                }
+                let _gpu_timer =
+                    crate::solver::gpu::GpuStageTimer::start("pirls.dense_xtwx.cpu_fallback");
                 let x_dense = x.to_dense_arc();
-                workspace.fill_sqrtweights(weights);
                 // Reuse workspace hessian buffer to avoid per-iteration allocation.
                 if workspace.hessian_buf.nrows() != p || workspace.hessian_buf.ncols() != p {
                     workspace.hessian_buf = Array2::zeros((p, p).f());
                 } else {
                     workspace.hessian_buf.fill(0.0);
                 }
-                PirlsWorkspace::add_dense_xtwx_streaming_from_sqrt(
-                    &workspace.sqrtw,
+                PirlsWorkspace::add_dense_xtwx_streaming_signed(
+                    weights,
                     &mut workspace.weighted_x_chunk,
                     x_dense.as_ref(),
                     &mut workspace.hessian_buf,
@@ -6468,7 +6478,6 @@ fn solve_penalized_least_squares_implicit(
     // ── Dense / QS-rotated path ──────────────────────────────────────────
 
     // 1. Prepare weighted buffers
-    workspace.fill_sqrtweights(&weights);
     if workspace.wz.len() != z.len() {
         workspace.wz = Array1::zeros(z.len());
     }
@@ -6483,14 +6492,28 @@ fn solve_penalized_least_squares_implicit(
         // Lazy operator-backed dense designs route to diag_xtw_x like sparse.
         DesignMatrix::Dense(x_dense) if x_dense.is_materialized_dense() => {
             let p = x_dense.ncols();
+            match crate::solver::gpu::dense_pirls_dispatch(
+                crate::solver::gpu::GpuOperation::DensePirlsXtWX,
+                x_dense.nrows(),
+                p,
+                true,
+            ) {
+                Ok(crate::solver::gpu::GpuDispatch::UseDevice) => unreachable!(
+                    "dense_pirls_dispatch cannot select a device without a registered backend"
+                ),
+                Ok(crate::solver::gpu::GpuDispatch::UseCpu { .. }) => {}
+                Err(msg) => return Err(EstimationError::InvalidInput(msg)),
+            }
+            let _gpu_timer =
+                crate::solver::gpu::GpuStageTimer::start("pls.dense_xtwx.cpu_fallback");
             let x_dense = x_dense.to_dense_arc();
             if workspace.hessian_buf.nrows() != p || workspace.hessian_buf.ncols() != p {
                 workspace.hessian_buf = Array2::zeros((p, p).f());
             } else {
                 workspace.hessian_buf.fill(0.0);
             }
-            PirlsWorkspace::add_dense_xtwx_streaming_from_sqrt(
-                &workspace.sqrtw,
+            PirlsWorkspace::add_dense_xtwx_streaming_signed(
+                &weights,
                 &mut workspace.weighted_x_chunk,
                 x_dense.as_ref(),
                 &mut workspace.hessian_buf,
@@ -9160,7 +9183,35 @@ mod tests {
     };
     use approx::assert_relative_eq;
     use faer::sparse::{SparseColMat, Triplet};
-    use ndarray::{Array1, Array2, ArrayView1, ArrayView2, array};
+    use ndarray::{Array1, Array2, ArrayView1, ArrayView2, ShapeBuilder, array};
+
+    #[test]
+    fn dense_workspace_xtwx_preserves_signed_observed_weights() {
+        let x = array![[1.0, 2.0], [3.0, -1.0], [-2.0, 4.0], [0.5, -3.0]];
+        let weights = array![2.0, -1.5, 0.25, -3.0];
+        let mut workspace = PirlsWorkspace::new(x.nrows(), x.ncols(), 0, 0);
+        let mut streamed = Array2::<f64>::zeros((x.ncols(), x.ncols()).f());
+
+        PirlsWorkspace::add_dense_xtwx_streaming_signed(
+            &weights,
+            &mut workspace.weighted_x_chunk,
+            &x,
+            &mut streamed,
+            faer::Par::Seq,
+        );
+
+        let wx = Array2::from_shape_fn(x.raw_dim(), |(i, j)| weights[i] * x[[i, j]]);
+        let expected = x.t().dot(&wx);
+        for i in 0..x.ncols() {
+            for j in 0..x.ncols() {
+                assert_relative_eq!(streamed[[i, j]], expected[[i, j]], epsilon = 1e-12);
+            }
+        }
+        assert!(
+            streamed[[0, 0]] < 0.0,
+            "negative row weights must not be clipped through a sqrt(max(0,w)) Gram path"
+        );
+    }
 
     /// Calculate scale parameter correctly for different link functions.
     ///


### PR DESCRIPTION
### Motivation
- Prepare a single, conservative integration point for future device backends so dense P‑IRLS hot paths can be implemented as device‑resident pipelines instead of thin BLAS wrappers.
- Preserve correct observed‑Hessian assembly semantics (signed weights) and enable per‑stage GPU timing/logging to guide development and benchmarking.
- Provide a safe `auto | off | force` runtime policy so production builds without a device backend fall back to CPU deterministically and `force` fails loudly.

### Description
- Add `src/solver/gpu.rs` that implements `GpuPolicy`, `GpuOperation`, `GpuDispatch`, `dense_pirls_dispatch(...)`, and a lightweight `GpuStageTimer` for one‑time fallback logging and optional `[gpu-timing]` instrumentation.
- Replace the prior `sqrt(max(0,w))` Gram streaming pattern with a sign‑preserving `add_dense_xtwx_streaming_signed(...)` in `PirlsWorkspace` that computes `Xᵀ (W X)` in bounded chunks and parallel reduction, avoiding negative‑weight clipping.
- Wire the dense materialized `X` code paths through the dispatch gate and timer (calls to `dense_pirls_dispatch` and `GpuStageTimer`) in the PIRLS Hessian assembly and implicit penalized least squares code so future GPU backends have a single call site.
- Export the new module via `src/solver/mod.rs` and `src/lib.rs` and add unit tests covering GPU policy parsing and signed `Xᵀ diag(w) X` streaming behavior.

### Testing
- Ran `cargo test --lib dense_workspace_xtwx_preserves_signed_observed_weights` and the test passed.
- Ran `cargo test --lib gpu_policy_parser_accepts_documented_values` and the test passed.
- Ran `cargo check --lib` to validate integration and the check completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a072ed4486c8324bdc61667aa3e80e2)