### PR TITLE
Add GPU backend detection and linalg dispatch hooks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,10 @@ resolver = "3"
 [lints.rust]
 warnings = "deny"
 
+[features]
+default = []
+cuda = []
+
 [dependencies]
 clap = { version = "4.6.0", features = ["derive"] }
 comfy-table = "7.2.2"
@@ -66,6 +70,7 @@ arrow = { version = "54", default-features = false, features = ["ffi"] }
 parquet = { version = "54", default-features = false, features = ["arrow", "snap", "zstd", "lz4"] }
 wide = "0.7"
 smallvec = "1"
+libloading = "0.8"
 
 [dependencies.general-mcmc]
 package = "general-mcmc"

--- a/src/gpu/device.rs
+++ b/src/gpu/device.rs
@@ -1,0 +1,87 @@
+use std::fmt;
+
+/// Coarse capability class used by dispatch policy before calibration data is
+/// available. The exact model is still reported through [`GpuDeviceInfo`].
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum GpuCapability {
+    Legacy,
+    Mainstream,
+    Datacenter,
+    HighEndDatacenter,
+}
+
+/// Device selected for acceleration, or the reason acceleration is not active.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum GpuSelection {
+    CpuOnly { reason: String },
+    Cuda { device: GpuDeviceInfo },
+}
+
+/// Runtime CUDA device facts used for logging and dispatch decisions.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct GpuDeviceInfo {
+    pub ordinal: usize,
+    pub name: String,
+    pub compute_capability_major: i32,
+    pub compute_capability_minor: i32,
+    pub total_memory_bytes: usize,
+    pub free_memory_bytes: Option<usize>,
+    pub capability: GpuCapability,
+}
+
+impl GpuDeviceInfo {
+    #[inline]
+    pub fn compute_capability(&self) -> (i32, i32) {
+        (self.compute_capability_major, self.compute_capability_minor)
+    }
+
+    #[inline]
+    pub fn total_memory_gib(&self) -> f64 {
+        self.total_memory_bytes as f64 / 1024.0 / 1024.0 / 1024.0
+    }
+
+    #[inline]
+    pub fn score(&self) -> u128 {
+        let cc_score = (self.compute_capability_major.max(0) as u128) * 10_000
+            + (self.compute_capability_minor.max(0) as u128) * 1_000;
+        let mem_score = self.total_memory_bytes as u128 / (1024 * 1024);
+        cc_score + mem_score
+    }
+}
+
+impl fmt::Display for GpuDeviceInfo {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "CUDA device {}: {} (cc {}.{}, {:.1} GiB total",
+            self.ordinal,
+            self.name,
+            self.compute_capability_major,
+            self.compute_capability_minor,
+            self.total_memory_gib()
+        )?;
+        if let Some(free) = self.free_memory_bytes {
+            write!(
+                f,
+                ", {:.1} GiB free",
+                free as f64 / 1024.0 / 1024.0 / 1024.0
+            )?;
+        }
+        write!(f, ", {:?})", self.capability)
+    }
+}
+
+#[inline]
+pub fn classify_capability(major: i32, minor: i32, total_memory_bytes: usize) -> GpuCapability {
+    let cc10 = major.saturating_mul(10).saturating_add(minor);
+    let mem_gib = total_memory_bytes / 1024 / 1024 / 1024;
+    if cc10 >= 90 || mem_gib >= 80 {
+        GpuCapability::HighEndDatacenter
+    } else if cc10 >= 70 && mem_gib >= 16 {
+        GpuCapability::Datacenter
+    } else if cc10 >= 60 {
+        GpuCapability::Mainstream
+    } else {
+        GpuCapability::Legacy
+    }
+}

--- a/src/gpu/kernels.rs
+++ b/src/gpu/kernels.rs
@@ -1,0 +1,11 @@
+//! CPU-safe placeholder module for the GPU backend.
+//!
+//! Concrete CUDA resources are introduced behind operation-level dispatch so
+//! CPU-only builds keep identical behavior and do not require CUDA libraries.
+
+/// Describes whether a value is host-resident or intended for device residency.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum Residency {
+    Host,
+    Device,
+}

