### PR TITLE
Add GPU HAL skeleton behind `cuda` feature; cudarc gating, policy, and runtime placeholders

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,26 @@ resolver = "3"
 [lints.rust]
 warnings = "deny"
 
+
+[features]
+default = []
+cuda = [
+    "dep:cudarc",
+    "cudarc/driver",
+    "cudarc/runtime",
+    "cudarc/nvrtc",
+    "cudarc/cublas",
+    "cudarc/cublaslt",
+    "cudarc/cusparse",
+    "cudarc/cusolver",
+    "cudarc/cusolvermg",
+    "cudarc/curand",
+    "cudarc/nvtx",
+    "cudarc/cupti",
+    "cudarc/fallback-dynamic-loading",
+    "cudarc/cuda-12080",
+]
+
 [dependencies]
 clap = { version = "4.6.0", features = ["derive"] }
 comfy-table = "7.2.2"
@@ -66,6 +86,7 @@ arrow = { version = "54", default-features = false, features = ["ffi"] }
 parquet = { version = "54", default-features = false, features = ["arrow", "snap", "zstd", "lz4"] }
 wide = "0.7"
 smallvec = "1"
+cudarc = { version = "0.19.6", optional = true, default-features = false }
 
 [dependencies.general-mcmc]
 package = "general-mcmc"

--- a/src/gpu/blas.rs
+++ b/src/gpu/blas.rs
@@ -1,0 +1,7 @@
+//! Phase-specific GPU backend placeholder.
+//!
+//! The public marker keeps the HAL surface explicit while the default build and
+//! unsupported CUDA configurations use CPU fallback through dispatch policy.
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct BackendPhaseMarker;

--- a/src/gpu/cpu_traits.rs
+++ b/src/gpu/cpu_traits.rs
@@ -1,0 +1,60 @@
+use super::memory::{DeviceMatrix, DeviceVector};
+use ndarray::{Array1, Array2};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ExecutionTarget {
+    Cpu,
+    Gpu,
+    Auto,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum MatrixLocation {
+    Host,
+    Device,
+    Unified,
+}
+
+pub trait DeviceBlas {
+    fn gemv(&self, a: &DeviceMatrix, x: &DeviceVector) -> Result<DeviceVector, String>;
+    fn atv(&self, a: &DeviceMatrix, x: &DeviceVector) -> Result<DeviceVector, String>;
+    fn xt_diag_x_signed(&self, x: &DeviceMatrix, w: &DeviceVector) -> Result<DeviceMatrix, String>;
+    fn xt_diag_x_sqrt(
+        &self,
+        x: &DeviceMatrix,
+        sqrt_w: &DeviceVector,
+    ) -> Result<DeviceMatrix, String>;
+    fn xt_diag_y(
+        &self,
+        x: &DeviceMatrix,
+        w: &DeviceVector,
+        y: &DeviceMatrix,
+    ) -> Result<DeviceMatrix, String>;
+}
+
+pub trait DeviceSolver {
+    fn potrf(&self, a: &mut DeviceMatrix) -> Result<(), String>;
+    fn potrs(&self, factor: &DeviceMatrix, rhs: &DeviceMatrix) -> Result<DeviceMatrix, String>;
+    fn syevd(&self, a: &DeviceMatrix) -> Result<(DeviceVector, DeviceMatrix), String>;
+}
+
+pub trait DeviceDesignOperator {
+    fn rows(&self) -> usize;
+    fn cols(&self) -> usize;
+    fn materialize_chunk_into_device(
+        &self,
+        start: usize,
+        rows: usize,
+        out: &mut DeviceMatrix,
+    ) -> Result<(), String>;
+    fn apply_device(&self, x: &DeviceVector) -> Result<DeviceVector, String>;
+}
+
+pub struct CpuFallbackBlas;
+
+impl CpuFallbackBlas {
+    #[must_use]
+    pub fn gemv_host(a: &Array2<f64>, x: &Array1<f64>) -> Array1<f64> {
+        a.dot(x)
+    }
+}

--- a/src/gpu/device.rs
+++ b/src/gpu/device.rs
@@ -1,0 +1,66 @@
+use serde::{Deserialize, Serialize};
+
+/// Capability flags derived from CUDA device attributes.  Compute capability is
+/// only a hint; runtime probing fills the concrete memory and SM attributes.
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct GpuCapability {
+    pub compute_major: i32,
+    pub compute_minor: i32,
+    pub has_tensor_cores: bool,
+    pub has_fp64_tensor_cores: bool,
+    pub has_async_copy: bool,
+    pub cluster_launch: bool,
+    pub tma: bool,
+    pub min_warp_size: i32,
+}
+
+impl GpuCapability {
+    #[must_use]
+    pub fn from_compute_capability(major: i32, minor: i32) -> Self {
+        Self {
+            compute_major: major,
+            compute_minor: minor,
+            has_tensor_cores: major >= 7,
+            has_fp64_tensor_cores: major >= 8,
+            has_async_copy: major >= 8,
+            cluster_launch: major >= 9,
+            tma: major >= 9,
+            min_warp_size: 32,
+        }
+    }
+}
+
+/// Device information consumed by dispatch policy and profile logs.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub struct GpuDeviceInfo {
+    pub ordinal: usize,
+    pub name: String,
+    pub capability: GpuCapability,
+    pub sm_count: i32,
+    pub max_threads_per_sm: i32,
+    pub shared_mem_per_block: usize,
+    pub l2_cache_bytes: usize,
+    pub total_mem_bytes: usize,
+    pub free_mem_bytes: usize,
+    pub ecc_enabled: bool,
+    pub integrated: bool,
+    pub mig_mode: bool,
+}
+
+impl GpuDeviceInfo {
+    #[must_use]
+    pub fn score(&self) -> f64 {
+        let free_gib = self.free_mem_bytes as f64 / (1024.0 * 1024.0 * 1024.0);
+        let fp64_bonus = if self.capability.has_fp64_tensor_cores {
+            100.0
+        } else {
+            0.0
+        };
+        let async_bonus = if self.capability.has_async_copy {
+            50.0
+        } else {
+            0.0
+        };
+        f64::from(self.sm_count.max(0)) + free_gib * 4.0 + fp64_bonus + async_bonus
+    }
+}

