### PR TITLE
Add GPU backend scaffolding and linalg dispatch hooks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,10 @@ resolver = "3"
 [lints.rust]
 warnings = "deny"
 
+[features]
+default = []
+cuda = []
+
 [dependencies]
 clap = { version = "4.6.0", features = ["derive"] }
 comfy-table = "7.2.2"

--- a/src/gpu/device.rs
+++ b/src/gpu/device.rs
@@ -1,0 +1,63 @@
+use std::fmt;
+
+/// Coarse hardware tiers used by dispatch policy defaults.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum GpuCapability {
+    Unknown,
+    Legacy,
+    Datacenter,
+    HopperOrNewer,
+}
+
+/// Runtime-discovered CUDA device metadata.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct GpuDeviceInfo {
+    pub ordinal: usize,
+    pub name: String,
+    pub compute_capability_major: i32,
+    pub compute_capability_minor: i32,
+    pub total_memory_bytes: Option<usize>,
+    pub free_memory_bytes: Option<usize>,
+}
+
+impl GpuDeviceInfo {
+    #[must_use]
+    pub fn compute_capability(&self) -> (i32, i32) {
+        (self.compute_capability_major, self.compute_capability_minor)
+    }
+
+    #[must_use]
+    pub fn capability_tier(&self) -> GpuCapability {
+        match self.compute_capability() {
+            (major, _) if major >= 9 => GpuCapability::HopperOrNewer,
+            (major, _) if major >= 7 => GpuCapability::Datacenter,
+            (major, _) if major > 0 => GpuCapability::Legacy,
+            _ => GpuCapability::Unknown,
+        }
+    }
+
+    #[must_use]
+    pub fn score(&self) -> u128 {
+        let memory = self.total_memory_bytes.unwrap_or(0) as u128;
+        let cc = (self.compute_capability_major.max(0) as u128) * 100
+            + self.compute_capability_minor.max(0) as u128;
+        (cc << 64) | memory
+    }
+}
+
+impl fmt::Display for GpuDeviceInfo {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "CUDA device {}: {} (sm_{}{})",
+            self.ordinal, self.name, self.compute_capability_major, self.compute_capability_minor
+        )?;
+        if let Some(total) = self.total_memory_bytes {
+            write!(f, ", total={} MiB", total / (1024 * 1024))?;
+        }
+        if let Some(free) = self.free_memory_bytes {
+            write!(f, ", free={} MiB", free / (1024 * 1024))?;
+        }
+        Ok(())
+    }
+}

--- a/src/gpu/kernels.rs
+++ b/src/gpu/kernels.rs
@@ -1,0 +1,15 @@
+use crate::gpu::memory::DeviceMatrix;
+use crate::gpu::stream::GpuStream;
+
+pub trait DeviceDesignOperator {
+    fn rows(&self) -> usize;
+    fn cols(&self) -> usize;
+
+    fn materialize_chunk_device(
+        &self,
+        row_start: usize,
+        row_count: usize,
+        out: &mut DeviceMatrix<f64>,
+        stream: &GpuStream,
+    ) -> Result<(), String>;
+}

--- a/src/gpu/linalg.rs
+++ b/src/gpu/linalg.rs
@@ -1,0 +1,28 @@
+use crate::gpu::policy::{GpuDispatchDecision, GpuOperation};
+use crate::gpu::runtime::runtime;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum GpuDenseKernel {
+    Gemm,
+    Gemv,
+    XtDiagX,
+    XtDiagY,
+    JointHessian2x2,
+}
+
+#[must_use]
+pub fn try_dispatch_dense(op: GpuOperation) -> GpuDispatchDecision {
+    if let Some(ctx) = runtime().context() {
+        ctx.policy.decide(op, true)
+    } else {
+        GpuDispatchDecision::Cpu
+    }
+}
+
+#[must_use]
+pub fn validation_enabled() -> bool {
+    matches!(
+        std::env::var("GAM_GPU_VALIDATE").ok().as_deref(),
+        Some("1" | "true" | "yes" | "on")
+    )
+}