--- a/src/gpu/linalg.rs
+++ b/src/gpu/linalg.rs
@@ -1,0 +1,215 @@
+use super::policy::Operation;
+use super::profile::{KernelStat, record_dispatch_candidate, record_gpu_fallback};
+use super::runtime::GpuRuntime;
+use ndarray::{Array1, Array2, ArrayBase, Data, Ix1, Ix2};
+
+#[inline]
+pub fn try_fast_atb<S1: Data<Elem = f64>, S2: Data<Elem = f64>>(
+    a: &ArrayBase<S1, Ix2>,
+    b: &ArrayBase<S2, Ix2>,
+) -> Option<Array2<f64>> {
+    let (rows, x_cols) = a.dim();
+    let y_cols = b.ncols();
+    let flops = 2_u128 * rows as u128 * x_cols as u128 * y_cols as u128;
+    maybe_dispatch(
+        Operation::Gemm {
+            m: x_cols,
+            n: y_cols,
+            k: rows,
+            resident: false,
+        },
+        "fast_atb",
+        rows,
+        x_cols,
+        y_cols,
+        flops,
+    )?;
+    None
+}
+
+#[inline]
+pub fn try_fast_ab<S1: Data<Elem = f64>, S2: Data<Elem = f64>>(
+    a: &ArrayBase<S1, Ix2>,
+    b: &ArrayBase<S2, Ix2>,
+) -> Option<Array2<f64>> {
+    let (m, k) = a.dim();
+    let n = b.ncols();
+    let flops = 2_u128 * m as u128 * n as u128 * k as u128;
+    maybe_dispatch(
+        Operation::Gemm {
+            m,
+            n,
+            k,
+            resident: false,
+        },
+        "fast_ab",
+        m,
+        n,
+        k,
+        flops,
+    )?;
+    None
+}
+
+#[inline]
+pub fn try_fast_av<S1: Data<Elem = f64>, S2: Data<Elem = f64>>(
+    a: &ArrayBase<S1, Ix2>,
+    _v: &ArrayBase<S2, Ix1>,
+) -> Option<Array1<f64>> {
+    let (rows, cols) = a.dim();
+    let flops = 2_u128 * rows as u128 * cols as u128;
+    maybe_dispatch(
+        Operation::Gemv {
+            rows,
+            cols,
+            transpose: false,
+            resident: false,
+        },
+        "fast_av",
+        rows,
+        cols,
+        1,
+        flops,
+    )?;
+    None
+}
+
+#[inline]
+pub fn try_fast_atv<S1: Data<Elem = f64>, S2: Data<Elem = f64>>(
+    a: &ArrayBase<S1, Ix2>,
+    _v: &ArrayBase<S2, Ix1>,
+) -> Option<Array1<f64>> {
+    let (rows, cols) = a.dim();
+    let flops = 2_u128 * rows as u128 * cols as u128;
+    maybe_dispatch(
+        Operation::Gemv {
+            rows,
+            cols,
+            transpose: true,
+            resident: false,
+        },
+        "fast_atv",
+        rows,
+        cols,
+        1,
+        flops,
+    )?;
+    None
+}
+
+#[inline]
+pub fn try_fast_xt_diag_x<S1: Data<Elem = f64>, S2: Data<Elem = f64>>(
+    x: &ArrayBase<S1, Ix2>,
+    _w: &ArrayBase<S2, Ix1>,
+) -> Option<Array2<f64>> {
+    let (rows, cols) = x.dim();
+    let flops = 2_u128 * rows as u128 * cols as u128 * cols as u128;
+    maybe_dispatch(
+        Operation::XtDiagX {
+            rows,
+            cols,
+            resident: false,
+        },
+        "fast_xt_diag_x",
+        rows,
+        cols,
+        cols,
+        flops,
+    )?;
+    None
+}
+
+#[inline]
+pub fn try_fast_xt_diag_y<S1: Data<Elem = f64>, S2: Data<Elem = f64>, S3: Data<Elem = f64>>(
+    x: &ArrayBase<S1, Ix2>,
+    _w: &ArrayBase<S2, Ix1>,
+    y: &ArrayBase<S3, Ix2>,
+) -> Option<Array2<f64>> {
+    let rows = x.nrows();
+    let x_cols = x.ncols();
+    let y_cols = y.ncols();
+    let flops = 2_u128 * rows as u128 * x_cols as u128 * y_cols as u128;
+    maybe_dispatch(
+        Operation::XtDiagY {
+            rows,
+            x_cols,
+            y_cols,
+            resident: false,
+        },
+        "fast_xt_diag_y",
+        rows,
+        x_cols,
+        y_cols,
+        flops,
+    )?;
+    None
+}
+
+#[inline]
+pub fn try_fast_joint_hessian_2x2<
+    S1: Data<Elem = f64>,
+    S2: Data<Elem = f64>,
+    S3: Data<Elem = f64>,
+    S4: Data<Elem = f64>,
+    S5: Data<Elem = f64>,
+>(
+    x_a: &ArrayBase<S1, Ix2>,
+    x_b: &ArrayBase<S2, Ix2>,
+    _w_aa: &ArrayBase<S3, Ix1>,
+    _w_ab: &ArrayBase<S4, Ix1>,
+    _w_bb: &ArrayBase<S5, Ix1>,
+) -> Option<Array2<f64>> {
+    let rows = x_a.nrows();
+    let cols_a = x_a.ncols();
+    let cols_b = x_b.ncols();
+    let p = cols_a.saturating_add(cols_b);
+    let flops = 2_u128 * rows as u128 * p as u128 * p as u128;
+    maybe_dispatch(
+        Operation::JointHessian2x2 {
+            rows,
+            cols_a,
+            cols_b,
+            resident: false,
+        },
+        "fast_joint_hessian_2x2",
+        rows,
+        p,
+        p,
+        flops,
+    )?;
+    None
+}
+
+fn maybe_dispatch(
+    operation: Operation,
+    name: &'static str,
+    n: usize,
+    p: usize,
+    k: usize,
+    flops: u128,
+) -> Option<()> {
+    let runtime = GpuRuntime::get();
+    if runtime
+        .policy
+        .should_use_gpu(operation, runtime.cuda_available())
+    {
+        record_dispatch_candidate(KernelStat {
+            name,
+            n,
+            p,
+            k,
+            nnz: None,
+            flops_est: flops,
+            bytes_est: 8_u128 * n as u128 * p.max(1) as u128,
+            cpu_ms: None,
+            gpu_ms: None,
+        });
+        record_gpu_fallback();
+        log::debug!(
+            "[GAM GPU] {name} selected by policy but device BLAS kernels are not linked in this build; using CPU fallback"
+        );
+        Some(())
+    } else {
+        None
+    }
+}