--- a/src/gpu/graph.rs
+++ b/src/gpu/graph.rs
@@ -1,0 +1,7 @@
+//! Phase-specific GPU backend placeholder.
+//!
+//! The public marker keeps the HAL surface explicit while the default build and
+//! unsupported CUDA configurations use CPU fallback through dispatch policy.
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct BackendPhaseMarker;

--- a/src/gpu/kernels/cell_moments.rs
+++ b/src/gpu/kernels/cell_moments.rs
@@ -1,0 +1,7 @@
+//! Phase-specific GPU backend placeholder.
+//!
+//! The public marker keeps the HAL surface explicit while the default build and
+//! unsupported CUDA configurations use CPU fallback through dispatch policy.
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct BackendPhaseMarker;

--- a/src/gpu/kernels/fused_xtwx.rs
+++ b/src/gpu/kernels/fused_xtwx.rs
@@ -1,0 +1,7 @@
+//! Phase-specific GPU backend placeholder.
+//!
+//! The public marker keeps the HAL surface explicit while the default build and
+//! unsupported CUDA configurations use CPU fallback through dispatch policy.
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct BackendPhaseMarker;

--- a/src/gpu/kernels/hutchpp.rs
+++ b/src/gpu/kernels/hutchpp.rs
@@ -1,0 +1,7 @@
+//! Phase-specific GPU backend placeholder.
+//!
+//! The public marker keeps the HAL surface explicit while the default build and
+//! unsupported CUDA configurations use CPU fallback through dispatch policy.
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct BackendPhaseMarker;

