### PR TITLE
GPU dispatch scaffold and signed dense XtWX streaming for PIRLS

### DIFF
--- a/src/gpu.rs
+++ b/src/gpu.rs
@@ -1,0 +1,265 @@
+//! GPU backend policy and dispatch scaffolding.
+//!
+//! This module intentionally keeps the public contract small: callers ask for
+//! `auto`, `off`, or `force` policy and backend implementations either execute
+//! a device-resident kernel or report that the requested operation is not yet
+//! supported.  The CPU P-IRLS/REML code can then make one decision at each hot
+//! dispatch point without mixing device-selection policy into numerical code.
+//!
+//! The default is `auto`, controlled by `GAM_GPU=auto|off|force` (or
+//! `0|false|no` and `1|true|yes`).  `force` is deliberately strict: if a GPU
+//! operation has no native implementation, the caller must fail loudly rather
+//! than silently falling back to CPU.
+
+use std::fmt;
+use std::sync::OnceLock;
+use std::time::{Duration, Instant};
+
+use thiserror::Error;
+
+/// User-facing GPU selection policy.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum GpuPolicy {
+    /// Use GPU only for supported, sufficiently large workloads; otherwise CPU.
+    Auto,
+    /// Disable GPU dispatch and always use CPU implementations.
+    Off,
+    /// Require GPU dispatch for eligible call sites; unsupported paths error.
+    Force,
+}
+
+impl Default for GpuPolicy {
+    fn default() -> Self {
+        Self::Auto
+    }
+}
+
+impl GpuPolicy {
+    /// Parse a policy string accepted by `GAM_GPU`.
+    pub fn parse(value: &str) -> Option<Self> {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "auto" | "" => Some(Self::Auto),
+            "off" | "cpu" | "none" | "0" | "false" | "no" => Some(Self::Off),
+            "force" | "gpu" | "on" | "1" | "true" | "yes" => Some(Self::Force),
+            _ => None,
+        }
+    }
+
+    #[inline]
+    pub fn from_env() -> Self {
+        std::env::var("GAM_GPU")
+            .ok()
+            .and_then(|raw| Self::parse(&raw))
+            .unwrap_or_default()
+    }
+}
+
+impl fmt::Display for GpuPolicy {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Auto => f.write_str("auto"),
+            Self::Off => f.write_str("off"),
+            Self::Force => f.write_str("force"),
+        }
+    }
+}
+
+/// Broad workload kind used for backend-selection logs and diagnostics.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum GpuOperation {
+    DenseMatvec,
+    DenseTransposeMatvec,
+    DenseXtDiagX,
+    PenalizedHessian,
+    CandidateScreen,
+    MatrixFreePcg,
+    SparseNormalAssembly,
+    SpatialKernelOperator,
+    MarginalSlopeRowKernel,
+    RemlTrace,
+    FinalInference,
+}
+
+impl fmt::Display for GpuOperation {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let name = match self {
+            Self::DenseMatvec => "dense-matvec",
+            Self::DenseTransposeMatvec => "dense-transpose-matvec",
+            Self::DenseXtDiagX => "dense-xt-diag-x",
+            Self::PenalizedHessian => "penalized-hessian",
+            Self::CandidateScreen => "candidate-screen",
+            Self::MatrixFreePcg => "matrix-free-pcg",
+            Self::SparseNormalAssembly => "sparse-normal-assembly",
+            Self::SpatialKernelOperator => "spatial-kernel-operator",
+            Self::MarginalSlopeRowKernel => "marginal-slope-row-kernel",
+            Self::RemlTrace => "reml-trace",
+            Self::FinalInference => "final-inference",
+        };
+        f.write_str(name)
+    }
+}
+
+/// Shape/feature summary supplied by numerical call sites.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct GpuWorkload {
+    pub rows: usize,
+    pub cols: usize,
+    pub nnz: Option<usize>,
+    pub signed_weights: bool,
+}
+
+impl GpuWorkload {
+    #[inline]
+    pub fn dense(rows: usize, cols: usize) -> Self {
+        Self {
+            rows,
+            cols,
+            nnz: None,
+            signed_weights: false,
+        }
+    }
+
+    #[inline]
+    pub fn with_signed_weights(mut self, signed_weights: bool) -> Self {
+        self.signed_weights = signed_weights;
+        self
+    }
+}
+
+/// Error returned when `GAM_GPU=force` requests an unsupported native backend.
+#[derive(Debug, Error)]
+#[error("GPU policy is 'force' but {operation} is unsupported for workload {workload:?}: {reason}")]
+pub struct GpuUnsupportedError {
+    pub operation: GpuOperation,
+    pub workload: GpuWorkload,
+    pub reason: &'static str,
+}
+
+/// Dispatch decision at a hot numerical call site.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum GpuDispatch {
+    Cpu { reason: &'static str },
+    Gpu,
+}
+
+/// Minimal backend capability probe.
+///
+/// Native kernels are intentionally not faked: until a concrete CUDA/HIP/Metal
+/// implementation is compiled in, `auto` falls back to CPU and `force` errors.
+pub trait GpuBackend: Send + Sync {
+    fn name(&self) -> &'static str;
+
+    fn supports(&self, operation: GpuOperation, workload: GpuWorkload) -> Result<(), &'static str>;
+}
+
+/// Placeholder backend used until vendor-specific crates are wired in.
+#[derive(Debug, Default)]
+pub struct NoNativeGpuBackend;
+
+impl GpuBackend for NoNativeGpuBackend {
+    fn name(&self) -> &'static str {
+        "none"
+    }
+
+    fn supports(
+        &self,
+        _operation: GpuOperation,
+        _workload: GpuWorkload,
+    ) -> Result<(), &'static str> {
+        Err("no native GPU backend is compiled into this build")
+    }
+}
+
+static BACKEND: OnceLock<NoNativeGpuBackend> = OnceLock::new();
+
+#[inline]
+pub fn backend() -> &'static dyn GpuBackend {
+    BACKEND.get_or_init(NoNativeGpuBackend::default)
+}
+
+/// Decide whether a call site should use a GPU implementation.
+pub fn dispatch(
+    operation: GpuOperation,
+    workload: GpuWorkload,
+) -> Result<GpuDispatch, GpuUnsupportedError> {
+    match GpuPolicy::from_env() {
+        GpuPolicy::Off => Ok(GpuDispatch::Cpu {
+            reason: "GAM_GPU=off",
+        }),
+        GpuPolicy::Auto => match backend().supports(operation, workload) {
+            Ok(()) => Ok(GpuDispatch::Gpu),
+            Err(reason) => Ok(GpuDispatch::Cpu { reason }),
+        },
+        GpuPolicy::Force => match backend().supports(operation, workload) {
+            Ok(()) => Ok(GpuDispatch::Gpu),
+            Err(reason) => Err(GpuUnsupportedError {
+                operation,
+                workload,
+                reason,
+            }),
+        },
+    }
+}
+
+/// A small timing helper used by GPU-aware CPU fallbacks.
+#[derive(Debug)]
+pub struct GpuStageTimer {
+    operation: GpuOperation,
+    workload: GpuWorkload,
+    backend: &'static str,
+    start: Instant,
+}
+
+impl GpuStageTimer {
+    #[inline]
+    pub fn start(operation: GpuOperation, workload: GpuWorkload, backend: &'static str) -> Self {
+        Self {
+            operation,
+            workload,
+            backend,
+            start: Instant::now(),
+        }
+    }
+
+    #[inline]
+    pub fn finish(self) -> Duration {
+        let elapsed = self.start.elapsed();
+        log::debug!(
+            "[gpu-stage] op={} backend={} rows={} cols={} signed_weights={} elapsed={:.6}s",
+            self.operation,
+            self.backend,
+            self.workload.rows,
+            self.workload.cols,
+            self.workload.signed_weights,
+            elapsed.as_secs_f64()
+        );
+        elapsed
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn gpu_policy_parser_accepts_documented_values() {
+        assert_eq!(GpuPolicy::parse("auto"), Some(GpuPolicy::Auto));
+        assert_eq!(GpuPolicy::parse("off"), Some(GpuPolicy::Off));
+        assert_eq!(GpuPolicy::parse("false"), Some(GpuPolicy::Off));
+        assert_eq!(GpuPolicy::parse("force"), Some(GpuPolicy::Force));
+        assert_eq!(GpuPolicy::parse("yes"), Some(GpuPolicy::Force));
+        assert_eq!(GpuPolicy::parse("wat"), None);
+    }
+
+    #[test]
+    fn force_policy_error_mentions_operation() {
+        let err = GpuUnsupportedError {
+            operation: GpuOperation::DenseXtDiagX,
+            workload: GpuWorkload::dense(10, 3).with_signed_weights(true),
+            reason: "test",
+        };
+        let rendered = err.to_string();
+        assert!(rendered.contains("dense-xt-diag-x"));
+        assert!(rendered.contains("force"));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,7 @@ pub fn init_parallelism() {
 }
 
 pub mod families;
+pub mod gpu;
 pub mod inference;
 pub mod linalg;
 pub mod report;

--- a/src/solver/pirls.rs
+++ b/src/solver/pirls.rs
@@ -5,6 +5,7 @@ use crate::faer_ndarray::{
     FaerArrayView, FaerCholesky, FaerEigh, FaerLinalgError, array1_to_col_matmut, array2_to_matmut,
     fast_ab, fast_atb, fast_atv, fast_av_into,
 };
+use crate::gpu::{self, GpuOperation, GpuStageTimer, GpuWorkload};
 use crate::linalg::sparse_exact::{
     factorize_sparse_spd, solve_sparse_spd, sparse_symmetric_upper_matvec_public,
 };
@@ -1029,6 +1030,64 @@ impl PirlsWorkspace {
         }
     }
 
+    /// Streaming chunked BLAS computation of Xᵀ·diag(W)·X with signed weights.
+    ///
+    /// Fisher updates with non-negative weights can use the faster Gram form on
+    /// sqrt(W)X. Observed-information updates can contain negative curvature
+    /// weights, so they must use the sign-preserving Xᵀ(WX) form instead of
+    /// clipping through sqrt(max(W, 0)).
+    fn add_dense_xtwx_streaming_signed<S>(
+        weights: &Array1<f64>,
+        weighted_x_chunk: &mut Array2<f64>,
+        x: &ArrayBase<S, Ix2>,
+        out: &mut Array2<f64>,
+        par: Par,
+    ) where
+        S: Data<Elem = f64> + Sync,
+    {
+        let n = x.nrows();
+        let p = x.ncols();
+        if n == 0 || p == 0 {
+            return;
+        }
+        debug_assert_eq!(
+            weights.len(),
+            n,
+            "weights length must match row count for streamed signed XtWX"
+        );
+        let chunkrows = Self::dense_xtwx_chunkrows(p).min(n);
+        if weighted_x_chunk.ncols() != p || weighted_x_chunk.nrows() != chunkrows {
+            *weighted_x_chunk = Array2::zeros((chunkrows, p).f());
+        }
+        let mut outview = array2_to_matmut(out);
+        for start in (0..n).step_by(chunkrows) {
+            let rows = (n - start).min(chunkrows);
+            {
+                let mut chunk = weighted_x_chunk.slice_mut(s![0..rows, ..]);
+                let x_slice = x.slice(s![start..start + rows, ..]);
+                let w_slice = weights.slice(s![start..start + rows]);
+                Zip::from(chunk.rows_mut())
+                    .and(x_slice.rows())
+                    .and(&w_slice)
+                    .par_for_each(|mut dst, src, &w| {
+                        Zip::from(&mut dst).and(&src).for_each(|d, &s| *d = s * w);
+                    });
+            }
+            let x_slice = x.slice(s![start..start + rows, ..]);
+            let wx_slice = weighted_x_chunk.slice(s![0..rows, ..]);
+            let x_view = FaerArrayView::new(&x_slice);
+            let wx_view = FaerArrayView::new(&wx_slice);
+            matmul(
+                outview.as_mut(),
+                Accum::Add,
+                x_view.as_ref().transpose(),
+                wx_view.as_ref(),
+                1.0,
+                par,
+            );
+        }
+    }
+
     #[inline]
     fn fill_sqrtweights<S>(&mut self, weights: &ArrayBase<S, Ix1>)
     where
@@ -1558,7 +1617,21 @@ impl<'a> GamWorkingModel<'a> {
         match &self.coordinate_design {
             WorkingCoordinateDesign::TransformedExplicit { x_transformed, .. } => {
                 if let Some(dense) = x_transformed.as_dense() {
+                    let workload = GpuWorkload::dense(dense.nrows(), dense.ncols());
+                    if let Ok(gpu::GpuDispatch::Cpu { reason }) =
+                        gpu::dispatch(GpuOperation::DenseMatvec, workload)
+                    {
+                        log::debug!(
+                            "[gpu-dispatch] op={} backend=cpu reason={} rows={} cols={}",
+                            GpuOperation::DenseMatvec,
+                            reason,
+                            dense.nrows(),
+                            dense.ncols()
+                        );
+                    }
+                    let timer = GpuStageTimer::start(GpuOperation::DenseMatvec, workload, "cpu");
                     fast_av_into(dense, beta.as_ref(), out);
+                    timer.finish();
                     return;
                 }
                 out.assign(&x_transformed.matrixvectormultiply(beta));
@@ -1568,7 +1641,21 @@ impl<'a> GamWorkingModel<'a> {
                 // then write X·(Qs·beta) directly into out when X is dense.
                 let beta_orig = transform.apply(beta.as_ref());
                 if let Some(dense) = self.x_original.as_dense() {
+                    let workload = GpuWorkload::dense(dense.nrows(), dense.ncols());
+                    if let Ok(gpu::GpuDispatch::Cpu { reason }) =
+                        gpu::dispatch(GpuOperation::DenseMatvec, workload)
+                    {
+                        log::debug!(
+                            "[gpu-dispatch] op={} backend=cpu reason={} rows={} cols={}",
+                            GpuOperation::DenseMatvec,
+                            reason,
+                            dense.nrows(),
+                            dense.ncols()
+                        );
+                    }
+                    let timer = GpuStageTimer::start(GpuOperation::DenseMatvec, workload, "cpu");
                     fast_av_into(dense, &beta_orig, out);
+                    timer.finish();
                 } else {
                     out.assign(&self.x_original.apply(&beta_orig));
                 }
@@ -1607,21 +1694,56 @@ impl<'a> GamWorkingModel<'a> {
             // cannot be densified; fall through to the operator XᵀWX path.
             DesignMatrix::Dense(x) if x.is_materialized_dense() => {
                 let p = x.ncols();
+                let n = x.nrows();
+                let has_signed_weights = weights.iter().any(|w| *w < 0.0);
+                let workload = GpuWorkload::dense(n, p).with_signed_weights(has_signed_weights);
+                match gpu::dispatch(GpuOperation::DenseXtDiagX, workload) {
+                    Ok(gpu::GpuDispatch::Gpu) => {
+                        // No native GPU backend is linked in this build yet; dispatch() only
+                        // returns Gpu when a concrete backend reports support. Keep the branch
+                        // explicit so CUDA/HIP/Metal implementations can slot in here without
+                        // changing P-IRLS control flow.
+                        unreachable!("native GPU DenseXtDiagX dispatch without implementation")
+                    }
+                    Ok(gpu::GpuDispatch::Cpu { reason }) => {
+                        log::debug!(
+                            "[gpu-dispatch] op={} backend=cpu reason={} rows={} cols={} signed_weights={}",
+                            GpuOperation::DenseXtDiagX,
+                            reason,
+                            n,
+                            p,
+                            has_signed_weights
+                        );
+                    }
+                    Err(err) => return Err(EstimationError::InvalidInput(err.to_string())),
+                }
+                let timer = GpuStageTimer::start(GpuOperation::DenseXtDiagX, workload, "cpu");
                 let x_dense = x.to_dense_arc();
-                workspace.fill_sqrtweights(weights);
                 // Reuse workspace hessian buffer to avoid per-iteration allocation.
                 if workspace.hessian_buf.nrows() != p || workspace.hessian_buf.ncols() != p {
                     workspace.hessian_buf = Array2::zeros((p, p).f());
                 } else {
                     workspace.hessian_buf.fill(0.0);
                 }
-                PirlsWorkspace::add_dense_xtwx_streaming_from_sqrt(
-                    &workspace.sqrtw,
-                    &mut workspace.weighted_x_chunk,
-                    x_dense.as_ref(),
-                    &mut workspace.hessian_buf,
-                    get_global_parallelism(),
-                );
+                if has_signed_weights {
+                    PirlsWorkspace::add_dense_xtwx_streaming_signed(
+                        weights,
+                        &mut workspace.weighted_x_chunk,
+                        x_dense.as_ref(),
+                        &mut workspace.hessian_buf,
+                        get_global_parallelism(),
+                    );
+                } else {
+                    workspace.fill_sqrtweights(weights);
+                    PirlsWorkspace::add_dense_xtwx_streaming_from_sqrt(
+                        &workspace.sqrtw,
+                        &mut workspace.weighted_x_chunk,
+                        x_dense.as_ref(),
+                        &mut workspace.hessian_buf,
+                        get_global_parallelism(),
+                    );
+                }
+                timer.finish();
                 // Move the buffer out instead of cloning — saves O(p²) memcpy.
                 // Next call will reallocate (same cost as the existing zero-fill).
                 Ok(std::mem::take(&mut workspace.hessian_buf))
@@ -10191,6 +10313,7 @@ mod tests {
 #[cfg(test)]
 mod root_cause_tests {
     use super::*;
+    use approx::assert_relative_eq;
     use ndarray::{Array1, Array2, array};
 
     fn scalar_working_state(
@@ -11465,6 +11588,37 @@ mod root_cause_tests {
              ExpectedInformationSurrogate (no silent ObservedExact relabel), \
              got {:?}",
             summary.exported_laplace_curvature
+        );
+    }
+
+    #[test]
+    fn dense_xtwx_signed_streaming_preserves_negative_weights() {
+        let x = array![[1.0, 2.0], [3.0, -1.0], [0.5, 4.0]];
+        let weights = array![2.0, -3.0, 0.25];
+        let mut chunk = Array2::<f64>::zeros((0, 0));
+        let mut got = Array2::<f64>::zeros((2, 2));
+        PirlsWorkspace::add_dense_xtwx_streaming_signed(
+            &weights,
+            &mut chunk,
+            &x,
+            &mut got,
+            faer::Par::Seq,
+        );
+
+        let mut expected = Array2::<f64>::zeros((2, 2));
+        for i in 0..x.nrows() {
+            for a in 0..x.ncols() {
+                for b in 0..x.ncols() {
+                    expected[[a, b]] += weights[i] * x[[i, a]] * x[[i, b]];
+                }
+            }
+        }
+        for (actual, expected) in got.iter().zip(expected.iter()) {
+            assert_relative_eq!(*actual, *expected, epsilon = 1e-12);
+        }
+        assert!(
+            got[[0, 0]] < 0.0,
+            "negative observed-Hessian weights must not be clipped away"
         );
     }
 }


### PR DESCRIPTION
### Motivation
- Provide a first-class GPU dispatch and policy surface so PIRLS/REML hot paths can choose a device backend when available instead of ad-hoc switches scattered through numerical code.
- Instrument hot dense operations (matvec and Xᵀ·diag(W)·X) so future CUDA/HIP/Metal kernels can plug in with minimal control-flow changes and accurate stage timing.
- Preserve correctness for observed-information Hessians by adding a sign-preserving dense streaming Xᵀ(WX) path that avoids clipping negative curvature weights.

### Description
- Add a new `src/gpu.rs` module exposing `GpuPolicy`, `GpuOperation`, `GpuWorkload`, a `GpuBackend` trait, a placeholder `NoNativeGpuBackend`, `dispatch()` decision API, and a `GpuStageTimer` for timing fallbacks and instrumentation.
- Export the new GPU module from the crate root so other modules can call into the dispatch surface (`pub mod gpu;` in `src/lib.rs`).
- Wire the dense P-IRLS `Xβ` matvec hot path and the dense `Xᵀ diag(W) X` streaming assembly in `src/solver/pirls.rs` through the dispatch/timing scaffold so callers can decide CPU vs GPU at each hot site while keeping the current CPU implementations as fallbacks.
- Implement `PirlsWorkspace::add_dense_xtwx_streaming_signed` to compute Xᵀ(WX) in a streaming, chunked BLAS manner that preserves signed weights (used for observed-information Hessians), and select it when negative weights are present.
- Add unit tests covering GPU policy parsing and force-mode error rendering, and a test that verifies the signed dense streaming result equals the scalar expected Xᵀ(WX) (negative weights are preserved).

### Testing
- Ran `cargo check` and the build completed successfully (no type errors).
- Ran targeted unit tests and they all passed: `cargo test gpu::tests::gpu_policy_parser_accepts_documented_values --lib` (ok), `cargo test gpu::tests::force_policy_error_mentions_operation --lib` (ok), and `cargo test solver::pirls::root_cause_tests::dense_xtwx_signed_streaming_preserves_negative_weights --lib` (ok).
- Also executed combined test invocations used during development (`cargo test` for the targeted tests) and observed successful completion of those automated tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a072ed4486c8324bdc61667aa3e80e2)