--- a/src/gpu/memory.rs
+++ b/src/gpu/memory.rs
@@ -1,0 +1,11 @@
+//! CPU-safe placeholder module for the GPU backend.
+//!
+//! Concrete CUDA resources are introduced behind operation-level dispatch so
+//! CPU-only builds keep identical behavior and do not require CUDA libraries.
+
+/// Describes whether a value is host-resident or intended for device residency.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum Residency {
+    Host,
+    Device,
+}

--- a/src/gpu/mod.rs
+++ b/src/gpu/mod.rs
@@ -1,0 +1,21 @@
+//! GPU acceleration backend entry points.
+//!
+//! This module is deliberately available in CPU-only builds. CUDA discovery is
+//! dynamic and policy-gated, so the public fitting API can keep using the
+//! existing CPU implementation when CUDA is unavailable, disabled, too small
+//! for a kernel, or numerically unsuitable.
+
+pub mod device;
+pub mod kernels;
+pub mod linalg;
+pub mod memory;
+pub mod policy;
+pub mod profile;
+pub mod runtime;
+pub mod solver;
+pub mod sparse;
+pub mod stream;
+
+pub use device::{GpuCapability, GpuDeviceInfo, GpuSelection};
+pub use policy::{AccelPolicy, GpuDispatchPolicy, Operation};
+pub use runtime::{GpuRuntime, gpu_available, selected_gpu_info};