--- a/src/gpu/kernels/irls_link.rs
+++ b/src/gpu/kernels/irls_link.rs
@@ -1,0 +1,7 @@
+//! Phase-specific GPU backend placeholder.
+//!
+//! The public marker keeps the HAL surface explicit while the default build and
+//! unsupported CUDA configurations use CPU fallback through dispatch policy.
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct BackendPhaseMarker;

--- a/src/gpu/kernels/mod.rs
+++ b/src/gpu/kernels/mod.rs
@@ -1,0 +1,7 @@
+//! Phase-specific GPU backend placeholder.
+//!
+//! The public marker keeps the HAL surface explicit while the default build and
+//! unsupported CUDA configurations use CPU fallback through dispatch policy.
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct BackendPhaseMarker;

--- a/src/gpu/kernels/reductions.rs
+++ b/src/gpu/kernels/reductions.rs
@@ -1,0 +1,7 @@
+//! Phase-specific GPU backend placeholder.
+//!
+//! The public marker keeps the HAL surface explicit while the default build and
+//! unsupported CUDA configurations use CPU fallback through dispatch policy.
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct BackendPhaseMarker;

--- a/src/gpu/kernels/row_scale.rs
+++ b/src/gpu/kernels/row_scale.rs
@@ -1,0 +1,7 @@
+//! Phase-specific GPU backend placeholder.
+//!
+//! The public marker keeps the HAL surface explicit while the default build and
+//! unsupported CUDA configurations use CPU fallback through dispatch policy.
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct BackendPhaseMarker;

--- a/src/gpu/kernels/spatial.rs
+++ b/src/gpu/kernels/spatial.rs
@@ -1,0 +1,7 @@
+//! Phase-specific GPU backend placeholder.
+//!
+//! The public marker keeps the HAL surface explicit while the default build and
+//! unsupported CUDA configurations use CPU fallback through dispatch policy.
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct BackendPhaseMarker;

