### PR TITLE
Add GPU acceleration backend skeleton

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,10 @@ resolver = "3"
 [lints.rust]
 warnings = "deny"
 
+[features]
+default = []
+cuda = ["dep:cudarc"]
+
 [dependencies]
 clap = { version = "4.6.0", features = ["derive"] }
 comfy-table = "7.2.2"
@@ -66,6 +70,7 @@ arrow = { version = "54", default-features = false, features = ["ffi"] }
 parquet = { version = "54", default-features = false, features = ["arrow", "snap", "zstd", "lz4"] }
 wide = "0.7"
 smallvec = "1"
+cudarc = { version = "0.19.6", optional = true, default-features = false, features = ["std", "driver", "runtime", "cublas", "cublaslt", "nvrtc", "fallback-dynamic-loading", "cuda-12080"] }
 
 [dependencies.general-mcmc]
 package = "general-mcmc"

--- a/src/gpu/device.rs
+++ b/src/gpu/device.rs
@@ -1,0 +1,148 @@
+use std::fmt;
+
+/// Coarse hardware class used by dispatch policy before per-device calibration
+/// data is available.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum GpuCapability {
+    Unknown,
+    Cuda,
+    CudaFp64Strong,
+    CudaHopperOrNewer,
+}
+
+/// Runtime-discovered GPU device metadata.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct GpuDeviceInfo {
+    pub ordinal: usize,
+    pub name: String,
+    pub uuid: Option<String>,
+    pub compute_capability_major: Option<i32>,
+    pub compute_capability_minor: Option<i32>,
+    pub total_memory_bytes: Option<u64>,
+    pub free_memory_bytes: Option<u64>,
+    pub capability: GpuCapability,
+}
+
+impl GpuDeviceInfo {
+    #[must_use]
+    pub fn compute_capability(&self) -> Option<(i32, i32)> {
+        Some((
+            self.compute_capability_major?,
+            self.compute_capability_minor?,
+        ))
+    }
+
+    #[must_use]
+    pub fn score(&self) -> u64 {
+        let cc_score = self.compute_capability().map_or(0_u64, |(maj, min)| {
+            (maj.max(0) as u64) * 100 + min.max(0) as u64
+        });
+        let mem_score = self.total_memory_bytes.unwrap_or(0) / (1024 * 1024 * 1024);
+        let class_bonus = match self.capability {
+            GpuCapability::Unknown => 0,
+            GpuCapability::Cuda => 1_000,
+            GpuCapability::CudaFp64Strong => 2_000,
+            GpuCapability::CudaHopperOrNewer => 4_000,
+        };
+        class_bonus + cc_score + mem_score
+    }
+
+    #[must_use]
+    pub fn from_nvidia_smi_csv(ordinal: usize, line: &str) -> Option<Self> {
+        let mut parts = line.split(',').map(str::trim);
+        let name = parts.next()?.to_string();
+        let uuid = parts
+            .next()
+            .and_then(|s| (!s.is_empty()).then(|| s.to_string()));
+        let cc_raw = parts.next().unwrap_or_default();
+        let (major, minor) = parse_compute_capability(cc_raw);
+        let total_memory_bytes = parts.next().and_then(parse_mib).map(mib_to_bytes);
+        let free_memory_bytes = parts.next().and_then(parse_mib).map(mib_to_bytes);
+        let capability = classify_capability(major, minor, &name);
+        Some(Self {
+            ordinal,
+            name,
+            uuid,
+            compute_capability_major: major,
+            compute_capability_minor: minor,
+            total_memory_bytes,
+            free_memory_bytes,
+            capability,
+        })
+    }
+}
+
+impl fmt::Display for GpuDeviceInfo {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let cc = self.compute_capability().map_or_else(
+            || "unknown".to_string(),
+            |(maj, min)| format!("{maj}.{min}"),
+        );
+        let total_gib = self.total_memory_bytes.map_or_else(
+            || "unknown".to_string(),
+            |b| format!("{:.1} GiB", b as f64 / 1024.0_f64.powi(3)),
+        );
+        write!(
+            f,
+            "#{ordinal} {name} (cc={cc}, memory={total_gib}, class={class:?})",
+            ordinal = self.ordinal,
+            name = self.name,
+            class = self.capability
+        )
+    }
+}
+
+#[must_use]
+pub fn classify_capability(major: Option<i32>, minor: Option<i32>, name: &str) -> GpuCapability {
+    if matches!(major, Some(m) if m >= 9) {
+        return GpuCapability::CudaHopperOrNewer;
+    }
+    let upper = name.to_ascii_uppercase();
+    if upper.contains("H100") || upper.contains("H200") || upper.contains("B200") {
+        return GpuCapability::CudaHopperOrNewer;
+    }
+    if upper.contains("A100") || upper.contains("V100") || upper.contains("L40") {
+        return GpuCapability::CudaFp64Strong;
+    }
+    if major.is_some()
+        || upper.contains("NVIDIA")
+        || upper.contains("TESLA")
+        || upper.contains("QUADRO")
+    {
+        return GpuCapability::Cuda;
+    }
+    let _ = minor;
+    GpuCapability::Unknown
+}
+
+fn parse_compute_capability(raw: &str) -> (Option<i32>, Option<i32>) {
+    let cleaned = raw.trim();
+    let Some((major, minor)) = cleaned.split_once('.') else {
+        return (cleaned.parse::<i32>().ok(), None);
+    };
+    (major.parse::<i32>().ok(), minor.parse::<i32>().ok())
+}
+
+fn parse_mib(raw: &str) -> Option<u64> {
+    raw.split_whitespace().next()?.parse::<u64>().ok()
+}
+
+const fn mib_to_bytes(mib: u64) -> u64 {
+    mib * 1024 * 1024
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_nvidia_smi_csv() {
+        let info =
+            GpuDeviceInfo::from_nvidia_smi_csv(1, "NVIDIA H200, GPU-deadbeef, 9.0, 143771, 140000")
+                .expect("valid csv");
+        assert_eq!(info.ordinal, 1);
+        assert_eq!(info.compute_capability(), Some((9, 0)));
+        assert_eq!(info.capability, GpuCapability::CudaHopperOrNewer);
+        assert_eq!(info.total_memory_bytes, Some(143_771 * 1024 * 1024));
+    }
+}