--- a/src/gpu/policy.rs
+++ b/src/gpu/policy.rs
@@ -1,0 +1,195 @@
+use super::device::{GpuCapability, GpuDeviceInfo};
+
+/// User-selected acceleration policy, controlled by `GAM_GPU`.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum AccelPolicy {
+    Auto,
+    CpuOnly,
+    GpuOnly,
+}
+
+/// Shape descriptor for operation-level CPU/GPU dispatch.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum Operation {
+    Gemm {
+        m: usize,
+        n: usize,
+        k: usize,
+        resident: bool,
+    },
+    Gemv {
+        rows: usize,
+        cols: usize,
+        transpose: bool,
+        resident: bool,
+    },
+    XtDiagX {
+        rows: usize,
+        cols: usize,
+        resident: bool,
+    },
+    XtDiagY {
+        rows: usize,
+        x_cols: usize,
+        y_cols: usize,
+        resident: bool,
+    },
+    JointHessian2x2 {
+        rows: usize,
+        cols_a: usize,
+        cols_b: usize,
+        resident: bool,
+    },
+    Potrf {
+        dim: usize,
+        resident: bool,
+    },
+    SparseXtDiagX {
+        rows: usize,
+        cols: usize,
+        nnz: usize,
+        resident: bool,
+    },
+    RowKernel {
+        rows: usize,
+        lanes: usize,
+        resident: bool,
+    },
+}
+
+/// Per-kernel thresholds. These are conservative defaults that are refined by
+/// future calibration data without changing public fitting APIs.
+#[derive(Clone, Debug)]
+pub struct GpuDispatchPolicy {
+    pub accel_policy: AccelPolicy,
+    pub gemm_min_flops: u128,
+    pub gemv_min_flops: u128,
+    pub xtwx_min_flops: u128,
+    pub potrf_min_p: usize,
+    pub sparse_min_nnz: usize,
+    pub row_kernel_min_n: usize,
+    pub keep_design_resident: bool,
+    pub prefer_gpu_for_f64_factorization: bool,
+}
+
+impl GpuDispatchPolicy {
+    #[inline]
+    pub fn for_device(accel_policy: AccelPolicy, device: Option<&GpuDeviceInfo>) -> Self {
+        let mut policy = Self {
+            accel_policy,
+            gemm_min_flops: 256_000_000,
+            gemv_min_flops: 32_000_000,
+            xtwx_min_flops: 512_000_000,
+            potrf_min_p: 2_048,
+            sparse_min_nnz: 2_000_000,
+            row_kernel_min_n: 250_000,
+            keep_design_resident: device.is_some(),
+            prefer_gpu_for_f64_factorization: false,
+        };
+        if let Some(info) = device {
+            match info.capability {
+                GpuCapability::HighEndDatacenter => {
+                    policy.gemm_min_flops = 32_000_000;
+                    policy.gemv_min_flops = 8_000_000;
+                    policy.xtwx_min_flops = 64_000_000;
+                    policy.potrf_min_p = 768;
+                    policy.sparse_min_nnz = 250_000;
+                    policy.row_kernel_min_n = 25_000;
+                    policy.prefer_gpu_for_f64_factorization = true;
+                }
+                GpuCapability::Datacenter => {
+                    policy.gemm_min_flops = 64_000_000;
+                    policy.gemv_min_flops = 16_000_000;
+                    policy.xtwx_min_flops = 128_000_000;
+                    policy.potrf_min_p = 1_024;
+                    policy.sparse_min_nnz = 500_000;
+                    policy.row_kernel_min_n = 75_000;
+                }
+                GpuCapability::Mainstream => {
+                    policy.gemm_min_flops = 128_000_000;
+                    policy.xtwx_min_flops = 256_000_000;
+                    policy.potrf_min_p = 1_536;
+                    policy.sparse_min_nnz = 1_000_000;
+                    policy.row_kernel_min_n = 125_000;
+                }
+                GpuCapability::Legacy => {}
+            }
+        }
+        policy.apply_env_overrides()
+    }
+
+    #[inline]
+    pub fn should_use_gpu(&self, operation: Operation, cuda_available: bool) -> bool {
+        if matches!(self.accel_policy, AccelPolicy::CpuOnly) || !cuda_available {
+            return false;
+        }
+        let force = matches!(self.accel_policy, AccelPolicy::GpuOnly);
+        let resident_bonus = match operation {
+            Operation::Gemm { resident, .. }
+            | Operation::Gemv { resident, .. }
+            | Operation::XtDiagX { resident, .. }
+            | Operation::XtDiagY { resident, .. }
+            | Operation::JointHessian2x2 { resident, .. }
+            | Operation::Potrf { resident, .. }
+            | Operation::SparseXtDiagX { resident, .. }
+            | Operation::RowKernel { resident, .. } => resident,
+        };
+        if force && resident_bonus {
+            return true;
+        }
+        match operation {
+            Operation::Gemm { m, n, k, .. } => {
+                2_u128 * m as u128 * n as u128 * k as u128 >= self.gemm_min_flops
+            }
+            Operation::Gemv { rows, cols, .. } => {
+                2_u128 * rows as u128 * cols as u128 >= self.gemv_min_flops
+            }
+            Operation::XtDiagX { rows, cols, .. } => {
+                2_u128 * rows as u128 * cols as u128 * cols as u128 >= self.xtwx_min_flops
+            }
+            Operation::XtDiagY {
+                rows,
+                x_cols,
+                y_cols,
+                ..
+            } => 2_u128 * rows as u128 * x_cols as u128 * y_cols as u128 >= self.xtwx_min_flops,
+            Operation::JointHessian2x2 {
+                rows,
+                cols_a,
+                cols_b,
+                ..
+            } => {
+                let p = cols_a.saturating_add(cols_b) as u128;
+                2_u128 * rows as u128 * p * p >= self.xtwx_min_flops
+            }
+            Operation::Potrf { dim, .. } => dim >= self.potrf_min_p,
+            Operation::SparseXtDiagX { nnz, .. } => nnz >= self.sparse_min_nnz,
+            Operation::RowKernel { rows, lanes, .. } => {
+                rows.saturating_mul(lanes) >= self.row_kernel_min_n
+            }
+        }
+    }
+
+    fn apply_env_overrides(mut self) -> Self {
+        if let Ok(value) = std::env::var("GAM_GPU_MIN_N") {
+            if let Ok(parsed) = value.parse::<usize>() {
+                self.row_kernel_min_n = parsed;
+            }
+        }
+        self
+    }
+}
+
+#[inline]
+pub fn accel_policy_from_env() -> AccelPolicy {
+    match std::env::var("GAM_GPU")
+        .unwrap_or_else(|_| "auto".to_string())
+        .trim()
+        .to_ascii_lowercase()
+        .as_str()
+    {
+        "off" | "0" | "false" | "cpu" | "cpuonly" | "cpu-only" => AccelPolicy::CpuOnly,
+        "force" | "on" | "1" | "true" | "gpu" | "gpuonly" | "gpu-only" => AccelPolicy::GpuOnly,
+        _ => AccelPolicy::Auto,
+    }
+}