--- a/src/gpu/memory.rs
+++ b/src/gpu/memory.rs
@@ -1,0 +1,83 @@
+use ndarray::{Array1, Array2};
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct DeviceBuffer {
+    pub len: usize,
+    pub bytes: usize,
+    pub backend: String,
+}
+
+impl DeviceBuffer {
+    #[must_use]
+    pub fn placeholder(len: usize, elem_bytes: usize) -> Self {
+        Self {
+            len,
+            bytes: len.saturating_mul(elem_bytes),
+            backend: "cpu-placeholder".to_string(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct DeviceMatrix {
+    pub rows: usize,
+    pub cols: usize,
+    pub buffer: DeviceBuffer,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct DeviceVector {
+    pub len: usize,
+    pub buffer: DeviceBuffer,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct DeviceCsrMatrix {
+    pub rows: usize,
+    pub cols: usize,
+    pub nnz: usize,
+    pub rowptr: DeviceBuffer,
+    pub colidx: DeviceBuffer,
+    pub values: DeviceBuffer,
+}
+
+impl DeviceMatrix {
+    #[must_use]
+    pub fn from_host_shape(host: &Array2<f64>) -> Self {
+        let (rows, cols) = host.dim();
+        Self {
+            rows,
+            cols,
+            buffer: DeviceBuffer::placeholder(rows.saturating_mul(cols), 8),
+        }
+    }
+}
+
+impl DeviceVector {
+    #[must_use]
+    pub fn from_host_shape(host: &Array1<f64>) -> Self {
+        Self {
+            len: host.len(),
+            buffer: DeviceBuffer::placeholder(host.len(), 8),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct GpuFitSession {
+    pub persistent_bytes: usize,
+    pub iteration_bytes: usize,
+    pub lm_attempt_bytes: usize,
+    pub dense_design: Option<DeviceMatrix>,
+    pub sparse_design: Option<DeviceCsrMatrix>,
+}
+
+impl GpuFitSession {
+    #[must_use]
+    pub fn total_bytes(&self) -> usize {
+        self.persistent_bytes
+            .saturating_add(self.iteration_bytes)
+            .saturating_add(self.lm_attempt_bytes)
+    }
+}

--- a/src/gpu/mod.rs
+++ b/src/gpu/mod.rs
@@ -1,0 +1,31 @@
+//! GPU acceleration HAL for `gam`.
+//!
+//! The module is intentionally backend-contained: solver and linalg code talk
+//! to the traits and policy types exported here, while cudarc-backed execution
+//! remains behind the `cuda` Cargo feature.  In the initial implementation all
+//! operations are routed through the CPU fallback unless a future backend marks
+//! the operation as supported by the active [`GpuRuntime`].
+
+pub mod blas;
+pub mod cpu_traits;
+pub mod device;
+pub mod graph;
+pub mod kernels;
+pub mod memory;
+pub mod policy;
+pub mod profile;
+pub mod rand;
+pub mod runtime;
+pub mod solver;
+pub mod sparse;
+pub mod stream;
+pub mod validate;
+
+pub use cpu_traits::{
+    DeviceBlas, DeviceDesignOperator, DeviceSolver, ExecutionTarget, MatrixLocation,
+};
+pub use device::{GpuCapability, GpuDeviceInfo};
+pub use memory::{DeviceBuffer, DeviceCsrMatrix, DeviceMatrix, DeviceVector, GpuFitSession};
+pub use policy::{GpuBackendDecision, GpuDispatchPolicy, GpuEnv, GpuOpKind};
+pub use profile::{GpuProfile, KernelStat, record_cpu_kernel};
+pub use runtime::{GpuRuntime, GpuRuntimeStatus};

--- a/src/gpu/policy.rs
+++ b/src/gpu/policy.rs
@@ -1,0 +1,183 @@
+use serde::{Deserialize, Serialize};
+use std::env;
+
+/// User-visible GPU environment policy. Defaults match `GAM_GPU=auto` with no
+/// validation, no forced graphs, and FP64 accepted-state numerics.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub struct GpuEnv {
+    pub mode: String,
+    pub device: Option<usize>,
+    pub mem_fraction: f64,
+    pub validate: String,
+    pub graphs: String,
+    pub mixed_precision: String,
+    pub profile: bool,
+    pub calibrate: String,
+    pub min_n_override: Option<usize>,
+    pub f32_operator_preconditioner: bool,
+    pub family_kernels: bool,
+}
+
+impl GpuEnv {
+    #[must_use]
+    pub fn from_env() -> Self {
+        Self {
+            mode: env::var("GAM_GPU").unwrap_or_else(|_| "auto".to_string()),
+            device: env::var("GAM_GPU_DEVICE").ok().and_then(|v| v.parse().ok()),
+            mem_fraction: env::var("GAM_GPU_MEM_FRACTION")
+                .ok()
+                .and_then(|v| v.parse().ok())
+                .unwrap_or(0.85),
+            validate: env::var("GAM_GPU_VALIDATE").unwrap_or_else(|_| "0".to_string()),
+            graphs: env::var("GAM_GPU_GRAPHS").unwrap_or_else(|_| "auto".to_string()),
+            mixed_precision: env::var("GAM_GPU_MIXED_PRECISION")
+                .unwrap_or_else(|_| "off".to_string()),
+            profile: env::var("GAM_GPU_PROFILE")
+                .map(|v| v == "1")
+                .unwrap_or(false),
+            calibrate: env::var("GAM_GPU_CALIBRATE").unwrap_or_else(|_| "auto".to_string()),
+            min_n_override: env::var("GAM_GPU_MIN_N").ok().and_then(|v| v.parse().ok()),
+            f32_operator_preconditioner: env::var("GAM_GPU_F32_OPERATOR_PRECONDITIONER")
+                .map(|v| v == "1")
+                .unwrap_or(false),
+            family_kernels: env::var("GAM_GPU_FAMILY_KERNELS")
+                .map(|v| v == "on" || v == "1")
+                .unwrap_or(false),
+        }
+    }
+
+    #[must_use]
+    pub fn disabled(&self) -> bool {
+        self.mode.eq_ignore_ascii_case("off")
+    }
+
+    #[must_use]
+    pub fn forced(&self) -> bool {
+        self.mode.eq_ignore_ascii_case("force")
+    }
+}
+
+/// Calibrated thresholds for every phase. Values are conservative CPU-fallback
+/// defaults and are overwritten by calibration when a real device is available.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub struct GpuDispatchPolicy {
+    pub xtwx_n_min: usize,
+    pub xtwx_flops_min: usize,
+    pub xtwx_use_fused_below_p: usize,
+    pub gemm_min_flops: usize,
+    pub potrf_min_p: usize,
+    pub syevd_min_p: usize,
+    pub sparse_min_nnz: usize,
+    pub fused_kernel_min_n: usize,
+    pub row_kernel_min_n: usize,
+    pub keep_design_resident_min_bytes: usize,
+    pub prefer_gpu_factorization_min_p: usize,
+    pub device_chunk_bytes: usize,
+}
+
+impl Default for GpuDispatchPolicy {
+    fn default() -> Self {
+        Self {
+            xtwx_n_min: 65_536,
+            xtwx_flops_min: 256 * 1024 * 1024,
+            xtwx_use_fused_below_p: 256,
+            gemm_min_flops: 128 * 1024 * 1024,
+            potrf_min_p: 512,
+            syevd_min_p: 512,
+            sparse_min_nnz: 2_000_000,
+            fused_kernel_min_n: 8_192,
+            row_kernel_min_n: 8_192,
+            keep_design_resident_min_bytes: 64 * 1024 * 1024,
+            prefer_gpu_factorization_min_p: 512,
+            device_chunk_bytes: 128 * 1024 * 1024,
+        }
+    }
+}
+
+/// Operation families covered by Phases 1--10.
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub enum GpuOpKind {
+    DenseGemv,
+    DenseAtv,
+    DenseGemm,
+    DenseXtDiagX,
+    DenseXtDiagY,
+    JointHessian2x2,
+    FusedLinkKernel,
+    PirlsResidentIteration,
+    LmCandidateScreen,
+    DenseCholesky,
+    DenseSymmetricEigen,
+    SparseXtWx,
+    SparseSpmm,
+    MatrixFreePcg,
+    SpatialKernelApply,
+    RemlDenseSpectralTrace,
+    HutchPlusPlusTrace,
+    ProjectedFactorTrace,
+    CustomFamilyRowKernel,
+    CudaGraphReplay,
+    MultiGpuRowShard,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub enum GpuBackendDecision {
+    Cpu { reason: String },
+    Gpu { reason: String },
+}
+
+impl GpuDispatchPolicy {
+    #[must_use]
+    pub fn decide(
+        &self,
+        op: GpuOpKind,
+        n: usize,
+        p: usize,
+        k: usize,
+        nnz: usize,
+        device_resident: bool,
+        runtime_available: bool,
+    ) -> GpuBackendDecision {
+        if !runtime_available {
+            return GpuBackendDecision::Cpu {
+                reason: "CUDA runtime unavailable".to_string(),
+            };
+        }
+        let flops = n.saturating_mul(p.max(1)).saturating_mul(k.max(1));
+        let use_gpu = match op {
+            GpuOpKind::DenseGemv | GpuOpKind::DenseAtv | GpuOpKind::DenseGemm => {
+                device_resident || flops >= self.gemm_min_flops
+            }
+            GpuOpKind::DenseXtDiagX | GpuOpKind::DenseXtDiagY | GpuOpKind::JointHessian2x2 => {
+                device_resident
+                    || (n >= self.xtwx_n_min
+                        && n.saturating_mul(p).saturating_mul(p) >= self.xtwx_flops_min)
+            }
+            GpuOpKind::DenseCholesky => device_resident && p >= self.potrf_min_p,
+            GpuOpKind::DenseSymmetricEigen => device_resident && p >= self.syevd_min_p,
+            GpuOpKind::SparseXtWx | GpuOpKind::SparseSpmm => nnz >= self.sparse_min_nnz,
+            GpuOpKind::MatrixFreePcg => device_resident && p >= 2048,
+            GpuOpKind::FusedLinkKernel
+            | GpuOpKind::PirlsResidentIteration
+            | GpuOpKind::LmCandidateScreen => n >= self.fused_kernel_min_n,
+            GpuOpKind::SpatialKernelApply => {
+                device_resident || n.saturating_mul(p) >= self.keep_design_resident_min_bytes / 8
+            }
+            GpuOpKind::RemlDenseSpectralTrace => device_resident,
+            GpuOpKind::HutchPlusPlusTrace => p >= 128 && k >= 4,
+            GpuOpKind::ProjectedFactorTrace => device_resident || flops >= self.gemm_min_flops,
+            GpuOpKind::CustomFamilyRowKernel => n >= self.row_kernel_min_n,
+            GpuOpKind::CudaGraphReplay => device_resident,
+            GpuOpKind::MultiGpuRowShard => false,
+        };
+        if use_gpu {
+            GpuBackendDecision::Gpu {
+                reason: format!("policy selected GPU for {op:?}"),
+            }
+        } else {
+            GpuBackendDecision::Cpu {
+                reason: format!("policy kept {op:?} on CPU"),
+            }
+        }
+    }
+}

--- a/src/gpu/profile.rs
+++ b/src/gpu/profile.rs
@@ -1,0 +1,80 @@
+use serde::{Deserialize, Serialize};
+use std::collections::VecDeque;
+use std::sync::{Mutex, OnceLock};
+use std::time::Instant;
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq)]
+pub struct KernelStat {
+    pub name: &'static str,
+    pub n: usize,
+    pub p: usize,
+    pub k: usize,
+    pub nnz: usize,
+    pub flops_est: usize,
+    pub bytes_est: usize,
+    pub cpu_ms: f64,
+    pub gpu_ms: Option<f64>,
+    pub backend: &'static str,
+}
+
+#[derive(Debug)]
+pub struct GpuProfile {
+    capacity: usize,
+    stats: Mutex<VecDeque<KernelStat>>,
+}
+
+impl GpuProfile {
+    #[must_use]
+    pub fn global() -> &'static Self {
+        static PROFILE: OnceLock<GpuProfile> = OnceLock::new();
+        PROFILE.get_or_init(|| GpuProfile {
+            capacity: 512,
+            stats: Mutex::new(VecDeque::with_capacity(512)),
+        })
+    }
+
+    pub fn push(&self, stat: KernelStat) {
+        if let Ok(mut stats) = self.stats.lock() {
+            if stats.len() == self.capacity {
+                stats.pop_front();
+            }
+            stats.push_back(stat);
+        }
+    }
+
+    #[must_use]
+    pub fn snapshot(&self) -> Vec<KernelStat> {
+        self.stats
+            .lock()
+            .map(|stats| stats.iter().cloned().collect())
+            .unwrap_or_default()
+    }
+}
+
+pub fn record_cpu_kernel<R, F: FnOnce() -> R>(
+    name: &'static str,
+    n: usize,
+    p: usize,
+    k: usize,
+    nnz: usize,
+    f: F,
+) -> R {
+    let start = Instant::now();
+    let out = f();
+    let cpu_ms = start.elapsed().as_secs_f64() * 1000.0;
+    let flops_est = n.saturating_mul(p.max(1)).saturating_mul(k.max(1));
+    let bytes_est = n.saturating_mul(p.max(1)).saturating_mul(8);
+    GpuProfile::global().push(KernelStat {
+        name,
+        n,
+        p,
+        k,
+        nnz,
+        flops_est,
+        bytes_est,
+        cpu_ms,
+        gpu_ms: None,
+        backend: "cpu",
+    });
+    out
+}

--- a/src/gpu/rand.rs
+++ b/src/gpu/rand.rs
@@ -1,0 +1,7 @@
+//! Phase-specific GPU backend placeholder.
+//!
+//! The public marker keeps the HAL surface explicit while the default build and
+//! unsupported CUDA configurations use CPU fallback through dispatch policy.
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct BackendPhaseMarker;

--- a/src/gpu/runtime.rs
+++ b/src/gpu/runtime.rs
@@ -1,0 +1,99 @@
+use super::device::GpuDeviceInfo;
+use super::policy::{GpuDispatchPolicy, GpuEnv};
+use serde::{Deserialize, Serialize};
+use std::sync::OnceLock;
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub enum GpuRuntimeStatus {
+    DisabledByEnv,
+    Unavailable { reason: String },
+    Available { device: GpuDeviceInfo },
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub struct GpuRuntime {
+    pub env: GpuEnv,
+    pub status: GpuRuntimeStatus,
+    pub policy: GpuDispatchPolicy,
+    pub resident_budget_bytes: usize,
+}
+
+impl GpuRuntime {
+    #[must_use]
+    pub fn probe() -> Option<Self> {
+        let env = GpuEnv::from_env();
+        if env.disabled() {
+            log::debug!("[GPU] disabled by GAM_GPU=off");
+            return None;
+        }
+        match Self::try_probe(&env) {
+            Some(runtime) => Some(runtime),
+            None => {
+                if env.forced() {
+                    log::warn!("[GPU] GAM_GPU=force requested but no CUDA device was detected");
+                } else {
+                    log::debug!("[GPU] CUDA unavailable; using CPU fallback");
+                }
+                None
+            }
+        }
+    }
+
+    #[must_use]
+    pub fn global() -> Option<&'static Self> {
+        static RUNTIME: OnceLock<Option<GpuRuntime>> = OnceLock::new();
+        RUNTIME.get_or_init(Self::probe).as_ref()
+    }
+
+    #[must_use]
+    pub fn is_available(&self) -> bool {
+        matches!(self.status, GpuRuntimeStatus::Available { .. })
+    }
+
+    #[cfg(feature = "cuda")]
+    fn try_probe(env: &GpuEnv) -> Option<Self> {
+        let _cudarc_context_type = core::any::type_name::<cudarc::driver::CudaContext>();
+        let ordinal = env.device.unwrap_or(0);
+        match cudarc::driver::CudaContext::new(ordinal) {
+            Ok(_ctx) => {
+                // Safe cudarc context creation proved dynamic loading and device access.
+                // Keep detailed attribute enumeration isolated for the real backend; these
+                // conservative placeholders still make policy/logging deterministic.
+                let total = 0usize;
+                let free = 0usize;
+                let info = GpuDeviceInfo {
+                    ordinal,
+                    name: format!("CUDA device {ordinal}"),
+                    capability: super::device::GpuCapability::from_compute_capability(0, 0),
+                    sm_count: 0,
+                    max_threads_per_sm: 0,
+                    shared_mem_per_block: 0,
+                    l2_cache_bytes: 0,
+                    total_mem_bytes: total,
+                    free_mem_bytes: free,
+                    ecc_enabled: false,
+                    integrated: false,
+                    mig_mode: false,
+                };
+                let budget = ((free as f64) * env.mem_fraction).max(0.0) as usize;
+                log::info!("[GPU] CUDA runtime available on {}", info.name);
+                Some(Self {
+                    env: env.clone(),
+                    status: GpuRuntimeStatus::Available { device: info },
+                    policy: GpuDispatchPolicy::default(),
+                    resident_budget_bytes: budget,
+                })
+            }
+            Err(err) => {
+                log::debug!("[GPU] cudarc probe failed: {err:?}");
+                None
+            }
+        }
+    }
+
+    #[cfg(not(feature = "cuda"))]
+    fn try_probe(env: &GpuEnv) -> Option<Self> {
+        let _ = env;
+        None
+    }
+}

--- a/src/gpu/solver.rs
+++ b/src/gpu/solver.rs
@@ -1,0 +1,7 @@
+//! Phase-specific GPU backend placeholder.
+//!
+//! The public marker keeps the HAL surface explicit while the default build and
+//! unsupported CUDA configurations use CPU fallback through dispatch policy.
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct BackendPhaseMarker;

--- a/src/gpu/sparse.rs
+++ b/src/gpu/sparse.rs
@@ -1,0 +1,7 @@
+//! Phase-specific GPU backend placeholder.
+//!
+//! The public marker keeps the HAL surface explicit while the default build and
+//! unsupported CUDA configurations use CPU fallback through dispatch policy.
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct BackendPhaseMarker;

--- a/src/gpu/stream.rs
+++ b/src/gpu/stream.rs
@@ -1,0 +1,7 @@
+//! Phase-specific GPU backend placeholder.
+//!
+//! The public marker keeps the HAL surface explicit while the default build and
+//! unsupported CUDA configurations use CPU fallback through dispatch policy.
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct BackendPhaseMarker;

--- a/src/gpu/validate.rs
+++ b/src/gpu/validate.rs
@@ -1,0 +1,7 @@
+//! Phase-specific GPU backend placeholder.
+//!
+//! The public marker keeps the HAL surface explicit while the default build and
+//! unsupported CUDA configurations use CPU fallback through dispatch policy.
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct BackendPhaseMarker;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,7 @@ pub fn init_parallelism() {
 }
 
 pub mod families;
+pub mod gpu;
 pub mod inference;
 pub mod linalg;
 pub mod report;


### PR DESCRIPTION
### Motivation
- Introduce a scoped GPU acceleration HAL so solver and linalg call sites can dispatch to device implementations without leaking cudarc types across the codebase. 
- Gate all CUDA-related code behind a new Cargo feature so CPU-only builds remain unchanged and dynamic loading can be used on systems without an NVIDIA driver. 
- Provide a lightweight policy/runtime/profile/memory surface to support phased Phase-0..Phase-10 development (instrumentation, dispatch, calibration, and later kernels).

### Description
- Add a new `src/gpu/` module tree with core HAL files and placeholders: `mod.rs`, `runtime.rs`, `device.rs`, `memory.rs`, `policy.rs`, `profile.rs`, `cpu_traits.rs`, and phase placeholder modules under `kernels/`, `blas`, `solver`, `sparse`, `stream`, `graph`, `rand`, `validate`, `profile` etc.; plus `Device*` types and `GpuFitSession` to represent device residency (persistent/iteration/lm workspaces).
- Wire a `GpuEnv` and `GpuDispatchPolicy` with conservative defaults and a `GpuRuntime::probe()` entry point to control availability and selection; add `GpuOpKind` and `GpuBackendDecision` for per-op dispatch decisions.
- Introduce CPU-fallback trait surfaces `DeviceBlas`, `DeviceSolver`, and `DeviceDesignOperator` in `src/gpu/cpu_traits.rs` so existing `fast_*` wrappers can be routed through the HAL without immediate GPU implementations.
- Update `Cargo.toml` to add a `cuda` feature that optionally depends on `cudarc` (added as optional dep) and enable the selected cudarc CUDA feature (`cudarc/cuda-12080`) for build-time compatibility with dynamic loading.
- Export `pub mod gpu;` from `src/lib.rs` so the HAL is visible to the codebase while keeping all real cudarc usage behind the `cuda` Cargo feature.

### Testing
- Built and type-checked with `cargo check` and `cargo check --features cuda`; an initial build panic from `cudarc`'s build script (missing CUDA-version feature) was fixed by enabling `cudarc/cuda-12080` in the `cuda` feature set, after which checks passed. 
- Ran the library unit tests with CUDA feature enabled via `cargo test --lib --features cuda`; the repo's test harness executed the comprehensive unit suite (thousands of tests) and the run completed after resolving the build-time configuration issue (no GPU kernel execution was performed because the HAL is a placeholder and runtime probing is guarded). 
- Verified that `cargo fmt` / `cargo check` succeed in both default and `cuda`-feature modes and that the new code compiles cleanly with the CPU fallback path active.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0739b4b2b883249ef1e84407e5e7ad)