--- a/src/gpu/kernels.rs
+++ b/src/gpu/kernels.rs
@@ -1,0 +1,23 @@
+use ndarray::{Array1, Array2, ArrayBase, Data, Ix1, Ix2};
+
+/// CPU reference implementation of the row scaling kernel used by the CUDA
+/// path. Keeping this here makes validation deterministic and gives the GPU
+/// module a single semantic definition of weighted design chunks.
+#[must_use]
+pub fn scale_rows_reference<S1: Data<Elem = f64>, S2: Data<Elem = f64>>(
+    x: &ArrayBase<S1, Ix2>,
+    w: &ArrayBase<S2, Ix1>,
+) -> Array2<f64> {
+    let (n, p) = x.dim();
+    debug_assert_eq!(n, w.len());
+    Array2::from_shape_fn((n, p), |(i, j)| x[[i, j]] * w[i])
+}
+
+#[must_use]
+pub fn weighted_response_reference<S1: Data<Elem = f64>, S2: Data<Elem = f64>>(
+    w: &ArrayBase<S1, Ix1>,
+    y: &ArrayBase<S2, Ix1>,
+) -> Array1<f64> {
+    debug_assert_eq!(w.len(), y.len());
+    Array1::from_iter(w.iter().zip(y.iter()).map(|(wi, yi)| wi * yi))
+}

--- a/src/gpu/linalg.rs
+++ b/src/gpu/linalg.rs
@@ -1,0 +1,116 @@
+use ndarray::{Array1, Array2, ArrayBase, Data, Ix1, Ix2};
+
+use super::policy::{Operation, OperationDecision};
+use super::runtime::GpuRuntime;
+
+#[must_use]
+pub fn should_dispatch_gemv<S1: Data<Elem = f64>, S2: Data<Elem = f64>>(
+    a: &ArrayBase<S1, Ix2>,
+    v: &ArrayBase<S2, Ix1>,
+    transposed: bool,
+) -> bool {
+    let (m, k) = a.dim();
+    let expected = if transposed { m } else { k };
+    debug_assert_eq!(v.len(), expected);
+    runtime_decision(Operation::Gemv {
+        m,
+        k,
+        transposed,
+        resident: false,
+    }) == OperationDecision::Gpu
+}
+
+#[must_use]
+pub fn should_dispatch_gemm<S1: Data<Elem = f64>, S2: Data<Elem = f64>>(
+    a: &ArrayBase<S1, Ix2>,
+    b: &ArrayBase<S2, Ix2>,
+) -> bool {
+    let (m, k) = a.dim();
+    let (_, n) = b.dim();
+    runtime_decision(Operation::Gemm {
+        m,
+        n,
+        k,
+        resident: false,
+    }) == OperationDecision::Gpu
+}
+
+#[must_use]
+pub fn should_dispatch_xt_diag_x(rows: usize, cols: usize) -> bool {
+    runtime_decision(Operation::XtDiagX {
+        rows,
+        cols,
+        resident: false,
+    }) == OperationDecision::Gpu
+}
+
+#[must_use]
+pub fn should_dispatch_xt_diag_y(rows: usize, x_cols: usize, y_cols: usize) -> bool {
+    runtime_decision(Operation::XtDiagY {
+        rows,
+        x_cols,
+        y_cols,
+        resident: false,
+    }) == OperationDecision::Gpu
+}
+
+#[must_use]
+pub fn should_dispatch_joint_hessian(rows: usize, a_cols: usize, b_cols: usize) -> bool {
+    runtime_decision(Operation::JointHessian2x2 {
+        rows,
+        a_cols,
+        b_cols,
+        resident: false,
+    }) == OperationDecision::Gpu
+}
+
+/// Placeholder for the CUDA GEMV implementation. It currently returns `None`
+/// so callers use the exact CPU implementation unless a future CUDA kernel is
+/// compiled in and passes validation.
+#[must_use]
+pub fn try_fast_av<S1: Data<Elem = f64>, S2: Data<Elem = f64>>(
+    _a: &ArrayBase<S1, Ix2>,
+    _v: &ArrayBase<S2, Ix1>,
+) -> Option<Array1<f64>> {
+    None
+}
+
+#[must_use]
+pub fn try_fast_atv<S1: Data<Elem = f64>, S2: Data<Elem = f64>>(
+    _a: &ArrayBase<S1, Ix2>,
+    _v: &ArrayBase<S2, Ix1>,
+) -> Option<Array1<f64>> {
+    None
+}
+
+#[must_use]
+pub fn try_fast_ab<S1: Data<Elem = f64>, S2: Data<Elem = f64>>(
+    _a: &ArrayBase<S1, Ix2>,
+    _b: &ArrayBase<S2, Ix2>,
+) -> Option<Array2<f64>> {
+    None
+}
+
+#[must_use]
+pub fn try_fast_xt_diag_x<S1: Data<Elem = f64>, S2: Data<Elem = f64>>(
+    _x: &ArrayBase<S1, Ix2>,
+    _w: &ArrayBase<S2, Ix1>,
+) -> Option<Array2<f64>> {
+    None
+}
+
+#[must_use]
+pub fn try_fast_xt_diag_y<S1: Data<Elem = f64>, S2: Data<Elem = f64>, S3: Data<Elem = f64>>(
+    _x: &ArrayBase<S1, Ix2>,
+    _w: &ArrayBase<S2, Ix1>,
+    _y: &ArrayBase<S3, Ix2>,
+) -> Option<Array2<f64>> {
+    None
+}
+
+fn runtime_decision(op: Operation) -> OperationDecision {
+    let runtime = GpuRuntime::global();
+    runtime
+        .selected_context()
+        .map_or(OperationDecision::Cpu, |ctx| ctx.target_for(op))
+}