--- a/src/gpu/profile.rs
+++ b/src/gpu/profile.rs
@@ -1,0 +1,38 @@
+use std::sync::atomic::{AtomicU64, Ordering};
+
+/// Lightweight structured counter for accelerated-kernel candidates.
+#[derive(Clone, Debug)]
+pub struct KernelStat {
+    pub name: &'static str,
+    pub n: usize,
+    pub p: usize,
+    pub k: usize,
+    pub nnz: Option<usize>,
+    pub flops_est: u128,
+    pub bytes_est: u128,
+    pub cpu_ms: Option<f64>,
+    pub gpu_ms: Option<f64>,
+}
+
+static DISPATCH_CANDIDATES: AtomicU64 = AtomicU64::new(0);
+static GPU_FALLBACKS: AtomicU64 = AtomicU64::new(0);
+
+#[inline]
+pub fn record_dispatch_candidate(_stat: KernelStat) {
+    DISPATCH_CANDIDATES.fetch_add(1, Ordering::Relaxed);
+}
+
+#[inline]
+pub fn record_gpu_fallback() {
+    GPU_FALLBACKS.fetch_add(1, Ordering::Relaxed);
+}
+
+#[inline]
+pub fn dispatch_candidate_count() -> u64 {
+    DISPATCH_CANDIDATES.load(Ordering::Relaxed)
+}
+
+#[inline]
+pub fn gpu_fallback_count() -> u64 {
+    GPU_FALLBACKS.load(Ordering::Relaxed)
+}