--- a/src/gpu/memory.rs
+++ b/src/gpu/memory.rs
@@ -1,0 +1,70 @@
+use std::marker::PhantomData;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum MatrixLayout {
+    RowMajor,
+    ColumnMajor,
+}
+
+/// Host-side descriptor for a future device buffer allocation.
+#[derive(Clone, Debug)]
+pub struct DeviceBuffer<T> {
+    len: usize,
+    _marker: PhantomData<T>,
+}
+
+impl<T> DeviceBuffer<T> {
+    #[must_use]
+    pub fn new_unallocated(len: usize) -> Self {
+        Self {
+            len,
+            _marker: PhantomData,
+        }
+    }
+
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.len
+    }
+
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct DeviceMatrix<T> {
+    pub rows: usize,
+    pub cols: usize,
+    pub ld: usize,
+    pub layout: MatrixLayout,
+    pub buffer: DeviceBuffer<T>,
+}
+
+impl<T> DeviceMatrix<T> {
+    #[must_use]
+    pub fn descriptor(rows: usize, cols: usize, layout: MatrixLayout) -> Self {
+        let ld = match layout {
+            MatrixLayout::RowMajor => cols,
+            MatrixLayout::ColumnMajor => rows,
+        };
+        Self {
+            rows,
+            cols,
+            ld,
+            layout,
+            buffer: DeviceBuffer::new_unallocated(rows * cols),
+        }
+    }
+}
+
+pub enum MatrixLocation<'a, T> {
+    Host(&'a ndarray::Array2<T>),
+    Device(&'a DeviceMatrix<T>),
+}
+
+pub enum MatrixLocationMut<'a, T> {
+    Host(&'a mut ndarray::Array2<T>),
+    Device(&'a mut DeviceMatrix<T>),
+}

--- a/src/gpu/mod.rs
+++ b/src/gpu/mod.rs
@@ -1,0 +1,24 @@
+//! GPU acceleration backend facade.
+//!
+//! The CPU implementation remains the reference path. This module provides the
+//! runtime probe, dispatch policy, device-memory descriptors, and profiling
+//! hooks that hot kernels use to decide when a CUDA implementation may be used.
+//! When the `cuda` feature is disabled, or CUDA cannot be loaded at runtime,
+//! every operation deterministically falls back to the existing CPU kernels.
+
+pub mod device;
+pub mod kernels;
+pub mod linalg;
+pub mod memory;
+pub mod policy;
+pub mod profile;
+pub mod runtime;
+pub mod solver;
+pub mod sparse;
+pub mod stream;
+
+pub use device::{GpuCapability, GpuDeviceInfo};
+pub use linalg::{GpuDenseKernel, try_dispatch_dense};
+pub use policy::{AccelPolicy, GpuDispatchDecision, GpuDispatchPolicy, GpuOperation};
+pub use profile::{KernelStat, record_cpu_kernel};
+pub use runtime::{ExecutionTarget, GpuContext, GpuRuntime, gpu_available, selected_gpu_info};

--- a/src/gpu/policy.rs
+++ b/src/gpu/policy.rs
@@ -1,0 +1,263 @@
+use crate::gpu::device::{GpuCapability, GpuDeviceInfo};
+use std::env;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum AccelPolicy {
+    Auto,
+    CpuOnly,
+    GpuOnly,
+}
+
+impl AccelPolicy {
+    #[must_use]
+    pub fn from_env() -> Self {
+        match env::var("GAM_GPU").ok().as_deref() {
+            Some("off" | "0" | "false" | "cpu") => Self::CpuOnly,
+            Some("force" | "on" | "1" | "true" | "gpu") => Self::GpuOnly,
+            _ => Self::Auto,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum GpuDispatchDecision {
+    Cpu,
+    Gpu,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum GpuOperation {
+    Gemm {
+        m: usize,
+        n: usize,
+        k: usize,
+    },
+    Gemv {
+        m: usize,
+        k: usize,
+    },
+    XtDiagX {
+        rows: usize,
+        cols: usize,
+        resident: bool,
+    },
+    XtDiagY {
+        rows: usize,
+        x_cols: usize,
+        y_cols: usize,
+        resident: bool,
+    },
+    JointHessian2x2 {
+        rows: usize,
+        a_cols: usize,
+        b_cols: usize,
+        resident: bool,
+    },
+    Cholesky {
+        cols: usize,
+        resident: bool,
+        rhs: usize,
+    },
+    SparseXtDiagX {
+        rows: usize,
+        cols: usize,
+        nnz: usize,
+        resident: bool,
+    },
+    RowKernel {
+        rows: usize,
+        axes: usize,
+        candidates: usize,
+        resident: bool,
+    },
+}
+
+impl GpuOperation {
+    #[must_use]
+    pub fn name(&self) -> &'static str {
+        match self {
+            Self::Gemm { .. } => "gemm",
+            Self::Gemv { .. } => "gemv",
+            Self::XtDiagX { .. } => "xt_diag_x",
+            Self::XtDiagY { .. } => "xt_diag_y",
+            Self::JointHessian2x2 { .. } => "joint_hessian_2x2",
+            Self::Cholesky { .. } => "cholesky",
+            Self::SparseXtDiagX { .. } => "sparse_xt_diag_x",
+            Self::RowKernel { .. } => "row_kernel",
+        }
+    }
+
+    #[must_use]
+    pub fn estimated_flops(&self) -> f64 {
+        match *self {
+            Self::Gemm { m, n, k } => 2.0 * (m as f64) * (n as f64) * (k as f64),
+            Self::Gemv { m, k } => 2.0 * (m as f64) * (k as f64),
+            Self::XtDiagX { rows, cols, .. } => 2.0 * (rows as f64) * (cols as f64).powi(2),
+            Self::XtDiagY {
+                rows,
+                x_cols,
+                y_cols,
+                ..
+            } => 2.0 * (rows as f64) * (x_cols as f64) * (y_cols as f64),
+            Self::JointHessian2x2 {
+                rows,
+                a_cols,
+                b_cols,
+                ..
+            } => {
+                let c = a_cols + b_cols;
+                2.0 * (rows as f64) * (c as f64).powi(2)
+            }
+            Self::Cholesky { cols, rhs, .. } => {
+                ((cols as f64).powi(3) / 3.0) + 2.0 * (cols as f64).powi(2) * (rhs as f64)
+            }
+            Self::SparseXtDiagX { nnz, cols, .. } => 2.0 * (nnz as f64) * (cols as f64),
+            Self::RowKernel {
+                rows,
+                axes,
+                candidates,
+                ..
+            } => (rows as f64) * axes.max(1) as f64 * candidates.max(1) as f64 * 128.0,
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct GpuDispatchPolicy {
+    pub accel_policy: AccelPolicy,
+    pub gemm_min_flops: f64,
+    pub xtwx_min_flops: f64,
+    pub potrf_min_p: usize,
+    pub sparse_min_nnz: usize,
+    pub row_kernel_min_n: usize,
+    pub keep_design_resident: bool,
+    pub prefer_gpu_for_f64_factorization: bool,
+}
+
+impl GpuDispatchPolicy {
+    #[must_use]
+    pub fn from_env_and_device(device: Option<&GpuDeviceInfo>) -> Self {
+        let tier = device
+            .map(GpuDeviceInfo::capability_tier)
+            .unwrap_or(GpuCapability::Unknown);
+        let mut policy = match tier {
+            GpuCapability::HopperOrNewer => Self {
+                accel_policy: AccelPolicy::from_env(),
+                gemm_min_flops: 8.0e7,
+                xtwx_min_flops: 1.5e8,
+                potrf_min_p: 768,
+                sparse_min_nnz: 1_000_000,
+                row_kernel_min_n: 50_000,
+                keep_design_resident: true,
+                prefer_gpu_for_f64_factorization: true,
+            },
+            GpuCapability::Datacenter => Self {
+                accel_policy: AccelPolicy::from_env(),
+                gemm_min_flops: 1.5e8,
+                xtwx_min_flops: 3.0e8,
+                potrf_min_p: 1024,
+                sparse_min_nnz: 2_000_000,
+                row_kernel_min_n: 100_000,
+                keep_design_resident: true,
+                prefer_gpu_for_f64_factorization: false,
+            },
+            _ => Self {
+                accel_policy: AccelPolicy::from_env(),
+                gemm_min_flops: 3.0e8,
+                xtwx_min_flops: 6.0e8,
+                potrf_min_p: 1536,
+                sparse_min_nnz: 4_000_000,
+                row_kernel_min_n: 250_000,
+                keep_design_resident: false,
+                prefer_gpu_for_f64_factorization: false,
+            },
+        };
+        if let Ok(value) = env::var("GAM_GPU_MIN_N") {
+            if let Ok(parsed) = value.parse::<usize>() {
+                policy.row_kernel_min_n = parsed;
+            }
+        }
+        policy
+    }
+
+    #[must_use]
+    pub fn decide(&self, op: GpuOperation, cuda_available: bool) -> GpuDispatchDecision {
+        if self.accel_policy == AccelPolicy::CpuOnly || !cuda_available {
+            return GpuDispatchDecision::Cpu;
+        }
+        if self.accel_policy == AccelPolicy::GpuOnly {
+            return GpuDispatchDecision::Gpu;
+        }
+        let flops = op.estimated_flops();
+        let gpu = match op {
+            GpuOperation::Gemm { .. } | GpuOperation::Gemv { .. } => flops >= self.gemm_min_flops,
+            GpuOperation::XtDiagX { resident, .. }
+            | GpuOperation::XtDiagY { resident, .. }
+            | GpuOperation::JointHessian2x2 { resident, .. } => {
+                resident || flops >= self.xtwx_min_flops
+            }
+            GpuOperation::Cholesky { cols, resident, .. } => {
+                cols >= self.potrf_min_p && (resident || self.prefer_gpu_for_f64_factorization)
+            }
+            GpuOperation::SparseXtDiagX { nnz, resident, .. } => {
+                resident || nnz >= self.sparse_min_nnz
+            }
+            GpuOperation::RowKernel { rows, resident, .. } => {
+                resident || rows >= self.row_kernel_min_n
+            }
+        };
+        if gpu {
+            GpuDispatchDecision::Gpu
+        } else {
+            GpuDispatchDecision::Cpu
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn auto_policy_keeps_small_gemv_on_cpu() {
+        let policy = GpuDispatchPolicy {
+            accel_policy: AccelPolicy::Auto,
+            gemm_min_flops: 1_000_000.0,
+            xtwx_min_flops: 1_000_000.0,
+            potrf_min_p: 512,
+            sparse_min_nnz: 10_000,
+            row_kernel_min_n: 10_000,
+            keep_design_resident: false,
+            prefer_gpu_for_f64_factorization: false,
+        };
+        assert_eq!(
+            policy.decide(GpuOperation::Gemv { m: 32, k: 16 }, true),
+            GpuDispatchDecision::Cpu
+        );
+    }
+
+    #[test]
+    fn resident_xtwx_can_use_gpu_even_below_flop_threshold() {
+        let policy = GpuDispatchPolicy {
+            accel_policy: AccelPolicy::Auto,
+            gemm_min_flops: 1.0e12,
+            xtwx_min_flops: 1.0e12,
+            potrf_min_p: 4096,
+            sparse_min_nnz: usize::MAX,
+            row_kernel_min_n: usize::MAX,
+            keep_design_resident: true,
+            prefer_gpu_for_f64_factorization: false,
+        };
+        assert_eq!(
+            policy.decide(
+                GpuOperation::XtDiagX {
+                    rows: 1024,
+                    cols: 16,
+                    resident: true,
+                },
+                true,
+            ),
+            GpuDispatchDecision::Gpu
+        );
+    }
+}

--- a/src/gpu/profile.rs
+++ b/src/gpu/profile.rs
@@ -1,0 +1,123 @@
+use crate::gpu::policy::GpuOperation;
+use std::env;
+use std::sync::{Mutex, OnceLock};
+use std::time::Duration;
+
+#[derive(Clone, Debug)]
+pub struct KernelStat {
+    pub name: &'static str,
+    pub n: usize,
+    pub p: usize,
+    pub k: usize,
+    pub nnz: Option<usize>,
+    pub flops_est: f64,
+    pub bytes_est: f64,
+    pub cpu_ms: f64,
+    pub gpu_ms: Option<f64>,
+}
+
+#[must_use]
+pub fn profiling_enabled() -> bool {
+    matches!(
+        env::var("GAM_GPU_PROFILE").ok().as_deref(),
+        Some("1" | "true" | "yes" | "on")
+    )
+}
+
+pub fn record_cpu_kernel(op: GpuOperation, elapsed: Duration) {
+    if !profiling_enabled() {
+        return;
+    }
+    let (n, p, k, nnz) = dimensions(op);
+    let stat = KernelStat {
+        name: op.name(),
+        n,
+        p,
+        k,
+        nnz,
+        flops_est: op.estimated_flops(),
+        bytes_est: estimated_bytes(op),
+        cpu_ms: elapsed.as_secs_f64() * 1_000.0,
+        gpu_ms: None,
+    };
+    stats()
+        .lock()
+        .expect("GPU profile mutex poisoned")
+        .push(stat);
+}
+
+#[must_use]
+pub fn snapshot() -> Vec<KernelStat> {
+    stats().lock().expect("GPU profile mutex poisoned").clone()
+}
+
+fn stats() -> &'static Mutex<Vec<KernelStat>> {
+    static STATS: OnceLock<Mutex<Vec<KernelStat>>> = OnceLock::new();
+    STATS.get_or_init(|| Mutex::new(Vec::new()))
+}
+
+fn dimensions(op: GpuOperation) -> (usize, usize, usize, Option<usize>) {
+    match op {
+        GpuOperation::Gemm { m, n, k } => (m, n, k, None),
+        GpuOperation::Gemv { m, k } => (m, 1, k, None),
+        GpuOperation::XtDiagX { rows, cols, .. } => (rows, cols, cols, None),
+        GpuOperation::XtDiagY {
+            rows,
+            x_cols,
+            y_cols,
+            ..
+        } => (rows, x_cols, y_cols, None),
+        GpuOperation::JointHessian2x2 {
+            rows,
+            a_cols,
+            b_cols,
+            ..
+        } => (rows, a_cols + b_cols, a_cols + b_cols, None),
+        GpuOperation::Cholesky { cols, rhs, .. } => (cols, cols, rhs, None),
+        GpuOperation::SparseXtDiagX {
+            rows, cols, nnz, ..
+        } => (rows, cols, cols, Some(nnz)),
+        GpuOperation::RowKernel {
+            rows,
+            axes,
+            candidates,
+            ..
+        } => (rows, axes, candidates, None),
+    }
+}
+
+fn estimated_bytes(op: GpuOperation) -> f64 {
+    let f64_bytes = 8.0;
+    match op {
+        GpuOperation::Gemm { m, n, k } => ((m * k) + (k * n) + (m * n)) as f64 * f64_bytes,
+        GpuOperation::Gemv { m, k } => ((m * k) + k + m) as f64 * f64_bytes,
+        GpuOperation::XtDiagX { rows, cols, .. } => {
+            ((rows * cols) + rows + (cols * cols)) as f64 * f64_bytes
+        }
+        GpuOperation::XtDiagY {
+            rows,
+            x_cols,
+            y_cols,
+            ..
+        } => ((rows * x_cols) + rows + (rows * y_cols) + (x_cols * y_cols)) as f64 * f64_bytes,
+        GpuOperation::JointHessian2x2 {
+            rows,
+            a_cols,
+            b_cols,
+            ..
+        } => {
+            let c = a_cols + b_cols;
+            ((rows * c) + (3 * rows) + (c * c)) as f64 * f64_bytes
+        }
+        GpuOperation::Cholesky { cols, rhs, .. } => {
+            ((cols * cols) + (cols * rhs)) as f64 * f64_bytes
+        }
+        GpuOperation::SparseXtDiagX { nnz, cols, .. } => (nnz + (cols * cols)) as f64 * f64_bytes,
+        GpuOperation::RowKernel {
+            rows,
+            axes,
+            candidates,
+            ..
+        } => (rows * axes.max(1) * candidates.max(1)) as f64 * f64_bytes,
+    }
+}

--- a/src/gpu/runtime.rs
+++ b/src/gpu/runtime.rs
@@ -1,0 +1,251 @@
+use crate::gpu::device::GpuDeviceInfo;
+use crate::gpu::policy::{GpuDispatchDecision, GpuDispatchPolicy, GpuOperation};
+use std::env;
+use std::sync::OnceLock;
+
+#[derive(Clone, Debug)]
+pub struct GpuContext {
+    pub device: GpuDeviceInfo,
+    pub policy: GpuDispatchPolicy,
+}
+
+impl GpuContext {
+    #[must_use]
+    pub fn target_for(&self, op: GpuOperation) -> ExecutionTarget {
+        match self.policy.decide(op, true) {
+            GpuDispatchDecision::Gpu => ExecutionTarget::Cuda(self.clone()),
+            GpuDispatchDecision::Cpu => ExecutionTarget::Cpu,
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub enum ExecutionTarget {
+    Cpu,
+    Cuda(GpuContext),
+}
+
+#[derive(Clone, Debug)]
+pub struct GpuRuntime {
+    context: Option<GpuContext>,
+    message: String,
+}
+
+impl GpuRuntime {
+    #[must_use]
+    pub fn probe() -> Self {
+        if matches!(
+            env::var("GAM_GPU").ok().as_deref(),
+            Some("off" | "0" | "false" | "cpu")
+        ) {
+            return Self {
+                context: None,
+                message: "disabled by GAM_GPU".to_string(),
+            };
+        }
+        match probe_cuda_devices() {
+            Ok(mut devices) if !devices.is_empty() => {
+                let selected = select_device(&mut devices);
+                let policy = GpuDispatchPolicy::from_env_and_device(Some(&selected));
+                Self {
+                    message: format!("selected {selected}"),
+                    context: Some(GpuContext {
+                        device: selected,
+                        policy,
+                    }),
+                }
+            }
+            Ok(_) => Self {
+                context: None,
+                message: "CUDA loaded but reported zero devices".to_string(),
+            },
+            Err(err) => Self {
+                context: None,
+                message: err,
+            },
+        }
+    }
+
+    #[must_use]
+    pub fn context(&self) -> Option<&GpuContext> {
+        self.context.as_ref()
+    }
+
+    #[must_use]
+    pub fn is_available(&self) -> bool {
+        self.context.is_some()
+    }
+
+    #[must_use]
+    pub fn message(&self) -> &str {
+        &self.message
+    }
+}
+
+#[must_use]
+pub fn gpu_available() -> bool {
+    runtime().is_available()
+}
+
+#[must_use]
+pub fn selected_gpu_info() -> Option<GpuDeviceInfo> {
+    runtime().context().map(|ctx| ctx.device.clone())
+}
+
+#[must_use]
+pub fn runtime() -> &'static GpuRuntime {
+    static RUNTIME: OnceLock<GpuRuntime> = OnceLock::new();
+    RUNTIME.get_or_init(GpuRuntime::probe)
+}
+
+fn select_device(devices: &mut [GpuDeviceInfo]) -> GpuDeviceInfo {
+    if let Ok(value) = env::var("GAM_GPU_DEVICE") {
+        if let Ok(ordinal) = value.parse::<usize>() {
+            if let Some(device) = devices.iter().find(|device| device.ordinal == ordinal) {
+                return device.clone();
+            }
+        }
+    }
+    devices
+        .iter()
+        .max_by_key(|device| device.score())
+        .expect("non-empty CUDA device list")
+        .clone()
+}
+
+#[cfg(all(feature = "cuda", unix))]
+fn probe_cuda_devices() -> Result<Vec<GpuDeviceInfo>, String> {
+    cuda_loader::probe_cuda_devices()
+}
+
+#[cfg(not(all(feature = "cuda", unix)))]
+fn probe_cuda_devices() -> Result<Vec<GpuDeviceInfo>, String> {
+    Err("built without the cuda feature; CPU fallback active".to_string())
+}
+
+#[cfg(all(feature = "cuda", unix))]
+mod cuda_loader {
+    use super::GpuDeviceInfo;
+    use std::ffi::{CStr, CString, c_char, c_int, c_uint, c_void};
+    use std::ptr;
+
+    type CuDevice = c_int;
+    type CuResult = c_int;
+    type CuInit = unsafe extern "C" fn(c_uint) -> CuResult;
+    type CuDeviceGetCount = unsafe extern "C" fn(*mut c_int) -> CuResult;
+    type CuDeviceGet = unsafe extern "C" fn(*mut CuDevice, c_int) -> CuResult;
+    type CuDeviceGetName = unsafe extern "C" fn(*mut c_char, c_int, CuDevice) -> CuResult;
+    type CuDeviceComputeCapability =
+        unsafe extern "C" fn(*mut c_int, *mut c_int, CuDevice) -> CuResult;
+    type CuMemGetInfo = unsafe extern "C" fn(*mut usize, *mut usize) -> CuResult;
+
+    #[link(name = "dl")]
+    unsafe extern "C" {
+        fn dlopen(filename: *const c_char, flag: c_int) -> *mut c_void;
+        fn dlsym(handle: *mut c_void, symbol: *const c_char) -> *mut c_void;
+    }
+
+    const RTLD_NOW: c_int = 2;
+    const CUDA_SUCCESS: CuResult = 0;
+
+    pub(super) fn probe_cuda_devices() -> Result<Vec<GpuDeviceInfo>, String> {
+        let lib = open_cuda()?;
+        let cu_init: CuInit = symbol(lib, "cuInit")?;
+        let cu_device_get_count: CuDeviceGetCount = symbol(lib, "cuDeviceGetCount")?;
+        let cu_device_get: CuDeviceGet = symbol(lib, "cuDeviceGet")?;
+        let cu_device_get_name: CuDeviceGetName = symbol(lib, "cuDeviceGetName")?;
+        let cu_device_compute_capability: CuDeviceComputeCapability =
+            symbol(lib, "cuDeviceComputeCapability")?;
+        let cu_mem_get_info: Option<CuMemGetInfo> = symbol(lib, "cuMemGetInfo_v2").ok();
+
+        check(unsafe { cu_init(0) }, "cuInit")?;
+        let mut count = 0;
+        check(
+            unsafe { cu_device_get_count(&mut count) },
+            "cuDeviceGetCount",
+        )?;
+        let mut devices = Vec::new();
+        for ordinal in 0..count {
+            let mut device = 0;
+            check(
+                unsafe { cu_device_get(&mut device, ordinal) },
+                "cuDeviceGet",
+            )?;
+            let mut name_buf = [0_i8; 256];
+            check(
+                unsafe {
+                    cu_device_get_name(name_buf.as_mut_ptr(), name_buf.len() as c_int, device)
+                },
+                "cuDeviceGetName",
+            )?;
+            let name = unsafe { CStr::from_ptr(name_buf.as_ptr()) }
+                .to_string_lossy()
+                .into_owned();
+            let mut major = 0;
+            let mut minor = 0;
+            check(
+                unsafe { cu_device_compute_capability(&mut major, &mut minor, device) },
+                "cuDeviceComputeCapability",
+            )?;
+            let (free_memory_bytes, total_memory_bytes) =
+                if let Some(cu_mem_get_info) = cu_mem_get_info {
+                    let mut free = 0;
+                    let mut total = 0;
+                    if unsafe { cu_mem_get_info(&mut free, &mut total) } == CUDA_SUCCESS {
+                        (Some(free), Some(total))
+                    } else {
+                        (None, None)
+                    }
+                } else {
+                    (None, None)
+                };
+            devices.push(GpuDeviceInfo {
+                ordinal: ordinal as usize,
+                name,
+                compute_capability_major: major,
+                compute_capability_minor: minor,
+                total_memory_bytes,
+                free_memory_bytes,
+            });
+        }
+        Ok(devices)
+    }
+
+    fn open_cuda() -> Result<*mut c_void, String> {
+        for name in ["libcuda.so.1", "libcuda.so"] {
+            let c_name = CString::new(name).expect("static library name contains no NUL");
+            let handle = unsafe { dlopen(c_name.as_ptr(), RTLD_NOW) };
+            if !handle.is_null() {
+                return Ok(handle);
+            }
+        }
+        Err("could not dynamically load libcuda.so; CPU fallback active".to_string())
+    }
+
+    fn symbol<T: Copy>(handle: *mut c_void, name: &str) -> Result<T, String> {
+        let c_name = CString::new(name).expect("static symbol name contains no NUL");
+        let ptr = unsafe { dlsym(handle, c_name.as_ptr()) };
+        if ptr.is_null() {
+            return Err(format!("missing CUDA symbol {name}"));
+        }
+        let mut out = std::mem::MaybeUninit::<T>::uninit();
+        unsafe {
+            ptr::copy_nonoverlapping(
+                (&ptr as *const *mut c_void).cast::<u8>(),
+                out.as_mut_ptr().cast::<u8>(),
+                std::mem::size_of::<T>(),
+            );
+            Ok(out.assume_init())
+        }
+    }
+
+    fn check(result: CuResult, name: &str) -> Result<(), String> {
+        if result == CUDA_SUCCESS {
+            Ok(())
+        } else {
+            Err(format!(
+                "{name} failed with CUDA driver error code {result}"
+            ))
+        }
+    }
+}

--- a/src/gpu/solver.rs
+++ b/src/gpu/solver.rs
@@ -1,0 +1,16 @@
+use crate::gpu::memory::MatrixLocationMut;
+
+pub trait DenseSpdSolver {
+    type Factor;
+    type Error;
+
+    fn potrf(&self, matrix: MatrixLocationMut<'_, f64>) -> Result<Self::Factor, Self::Error>;
+    fn potrs(
+        &self,
+        factor: &Self::Factor,
+        rhs: MatrixLocationMut<'_, f64>,
+    ) -> Result<(), Self::Error>;
+}
+
+#[derive(Clone, Debug)]
+pub struct GpuSolverUnavailable;

--- a/src/gpu/sparse.rs
+++ b/src/gpu/sparse.rs
@@ -1,0 +1,25 @@
+use crate::gpu::memory::DeviceBuffer;
+
+#[derive(Clone, Debug)]
+pub struct DeviceCsrMatrix<T> {
+    pub row_offsets: DeviceBuffer<i32>,
+    pub col_indices: DeviceBuffer<i32>,
+    pub values: DeviceBuffer<T>,
+    pub rows: usize,
+    pub cols: usize,
+    pub nnz: usize,
+}
+
+impl<T> DeviceCsrMatrix<T> {
+    #[must_use]
+    pub fn descriptor(rows: usize, cols: usize, nnz: usize) -> Self {
+        Self {
+            row_offsets: DeviceBuffer::new_unallocated(rows + 1),
+            col_indices: DeviceBuffer::new_unallocated(nnz),
+            values: DeviceBuffer::new_unallocated(nnz),
+            rows,
+            cols,
+            nnz,
+        }
+    }
+}

--- a/src/gpu/stream.rs
+++ b/src/gpu/stream.rs
@@ -1,0 +1,29 @@
+#[derive(Clone, Debug, Default)]
+pub struct GpuStream {
+    pub ordinal: usize,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct GpuEvent {
+    pub ordinal: usize,
+}
+
+#[derive(Clone, Debug)]
+pub struct GpuStreamPool {
+    streams: Vec<GpuStream>,
+}
+
+impl GpuStreamPool {
+    #[must_use]
+    pub fn new(size: usize) -> Self {
+        let streams = (0..size.max(1))
+            .map(|ordinal| GpuStream { ordinal })
+            .collect();
+        Self { streams }
+    }
+
+    #[must_use]
+    pub fn get(&self, ordinal: usize) -> &GpuStream {
+        &self.streams[ordinal % self.streams.len()]
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,7 @@ pub fn init_parallelism() {
 }
 
 pub mod families;
+pub mod gpu;
 pub mod inference;
 pub mod linalg;
 pub mod report;

--- a/src/linalg/faer_ndarray.rs
+++ b/src/linalg/faer_ndarray.rs
@@ -158,6 +158,26 @@ pub(crate) fn matmul_parallelism(m: usize, n: usize, k: usize) -> Par {
 }
 
 #[inline]
+fn gpu_profile_start(
+    op: crate::gpu::GpuOperation,
+) -> (crate::gpu::GpuOperation, Option<std::time::Instant>) {
+    let _decision = crate::gpu::try_dispatch_dense(op);
+    let start = if crate::gpu::profile::profiling_enabled() {
+        Some(std::time::Instant::now())
+    } else {
+        None
+    };
+    (op, start)
+}
+
+#[inline]
+fn gpu_profile_finish(op: crate::gpu::GpuOperation, start: Option<std::time::Instant>) {
+    if let Some(start) = start {
+        crate::gpu::record_cpu_kernel(op, start.elapsed());
+    }
+}
+
+#[inline]
 pub fn array2_to_matmut(array: &mut Array2<f64>) -> MatMut<'_, f64> {
     let (rows, cols) = array.dim();
     let strides = array.strides();
@@ -212,11 +232,14 @@ pub fn fast_ata_into<S: Data<Elem = f64>>(a: &ArrayBase<S, Ix2>, out: &mut Array
     use faer::linalg::matmul::matmul;
 
     let (n, p) = a.dim();
+    let (profile_op, profile_start) =
+        gpu_profile_start(crate::gpu::GpuOperation::Gemm { m: p, n: p, k: n });
     debug_assert_eq!(out.nrows(), p, "output rows must match p");
     debug_assert_eq!(out.ncols(), p, "output cols must match p");
 
     if !should_use_faer_matmul(p, p, n) {
         out.assign(&a.t().dot(a));
+        gpu_profile_finish(profile_op, profile_start);
         return;
     }
 
@@ -227,6 +250,7 @@ pub fn fast_ata_into<S: Data<Elem = f64>>(a: &ArrayBase<S, Ix2>, out: &mut Array
     let a_t = a_ref.transpose();
     let par = matmul_parallelism(p, p, n);
     matmul(outview.as_mut(), Accum::Replace, a_t, a_ref, 1.0, par);
+    gpu_profile_finish(profile_op, profile_start);
 }
 
 /// Compute A^T * B using faer's SIMD-optimized GEMM.
@@ -255,11 +279,15 @@ pub fn fast_atb_with_parallelism<S1: Data<Elem = f64>, S2: Data<Elem = f64>>(
 
     let (n_a, p) = a.dim();
     let (n_b, q) = b.dim();
+    let (profile_op, profile_start) =
+        gpu_profile_start(crate::gpu::GpuOperation::Gemm { m: p, n: q, k: n_a });
     debug_assert_eq!(n_a, n_b, "A and B must have same number of rows");
 
     // For very small matrices, ndarray might be faster due to less overhead
     if !should_use_faer_matmul(p, q, n_a) {
-        return a.t().dot(b);
+        let out = a.t().dot(b);
+        gpu_profile_finish(profile_op, profile_start);
+        return out;
     }
 
     let mut result = Mat::<f64>::zeros(p, q);
@@ -279,7 +307,9 @@ pub fn fast_atb_with_parallelism<S1: Data<Elem = f64>, S2: Data<Elem = f64>>(
         par,
     );
 
-    mat_to_array(result.as_ref())
+    let out = mat_to_array(result.as_ref());
+    gpu_profile_finish(profile_op, profile_start);
+    out
 }
 
 /// Compute A * B using faer's SIMD-optimized GEMM.
@@ -308,10 +338,14 @@ pub fn fast_av<S1: Data<Elem = f64>, S2: Data<Elem = f64>>(
     use faer::{Accum, Mat};
 
     let (n, p) = a.dim();
+    let (profile_op, profile_start) =
+        gpu_profile_start(crate::gpu::GpuOperation::Gemv { m: n, k: p });
     debug_assert_eq!(p, v.len(), "A cols must match v length");
 
     if !should_use_faer_matmul(n, 1, p) {
-        return a.dot(v);
+        let out = a.dot(v);
+        gpu_profile_finish(profile_op, profile_start);
+        return out;
     }
 
     let mut result = Mat::<f64>::zeros(n, 1);
@@ -328,6 +362,7 @@ pub fn fast_av<S1: Data<Elem = f64>, S2: Data<Elem = f64>>(
     for i in 0..n {
         out[i] = result[(i, 0)];
     }
+    gpu_profile_finish(profile_op, profile_start);
     out
 }
 
@@ -343,11 +378,14 @@ pub fn fast_av_into<S1: Data<Elem = f64>, S2: Data<Elem = f64>>(
     use faer::linalg::matmul::matmul;
 
     let (n, p) = a.dim();
+    let (profile_op, profile_start) =
+        gpu_profile_start(crate::gpu::GpuOperation::Gemv { m: n, k: p });
     debug_assert_eq!(v.len(), p, "vector length must match A cols");
     debug_assert_eq!(out.len(), n, "output length must match A rows");
 
     if !should_use_faer_matmul(n, 1, p) {
         out.assign(&a.dot(v));
+        gpu_profile_finish(profile_op, profile_start);
         return;
     }
 
@@ -359,6 +397,7 @@ pub fn fast_av_into<S1: Data<Elem = f64>, S2: Data<Elem = f64>>(
     let v_ref = vview.as_ref();
     let par = matmul_parallelism(n, 1, p);
     matmul(outview.as_mut(), Accum::Replace, a_ref, v_ref, 1.0, par);
+    gpu_profile_finish(profile_op, profile_start);
 }
 
 /// Compute A * v into a pre-allocated `ArrayViewMut1` slice. Like
@@ -417,11 +456,15 @@ pub fn fast_atv<S1: Data<Elem = f64>, S2: Data<Elem = f64>>(
     use faer::{Accum, Mat};
 
     let (n, p) = a.dim();
+    let (profile_op, profile_start) =
+        gpu_profile_start(crate::gpu::GpuOperation::Gemv { m: n, k: p });
     debug_assert_eq!(n, v.len(), "A rows must match v length");
 
     // For very small arrays, ndarray might be faster
     if !should_use_faer_matmul(p, 1, n) {
-        return a.t().dot(v);
+        let out = a.t().dot(v);
+        gpu_profile_finish(profile_op, profile_start);
+        return out;
     }
 
     let mut result = Mat::<f64>::zeros(p, 1);
@@ -446,6 +489,7 @@ pub fn fast_atv<S1: Data<Elem = f64>, S2: Data<Elem = f64>>(
     for i in 0..p {
         out[i] = result[(i, 0)];
     }
+    gpu_profile_finish(profile_op, profile_start);
     out
 }
 
@@ -461,11 +505,14 @@ pub fn fast_atv_into<S: Data<Elem = f64>>(
     use faer::linalg::matmul::matmul;
 
     let (n, p) = a.dim();
+    let (profile_op, profile_start) =
+        gpu_profile_start(crate::gpu::GpuOperation::Gemv { m: n, k: p });
     debug_assert_eq!(v.len(), n, "vector length must match A rows");
     debug_assert_eq!(out.len(), p, "output length must match A cols");
 
     if !should_use_faer_matmul(p, 1, n) {
         out.assign(&a.t().dot(v));
+        gpu_profile_finish(profile_op, profile_start);
         return;
     }
 
@@ -484,6 +531,7 @@ pub fn fast_atv_into<S: Data<Elem = f64>>(
         1.0,
         par,
     );
+    gpu_profile_finish(profile_op, profile_start);
 }
 
 /// Compute A^T * diag(W) * A using streaming chunks to avoid O(n*p) allocation.
@@ -509,13 +557,22 @@ pub fn fast_xt_diag_x_with_parallelism<S1: Data<Elem = f64>, S2: Data<Elem = f64
     use ndarray::{ShapeBuilder, s};
 
     let (n, p) = x.dim();
+    let (profile_op, profile_start) = gpu_profile_start(crate::gpu::GpuOperation::XtDiagX {
+        rows: n,
+        cols: p,
+        resident: false,
+    });
     debug_assert_eq!(n, w.len(), "X rows must match W length");
     if n == 0 || p == 0 {
-        return Array2::<f64>::zeros((p, p));
+        let out = Array2::<f64>::zeros((p, p));
+        gpu_profile_finish(profile_op, profile_start);
+        return out;
     }
     if !should_use_faer_matmul(p, p, n) {
         let w_x = Array2::from_shape_fn((n, p), |(i, j)| w[i] * x[[i, j]]);
-        return x.t().dot(&w_x);
+        let out = x.t().dot(&w_x);
+        gpu_profile_finish(profile_op, profile_start);
+        return out;
     }
 
     // Streaming chunked: peak allocation is chunk_rows × p instead of n × p.
@@ -560,6 +617,7 @@ pub fn fast_xt_diag_x_with_parallelism<S1: Data<Elem = f64>, S2: Data<Elem = f64
         );
     }
 
+    gpu_profile_finish(profile_op, profile_start);
     result
 }
 
@@ -576,14 +634,24 @@ pub fn fast_xt_diag_y<S1: Data<Elem = f64>, S2: Data<Elem = f64>, S3: Data<Elem 
 
     let (n, q) = y.dim();
     let px = x.ncols();
+    let (profile_op, profile_start) = gpu_profile_start(crate::gpu::GpuOperation::XtDiagY {
+        rows: n,
+        x_cols: px,
+        y_cols: q,
+        resident: false,
+    });
     debug_assert_eq!(n, w.len(), "Y rows must match W length");
     debug_assert_eq!(n, x.nrows(), "X rows must match Y rows");
     if n == 0 || px == 0 || q == 0 {
-        return Array2::<f64>::zeros((px, q));
+        let out = Array2::<f64>::zeros((px, q));
+        gpu_profile_finish(profile_op, profile_start);
+        return out;
     }
     if !should_use_faer_matmul(px, q, n) {
         let w_y = Array2::from_shape_fn((n, q), |(i, j)| w[i] * y[[i, j]]);
-        return x.t().dot(&w_y);
+        let out = x.t().dot(&w_y);
+        gpu_profile_finish(profile_op, profile_start);
+        return out;
     }
 
     // Streaming: only allocate chunk_rows × q for the weighted Y slice.
@@ -626,6 +694,7 @@ pub fn fast_xt_diag_y<S1: Data<Elem = f64>, S2: Data<Elem = f64>, S3: Data<Elem 
         );
     }
 
+    gpu_profile_finish(profile_op, profile_start);
     result
 }
 
@@ -655,13 +724,22 @@ pub fn fast_joint_hessian_2x2<
     let pa = x_a.ncols();
     let pb = x_b.ncols();
     let total = pa + pb;
+    let (profile_op, profile_start) =
+        gpu_profile_start(crate::gpu::GpuOperation::JointHessian2x2 {
+            rows: n,
+            a_cols: pa,
+            b_cols: pb,
+            resident: false,
+        });
     debug_assert_eq!(n, x_b.nrows());
     debug_assert_eq!(n, w_aa.len());
     debug_assert_eq!(n, w_ab.len());
     debug_assert_eq!(n, w_bb.len());
 
     if n == 0 || total == 0 {
-        return Array2::<f64>::zeros((total, total));
+        let out = Array2::<f64>::zeros((total, total));
+        gpu_profile_finish(profile_op, profile_start);
+        return out;
     }
 
     // For small problems, fall back to separate computations
@@ -679,6 +757,7 @@ pub fn fast_joint_hessian_2x2<
                 out[[i, j]] = out[[j, i]];
             }
         }
+        gpu_profile_finish(profile_op, profile_start);
         return out;
     }
 
@@ -767,6 +846,7 @@ pub fn fast_joint_hessian_2x2<
             out[[i, j]] = out[[j, i]];
         }
     }
+    gpu_profile_finish(profile_op, profile_start);
     out
 }
 
@@ -810,11 +890,14 @@ pub fn fast_ab_into<S1: Data<Elem = f64>, S2: Data<Elem = f64>>(
 
     let (n, p) = a.dim();
     let (p_b, q) = b.dim();
+    let (profile_op, profile_start) =
+        gpu_profile_start(crate::gpu::GpuOperation::Gemm { m: n, n: q, k: p });
     debug_assert_eq!(p, p_b, "A and B must have compatible inner dimensions");
     debug_assert_eq!(out.dim(), (n, q), "output dimensions must match A*B result");
 
     if !should_use_faer_matmul(n, q, p) {
         out.assign(&a.dot(b));
+        gpu_profile_finish(profile_op, profile_start);
         return;
     }
 
@@ -826,6 +909,7 @@ pub fn fast_ab_into<S1: Data<Elem = f64>, S2: Data<Elem = f64>>(
     let par = matmul_parallelism(n, q, p);
     let mut outview = array2_to_matmut(out);
     matmul(outview.as_mut(), Accum::Replace, a_ref, b_ref, 1.0, par);
+    gpu_profile_finish(profile_op, profile_start);
 }
 
 fn diag_to_array(diag: DiagRef<'_, f64>) -> Array1<f64> {


### PR DESCRIPTION
### Motivation
- Introduce a structured GPU execution backend so hot linear-algebra and row-wise kernels can be accelerated on CUDA devices while preserving the existing CPU engine as the deterministic fallback. 
- Provide runtime detection, hardware-aware dispatch policy, and device-resident memory abstractions so device work can be kept resident across PIRLS/REML iterations in future patches. 
- Instrument the most important dense hot paths so policy decisions and profiling data are available before adding CUDA kernels. 

### Description
- Added a new `src/gpu/` module tree with `runtime.rs`, `device.rs`, `policy.rs`, `memory.rs`, `stream.rs`, `linalg.rs`, `sparse.rs`, `solver.rs`, `kernels.rs`, and `profile.rs` implementing probing, `GpuDeviceInfo`, `GpuDispatchPolicy`, device buffer/matrix descriptors, stream primitives, solver/CSR/operator scaffolding, and profiling counters. 
- Introduced a `cuda` Cargo feature (`Cargo.toml`) so builds are CPU-only by default and CUDA-dependent code is opt-in, and added environment-controlled policies via `GAM_GPU` / `GAM_GPU_DEVICE` / `GAM_GPU_PROFILE` etc. 
- Wired dispatch and lightweight profiling hooks into existing dense linalg wrappers in `src/linalg/faer_ndarray.rs` (`fast_ata`, `fast_atb`, `fast_ab`, `fast_av`, `fast_atv`, `fast_xt_diag_x`, `fast_xt_diag_y`, `fast_joint_hessian_2x2`, `fast_ab_into`) so callers record CPU timings and can query `try_dispatch_dense`/policy decisions without changing numerical CPU behaviour. 
- Added small API integration points for future GPU kernels: `DeviceMatrix`, `DeviceCsrMatrix`, `DenseSpdSolver` trait, `DeviceDesignOperator` trait, `GpuContext`/`ExecutionTarget`, and `KernelStat` profiling records. 
- Included unit tests for the dispatch policy logic (resident vs flop-threshold behavior) to lock down expected policy decisions. 

### Testing
- Ran `cargo check --lib` and it succeeded for the default (CPU-only) build. 
- Ran `cargo check --lib --features cuda` to validate feature-gated compile paths and dynamic-CUDA loader branches; it succeeded. 
- Executed `cargo test --lib gpu::policy` and the policy unit tests passed. 
- Ran `rustfmt --check` for the new GPU files and the modified `faer_ndarray` wiring; formatting checks passed for those files (noting unrelated pre-existing formatting in other unrelated test files). 
- Ran `git diff --check` (no new whitespace/merge errors) and snapshot/profile instrumentation was exercised via the profiling hooks (profiling is no-op unless `GAM_GPU_PROFILE` enabled).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a072f265c6c832491c55ed680f4de74)