### PR TITLE
Add GPU acceleration HAL skeleton

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,10 @@ resolver = "3"
 [lints.rust]
 warnings = "deny"
 
+[features]
+default = []
+cuda = ["dep:cudarc"]
+
 [dependencies]
 clap = { version = "4.6.0", features = ["derive"] }
 comfy-table = "7.2.2"
@@ -66,6 +70,7 @@ arrow = { version = "54", default-features = false, features = ["ffi"] }
 parquet = { version = "54", default-features = false, features = ["arrow", "snap", "zstd", "lz4"] }
 wide = "0.7"
 smallvec = "1"
+cudarc = { version = "0.19.6", optional = true, default-features = false, features = ["std", "driver", "runtime", "nvrtc", "cublas", "cublaslt", "cusparse", "cusolver", "cusolvermg", "curand", "nvtx", "cupti", "fallback-dynamic-loading", "cuda-12080"] }
 
 [dependencies.general-mcmc]
 package = "general-mcmc"

--- a/src/gpu/blas.rs
+++ b/src/gpu/blas.rs
@@ -1,0 +1,16 @@
+//! Placeholder module for the CUDA backend phase described in the GPU HAL.
+//!
+//! The public HAL is present so solver call sites can be routed without CUDA
+//! types. Concrete cudarc kernels are intentionally isolated here in follow-up
+//! implementations and unavailable backends fall back to CPU numerics.
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum BackendStatus {
+    CpuFallback,
+    CudaUnavailable,
+    CudaReady,
+}
+
+pub fn backend_status() -> BackendStatus {
+    BackendStatus::CpuFallback
+}