--- a/src/gpu/runtime.rs
+++ b/src/gpu/runtime.rs
@@ -1,0 +1,203 @@
+use super::device::{GpuDeviceInfo, GpuSelection, classify_capability};
+use super::policy::{AccelPolicy, GpuDispatchPolicy, accel_policy_from_env};
+use libloading::Library;
+use std::ffi::c_char;
+use std::sync::OnceLock;
+
+type CuResult = i32;
+type CuDevice = i32;
+type CuInit = unsafe extern "C" fn(u32) -> CuResult;
+type CuDeviceGetCount = unsafe extern "C" fn(*mut i32) -> CuResult;
+type CuDeviceGet = unsafe extern "C" fn(*mut CuDevice, i32) -> CuResult;
+type CuDeviceGetName = unsafe extern "C" fn(*mut c_char, i32, CuDevice) -> CuResult;
+type CuDeviceComputeCapability = unsafe extern "C" fn(*mut i32, *mut i32, CuDevice) -> CuResult;
+type CuDeviceTotalMem = unsafe extern "C" fn(*mut usize, CuDevice) -> CuResult;
+
+/// Cached runtime discovery result.
+#[derive(Clone, Debug)]
+pub struct GpuRuntime {
+    pub selection: GpuSelection,
+    pub policy: GpuDispatchPolicy,
+}
+
+impl GpuRuntime {
+    #[inline]
+    pub fn get() -> &'static Self {
+        static RUNTIME: OnceLock<GpuRuntime> = OnceLock::new();
+        RUNTIME.get_or_init(Self::probe)
+    }
+
+    pub fn probe() -> Self {
+        let accel_policy = accel_policy_from_env();
+        if matches!(accel_policy, AccelPolicy::CpuOnly) {
+            return Self::cpu("GAM_GPU disabled acceleration".to_string(), accel_policy);
+        }
+        match probe_cuda_devices() {
+            Ok(mut devices) if !devices.is_empty() => {
+                devices.sort_by_key(|device| std::cmp::Reverse(device.score()));
+                let selected = select_device(devices);
+                let policy = GpuDispatchPolicy::for_device(accel_policy, Some(&selected));
+                Self {
+                    selection: GpuSelection::Cuda { device: selected },
+                    policy,
+                }
+            }
+            Ok(_) => Self::cpu(
+                "CUDA driver loaded but reported no devices".to_string(),
+                accel_policy,
+            ),
+            Err(err) => {
+                if matches!(accel_policy, AccelPolicy::GpuOnly) {
+                    log::warn!(
+                        "[GAM GPU] GAM_GPU=force but CUDA probing failed: {err}; falling back to CPU"
+                    );
+                }
+                Self::cpu(err, accel_policy)
+            }
+        }
+    }
+
+    #[inline]
+    pub fn cuda_available(&self) -> bool {
+        matches!(self.selection, GpuSelection::Cuda { .. })
+    }
+
+    #[inline]
+    pub fn selected_device(&self) -> Option<&GpuDeviceInfo> {
+        match &self.selection {
+            GpuSelection::CpuOnly { .. } => None,
+            GpuSelection::Cuda { device } => Some(device),
+        }
+    }
+
+    fn cpu(reason: String, accel_policy: AccelPolicy) -> Self {
+        Self {
+            selection: GpuSelection::CpuOnly { reason },
+            policy: GpuDispatchPolicy::for_device(accel_policy, None),
+        }
+    }
+}
+
+#[inline]
+pub fn gpu_available() -> bool {
+    GpuRuntime::get().cuda_available()
+}
+
+#[inline]
+pub fn selected_gpu_info() -> Option<GpuDeviceInfo> {
+    GpuRuntime::get().selected_device().cloned()
+}
+
+fn select_device(devices: Vec<GpuDeviceInfo>) -> GpuDeviceInfo {
+    if let Ok(requested) = std::env::var("GAM_GPU_DEVICE") {
+        if let Ok(ordinal) = requested.parse::<usize>() {
+            if let Some(device) = devices.iter().find(|device| device.ordinal == ordinal) {
+                return device.clone();
+            }
+            log::warn!(
+                "[GAM GPU] requested GAM_GPU_DEVICE={ordinal} was not found; using best scored CUDA device"
+            );
+        }
+    }
+    devices
+        .into_iter()
+        .next()
+        .expect("device list is non-empty")
+}
+
+fn probe_cuda_devices() -> Result<Vec<GpuDeviceInfo>, String> {
+    let lib = load_cuda_driver()?;
+    let cu_init: libloading::Symbol<'_, CuInit> =
+        unsafe { lib.get(b"cuInit\0") }.map_err(|err| err.to_string())?;
+    let cu_device_get_count: libloading::Symbol<'_, CuDeviceGetCount> =
+        unsafe { lib.get(b"cuDeviceGetCount\0") }.map_err(|err| err.to_string())?;
+    let cu_device_get: libloading::Symbol<'_, CuDeviceGet> =
+        unsafe { lib.get(b"cuDeviceGet\0") }.map_err(|err| err.to_string())?;
+    let cu_device_get_name: libloading::Symbol<'_, CuDeviceGetName> =
+        unsafe { lib.get(b"cuDeviceGetName\0") }.map_err(|err| err.to_string())?;
+    let cu_device_compute_capability: libloading::Symbol<'_, CuDeviceComputeCapability> =
+        unsafe { lib.get(b"cuDeviceComputeCapability\0") }.map_err(|err| err.to_string())?;
+    let cu_device_total_mem = unsafe { lib.get::<CuDeviceTotalMem>(b"cuDeviceTotalMem_v2\0") }
+        .or_else(|_| unsafe { lib.get::<CuDeviceTotalMem>(b"cuDeviceTotalMem\0") })
+        .map_err(|err| err.to_string())?;
+
+    check_cuda(unsafe { cu_init(0) }, "cuInit")?;
+    let mut count = 0_i32;
+    check_cuda(
+        unsafe { cu_device_get_count(&mut count) },
+        "cuDeviceGetCount",
+    )?;
+    let mut devices = Vec::with_capacity(count.max(0) as usize);
+    for ordinal in 0..count.max(0) {
+        let mut raw_device = 0_i32;
+        check_cuda(
+            unsafe { cu_device_get(&mut raw_device, ordinal) },
+            "cuDeviceGet",
+        )?;
+        let mut name_bytes = [0_i8; 256];
+        check_cuda(
+            unsafe {
+                cu_device_get_name(name_bytes.as_mut_ptr(), name_bytes.len() as i32, raw_device)
+            },
+            "cuDeviceGetName",
+        )?;
+        let mut major = 0_i32;
+        let mut minor = 0_i32;
+        check_cuda(
+            unsafe { cu_device_compute_capability(&mut major, &mut minor, raw_device) },
+            "cuDeviceComputeCapability",
+        )?;
+        let mut total_memory_bytes = 0_usize;
+        check_cuda(
+            unsafe { cu_device_total_mem(&mut total_memory_bytes, raw_device) },
+            "cuDeviceTotalMem",
+        )?;
+        let name = c_name_to_string(&name_bytes);
+        devices.push(GpuDeviceInfo {
+            ordinal: ordinal as usize,
+            name,
+            compute_capability_major: major,
+            compute_capability_minor: minor,
+            total_memory_bytes,
+            free_memory_bytes: None,
+            capability: classify_capability(major, minor, total_memory_bytes),
+        });
+    }
+    Ok(devices)
+}
+
+fn load_cuda_driver() -> Result<Library, String> {
+    let candidates: &[&str] = if cfg!(target_os = "windows") {
+        &["nvcuda.dll"]
+    } else if cfg!(target_os = "macos") {
+        &["/usr/local/cuda/lib/libcuda.dylib", "libcuda.dylib"]
+    } else {
+        &["libcuda.so.1", "libcuda.so"]
+    };
+    let mut errors = Vec::new();
+    for candidate in candidates {
+        match unsafe { Library::new(candidate) } {
+            Ok(lib) => return Ok(lib),
+            Err(err) => errors.push(format!("{candidate}: {err}")),
+        }
+    }
+    Err(format!(
+        "CUDA driver library not found ({})",
+        errors.join("; ")
+    ))
+}
+
+#[inline]
+fn check_cuda(result: CuResult, call: &str) -> Result<(), String> {
+    if result == 0 {
+        Ok(())
+    } else {
+        Err(format!("{call} failed with CUDA driver code {result}"))
+    }
+}
+
+fn c_name_to_string(bytes: &[i8]) -> String {
+    let nul = bytes.iter().position(|&b| b == 0).unwrap_or(bytes.len());
+    let raw: Vec<u8> = bytes[..nul].iter().map(|&b| b as u8).collect();
+    String::from_utf8_lossy(&raw).trim().to_string()
+}