--- a/src/gpu/memory.rs
+++ b/src/gpu/memory.rs
@@ -1,0 +1,107 @@
+use ndarray::Array2;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum MatrixLayout {
+    RowMajor,
+    ColumnMajor,
+}
+
+#[derive(Clone, Debug)]
+pub struct DeviceBuffer<T> {
+    host_mirror: Vec<T>,
+}
+
+impl<T: Clone + Default> DeviceBuffer<T> {
+    #[must_use]
+    pub fn zeros(len: usize) -> Self {
+        Self {
+            host_mirror: vec![T::default(); len],
+        }
+    }
+}
+
+impl<T> DeviceBuffer<T> {
+    #[must_use]
+    pub fn from_vec(values: Vec<T>) -> Self {
+        Self {
+            host_mirror: values,
+        }
+    }
+
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.host_mirror.len()
+    }
+
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.host_mirror.is_empty()
+    }
+
+    #[must_use]
+    pub fn as_host_slice(&self) -> &[T] {
+        &self.host_mirror
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct DeviceMatrix<T> {
+    buffer: DeviceBuffer<T>,
+    rows: usize,
+    cols: usize,
+    ld: usize,
+    layout: MatrixLayout,
+}
+
+impl DeviceMatrix<f64> {
+    #[must_use]
+    pub fn from_host_row_major(matrix: &Array2<f64>) -> Self {
+        let rows = matrix.nrows();
+        let cols = matrix.ncols();
+        let values = matrix.iter().copied().collect();
+        Self {
+            buffer: DeviceBuffer::from_vec(values),
+            rows,
+            cols,
+            ld: cols,
+            layout: MatrixLayout::RowMajor,
+        }
+    }
+}
+
+impl<T> DeviceMatrix<T> {
+    #[must_use]
+    pub const fn rows(&self) -> usize {
+        self.rows
+    }
+
+    #[must_use]
+    pub const fn cols(&self) -> usize {
+        self.cols
+    }
+
+    #[must_use]
+    pub const fn leading_dimension(&self) -> usize {
+        self.ld
+    }
+
+    #[must_use]
+    pub const fn layout(&self) -> MatrixLayout {
+        self.layout
+    }
+
+    #[must_use]
+    pub fn buffer(&self) -> &DeviceBuffer<T> {
+        &self.buffer
+    }
+}
+
+pub enum MatrixLocation<'a> {
+    Host(&'a Array2<f64>),
+    Device(&'a DeviceMatrix<f64>),
+}
+
+pub enum MatrixLocationMut<'a> {
+    Host(&'a mut Array2<f64>),
+    Device(&'a mut DeviceMatrix<f64>),
+}

--- a/src/gpu/mod.rs
+++ b/src/gpu/mod.rs
@@ -1,0 +1,21 @@
+//! GPU acceleration facade.
+//!
+//! The module is intentionally always compiled so CPU-only builds can expose a
+//! stable API and deterministic fallback behavior. CUDA-specific crates remain
+//! behind the optional `cuda` Cargo feature and runtime policy defaults to CPU
+//! unless a usable device is detected and the operation is large enough.
+
+pub mod device;
+pub mod kernels;
+pub mod linalg;
+pub mod memory;
+pub mod policy;
+pub mod profile;
+pub mod runtime;
+pub mod solver;
+pub mod sparse;
+pub mod stream;
+
+pub use device::{GpuCapability, GpuDeviceInfo};
+pub use policy::{AccelPolicy, GpuDispatchPolicy, Operation, OperationDecision};
+pub use runtime::{ExecutionTarget, GpuContext, GpuRuntime, gpu_available, selected_gpu_info};

--- a/src/gpu/policy.rs
+++ b/src/gpu/policy.rs
@@ -1,0 +1,307 @@
+use std::env;
+
+use super::device::{GpuCapability, GpuDeviceInfo};
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum AccelPolicy {
+    Auto,
+    CpuOnly,
+    GpuOnly,
+}
+
+impl AccelPolicy {
+    #[must_use]
+    pub fn from_env() -> Self {
+        match env::var("GAM_GPU")
+            .unwrap_or_else(|_| "auto".to_string())
+            .to_ascii_lowercase()
+            .as_str()
+        {
+            "off" | "0" | "false" | "cpu" | "cpu-only" => Self::CpuOnly,
+            "force" | "on" | "1" | "true" | "gpu" | "gpu-only" => Self::GpuOnly,
+            _ => Self::Auto,
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct GpuDispatchPolicy {
+    pub accel_policy: AccelPolicy,
+    pub gemm_min_flops: f64,
+    pub gemv_min_flops: f64,
+    pub xtwx_min_flops: f64,
+    pub xtwy_min_flops: f64,
+    pub joint_hessian_min_flops: f64,
+    pub potrf_min_p: usize,
+    pub sparse_min_nnz: usize,
+    pub row_kernel_min_n: usize,
+    pub keep_design_resident: bool,
+    pub prefer_gpu_for_f64_factorization: bool,
+    pub mem_fraction: f64,
+    pub validate: bool,
+    pub profile: bool,
+}
+
+impl Default for GpuDispatchPolicy {
+    fn default() -> Self {
+        Self {
+            accel_policy: AccelPolicy::Auto,
+            gemm_min_flops: 2.0e9,
+            gemv_min_flops: 2.5e8,
+            xtwx_min_flops: 1.0e9,
+            xtwy_min_flops: 5.0e8,
+            joint_hessian_min_flops: 1.0e9,
+            potrf_min_p: 1_536,
+            sparse_min_nnz: 2_000_000,
+            row_kernel_min_n: 250_000,
+            keep_design_resident: true,
+            prefer_gpu_for_f64_factorization: false,
+            mem_fraction: 0.85,
+            validate: false,
+            profile: false,
+        }
+    }
+}
+
+impl GpuDispatchPolicy {
+    #[must_use]
+    pub fn from_env_and_device(device: Option<&GpuDeviceInfo>) -> Self {
+        let mut policy = Self {
+            accel_policy: AccelPolicy::from_env(),
+            ..Self::default()
+        };
+        if let Some(device) = device {
+            policy.apply_device_defaults(device);
+        }
+        policy.mem_fraction =
+            env_f64("GAM_GPU_MEM_FRACTION", policy.mem_fraction).clamp(0.05, 0.98);
+        policy.gemv_min_flops = env_f64("GAM_GPU_GEMV_MIN_FLOPS", policy.gemv_min_flops);
+        policy.gemm_min_flops = env_f64("GAM_GPU_GEMM_MIN_FLOPS", policy.gemm_min_flops);
+        policy.xtwx_min_flops = env_f64("GAM_GPU_XTWX_MIN_FLOPS", policy.xtwx_min_flops);
+        policy.row_kernel_min_n = env_usize("GAM_GPU_MIN_N", policy.row_kernel_min_n);
+        policy.validate = env_bool("GAM_GPU_VALIDATE");
+        policy.profile = env_bool("GAM_GPU_PROFILE");
+        policy
+    }
+
+    pub fn apply_device_defaults(&mut self, device: &GpuDeviceInfo) {
+        match device.capability {
+            GpuCapability::CudaHopperOrNewer => {
+                self.gemm_min_flops = 5.0e8;
+                self.gemv_min_flops = 8.0e7;
+                self.xtwx_min_flops = 3.5e8;
+                self.xtwy_min_flops = 2.0e8;
+                self.joint_hessian_min_flops = 3.5e8;
+                self.potrf_min_p = 512;
+                self.sparse_min_nnz = 500_000;
+                self.row_kernel_min_n = 50_000;
+                self.prefer_gpu_for_f64_factorization = true;
+            }
+            GpuCapability::CudaFp64Strong => {
+                self.gemm_min_flops = 8.0e8;
+                self.gemv_min_flops = 1.2e8;
+                self.xtwx_min_flops = 5.0e8;
+                self.xtwy_min_flops = 2.5e8;
+                self.joint_hessian_min_flops = 5.0e8;
+                self.potrf_min_p = 768;
+                self.sparse_min_nnz = 800_000;
+                self.row_kernel_min_n = 75_000;
+                self.prefer_gpu_for_f64_factorization = true;
+            }
+            GpuCapability::Cuda => {}
+            GpuCapability::Unknown => {
+                self.accel_policy = AccelPolicy::CpuOnly;
+            }
+        }
+    }
+
+    #[must_use]
+    pub fn decide(&self, op: Operation, device_available: bool) -> OperationDecision {
+        if self.accel_policy == AccelPolicy::CpuOnly || !device_available {
+            return OperationDecision::Cpu;
+        }
+        if self.accel_policy == AccelPolicy::GpuOnly {
+            return OperationDecision::Gpu;
+        }
+        let flops = op.estimated_flops();
+        let resident_bonus = if op.inputs_resident() { 0.25 } else { 1.0 };
+        let threshold = match op {
+            Operation::Gemm { .. } => self.gemm_min_flops,
+            Operation::Gemv { .. } => self.gemv_min_flops,
+            Operation::XtDiagX { .. } => self.xtwx_min_flops,
+            Operation::XtDiagY { .. } => self.xtwy_min_flops,
+            Operation::JointHessian2x2 { .. } => self.joint_hessian_min_flops,
+            Operation::Potrf { p, resident } => {
+                if resident && p >= self.potrf_min_p {
+                    return OperationDecision::Gpu;
+                }
+                return OperationDecision::Cpu;
+            }
+            Operation::SparseXtDiagX { nnz, pattern_reuse } => {
+                if nnz >= self.sparse_min_nnz && pattern_reuse {
+                    return OperationDecision::Gpu;
+                }
+                return OperationDecision::Cpu;
+            }
+            Operation::RowKernel { n, batched } => {
+                if n >= self.row_kernel_min_n || (batched && n >= self.row_kernel_min_n / 4) {
+                    return OperationDecision::Gpu;
+                }
+                return OperationDecision::Cpu;
+            }
+        };
+        if flops >= threshold * resident_bonus {
+            OperationDecision::Gpu
+        } else {
+            OperationDecision::Cpu
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum Operation {
+    Gemm {
+        m: usize,
+        n: usize,
+        k: usize,
+        resident: bool,
+    },
+    Gemv {
+        m: usize,
+        k: usize,
+        transposed: bool,
+        resident: bool,
+    },
+    XtDiagX {
+        rows: usize,
+        cols: usize,
+        resident: bool,
+    },
+    XtDiagY {
+        rows: usize,
+        x_cols: usize,
+        y_cols: usize,
+        resident: bool,
+    },
+    JointHessian2x2 {
+        rows: usize,
+        a_cols: usize,
+        b_cols: usize,
+        resident: bool,
+    },
+    Potrf {
+        p: usize,
+        resident: bool,
+    },
+    SparseXtDiagX {
+        nnz: usize,
+        pattern_reuse: bool,
+    },
+    RowKernel {
+        n: usize,
+        batched: bool,
+    },
+}
+
+impl Operation {
+    #[must_use]
+    pub fn estimated_flops(self) -> f64 {
+        match self {
+            Self::Gemm { m, n, k, .. } => 2.0 * m as f64 * n as f64 * k as f64,
+            Self::Gemv { m, k, .. } => 2.0 * m as f64 * k as f64,
+            Self::XtDiagX { rows, cols, .. } => 2.0 * rows as f64 * cols as f64 * cols as f64,
+            Self::XtDiagY {
+                rows,
+                x_cols,
+                y_cols,
+                ..
+            } => 2.0 * rows as f64 * x_cols as f64 * y_cols as f64,
+            Self::JointHessian2x2 {
+                rows,
+                a_cols,
+                b_cols,
+                ..
+            } => 2.0 * rows as f64 * (a_cols * a_cols + a_cols * b_cols + b_cols * b_cols) as f64,
+            Self::Potrf { p, .. } => (p as f64).powi(3) / 3.0,
+            Self::SparseXtDiagX { nnz, .. } => nnz as f64,
+            Self::RowKernel { n, batched } => {
+                if batched {
+                    200.0 * n as f64
+                } else {
+                    50.0 * n as f64
+                }
+            }
+        }
+    }
+
+    #[must_use]
+    pub const fn inputs_resident(self) -> bool {
+        match self {
+            Self::Gemm { resident, .. }
+            | Self::Gemv { resident, .. }
+            | Self::XtDiagX { resident, .. }
+            | Self::XtDiagY { resident, .. }
+            | Self::JointHessian2x2 { resident, .. }
+            | Self::Potrf { resident, .. } => resident,
+            Self::SparseXtDiagX { .. } | Self::RowKernel { .. } => false,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum OperationDecision {
+    Cpu,
+    Gpu,
+}
+
+fn env_f64(name: &str, default: f64) -> f64 {
+    env::var(name)
+        .ok()
+        .and_then(|s| s.parse::<f64>().ok())
+        .unwrap_or(default)
+}
+
+fn env_usize(name: &str, default: usize) -> usize {
+    env::var(name)
+        .ok()
+        .and_then(|s| s.parse::<usize>().ok())
+        .unwrap_or(default)
+}
+
+fn env_bool(name: &str) -> bool {
+    matches!(
+        env::var(name)
+            .unwrap_or_default()
+            .to_ascii_lowercase()
+            .as_str(),
+        "1" | "true" | "yes" | "on"
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn auto_policy_keeps_tiny_gemv_on_cpu() {
+        let policy = GpuDispatchPolicy::default();
+        let op = Operation::Gemv {
+            m: 100,
+            k: 10,
+            transposed: false,
+            resident: false,
+        };
+        assert_eq!(policy.decide(op, true), OperationDecision::Cpu);
+    }
+
+    #[test]
+    fn auto_policy_sends_large_resident_xtwx_to_gpu() {
+        let policy = GpuDispatchPolicy::default();
+        let op = Operation::XtDiagX {
+            rows: 1_000_000,
+            cols: 128,
+            resident: true,
+        };
+        assert_eq!(policy.decide(op, true), OperationDecision::Gpu);
+    }
+}

--- a/src/gpu/profile.rs
+++ b/src/gpu/profile.rs
@@ -1,0 +1,65 @@
+use std::fmt;
+use std::sync::{Mutex, OnceLock};
+use std::time::Duration;
+
+#[derive(Clone, Debug)]
+pub struct KernelStat {
+    pub name: &'static str,
+    pub n: usize,
+    pub p: usize,
+    pub k: usize,
+    pub nnz: Option<usize>,
+    pub flops_est: f64,
+    pub bytes_est: f64,
+    pub cpu: Option<Duration>,
+    pub gpu: Option<Duration>,
+}
+
+impl fmt::Display for KernelStat {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{} n={} p={} k={} nnz={:?} flops={:.3e} bytes={:.3e} cpu_ms={:?} gpu_ms={:?}",
+            self.name,
+            self.n,
+            self.p,
+            self.k,
+            self.nnz,
+            self.flops_est,
+            self.bytes_est,
+            self.cpu.map(|d| d.as_secs_f64() * 1_000.0),
+            self.gpu.map(|d| d.as_secs_f64() * 1_000.0)
+        )
+    }
+}
+
+static STATS: OnceLock<Mutex<Vec<KernelStat>>> = OnceLock::new();
+
+pub fn record(stat: KernelStat) {
+    if !profile_enabled() {
+        return;
+    }
+    let stats = STATS.get_or_init(|| Mutex::new(Vec::new()));
+    if let Ok(mut guard) = stats.lock() {
+        guard.push(stat);
+    }
+}
+
+#[must_use]
+pub fn take_stats() -> Vec<KernelStat> {
+    let stats = STATS.get_or_init(|| Mutex::new(Vec::new()));
+    stats
+        .lock()
+        .map_or_else(|_| Vec::new(), |mut guard| std::mem::take(&mut *guard))
+}
+
+#[must_use]
+pub fn profile_enabled() -> bool {
+    matches!(
+        std::env::var("GAM_GPU_PROFILE")
+            .unwrap_or_default()
+            .to_ascii_lowercase()
+            .as_str(),
+        "1" | "true" | "yes" | "on"
+    )
+}

--- a/src/gpu/runtime.rs
+++ b/src/gpu/runtime.rs
@@ -1,0 +1,152 @@
+use std::env;
+use std::process::Command;
+use std::sync::OnceLock;
+
+use super::device::GpuDeviceInfo;
+use super::policy::{GpuDispatchPolicy, Operation, OperationDecision};
+
+#[derive(Clone, Debug)]
+pub enum ExecutionTarget {
+    Cpu,
+    Cuda(GpuContext),
+}
+
+#[derive(Clone, Debug)]
+pub struct GpuContext {
+    pub device: GpuDeviceInfo,
+    pub policy: GpuDispatchPolicy,
+}
+
+impl GpuContext {
+    #[must_use]
+    pub fn target_for(&self, op: Operation) -> OperationDecision {
+        self.policy.decide(op, true)
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct GpuRuntime {
+    devices: Vec<GpuDeviceInfo>,
+    selected: Option<GpuContext>,
+    cuda_feature_enabled: bool,
+    probe_message: String,
+}
+
+impl GpuRuntime {
+    #[must_use]
+    pub fn probe() -> Self {
+        let cuda_feature_enabled = cfg!(feature = "cuda");
+        let devices = if env::var("GAM_GPU").map_or(false, |v| is_off(&v)) {
+            Vec::new()
+        } else {
+            probe_devices_with_nvidia_smi()
+        };
+        let selected_device = select_device(&devices);
+        let selected = selected_device.map(|device| {
+            let policy = GpuDispatchPolicy::from_env_and_device(Some(&device));
+            GpuContext { device, policy }
+        });
+        let probe_message = if let Some(ctx) = &selected {
+            format!(
+                "[GAM GPU] CUDA runtime probe selected {}; cargo cuda feature: {}",
+                ctx.device, cuda_feature_enabled
+            )
+        } else if cuda_feature_enabled {
+            "[GAM GPU] cuda feature enabled, but no usable CUDA device was detected; CPU fallback active".to_string()
+        } else {
+            "[GAM GPU] cuda feature disabled or no usable CUDA device detected; CPU fallback active"
+                .to_string()
+        };
+        Self {
+            devices,
+            selected,
+            cuda_feature_enabled,
+            probe_message,
+        }
+    }
+
+    #[must_use]
+    pub fn global() -> &'static Self {
+        static RUNTIME: OnceLock<GpuRuntime> = OnceLock::new();
+        RUNTIME.get_or_init(Self::probe)
+    }
+
+    #[must_use]
+    pub fn is_available(&self) -> bool {
+        self.selected.is_some()
+    }
+
+    #[must_use]
+    pub fn selected_device(&self) -> Option<&GpuDeviceInfo> {
+        self.selected.as_ref().map(|ctx| &ctx.device)
+    }
+
+    #[must_use]
+    pub fn selected_context(&self) -> Option<&GpuContext> {
+        self.selected.as_ref()
+    }
+
+    #[must_use]
+    pub fn devices(&self) -> &[GpuDeviceInfo] {
+        &self.devices
+    }
+
+    #[must_use]
+    pub const fn cuda_feature_enabled(&self) -> bool {
+        self.cuda_feature_enabled
+    }
+
+    #[must_use]
+    pub fn probe_message(&self) -> &str {
+        &self.probe_message
+    }
+}
+
+#[must_use]
+pub fn gpu_available() -> bool {
+    GpuRuntime::global().is_available()
+}
+
+#[must_use]
+pub fn selected_gpu_info() -> Option<GpuDeviceInfo> {
+    GpuRuntime::global().selected_device().cloned()
+}
+
+fn select_device(devices: &[GpuDeviceInfo]) -> Option<GpuDeviceInfo> {
+    if devices.is_empty() {
+        return None;
+    }
+    if let Ok(raw) = env::var("GAM_GPU_DEVICE") {
+        if let Ok(ordinal) = raw.parse::<usize>() {
+            return devices.iter().find(|d| d.ordinal == ordinal).cloned();
+        }
+    }
+    devices.iter().max_by_key(|device| device.score()).cloned()
+}
+
+fn probe_devices_with_nvidia_smi() -> Vec<GpuDeviceInfo> {
+    let output = Command::new("nvidia-smi")
+        .args([
+            "--query-gpu=name,uuid,compute_cap,memory.total,memory.free",
+            "--format=csv,noheader,nounits",
+        ])
+        .output();
+    let Ok(output) = output else {
+        return Vec::new();
+    };
+    if !output.status.success() {
+        return Vec::new();
+    }
+    String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .enumerate()
+        .filter_map(|(ordinal, line)| GpuDeviceInfo::from_nvidia_smi_csv(ordinal, line))
+        .collect()
+}
+
+fn is_off(value: &str) -> bool {
+    matches!(
+        value.to_ascii_lowercase().as_str(),
+        "off" | "0" | "false" | "cpu" | "cpu-only"
+    )
+}

--- a/src/gpu/solver.rs
+++ b/src/gpu/solver.rs
@@ -1,0 +1,79 @@
+use ndarray::Array2;
+
+use super::memory::MatrixLocationMut;
+use super::policy::{Operation, OperationDecision};
+use super::runtime::GpuRuntime;
+
+#[derive(Clone, Debug)]
+pub struct DenseFactorInfo {
+    pub p: usize,
+    pub logdet: Option<f64>,
+    pub on_gpu: bool,
+}
+
+pub trait DenseSpdSolver {
+    fn potrf(&self, matrix: MatrixLocationMut<'_>) -> Result<DenseFactorInfo, String>;
+    fn potrs(&self, factor: &DenseFactorInfo, rhs: MatrixLocationMut<'_>) -> Result<(), String>;
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+pub struct GpuSolver;
+
+impl GpuSolver {
+    #[must_use]
+    pub fn should_use_gpu_potrf(p: usize, resident: bool) -> bool {
+        GpuRuntime::global().selected_context().is_some_and(|ctx| {
+            ctx.target_for(Operation::Potrf { p, resident }) == OperationDecision::Gpu
+        })
+    }
+}
+
+impl DenseSpdSolver for GpuSolver {
+    fn potrf(&self, matrix: MatrixLocationMut<'_>) -> Result<DenseFactorInfo, String> {
+        match matrix {
+            MatrixLocationMut::Host(a) => Ok(DenseFactorInfo {
+                p: a.nrows(),
+                logdet: cholesky_logdet_reference(a),
+                on_gpu: false,
+            }),
+            MatrixLocationMut::Device(a) => Ok(DenseFactorInfo {
+                p: a.rows(),
+                logdet: None,
+                on_gpu: true,
+            }),
+        }
+    }
+
+    fn potrs(&self, _factor: &DenseFactorInfo, _rhs: MatrixLocationMut<'_>) -> Result<(), String> {
+        Err("GPU dense solve backend is unavailable in this CPU fallback build".to_string())
+    }
+}
+
+fn cholesky_logdet_reference(a: &Array2<f64>) -> Option<f64> {
+    if a.nrows() != a.ncols() {
+        return None;
+    }
+    let mut work = a.clone();
+    let n = work.nrows();
+    let mut logdet = 0.0;
+    for j in 0..n {
+        let mut diag = work[[j, j]];
+        for k in 0..j {
+            diag -= work[[j, k]] * work[[j, k]];
+        }
+        if diag <= 0.0 || !diag.is_finite() {
+            return None;
+        }
+        let l_jj = diag.sqrt();
+        work[[j, j]] = l_jj;
+        logdet += 2.0 * l_jj.ln();
+        for i in j + 1..n {
+            let mut value = work[[i, j]];
+            for k in 0..j {
+                value -= work[[i, k]] * work[[j, k]];
+            }
+            work[[i, j]] = value / l_jj;
+        }
+    }
+    Some(logdet)
+}

--- a/src/gpu/sparse.rs
+++ b/src/gpu/sparse.rs
@@ -1,0 +1,25 @@
+use super::policy::{Operation, OperationDecision};
+use super::runtime::GpuRuntime;
+
+#[derive(Clone, Debug)]
+pub struct DeviceCsrMatrix<T> {
+    pub row_offsets: Vec<i32>,
+    pub col_indices: Vec<i32>,
+    pub values: Vec<T>,
+    pub rows: usize,
+    pub cols: usize,
+}
+
+impl<T> DeviceCsrMatrix<T> {
+    #[must_use]
+    pub fn nnz(&self) -> usize {
+        self.values.len()
+    }
+}
+
+#[must_use]
+pub fn should_dispatch_sparse_xt_diag_x(nnz: usize, pattern_reuse: bool) -> bool {
+    GpuRuntime::global().selected_context().is_some_and(|ctx| {
+        ctx.target_for(Operation::SparseXtDiagX { nnz, pattern_reuse }) == OperationDecision::Gpu
+    })
+}

--- a/src/gpu/stream.rs
+++ b/src/gpu/stream.rs
@@ -1,0 +1,34 @@
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct GpuStream {
+    id: usize,
+}
+
+impl GpuStream {
+    #[must_use]
+    pub const fn default() -> Self {
+        Self { id: 0 }
+    }
+
+    #[must_use]
+    pub const fn id(self) -> usize {
+        self.id
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct GpuEvent;
+
+#[derive(Clone, Debug, Default)]
+pub struct StreamPool;
+
+impl StreamPool {
+    #[must_use]
+    pub const fn new() -> Self {
+        Self
+    }
+
+    #[must_use]
+    pub const fn next(&self) -> GpuStream {
+        GpuStream::default()
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,7 @@ pub fn init_parallelism() {
 }
 
 pub mod families;
+pub mod gpu;
 pub mod inference;
 pub mod linalg;
 pub mod report;
@@ -35,6 +36,7 @@ pub mod types;
 pub use data::{
     encode_recordswith_inferred_schema, load_csvwith_inferred_schema, load_csvwith_schema,
 };
+pub use gpu::{gpu_available, selected_gpu_info};
 pub use inference::{
     alo, data, diagnostics, generative, hmc, predict, probability, quadrature, sample,
 };

--- a/src/linalg/faer_ndarray.rs
+++ b/src/linalg/faer_ndarray.rs
@@ -290,6 +290,11 @@ pub fn fast_ab<S1: Data<Elem = f64>, S2: Data<Elem = f64>>(
     a: &ArrayBase<S1, Ix2>,
     b: &ArrayBase<S2, Ix2>,
 ) -> Array2<f64> {
+    if crate::gpu::linalg::should_dispatch_gemm(a, b) {
+        if let Some(out) = crate::gpu::linalg::try_fast_ab(a, b) {
+            return out;
+        }
+    }
     let (n, _) = a.dim();
     let (_, q) = b.dim();
     let mut out = Array2::<f64>::zeros((n, q));
@@ -309,6 +314,12 @@ pub fn fast_av<S1: Data<Elem = f64>, S2: Data<Elem = f64>>(
 
     let (n, p) = a.dim();
     debug_assert_eq!(p, v.len(), "A cols must match v length");
+
+    if crate::gpu::linalg::should_dispatch_gemv(a, v, false) {
+        if let Some(out) = crate::gpu::linalg::try_fast_av(a, v) {
+            return out;
+        }
+    }
 
     if !should_use_faer_matmul(n, 1, p) {
         return a.dot(v);
@@ -419,6 +430,12 @@ pub fn fast_atv<S1: Data<Elem = f64>, S2: Data<Elem = f64>>(
     let (n, p) = a.dim();
     debug_assert_eq!(n, v.len(), "A rows must match v length");
 
+    if crate::gpu::linalg::should_dispatch_gemv(a, v, true) {
+        if let Some(out) = crate::gpu::linalg::try_fast_atv(a, v) {
+            return out;
+        }
+    }
+
     // For very small arrays, ndarray might be faster
     if !should_use_faer_matmul(p, 1, n) {
         return a.t().dot(v);
@@ -513,6 +530,11 @@ pub fn fast_xt_diag_x_with_parallelism<S1: Data<Elem = f64>, S2: Data<Elem = f64
     if n == 0 || p == 0 {
         return Array2::<f64>::zeros((p, p));
     }
+    if crate::gpu::linalg::should_dispatch_xt_diag_x(n, p) {
+        if let Some(out) = crate::gpu::linalg::try_fast_xt_diag_x(x, w) {
+            return out;
+        }
+    }
     if !should_use_faer_matmul(p, p, n) {
         let w_x = Array2::from_shape_fn((n, p), |(i, j)| w[i] * x[[i, j]]);
         return x.t().dot(&w_x);
@@ -580,6 +602,11 @@ pub fn fast_xt_diag_y<S1: Data<Elem = f64>, S2: Data<Elem = f64>, S3: Data<Elem 
     debug_assert_eq!(n, x.nrows(), "X rows must match Y rows");
     if n == 0 || px == 0 || q == 0 {
         return Array2::<f64>::zeros((px, q));
+    }
+    if crate::gpu::linalg::should_dispatch_xt_diag_y(n, px, q) {
+        if let Some(out) = crate::gpu::linalg::try_fast_xt_diag_y(x, w, y) {
+            return out;
+        }
     }
     if !should_use_faer_matmul(px, q, n) {
         let w_y = Array2::from_shape_fn((n, q), |(i, j)| w[i] * y[[i, j]]);
@@ -663,6 +690,8 @@ pub fn fast_joint_hessian_2x2<
     if n == 0 || total == 0 {
         return Array2::<f64>::zeros((total, total));
     }
+
+    let _gpu_preferred = crate::gpu::linalg::should_dispatch_joint_hessian(n, pa, pb);
 
     // For small problems, fall back to separate computations
     if !should_use_faer_matmul(pa.max(pb), pa.max(pb), n) {


### PR DESCRIPTION
### Motivation
- Introduce a structured, runtime-driven GPU backend so high-flop, row-parallel kernels can be accelerated without changing the public fitting API. 
- Provide dynamic, hardware-aware dispatch with a safe CPU fallback so CPU-only builds remain identical in behavior.
- Prepare insertion points for cuBLAS/cuBLASLt/cuSPARSE/cuSOLVER kernels under a feature-guarded `cuda` Cargo feature.

### Description
- Add a new `src/gpu/` facade with modules: `runtime`, `device`, `policy`, `memory`, `stream`, `linalg`, `sparse`, `solver`, `kernels`, and `profile` that implement probing, device metadata, dispatch policy, device buffer/matrix abstractions, stream stubs, placeholder linalg/sparse/solver facades, and profiling counters.
- Add an optional Cargo feature `cuda` and an optional `cudarc` dependency (dynamic-loading style) in `Cargo.toml` so CUDA support is feature-gated and CPU-only builds do not require CUDA.
- Implement runtime probe and selection (`GpuRuntime::probe`) using `nvidia-smi` CSV parsing and environment control (`GAM_GPU`, `GAM_GPU_DEVICE`, `GAM_GPU_MEM_FRACTION`, `GAM_GPU_VALIDATE`, `GAM_GPU_PROFILE`, `GAM_GPU_MIN_N`).
- Add a hardware-aware `GpuDispatchPolicy` for per-operation decisions and an `Operation` enum (GEMM/GEMV/`XtDiagX`/`XtDiagY`/joint Hessian/`Potrf`/sparse/row kernels) used to decide CPU vs GPU per-call.
- Wire hot CPU linear-algebra wrappers in `src/linalg/faer_ndarray.rs` (`fast_ab`, `fast_av`, `fast_atv`, `fast_xt_diag_x`, `fast_xt_diag_y`, `fast_joint_hessian_2x2`) to consult `crate::gpu::linalg::should_dispatch_*` and attempt `try_fast_*` GPU paths while preserving exact CPU fallbacks when GPU implementations are not available.
- Add device-side abstractions: `DeviceBuffer`, `DeviceMatrix`, `MatrixLocation`/`MatrixLocationMut`, `DeviceCsrMatrix`, and a `GpuSolver` trait scaffold (placeholders returning CPU fallback results where appropriate).
- Provide CPU-reference small kernels and placeholders (`src/gpu/kernels.rs`) and a profiling facility (`src/gpu/profile.rs`) to record future kernel timings and validation comparisons.

### Testing
- Ran `cargo check` (no features) and it completed successfully.
- Ran `cargo check --features cuda` to validate the feature-gated dependency path and it completed successfully after adding the appropriate cudarc configuration.
- Ran the focused unit tests with `cargo test gpu:: --lib` and the added GPU-policy/device parsing tests passed (3 passed; 0 failed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a072f265c6c832491c55ed680f4de74)