### PR TITLE
Add GPU policy hooks and PIRLS candidate screening

### DIFF
--- a/crates/gam-pyffi/src/lib.rs
+++ b/crates/gam-pyffi/src/lib.rs
@@ -74,6 +74,7 @@ struct PyFitConfig {
     noise_offset: Option<String>,
 
     firth: Option<bool>,
+    gpu: Option<String>,
 
     // Frailty (only consumed by survival families today). Mirrors the CLI
     // names: --frailty-kind, --frailty-sd, --hazard-loading.
@@ -1174,6 +1175,14 @@ fn parse_fit_config(config_json: Option<&str>) -> Result<FitConfig, String> {
     }
     if let Some(flag) = py_config.firth {
         fit_config.firth = flag;
+    }
+    if let Some(raw_gpu) = py_config.gpu {
+        fit_config.gpu_policy = gam::gpu::GpuPolicy::parse(&raw_gpu).ok_or_else(|| {
+            format!(
+                "invalid gpu policy '{}'; supported values are auto, off, force",
+                raw_gpu
+            )
+        })?;
     }
     if let Some(kind) = py_config.frailty_kind {
         let trimmed = kind.trim().to_ascii_lowercase();

--- a/src/gpu.rs
+++ b/src/gpu.rs
@@ -1,0 +1,192 @@
+//! GPU execution policy and instrumentation hooks.
+//!
+//! The first production-safe step for acceleration is an explicit policy layer:
+//! `Auto` may opportunistically use supported device-resident kernels, `Off`
+//! guarantees the CPU path, and `Force` turns an unsupported GPU route into a
+//! hard error instead of a silent CPU fallback.  The numerical kernels are wired
+//! to call these helpers before selecting a backend; until a vendor backend is
+//! compiled in this module intentionally reports "unsupported" so `force` fails
+//! loudly while `auto` remains a correct CPU fallback.
+
+use serde::{Deserialize, Serialize};
+use std::sync::OnceLock;
+
+/// User-facing GPU backend policy.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum GpuPolicy {
+    /// Let the solver use GPU kernels only for supported, large-enough paths.
+    #[default]
+    Auto,
+    /// Always use CPU kernels.
+    Off,
+    /// Require GPU kernels and error if the requested path is unsupported.
+    Force,
+}
+
+impl GpuPolicy {
+    #[inline]
+    pub fn from_env() -> Self {
+        match std::env::var("GAM_GPU") {
+            Ok(raw) => Self::parse(&raw).unwrap_or(Self::Auto),
+            Err(_) => Self::Auto,
+        }
+    }
+
+    pub fn parse(raw: &str) -> Option<Self> {
+        match raw.trim().to_ascii_lowercase().as_str() {
+            "auto" | "" => Some(Self::Auto),
+            "off" | "false" | "0" | "cpu" => Some(Self::Off),
+            "force" | "on" | "true" | "1" | "gpu" => Some(Self::Force),
+            _ => None,
+        }
+    }
+
+    #[inline]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Auto => "auto",
+            Self::Off => "off",
+            Self::Force => "force",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum GpuKernel {
+    DenseMatvec,
+    DenseTransposeMatvec,
+    DenseXtWX,
+    CandidateScreen,
+    DenseSolve,
+    MatrixFreePcg,
+    SparseAssembly,
+    SpatialKernelOperator,
+    MarginalSlopeRows,
+    RemlTrace,
+    FinalInference,
+}
+
+impl GpuKernel {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::DenseMatvec => "dense-matvec",
+            Self::DenseTransposeMatvec => "dense-transpose-matvec",
+            Self::DenseXtWX => "dense-xtwx",
+            Self::CandidateScreen => "candidate-screen",
+            Self::DenseSolve => "dense-solve",
+            Self::MatrixFreePcg => "matrix-free-pcg",
+            Self::SparseAssembly => "sparse-assembly",
+            Self::SpatialKernelOperator => "spatial-kernel-operator",
+            Self::MarginalSlopeRows => "marginal-slope-rows",
+            Self::RemlTrace => "reml-trace",
+            Self::FinalInference => "final-inference",
+        }
+    }
+}
+
+/// A backend-selection decision for a single hot kernel.
+#[derive(Clone, Debug)]
+pub struct GpuDecision {
+    pub policy: GpuPolicy,
+    pub kernel: GpuKernel,
+    pub use_gpu: bool,
+    pub reason: &'static str,
+}
+
+static POLICY: OnceLock<GpuPolicy> = OnceLock::new();
+
+#[inline]
+pub fn global_policy() -> GpuPolicy {
+    *POLICY.get_or_init(GpuPolicy::from_env)
+}
+
+/// Configure the process-wide policy before solver kernels are selected.
+/// If a kernel already initialized the policy (for example via `GAM_GPU`),
+/// the first value wins so concurrent fits cannot race policy changes.
+pub fn configure_global_policy(policy: GpuPolicy) {
+    let _ = POLICY.set(policy);
+}
+
+/// Decide whether a GPU kernel may run.  This is deliberately conservative:
+/// with no compiled vendor backend, `auto` returns CPU fallback and `force`
+/// returns an error at the call site through [`GpuDecision::require_supported`].
+pub fn decide(kernel: GpuKernel, supported: bool, large_enough: bool) -> GpuDecision {
+    let policy = global_policy();
+    let (use_gpu, reason) = match policy {
+        GpuPolicy::Off => (false, "gpu-policy-off"),
+        GpuPolicy::Auto if !supported => (false, "gpu-backend-not-compiled"),
+        GpuPolicy::Auto if !large_enough => (false, "workload-below-gpu-threshold"),
+        GpuPolicy::Auto => (true, "gpu-auto-supported"),
+        GpuPolicy::Force if !supported => (false, "gpu-force-unsupported"),
+        GpuPolicy::Force => (true, "gpu-force-supported"),
+    };
+    GpuDecision {
+        policy,
+        kernel,
+        use_gpu,
+        reason,
+    }
+}
+
+impl GpuDecision {
+    pub fn require_supported(&self) -> Result<(), String> {
+        if self.policy == GpuPolicy::Force && !self.use_gpu {
+            return Err(format!(
+                "gpu=force requested kernel '{}' but no supported device backend is available ({})",
+                self.kernel.as_str(),
+                self.reason
+            ));
+        }
+        Ok(())
+    }
+
+    pub fn log(self) {
+        log::debug!(
+            "[GPU backend] kernel={} policy={} selected={} reason={}",
+            self.kernel.as_str(),
+            self.policy.as_str(),
+            self.use_gpu,
+            self.reason
+        );
+    }
+}
+
+/// Emit the roadmap-visible kernels at startup/debug time without affecting
+/// numerical execution. This keeps backend coverage auditable as real device
+/// kernels are added incrementally.
+pub fn log_backend_inventory_once() {
+    static LOGGED: OnceLock<()> = OnceLock::new();
+    LOGGED.get_or_init(|| {
+        log::debug!(
+            "[GPU backend] policy={} compiled_backends=none kernels=dense-matvec,dense-transpose-matvec,dense-xtwx,candidate-screen,dense-solve,matrix-free-pcg,sparse-assembly,spatial-kernel-operator,marginal-slope-rows,reml-trace,final-inference",
+            global_policy().as_str()
+        );
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_user_gpu_policy_aliases() {
+        assert_eq!(GpuPolicy::parse("auto"), Some(GpuPolicy::Auto));
+        assert_eq!(GpuPolicy::parse("cpu"), Some(GpuPolicy::Off));
+        assert_eq!(GpuPolicy::parse("force"), Some(GpuPolicy::Force));
+        assert_eq!(GpuPolicy::parse("wat"), None);
+    }
+
+    #[test]
+    fn force_policy_reports_unsupported_kernel() {
+        let decision = GpuDecision {
+            policy: GpuPolicy::Force,
+            kernel: GpuKernel::DenseXtWX,
+            use_gpu: false,
+            reason: "gpu-force-unsupported",
+        };
+        let err = decision.require_supported().unwrap_err();
+        assert!(err.contains("dense-xtwx"));
+        assert!(err.contains("gpu=force"));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,7 @@ pub fn init_parallelism() {
 }
 
 pub mod families;
+pub mod gpu;
 pub mod inference;
 pub mod linalg;
 pub mod report;

--- a/src/solver/pirls.rs
+++ b/src/solver/pirls.rs
@@ -509,6 +509,17 @@ pub trait WorkingModel {
         self.update_with_curvature(beta, curvature)
     }
 
+    fn screen_candidate(
+        &mut self,
+        beta: &Coefficients,
+        _: &Array1<f64>,
+        _: &LinearPredictor,
+        curvature: HessianCurvatureKind,
+    ) -> Result<CandidateEvaluation, EstimationError> {
+        self.update_candidate(beta, curvature)
+            .map(CandidateEvaluation::Full)
+    }
+
     fn supports_observed_information_curvature(&self) -> bool {
         false
     }
@@ -729,6 +740,51 @@ pub enum ExportedLaplaceCurvature {
         pd_tolerance: f64,
         gradient_norm: f64,
     },
+}
+
+#[derive(Debug, Clone)]
+pub struct CandidateScreen {
+    pub penalized_objective: f64,
+    pub deviance: f64,
+    pub penalty_term: f64,
+    pub arithmetic_finite: bool,
+}
+
+pub enum CandidateEvaluation {
+    Screen(CandidateScreen),
+    Full(WorkingState),
+}
+
+impl CandidateEvaluation {
+    #[inline]
+    fn penalized_objective(&self, firth_bias_reduction: bool) -> f64 {
+        match self {
+            Self::Screen(screen) => screen.penalized_objective,
+            Self::Full(state) => {
+                let mut value = state.deviance + state.penalty_term;
+                if firth_bias_reduction && let Some(jeffreys_logdet) = state.jeffreys_logdet() {
+                    value -= 2.0 * jeffreys_logdet;
+                }
+                value
+            }
+        }
+    }
+
+    #[inline]
+    fn arithmetic_finite(&self) -> bool {
+        match self {
+            Self::Screen(screen) => screen.arithmetic_finite,
+            Self::Full(state) => state.gradient.iter().all(|g| g.is_finite()),
+        }
+    }
+
+    #[inline]
+    fn into_full(self) -> Option<WorkingState> {
+        match self {
+            Self::Full(state) => Some(state),
+            Self::Screen(_) => None,
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -1026,6 +1082,60 @@ impl PirlsWorkspace {
                     par,
                 );
             }
+        }
+    }
+
+    fn add_dense_xtwx_streaming_signed<S>(
+        weights: &Array1<f64>,
+        weighted_x_chunk: &mut Array2<f64>,
+        x: &ArrayBase<S, Ix2>,
+        out: &mut Array2<f64>,
+        par: Par,
+    ) where
+        S: Data<Elem = f64> + Sync,
+    {
+        let n = x.nrows();
+        let p = x.ncols();
+        if n == 0 || p == 0 {
+            return;
+        }
+        debug_assert_eq!(
+            weights.len(),
+            n,
+            "weight length must match row count for signed streamed XtWX"
+        );
+        let chunkrows = Self::dense_xtwx_chunkrows(p).min(n);
+        if weighted_x_chunk.ncols() != p || weighted_x_chunk.nrows() != chunkrows {
+            *weighted_x_chunk = Array2::zeros((chunkrows, p).f());
+        }
+        let mut outview = array2_to_matmut(out);
+        for start in (0..n).step_by(chunkrows) {
+            let rows = (n - start).min(chunkrows);
+            {
+                let mut chunk = weighted_x_chunk.slice_mut(s![0..rows, ..]);
+                let x_slice = x.slice(s![start..start + rows, ..]);
+                let w_slice = weights.slice(s![start..start + rows]);
+                Zip::from(chunk.rows_mut())
+                    .and(x_slice.rows())
+                    .and(&w_slice)
+                    .par_for_each(|mut dst, src, &w| {
+                        Zip::from(&mut dst)
+                            .and(&src)
+                            .for_each(|d, &xij| *d = xij * w);
+                    });
+            }
+            let weighted_rows = weighted_x_chunk.slice(s![0..rows, ..]);
+            let x_rows = x.slice(s![start..start + rows, ..]);
+            let weighted_view = FaerArrayView::new(&weighted_rows);
+            let x_view = FaerArrayView::new(&x_rows);
+            matmul(
+                outview.as_mut(),
+                Accum::Add,
+                x_view.as_ref().transpose(),
+                weighted_view.as_ref(),
+                1.0,
+                par,
+            );
         }
     }
 
@@ -1608,20 +1718,40 @@ impl<'a> GamWorkingModel<'a> {
             DesignMatrix::Dense(x) if x.is_materialized_dense() => {
                 let p = x.ncols();
                 let x_dense = x.to_dense_arc();
-                workspace.fill_sqrtweights(weights);
                 // Reuse workspace hessian buffer to avoid per-iteration allocation.
                 if workspace.hessian_buf.nrows() != p || workspace.hessian_buf.ncols() != p {
                     workspace.hessian_buf = Array2::zeros((p, p).f());
                 } else {
                     workspace.hessian_buf.fill(0.0);
                 }
-                PirlsWorkspace::add_dense_xtwx_streaming_from_sqrt(
-                    &workspace.sqrtw,
-                    &mut workspace.weighted_x_chunk,
-                    x_dense.as_ref(),
-                    &mut workspace.hessian_buf,
-                    get_global_parallelism(),
-                );
+                crate::gpu::log_backend_inventory_once();
+                let large_enough = x.nrows() >= 100_000 || (x.nrows() * p) >= 2_000_000;
+                let gpu_decision =
+                    crate::gpu::decide(crate::gpu::GpuKernel::DenseXtWX, false, large_enough);
+                gpu_decision
+                    .require_supported()
+                    .map_err(EstimationError::InvalidInput)?;
+                gpu_decision.log();
+                if weights.iter().any(|&w| w < 0.0) {
+                    // Observed-information assembly may have signed row
+                    // weights.  Use Xᵀ(WX) exactly; never sqrt/clip.
+                    PirlsWorkspace::add_dense_xtwx_streaming_signed(
+                        weights,
+                        &mut workspace.weighted_x_chunk,
+                        x_dense.as_ref(),
+                        &mut workspace.hessian_buf,
+                        get_global_parallelism(),
+                    );
+                } else {
+                    workspace.fill_sqrtweights(weights);
+                    PirlsWorkspace::add_dense_xtwx_streaming_from_sqrt(
+                        &workspace.sqrtw,
+                        &mut workspace.weighted_x_chunk,
+                        x_dense.as_ref(),
+                        &mut workspace.hessian_buf,
+                        get_global_parallelism(),
+                    );
+                }
                 // Move the buffer out instead of cloning — saves O(p²) memcpy.
                 // Next call will reallocate (same cost as the existing zero-fill).
                 Ok(std::mem::take(&mut workspace.hessian_buf))
@@ -1701,6 +1831,113 @@ impl<'a> GamWorkingModel<'a> {
             &mut self.lasthessian_d,
         )?;
         Ok(HessianCurvatureKind::Observed)
+    }
+
+    fn screen_candidate_from_direction(
+        &mut self,
+        beta: &Coefficients,
+        direction: &Array1<f64>,
+        current_eta: &LinearPredictor,
+    ) -> Result<CandidateScreen, EstimationError> {
+        crate::gpu::log_backend_inventory_once();
+        let decision = crate::gpu::decide(
+            crate::gpu::GpuKernel::CandidateScreen,
+            false,
+            self.offset.len() >= 100_000,
+        );
+        decision
+            .require_supported()
+            .map_err(EstimationError::InvalidInput)?;
+        decision.log();
+
+        let n = self.offset.len();
+        if self.workspace.eta_buf.len() != n {
+            self.workspace.eta_buf = Array1::zeros(n);
+        }
+        if self.workspace.delta_eta.len() != n {
+            self.workspace.delta_eta = Array1::zeros(n);
+        }
+        let mut delta_eta = std::mem::take(&mut self.workspace.delta_eta);
+        self.transformed_matvec_into(&Coefficients::new(direction.clone()), &mut delta_eta);
+        Zip::from(&mut self.workspace.eta_buf)
+            .and(current_eta.as_ref())
+            .and(&delta_eta)
+            .par_for_each(|eta, &base, &delta| *eta = base + delta);
+        self.workspace.delta_eta = delta_eta;
+
+        if self.likelihood.scale.gamma_shape_is_estimated() {
+            let shape =
+                estimate_gamma_shape_from_eta(self.y, &self.workspace.eta_buf, self.priorweights);
+            self.likelihood = self.likelihood.with_gamma_shape(shape);
+        }
+
+        let integrated = self.covariate_se.as_ref().map(|se| IntegratedWorkingInput {
+            quadctx: &self.quadctx,
+            se: se.view(),
+            mixture_link_state: self.link_kind.mixture_state(),
+            sas_link_state: self.link_kind.sas_state(),
+        });
+        match &self.link_kind {
+            InverseLink::Mixture(_)
+            | InverseLink::LatentCLogLog(_)
+            | InverseLink::Sas(_)
+            | InverseLink::BetaLogistic(_) => {
+                if let Some(integ) = integrated {
+                    update_glmvectors_integrated_for_link(
+                        integ.quadctx,
+                        self.y,
+                        &self.workspace.eta_buf,
+                        integ.se,
+                        &self.link_kind,
+                        self.priorweights,
+                        &mut self.lastmu,
+                        &mut self.lastweights,
+                        &mut self.lastz,
+                        None,
+                    )?;
+                } else {
+                    update_glmvectors(
+                        self.y,
+                        &self.workspace.eta_buf,
+                        &self.link_kind,
+                        self.priorweights,
+                        &mut self.lastmu,
+                        &mut self.lastweights,
+                        &mut self.lastz,
+                        None,
+                    )?;
+                }
+            }
+            InverseLink::Standard(_) => {
+                self.likelihood.irls_update(
+                    self.y,
+                    &self.workspace.eta_buf,
+                    self.priorweights,
+                    &mut self.lastmu,
+                    &mut self.lastweights,
+                    &mut self.lastz,
+                    integrated,
+                    None,
+                )?;
+            }
+        }
+
+        let deviance = self
+            .likelihood
+            .loglik_deviance(self.y, &self.lastmu, self.priorweights)?;
+        let s_beta = self.penalty.apply(beta.as_ref());
+        let penalty_term = beta.as_ref().dot(&s_beta);
+        let penalized_objective = deviance + penalty_term;
+        let arithmetic_finite = penalized_objective.is_finite()
+            && self.workspace.eta_buf.iter().all(|v| v.is_finite())
+            && self.lastmu.iter().all(|v| v.is_finite())
+            && self.lastweights.iter().all(|v| v.is_finite());
+        Ok(CandidateScreen {
+            penalized_objective,
+            deviance,
+            penalty_term,
+            arithmetic_finite,
+        })
     }
 
     fn sparse_penalized_hessian(
@@ -2086,6 +2323,22 @@ impl<'a> WorkingModel for GamWorkingModel<'a> {
         let result = self.update_with_curvature(beta, curvature);
         self.firth_bias_reduction = firth_enabled;
         result
+    }
+
+    fn screen_candidate(
+        &mut self,
+        beta: &Coefficients,
+        direction: &Array1<f64>,
+        current_eta: &LinearPredictor,
+        curvature: HessianCurvatureKind,
+    ) -> Result<CandidateEvaluation, EstimationError> {
+        if self.firth_bias_reduction {
+            return self
+                .update_candidate(beta, curvature)
+                .map(CandidateEvaluation::Full);
+        }
+        self.screen_candidate_from_direction(beta, direction, current_eta)
+            .map(CandidateEvaluation::Screen)
     }
 
     fn supports_observed_information_curvature(&self) -> bool {
@@ -4262,12 +4515,17 @@ where
             }
             let candidate_beta = Coefficients::new(candidatevec);
             let candidate_eval_start = std::time::Instant::now();
-            let candidate_eval_result =
-                model.update_candidate(&candidate_beta, state.hessian_curvature);
+            let candidate_eval_result = model.screen_candidate(
+                &candidate_beta,
+                direction,
+                &state.eta,
+                state.hessian_curvature,
+            );
             lm_candidate_total += candidate_eval_start.elapsed();
             match candidate_eval_result {
-                Ok(candidate_state) => {
-                    let screening_penalized = penalizedobjective(&candidate_state);
+                Ok(candidate_eval) => {
+                    let screening_penalized =
+                        candidate_eval.penalized_objective(options.firth_bias_reduction);
                     let screening_reduction = current_penalized - screening_penalized;
 
                     // 4. Gain Ratio
@@ -4291,19 +4549,22 @@ where
                     // reason to reject a candidate; only non-finite objective
                     // or gradient arithmetic is. Saturation is diagnosed later
                     // by `pirls_soft_acceptance`.
-                    let candidate_grad_finite =
-                        candidate_state.gradient.iter().all(|g| g.is_finite());
+                    let candidate_arithmetic_finite = candidate_eval.arithmetic_finite();
 
                     if screening_rho > 0.0
                         && screening_penalized.is_finite()
-                        && candidate_grad_finite
+                        && candidate_arithmetic_finite
                     {
-                        let accepted_state = if options.firth_bias_reduction {
-                            let firth_curv_start = std::time::Instant::now();
-                            let firth_curv_result = model
+                        let accepted_state = if let Some(candidate_state) =
+                            candidate_eval.into_full()
+                        {
+                            candidate_state
+                        } else {
+                            let accepted_curv_start = std::time::Instant::now();
+                            let accepted_curv_result = model
                                 .update_with_curvature(&candidate_beta, state.hessian_curvature);
-                            curvature_total += firth_curv_start.elapsed();
-                            match firth_curv_result {
+                            curvature_total += accepted_curv_start.elapsed();
+                            match accepted_curv_result {
                                 Ok(state) => state,
                                 Err(err) => {
                                     if !is_lm_retriable_candidate_error(&err) {
@@ -4330,8 +4591,6 @@ where
                                     continue;
                                 }
                             }
-                        } else {
-                            candidate_state
                         };
                         let candidate_penalized = penalizedobjective(&accepted_state);
                         if candidate_penalized.is_finite()

--- a/src/solver/workflow.rs
+++ b/src/solver/workflow.rs
@@ -1342,6 +1342,11 @@ pub struct FitConfig {
     /// Enable Firth bias reduction for standard single-parameter families.
     pub firth: bool,
 
+    /// GPU backend selection policy. `Auto` uses supported device kernels for
+    /// large workloads, `Off` pins execution to CPU kernels, and `Force` fails
+    /// loudly when a requested GPU kernel has no compiled backend.
+    pub gpu_policy: crate::gpu::GpuPolicy,
+
     /// Optional override of the [`crate::resource::ResourcePolicy`] used when
     /// planning spatial bases (TPS / Matern / Duchon) during term construction.
     /// When `None`, the default-library policy is used.
@@ -1380,6 +1385,7 @@ impl Default for FitConfig {
             ridge_lambda: 1e-6,
             transformation_normal: false,
             firth: false,
+            gpu_policy: crate::gpu::GpuPolicy::Auto,
             resource_policy: None,
         }
     }
@@ -1440,6 +1446,7 @@ pub fn materialize<'a>(
     data: &'a Dataset,
     config: &FitConfig,
 ) -> Result<MaterializedModel<'a>, String> {
+    crate::gpu::configure_global_policy(config.gpu_policy);
     let parsed = parse_formula(formula)?;
     let col_map = data.column_map();
 


### PR DESCRIPTION
### Motivation
- Introduce a conservative, auditable GPU policy layer so future device kernels can be enabled without changing solver invariants and so users can choose `auto | off | force` behavior via `GAM_GPU` or `FitConfig`.
- Reduce wasted inner-loop work in the PIRLS LM loop by cheaply screening LM candidates using `eta + X·δ` so rejected candidates do not pay for a full `Xβ` + link + Hessian rebuild.
- Preserve numerical correctness of observed-information Hessian assembly by avoiding the previous `sqrt(max(0,w))` clip for signed weights and adding a signed `Xᵀ(WX)` streaming path.

### Description
- Added a new GPU policy module `src/gpu.rs` that exposes `GpuPolicy` (`Auto|Off|Force`), `GpuKernel` enum, `decide()` and `configure_global_policy()` helpers, and debug inventory logging for available kernels.
- Plumbed GPU policy into the crate by exporting `pub mod gpu;` in `src/lib.rs`, adding `gpu_policy: crate::gpu::GpuPolicy` to `FitConfig`, and calling `crate::gpu::configure_global_policy(config.gpu_policy)` during `materialize()` in `src/solver/workflow.rs`.
- Extended Python config parsing (`crates/gam-pyffi/src/lib.rs`) to accept a `

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a072ed4486c8324bdc61667aa3e80e2)