--- a/src/gpu/solver.rs
+++ b/src/gpu/solver.rs
@@ -1,0 +1,11 @@
+//! CPU-safe placeholder module for the GPU backend.
+//!
+//! Concrete CUDA resources are introduced behind operation-level dispatch so
+//! CPU-only builds keep identical behavior and do not require CUDA libraries.
+
+/// Describes whether a value is host-resident or intended for device residency.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum Residency {
+    Host,
+    Device,
+}

--- a/src/gpu/sparse.rs
+++ b/src/gpu/sparse.rs
@@ -1,0 +1,11 @@
+//! CPU-safe placeholder module for the GPU backend.
+//!
+//! Concrete CUDA resources are introduced behind operation-level dispatch so
+//! CPU-only builds keep identical behavior and do not require CUDA libraries.
+
+/// Describes whether a value is host-resident or intended for device residency.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum Residency {
+    Host,
+    Device,
+}

--- a/src/gpu/stream.rs
+++ b/src/gpu/stream.rs
@@ -1,0 +1,11 @@
+//! CPU-safe placeholder module for the GPU backend.
+//!
+//! Concrete CUDA resources are introduced behind operation-level dispatch so
+//! CPU-only builds keep identical behavior and do not require CUDA libraries.
+
+/// Describes whether a value is host-resident or intended for device residency.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum Residency {
+    Host,
+    Device,
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,7 @@ pub fn init_parallelism() {
 }
 
 pub mod families;
+pub mod gpu;
 pub mod inference;
 pub mod linalg;
 pub mod report;