--- a/src/gpu/cpu_traits.rs
+++ b/src/gpu/cpu_traits.rs
@@ -1,0 +1,79 @@
+use ndarray::{Array1, Array2, ArrayViewMut1};
+
+use super::memory::{DeviceCsrMatrix, DeviceMatrix, DeviceVector};
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ExecutionTarget {
+    Cpu,
+    Gpu,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum MatrixLocation {
+    Host,
+    Device,
+    Unified,
+}
+
+pub trait DeviceBlas {
+    fn gemv(&self, a: &DeviceMatrix, x: &DeviceVector) -> Result<DeviceVector, String>;
+    fn gemv_into(
+        &self,
+        a: &DeviceMatrix,
+        x: &DeviceVector,
+        out: &mut DeviceVector,
+    ) -> Result<(), String>;
+    fn gemm(&self, a: &DeviceMatrix, b: &DeviceMatrix) -> Result<DeviceMatrix, String>;
+    fn xt_v(&self, x: &DeviceMatrix, v: &DeviceVector) -> Result<DeviceVector, String>;
+    fn xt_diag_x_signed(&self, x: &DeviceMatrix, w: &DeviceVector) -> Result<DeviceMatrix, String>;
+    fn xt_diag_x_from_sqrt(
+        &self,
+        x: &DeviceMatrix,
+        sqrt_w: &DeviceVector,
+    ) -> Result<DeviceMatrix, String>;
+    fn xt_diag_y_signed(
+        &self,
+        x: &DeviceMatrix,
+        w: &DeviceVector,
+        y: &DeviceMatrix,
+    ) -> Result<DeviceMatrix, String>;
+    fn row_scale_signed(&self, x: &DeviceMatrix, w: &DeviceVector) -> Result<DeviceMatrix, String>;
+    fn axpy(&self, alpha: f64, x: &DeviceVector, y: &mut DeviceVector) -> Result<(), String>;
+    fn dot(&self, x: &DeviceVector, y: &DeviceVector) -> Result<f64, String>;
+    fn l2norm(&self, x: &DeviceVector) -> Result<f64, String>;
+    fn scale(&self, alpha: f64, x: &mut DeviceVector) -> Result<(), String>;
+}
+
+pub trait DeviceSolver {
+    fn potrf(&self, a: &mut DeviceMatrix) -> Result<(), String>;
+    fn potrs(&self, factor: &DeviceMatrix, rhs: &mut DeviceMatrix) -> Result<(), String>;
+    fn syevd(&self, a: &mut DeviceMatrix) -> Result<DeviceVector, String>;
+    fn getrf(&self, a: &mut DeviceMatrix) -> Result<DeviceVector, String>;
+    fn getrs(
+        &self,
+        factor: &DeviceMatrix,
+        pivots: &DeviceVector,
+        rhs: &mut DeviceMatrix,
+    ) -> Result<(), String>;
+}
+
+pub trait DeviceDesignOperator {
+    fn rows(&self) -> usize;
+    fn cols(&self) -> usize;
+    fn location(&self) -> MatrixLocation;
+    fn materialize_chunk_into_device(
+        &self,
+        start: usize,
+        end: usize,
+        out: &mut DeviceMatrix,
+    ) -> Result<(), String>;
+    fn apply_device(&self, x: &DeviceVector) -> Result<DeviceVector, String>;
+    fn apply_transpose_device(&self, x: &DeviceVector) -> Result<DeviceVector, String>;
+    fn as_dense_device(&self) -> Option<&DeviceMatrix>;
+    fn as_csr_device(&self) -> Option<&DeviceCsrMatrix>;
+}
+
+pub trait HostDesignOperatorBridge {
+    fn apply_host_into(&self, x: &Array1<f64>, out: ArrayViewMut1<'_, f64>);
+    fn materialize_host(&self) -> Option<Array2<f64>>;
+}

--- a/src/gpu/device.rs
+++ b/src/gpu/device.rs
@@ -1,0 +1,61 @@
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct GpuCapability {
+    pub compute_major: i32,
+    pub compute_minor: i32,
+    pub has_tensor_cores: bool,
+    pub has_fp64_tensor_cores: bool,
+    pub has_async_copy: bool,
+    pub has_cluster_launch: bool,
+    pub has_tma: bool,
+    pub min_warp_size: i32,
+}
+
+impl GpuCapability {
+    pub fn from_compute_capability(major: i32, minor: i32) -> Self {
+        Self {
+            compute_major: major,
+            compute_minor: minor,
+            has_tensor_cores: major >= 7,
+            has_fp64_tensor_cores: major >= 8,
+            has_async_copy: major >= 8,
+            has_cluster_launch: major >= 9,
+            has_tma: major >= 9,
+            min_warp_size: 32,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct GpuDeviceInfo {
+    pub ordinal: usize,
+    pub name: String,
+    pub capability: GpuCapability,
+    pub sm_count: i32,
+    pub max_threads_per_sm: i32,
+    pub max_shared_mem_per_block: usize,
+    pub l2_cache_bytes: usize,
+    pub total_mem_bytes: usize,
+    pub free_mem_bytes: usize,
+    pub ecc_enabled: bool,
+    pub integrated: bool,
+    pub mig_mode: bool,
+}
+
+impl GpuDeviceInfo {
+    pub fn score(&self) -> f64 {
+        let fp64_bonus = if self.capability.has_fp64_tensor_cores {
+            100.0
+        } else {
+            0.0
+        };
+        let async_bonus = if self.capability.has_async_copy {
+            50.0
+        } else {
+            0.0
+        };
+        f64::from(self.sm_count)
+            + (self.free_mem_bytes as f64 / 1_073_741_824.0) * 4.0
+            + fp64_bonus
+            + async_bonus
+    }
+}

--- a/src/gpu/graph.rs
+++ b/src/gpu/graph.rs
@@ -1,0 +1,16 @@
+//! Placeholder module for the CUDA backend phase described in the GPU HAL.
+//!
+//! The public HAL is present so solver call sites can be routed without CUDA
+//! types. Concrete cudarc kernels are intentionally isolated here in follow-up
+//! implementations and unavailable backends fall back to CPU numerics.
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum BackendStatus {
+    CpuFallback,
+    CudaUnavailable,
+    CudaReady,
+}
+
+pub fn backend_status() -> BackendStatus {
+    BackendStatus::CpuFallback
+}

--- a/src/gpu/kernels/cell_moments.rs
+++ b/src/gpu/kernels/cell_moments.rs
@@ -1,0 +1,16 @@
+//! Placeholder module for the CUDA backend phase described in the GPU HAL.
+//!
+//! The public HAL is present so solver call sites can be routed without CUDA
+//! types. Concrete cudarc kernels are intentionally isolated here in follow-up
+//! implementations and unavailable backends fall back to CPU numerics.
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum BackendStatus {
+    CpuFallback,
+    CudaUnavailable,
+    CudaReady,
+}
+
+pub fn backend_status() -> BackendStatus {
+    BackendStatus::CpuFallback
+}

--- a/src/gpu/kernels/fused_xtwx.rs
+++ b/src/gpu/kernels/fused_xtwx.rs
@@ -1,0 +1,16 @@
+//! Placeholder module for the CUDA backend phase described in the GPU HAL.
+//!
+//! The public HAL is present so solver call sites can be routed without CUDA
+//! types. Concrete cudarc kernels are intentionally isolated here in follow-up
+//! implementations and unavailable backends fall back to CPU numerics.
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum BackendStatus {
+    CpuFallback,
+    CudaUnavailable,
+    CudaReady,
+}
+
+pub fn backend_status() -> BackendStatus {
+    BackendStatus::CpuFallback
+}

--- a/src/gpu/kernels/hutchpp.rs
+++ b/src/gpu/kernels/hutchpp.rs
@@ -1,0 +1,16 @@
+//! Placeholder module for the CUDA backend phase described in the GPU HAL.
+//!
+//! The public HAL is present so solver call sites can be routed without CUDA
+//! types. Concrete cudarc kernels are intentionally isolated here in follow-up
+//! implementations and unavailable backends fall back to CPU numerics.
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum BackendStatus {
+    CpuFallback,
+    CudaUnavailable,
+    CudaReady,
+}
+
+pub fn backend_status() -> BackendStatus {
+    BackendStatus::CpuFallback
+}

--- a/src/gpu/kernels/irls_link.rs
+++ b/src/gpu/kernels/irls_link.rs
@@ -1,0 +1,16 @@
+//! Placeholder module for the CUDA backend phase described in the GPU HAL.
+//!
+//! The public HAL is present so solver call sites can be routed without CUDA
+//! types. Concrete cudarc kernels are intentionally isolated here in follow-up
+//! implementations and unavailable backends fall back to CPU numerics.
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum BackendStatus {
+    CpuFallback,
+    CudaUnavailable,
+    CudaReady,
+}
+
+pub fn backend_status() -> BackendStatus {
+    BackendStatus::CpuFallback
+}

--- a/src/gpu/kernels/reductions.rs
+++ b/src/gpu/kernels/reductions.rs
@@ -1,0 +1,16 @@
+//! Placeholder module for the CUDA backend phase described in the GPU HAL.
+//!
+//! The public HAL is present so solver call sites can be routed without CUDA
+//! types. Concrete cudarc kernels are intentionally isolated here in follow-up
+//! implementations and unavailable backends fall back to CPU numerics.
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum BackendStatus {
+    CpuFallback,
+    CudaUnavailable,
+    CudaReady,
+}
+
+pub fn backend_status() -> BackendStatus {
+    BackendStatus::CpuFallback
+}

--- a/src/gpu/kernels/row_scale.rs
+++ b/src/gpu/kernels/row_scale.rs
@@ -1,0 +1,16 @@
+//! Placeholder module for the CUDA backend phase described in the GPU HAL.
+//!
+//! The public HAL is present so solver call sites can be routed without CUDA
+//! types. Concrete cudarc kernels are intentionally isolated here in follow-up
+//! implementations and unavailable backends fall back to CPU numerics.
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum BackendStatus {
+    CpuFallback,
+    CudaUnavailable,
+    CudaReady,
+}
+
+pub fn backend_status() -> BackendStatus {
+    BackendStatus::CpuFallback
+}

--- a/src/gpu/kernels/spatial.rs
+++ b/src/gpu/kernels/spatial.rs
@@ -1,0 +1,16 @@
+//! Placeholder module for the CUDA backend phase described in the GPU HAL.
+//!
+//! The public HAL is present so solver call sites can be routed without CUDA
+//! types. Concrete cudarc kernels are intentionally isolated here in follow-up
+//! implementations and unavailable backends fall back to CPU numerics.
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum BackendStatus {
+    CpuFallback,
+    CudaUnavailable,
+    CudaReady,
+}
+
+pub fn backend_status() -> BackendStatus {
+    BackendStatus::CpuFallback
+}

--- a/src/gpu/memory.rs
+++ b/src/gpu/memory.rs
@@ -1,0 +1,89 @@
+use ndarray::{Array1, Array2};
+
+use super::cpu_traits::MatrixLocation;
+
+#[derive(Clone, Debug)]
+pub struct DeviceBuffer<T> {
+    host_shadow: Vec<T>,
+    location: MatrixLocation,
+}
+
+impl<T> DeviceBuffer<T> {
+    pub fn from_host_shadow(host_shadow: Vec<T>) -> Self {
+        Self {
+            host_shadow,
+            location: MatrixLocation::Host,
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        self.host_shadow.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.host_shadow.is_empty()
+    }
+
+    pub fn location(&self) -> MatrixLocation {
+        self.location
+    }
+
+    pub fn host_shadow(&self) -> &[T] {
+        &self.host_shadow
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct DeviceVector {
+    pub len: usize,
+    pub data: DeviceBuffer<f64>,
+}
+
+impl DeviceVector {
+    pub fn from_array(array: &Array1<f64>) -> Self {
+        Self {
+            len: array.len(),
+            data: DeviceBuffer::from_host_shadow(array.to_vec()),
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct DeviceMatrix {
+    pub rows: usize,
+    pub cols: usize,
+    pub data: DeviceBuffer<f64>,
+    pub column_major: bool,
+}
+
+impl DeviceMatrix {
+    pub fn from_array(array: &Array2<f64>) -> Self {
+        Self {
+            rows: array.nrows(),
+            cols: array.ncols(),
+            data: DeviceBuffer::from_host_shadow(array.iter().copied().collect()),
+            column_major: false,
+        }
+    }
+
+    pub fn bytes(&self) -> usize {
+        self.rows
+            .saturating_mul(self.cols)
+            .saturating_mul(std::mem::size_of::<f64>())
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct DeviceCsrMatrix {
+    pub rows: usize,
+    pub cols: usize,
+    pub rowptr: DeviceBuffer<i32>,
+    pub colidx: DeviceBuffer<i32>,
+    pub values: DeviceBuffer<f64>,
+}
+
+impl DeviceCsrMatrix {
+    pub fn nnz(&self) -> usize {
+        self.values.len()
+    }
+}

--- a/src/gpu/mod.rs
+++ b/src/gpu/mod.rs
@@ -1,0 +1,39 @@
+//! GPU acceleration hardware-abstraction layer.
+//!
+//! The module is intentionally callable from CPU-only builds: all public entry
+//! points are available without CUDA, and the runtime reports an unavailable
+//! backend instead of changing numerical results.  CUDA-specific code is kept
+//! behind the `cuda` Cargo feature and does not leak into solver modules.
+
+pub mod blas;
+pub mod cpu_traits;
+pub mod device;
+pub mod graph;
+pub mod memory;
+pub mod policy;
+pub mod profile;
+pub mod rand;
+pub mod runtime;
+pub mod solver;
+pub mod sparse;
+pub mod stream;
+pub mod validate;
+
+pub mod kernels {
+    pub mod cell_moments;
+    pub mod fused_xtwx;
+    pub mod hutchpp;
+    pub mod irls_link;
+    pub mod reductions;
+    pub mod row_scale;
+    pub mod spatial;
+}
+
+pub use cpu_traits::{
+    DeviceBlas, DeviceDesignOperator, DeviceSolver, ExecutionTarget, MatrixLocation,
+};
+pub use device::{GpuCapability, GpuDeviceInfo};
+pub use memory::{DeviceBuffer, DeviceCsrMatrix, DeviceMatrix, DeviceVector};
+pub use policy::{GpuDispatchPolicy, MixedPrecisionPolicy};
+pub use profile::{KernelStat, KernelStatsSnapshot};
+pub use runtime::{GpuProbeError, GpuRuntime};

--- a/src/gpu/policy.rs
+++ b/src/gpu/policy.rs
@@ -1,0 +1,57 @@
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum MixedPrecisionPolicy {
+    Off,
+    Screening,
+    Never,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct GpuDispatchPolicy {
+    pub xtwx_n_min: usize,
+    pub xtwx_flops_min: usize,
+    pub xtwx_use_fused_below_p: usize,
+    pub gemm_min_flops: usize,
+    pub potrf_min_p: usize,
+    pub syevd_min_p: usize,
+    pub sparse_min_nnz: usize,
+    pub fused_kernel_min_n: usize,
+    pub keep_design_resident_min_bytes: usize,
+    pub prefer_gpu_factorization_min_p: usize,
+    pub row_kernel_min_n: usize,
+    pub mixed_precision: MixedPrecisionPolicy,
+}
+
+impl Default for GpuDispatchPolicy {
+    fn default() -> Self {
+        Self {
+            xtwx_n_min: 8_192,
+            xtwx_flops_min: 64 * 1024 * 1024,
+            xtwx_use_fused_below_p: 256,
+            gemm_min_flops: 32 * 1024 * 1024,
+            potrf_min_p: 512,
+            syevd_min_p: 256,
+            sparse_min_nnz: 1_000_000,
+            fused_kernel_min_n: 8_192,
+            keep_design_resident_min_bytes: 32 * 1024 * 1024,
+            prefer_gpu_factorization_min_p: 512,
+            row_kernel_min_n: 8_192,
+            mixed_precision: MixedPrecisionPolicy::Off,
+        }
+    }
+}
+
+impl GpuDispatchPolicy {
+    pub fn dense_gemv_target_is_gpu(&self, n: usize, p: usize, resident: bool) -> bool {
+        resident || n.saturating_mul(p).saturating_mul(2) >= self.gemm_min_flops
+    }
+
+    pub fn xtwx_target_is_gpu(&self, n: usize, p: usize, materialized: bool) -> bool {
+        materialized
+            && n >= self.xtwx_n_min
+            && n.saturating_mul(p).saturating_mul(p).saturating_mul(2) >= self.xtwx_flops_min
+    }
+
+    pub fn potrf_target_is_gpu(&self, p: usize, h_resident: bool) -> bool {
+        h_resident && p >= self.potrf_min_p
+    }
+}

--- a/src/gpu/profile.rs
+++ b/src/gpu/profile.rs
@@ -1,0 +1,79 @@
+use std::collections::VecDeque;
+use std::sync::{Mutex, OnceLock};
+use std::time::Instant;
+
+const MAX_STATS: usize = 1024;
+
+#[derive(Clone, Debug, Default)]
+pub struct KernelStat {
+    pub name: &'static str,
+    pub n: usize,
+    pub p: usize,
+    pub k: usize,
+    pub nnz: usize,
+    pub flops_est: usize,
+    pub bytes_est: usize,
+    pub cpu_ms: f64,
+    pub gpu_ms: Option<f64>,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct KernelStatsSnapshot {
+    pub stats: Vec<KernelStat>,
+}
+
+static STATS: OnceLock<Mutex<VecDeque<KernelStat>>> = OnceLock::new();
+
+fn stats() -> &'static Mutex<VecDeque<KernelStat>> {
+    STATS.get_or_init(|| Mutex::new(VecDeque::with_capacity(MAX_STATS)))
+}
+
+pub fn record(stat: KernelStat) {
+    if let Ok(mut guard) = stats().lock() {
+        if guard.len() == MAX_STATS {
+            guard.pop_front();
+        }
+        guard.push_back(stat);
+    }
+}
+
+pub fn snapshot() -> KernelStatsSnapshot {
+    if let Ok(guard) = stats().lock() {
+        KernelStatsSnapshot {
+            stats: guard.iter().cloned().collect(),
+        }
+    } else {
+        KernelStatsSnapshot::default()
+    }
+}
+
+pub fn clear() {
+    if let Ok(mut guard) = stats().lock() {
+        guard.clear();
+    }
+}
+
+pub fn cpu_scope<R>(
+    name: &'static str,
+    n: usize,
+    p: usize,
+    k: usize,
+    bytes_est: usize,
+    op: impl FnOnce() -> R,
+) -> R {
+    let start = Instant::now();
+    let out = op();
+    let cpu_ms = start.elapsed().as_secs_f64() * 1_000.0;
+    record(KernelStat {
+        name,
+        n,
+        p,
+        k,
+        nnz: 0,
+        flops_est: n.saturating_mul(p).saturating_mul(k).saturating_mul(2),
+        bytes_est,
+        cpu_ms,
+        gpu_ms: None,
+    });
+    out
+}

--- a/src/gpu/rand.rs
+++ b/src/gpu/rand.rs
@@ -1,0 +1,16 @@
+//! Placeholder module for the CUDA backend phase described in the GPU HAL.
+//!
+//! The public HAL is present so solver call sites can be routed without CUDA
+//! types. Concrete cudarc kernels are intentionally isolated here in follow-up
+//! implementations and unavailable backends fall back to CPU numerics.
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum BackendStatus {
+    CpuFallback,
+    CudaUnavailable,
+    CudaReady,
+}
+
+pub fn backend_status() -> BackendStatus {
+    BackendStatus::CpuFallback
+}

--- a/src/gpu/runtime.rs
+++ b/src/gpu/runtime.rs
@@ -1,0 +1,43 @@
+use std::sync::OnceLock;
+
+use super::device::GpuDeviceInfo;
+use super::policy::GpuDispatchPolicy;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum GpuProbeError {
+    CudaFeatureDisabled,
+    DynamicLoaderUnavailable,
+    NoDevice,
+    Driver(String),
+}
+
+#[derive(Clone, Debug)]
+pub struct GpuRuntime {
+    pub device: GpuDeviceInfo,
+    pub policy: GpuDispatchPolicy,
+    pub memory_budget_bytes: usize,
+}
+
+impl GpuRuntime {
+    pub fn probe() -> Result<Option<Self>, GpuProbeError> {
+        #[cfg(feature = "cuda")]
+        {
+            Ok(None)
+        }
+        #[cfg(not(feature = "cuda"))]
+        {
+            Ok(None)
+        }
+    }
+
+    pub fn global() -> Option<&'static Self> {
+        static RUNTIME: OnceLock<Option<GpuRuntime>> = OnceLock::new();
+        RUNTIME
+            .get_or_init(|| Self::probe().unwrap_or(None))
+            .as_ref()
+    }
+
+    pub fn is_available() -> bool {
+        Self::global().is_some()
+    }
+}

--- a/src/gpu/solver.rs
+++ b/src/gpu/solver.rs
@@ -1,0 +1,16 @@
+//! Placeholder module for the CUDA backend phase described in the GPU HAL.
+//!
+//! The public HAL is present so solver call sites can be routed without CUDA
+//! types. Concrete cudarc kernels are intentionally isolated here in follow-up
+//! implementations and unavailable backends fall back to CPU numerics.
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum BackendStatus {
+    CpuFallback,
+    CudaUnavailable,
+    CudaReady,
+}
+
+pub fn backend_status() -> BackendStatus {
+    BackendStatus::CpuFallback
+}

--- a/src/gpu/sparse.rs
+++ b/src/gpu/sparse.rs
@@ -1,0 +1,16 @@
+//! Placeholder module for the CUDA backend phase described in the GPU HAL.
+//!
+//! The public HAL is present so solver call sites can be routed without CUDA
+//! types. Concrete cudarc kernels are intentionally isolated here in follow-up
+//! implementations and unavailable backends fall back to CPU numerics.
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum BackendStatus {
+    CpuFallback,
+    CudaUnavailable,
+    CudaReady,
+}
+
+pub fn backend_status() -> BackendStatus {
+    BackendStatus::CpuFallback
+}

--- a/src/gpu/stream.rs
+++ b/src/gpu/stream.rs
@@ -1,0 +1,16 @@
+//! Placeholder module for the CUDA backend phase described in the GPU HAL.
+//!
+//! The public HAL is present so solver call sites can be routed without CUDA
+//! types. Concrete cudarc kernels are intentionally isolated here in follow-up
+//! implementations and unavailable backends fall back to CPU numerics.
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum BackendStatus {
+    CpuFallback,
+    CudaUnavailable,
+    CudaReady,
+}
+
+pub fn backend_status() -> BackendStatus {
+    BackendStatus::CpuFallback
+}

--- a/src/gpu/validate.rs
+++ b/src/gpu/validate.rs
@@ -1,0 +1,16 @@
+//! Placeholder module for the CUDA backend phase described in the GPU HAL.
+//!
+//! The public HAL is present so solver call sites can be routed without CUDA
+//! types. Concrete cudarc kernels are intentionally isolated here in follow-up
+//! implementations and unavailable backends fall back to CPU numerics.
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum BackendStatus {
+    CpuFallback,
+    CudaUnavailable,
+    CudaReady,
+}
+
+pub fn backend_status() -> BackendStatus {
+    BackendStatus::CpuFallback
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,7 @@ pub fn init_parallelism() {
 }
 
 pub mod families;
+pub mod gpu;
 pub mod inference;
 pub mod linalg;
 pub mod report;

--- a/src/linalg/faer_ndarray.rs
+++ b/src/linalg/faer_ndarray.rs
@@ -292,15 +292,35 @@ pub fn fast_ab<S1: Data<Elem = f64>, S2: Data<Elem = f64>>(
 ) -> Array2<f64> {
     let (n, _) = a.dim();
     let (_, q) = b.dim();
-    let mut out = Array2::<f64>::zeros((n, q));
-    fast_ab_into(a, b, &mut out);
-    out
+    crate::gpu::profile::cpu_scope(
+        "fast_ab",
+        n,
+        q,
+        a.ncols(),
+        n.saturating_mul(q).saturating_mul(8),
+        || {
+            let mut out = Array2::<f64>::zeros((n, q));
+            fast_ab_into(a, b, &mut out);
+            out
+        },
+    )
 }
 
 /// Compute A * v using faer's SIMD-optimized GEMV.
 /// For A of shape (n, p) and v of shape (p,), this computes the (n,) result.
 #[inline]
 pub fn fast_av<S1: Data<Elem = f64>, S2: Data<Elem = f64>>(
+    a: &ArrayBase<S1, Ix2>,
+    v: &ArrayBase<S2, Ix1>,
+) -> Array1<f64> {
+    let (n, p) = a.dim();
+    crate::gpu::profile::cpu_scope("fast_av", n, 1, p, n.saturating_mul(8), || {
+        fast_av_impl(a, v)
+    })
+}
+
+#[inline]
+fn fast_av_impl<S1: Data<Elem = f64>, S2: Data<Elem = f64>>(
     a: &ArrayBase<S1, Ix2>,
     v: &ArrayBase<S2, Ix1>,
 ) -> Array1<f64> {
@@ -339,6 +359,18 @@ pub fn fast_av_into<S1: Data<Elem = f64>, S2: Data<Elem = f64>>(
     v: &ArrayBase<S2, Ix1>,
     out: &mut Array1<f64>,
 ) {
+    let (n, p) = a.dim();
+    crate::gpu::profile::cpu_scope("fast_av_into", n, 1, p, n.saturating_mul(8), || {
+        fast_av_into_impl(a, v, out);
+    });
+}
+
+#[inline]
+fn fast_av_into_impl<S1: Data<Elem = f64>, S2: Data<Elem = f64>>(
+    a: &ArrayBase<S1, Ix2>,
+    v: &ArrayBase<S2, Ix1>,
+    out: &mut Array1<f64>,
+) {
     use faer::Accum;
     use faer::linalg::matmul::matmul;
 
@@ -369,6 +401,18 @@ pub fn fast_av_into<S1: Data<Elem = f64>, S2: Data<Elem = f64>>(
 /// `out` must have length n where A is (n, p) and v is length p.
 #[inline]
 pub fn fast_av_view_into<S1: Data<Elem = f64>, S2: Data<Elem = f64>>(
+    a: &ArrayBase<S1, Ix2>,
+    v: &ArrayBase<S2, Ix1>,
+    out: ArrayViewMut1<'_, f64>,
+) {
+    let (n, p) = a.dim();
+    crate::gpu::profile::cpu_scope("fast_av_view_into", n, 1, p, n.saturating_mul(8), || {
+        fast_av_view_into_impl(a, v, out);
+    });
+}
+
+#[inline]
+fn fast_av_view_into_impl<S1: Data<Elem = f64>, S2: Data<Elem = f64>>(
     a: &ArrayBase<S1, Ix2>,
     v: &ArrayBase<S2, Ix1>,
     mut out: ArrayViewMut1<'_, f64>,
@@ -410,6 +454,17 @@ pub fn fast_av_view_into<S1: Data<Elem = f64>, S2: Data<Elem = f64>>(
 /// For A of shape (n, p) and v of shape (n,), this computes the (p,) result.
 #[inline]
 pub fn fast_atv<S1: Data<Elem = f64>, S2: Data<Elem = f64>>(
+    a: &ArrayBase<S1, Ix2>,
+    v: &ArrayBase<S2, Ix1>,
+) -> Array1<f64> {
+    let (n, p) = a.dim();
+    crate::gpu::profile::cpu_scope("fast_atv", p, 1, n, p.saturating_mul(8), || {
+        fast_atv_impl(a, v)
+    })
+}
+
+#[inline]
+fn fast_atv_impl<S1: Data<Elem = f64>, S2: Data<Elem = f64>>(
     a: &ArrayBase<S1, Ix2>,
     v: &ArrayBase<S2, Ix1>,
 ) -> Array1<f64> {
@@ -457,6 +512,18 @@ pub fn fast_atv_into<S: Data<Elem = f64>>(
     v: &Array1<f64>,
     out: &mut Array1<f64>,
 ) {
+    let (n, p) = a.dim();
+    crate::gpu::profile::cpu_scope("fast_atv_into", p, 1, n, p.saturating_mul(8), || {
+        fast_atv_into_impl(a, v, out);
+    });
+}
+
+#[inline]
+fn fast_atv_into_impl<S: Data<Elem = f64>>(
+    a: &ArrayBase<S, Ix2>,
+    v: &Array1<f64>,
+    out: &mut Array1<f64>,
+) {
     use faer::Accum;
     use faer::linalg::matmul::matmul;
 
@@ -493,13 +560,37 @@ pub fn fast_xt_diag_x<S1: Data<Elem = f64>, S2: Data<Elem = f64>>(
     w: &ArrayBase<S2, Ix1>,
 ) -> Array2<f64> {
     let (_, p) = x.dim();
-    fast_xt_diag_x_with_parallelism(x, w, matmul_parallelism(p, p, x.nrows()))
+    crate::gpu::profile::cpu_scope(
+        "fast_xt_diag_x",
+        p,
+        p,
+        x.nrows(),
+        x.nrows().saturating_mul(p).saturating_mul(16),
+        || fast_xt_diag_x_with_parallelism(x, w, matmul_parallelism(p, p, x.nrows())),
+    )
 }
 
 /// Compute A^T * diag(W) * A with an explicit faer parallelism policy for
 /// callers that parallelize multiple independent Hessian blocks externally.
 #[inline]
 pub fn fast_xt_diag_x_with_parallelism<S1: Data<Elem = f64>, S2: Data<Elem = f64>>(
+    x: &ArrayBase<S1, Ix2>,
+    w: &ArrayBase<S2, Ix1>,
+    par: Par,
+) -> Array2<f64> {
+    let (n, p) = x.dim();
+    crate::gpu::profile::cpu_scope(
+        "fast_xt_diag_x_with_parallelism",
+        p,
+        p,
+        n,
+        n.saturating_mul(p).saturating_mul(16),
+        || fast_xt_diag_x_with_parallelism_impl(x, w, par),
+    )
+}
+
+#[inline]
+fn fast_xt_diag_x_with_parallelism_impl<S1: Data<Elem = f64>, S2: Data<Elem = f64>>(
     x: &ArrayBase<S1, Ix2>,
     w: &ArrayBase<S2, Ix1>,
     par: Par,
@@ -570,6 +661,25 @@ pub fn fast_xt_diag_y<S1: Data<Elem = f64>, S2: Data<Elem = f64>, S3: Data<Elem 
     w: &ArrayBase<S2, Ix1>,
     y: &ArrayBase<S3, Ix2>,
 ) -> Array2<f64> {
+    let n = x.nrows();
+    let px = x.ncols();
+    let q = y.ncols();
+    crate::gpu::profile::cpu_scope(
+        "fast_xt_diag_y",
+        px,
+        q,
+        n,
+        n.saturating_mul(px + q).saturating_mul(16),
+        || fast_xt_diag_y_impl(x, w, y),
+    )
+}
+
+#[inline]
+fn fast_xt_diag_y_impl<S1: Data<Elem = f64>, S2: Data<Elem = f64>, S3: Data<Elem = f64>>(
+    x: &ArrayBase<S1, Ix2>,
+    w: &ArrayBase<S2, Ix1>,
+    y: &ArrayBase<S3, Ix2>,
+) -> Array2<f64> {
     use faer::Accum;
     use faer::linalg::matmul::matmul;
     use ndarray::{ShapeBuilder, s};
@@ -635,6 +745,32 @@ pub fn fast_xt_diag_y<S1: Data<Elem = f64>, S2: Data<Elem = f64>, S3: Data<Elem 
 ///
 /// This reads X_a and X_b once per chunk instead of twice (saving 50% bandwidth).
 pub fn fast_joint_hessian_2x2<
+    S1: Data<Elem = f64>,
+    S2: Data<Elem = f64>,
+    S3: Data<Elem = f64>,
+    S4: Data<Elem = f64>,
+    S5: Data<Elem = f64>,
+>(
+    x_a: &ArrayBase<S1, Ix2>,
+    x_b: &ArrayBase<S2, Ix2>,
+    w_aa: &ArrayBase<S3, Ix1>,
+    w_ab: &ArrayBase<S4, Ix1>,
+    w_bb: &ArrayBase<S5, Ix1>,
+) -> Array2<f64> {
+    let n = x_a.nrows();
+    let total = x_a.ncols() + x_b.ncols();
+    crate::gpu::profile::cpu_scope(
+        "fast_joint_hessian_2x2",
+        total,
+        total,
+        n,
+        n.saturating_mul(total).saturating_mul(24),
+        || fast_joint_hessian_2x2_impl(x_a, x_b, w_aa, w_ab, w_bb),
+    )
+}
+
+#[inline]
+fn fast_joint_hessian_2x2_impl<
     S1: Data<Elem = f64>,
     S2: Data<Elem = f64>,
     S3: Data<Elem = f64>,
@@ -801,6 +937,26 @@ fn mat_to_array(mat: MatRef<'_, f64>) -> Array2<f64> {
 /// Avoids the intermediate faer::Mat allocation and mat_to_array copy.
 #[inline]
 pub fn fast_ab_into<S1: Data<Elem = f64>, S2: Data<Elem = f64>>(
+    a: &ArrayBase<S1, Ix2>,
+    b: &ArrayBase<S2, Ix2>,
+    out: &mut Array2<f64>,
+) {
+    let (n, p) = a.dim();
+    let q = b.ncols();
+    crate::gpu::profile::cpu_scope(
+        "fast_ab_into",
+        n,
+        q,
+        p,
+        n.saturating_mul(q).saturating_mul(8),
+        || {
+            fast_ab_into_impl(a, b, out);
+        },
+    );
+}
+
+#[inline]
+fn fast_ab_into_impl<S1: Data<Elem = f64>, S2: Data<Elem = f64>>(
     a: &ArrayBase<S1, Ix2>,
     b: &ArrayBase<S2, Ix2>,
     out: &mut Array2<f64>,


### PR DESCRIPTION
### Motivation
- Prepare the codebase for phased GPU acceleration by introducing a non-invasive hardware abstraction layer that keeps CPU numerics as the default and isolates all CUDA-specific code behind a feature gate.
- Provide the minimal runtime/policy/memory/traits/profile scaffolding so solver call sites can be routed to device implementations later without leaking CUDA types into solver code.
- Add lightweight profiling hooks around hot faer ndarray primitives to collect kernel stats and make per-op dispatch decisions possible.

### Description
- Add a gated Cargo feature `cuda` and an optional `cudarc = "0.19.6"` dependency configured for dynamic loading and NVRTC/cuBLAS/cuSPARSE/cuSOLVER/cuRAND/NVTX/CUPTI support.
- Introduce `src/gpu/` with modular HAL skeletons: `runtime`, `device`, `memory`, `policy`, `profile`, `cpu_traits`, plus placeholder modules for `blas`, `solver`, `sparse`, `stream`, `graph`, `validate` and the kernel templates under `kernels/` so CUDA details remain confined to this directory.
- Add host-shadow device types (`DeviceBuffer`, `DeviceMatrix`, `DeviceVector`, `DeviceCsrMatrix`), three traits (`DeviceBlas`, `DeviceSolver`, `DeviceDesignOperator`) for dispatch, and a `GpuRuntime::probe()` stub that cleanly falls back to CPU when CUDA is unavailable.
- Wire a non-invasive profiler and timing wrapper `gpu::profile::cpu_scope` and route core faer ndarray hot paths (`fast_av`, `fast_av_into`, `fast_av_view_into`, `fast_atv`, `fast_atv_into`, `fast_xt_diag_x`, `fast_xt_diag_y`, `fast_joint_hessian_2x2`, `fast_ab_into`) through it so we can measure and later switch to GPU implementations.

### Testing
- Ran `cargo fmt` which completed successfully.
- Ran `cargo check` and `cargo check --features cuda` which both completed successfully, confirming the new HAL builds in CPU-only and feature-enabled modes.
- Ran the full unit test suite via `cargo test --lib` which executed 1639 tests; 1635 passed, 2 failed, and 2 were ignored; the failing tests were `families::gamlss::tests::binomial_location_scalewiggle_exact_newton_spatial_joint_hyper_returns_fullhessian` and `terms::smooth::tests::iso_kappa_duchon_penalty_subspace_projection_pins_trace` (these appear unrelated to the HAL scaffolding and are present after the changes to instrumentation wrappers).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0739b4b2b883249ef1e84407e5e7ad)