--- a/src/linalg/faer_ndarray.rs
+++ b/src/linalg/faer_ndarray.rs
@@ -250,6 +250,9 @@ pub fn fast_atb_with_parallelism<S1: Data<Elem = f64>, S2: Data<Elem = f64>>(
     b: &ArrayBase<S2, Ix2>,
     par: Par,
 ) -> Array2<f64> {
+    if let Some(out) = crate::gpu::linalg::try_fast_atb(a, b) {
+        return out;
+    }
     use faer::linalg::matmul::matmul;
     use faer::{Accum, Mat};
 
@@ -290,6 +293,9 @@ pub fn fast_ab<S1: Data<Elem = f64>, S2: Data<Elem = f64>>(
     a: &ArrayBase<S1, Ix2>,
     b: &ArrayBase<S2, Ix2>,
 ) -> Array2<f64> {
+    if let Some(out) = crate::gpu::linalg::try_fast_ab(a, b) {
+        return out;
+    }
     let (n, _) = a.dim();
     let (_, q) = b.dim();
     let mut out = Array2::<f64>::zeros((n, q));
@@ -304,6 +310,9 @@ pub fn fast_av<S1: Data<Elem = f64>, S2: Data<Elem = f64>>(
     a: &ArrayBase<S1, Ix2>,
     v: &ArrayBase<S2, Ix1>,
 ) -> Array1<f64> {
+    if let Some(out) = crate::gpu::linalg::try_fast_av(a, v) {
+        return out;
+    }
     use faer::linalg::matmul::matmul;
     use faer::{Accum, Mat};
 
@@ -339,6 +348,10 @@ pub fn fast_av_into<S1: Data<Elem = f64>, S2: Data<Elem = f64>>(
     v: &ArrayBase<S2, Ix1>,
     out: &mut Array1<f64>,
 ) {
+    if let Some(gpu_out) = crate::gpu::linalg::try_fast_av(a, v) {
+        out.assign(&gpu_out);
+        return;
+    }
     use faer::Accum;
     use faer::linalg::matmul::matmul;
 
@@ -413,6 +426,9 @@ pub fn fast_atv<S1: Data<Elem = f64>, S2: Data<Elem = f64>>(
     a: &ArrayBase<S1, Ix2>,
     v: &ArrayBase<S2, Ix1>,
 ) -> Array1<f64> {
+    if let Some(out) = crate::gpu::linalg::try_fast_atv(a, v) {
+        return out;
+    }
     use faer::linalg::matmul::matmul;
     use faer::{Accum, Mat};
 
@@ -457,6 +473,10 @@ pub fn fast_atv_into<S: Data<Elem = f64>>(
     v: &Array1<f64>,
     out: &mut Array1<f64>,
 ) {
+    if let Some(gpu_out) = crate::gpu::linalg::try_fast_atv(a, v) {
+        out.assign(&gpu_out);
+        return;
+    }
     use faer::Accum;
     use faer::linalg::matmul::matmul;
 
@@ -504,6 +524,9 @@ pub fn fast_xt_diag_x_with_parallelism<S1: Data<Elem = f64>, S2: Data<Elem = f64
     w: &ArrayBase<S2, Ix1>,
     par: Par,
 ) -> Array2<f64> {
+    if let Some(out) = crate::gpu::linalg::try_fast_xt_diag_x(x, w) {
+        return out;
+    }
     use faer::Accum;
     use faer::linalg::matmul::matmul;
     use ndarray::{ShapeBuilder, s};
@@ -570,6 +593,9 @@ pub fn fast_xt_diag_y<S1: Data<Elem = f64>, S2: Data<Elem = f64>, S3: Data<Elem 
     w: &ArrayBase<S2, Ix1>,
     y: &ArrayBase<S3, Ix2>,
 ) -> Array2<f64> {
+    if let Some(out) = crate::gpu::linalg::try_fast_xt_diag_y(x, w, y) {
+        return out;
+    }
     use faer::Accum;
     use faer::linalg::matmul::matmul;
     use ndarray::{ShapeBuilder, s};
@@ -647,6 +673,9 @@ pub fn fast_joint_hessian_2x2<
     w_ab: &ArrayBase<S4, Ix1>,
     w_bb: &ArrayBase<S5, Ix1>,
 ) -> Array2<f64> {
+    if let Some(out) = crate::gpu::linalg::try_fast_joint_hessian_2x2(x_a, x_b, w_aa, w_ab, w_bb) {
+        return out;
+    }
     use faer::Accum;
     use faer::linalg::matmul::matmul;
     use ndarray::{ShapeBuilder, s};


### PR DESCRIPTION
### Motivation
- Introduce a coherent GPU acceleration backend so hot linear-algebra and row-wise kernels can be accelerated without changing the public fitting API.
- Provide dynamic CUDA discovery and a hardware-aware dispatch policy so execution decisions are calibrated per-device and can fall back to the existing CPU engine.
- Wire dispatch points into the existing high-impact linalg wrappers so early integration accelerates the most frequent operations (`Xβ`, `Xᵀv`, `XᵀWX`, `XᵀWy`, joint Hessians) while preserving correctness and CPU behavior.

### Description
- Add a GPU module tree under `src/gpu/` including `runtime.rs` (dynamic CUDA probing via `libloading`), `device.rs` (device metadata and scoring), `policy.rs` (per-operation dispatch thresholds and env overrides), `linalg.rs` (dispatch shims), and `profile.rs` (lightweight counters), plus placeholder modules for memory/streams/kernels/solver/sparse to keep CPU-only builds working.
- Add a `cuda` Cargo feature scaffold and `libloading` dependency so CUDA is dynamically discovered at runtime and CPU-only builds remain undisturbed (`Cargo.toml` updated; `GAM_GPU` env-driven policy supported).
- Insert policy-driven GPU hooks into existing hot wrappers in `src/linalg/faer_ndarray.rs` (calls to `try_fast_atb`, `try_fast_ab`, `try_fast_av`, `try_fast_av_into`, `try_fast_atv`, `try_fast_atv_into`, `fast_xt_diag_x`, `fast_xt_diag_y`, and `fast_joint_hessian_2x2`) so operations consult `GpuRuntime` and either short-circuit to a GPU implementation (future work) or fall back to the current `faer`/`ndarray` CPU paths.
- Add runtime probing and device selection that scores devices, selects by ordinal/env override, and constructs a `GpuDispatchPolicy` tuned by coarse capability classes; add structured counters to record dispatch candidates and GPU-fallback events for later calibration and profiling.

### Testing
- Ran `cargo check --lib` and confirmed it completed successfully (CPU-only build).
- Ran `cargo check --lib --features cuda` and confirmed it completed successfully (build with CUDA-feature scaffolding present).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a072f265c6c832491c55ed680f4de74)