### PR TITLE
Add GPU HAL scaffold and routing hooks (src/gpu) + linalg instrumentation and optional cudarc feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,10 @@ resolver = "3"
 [lints.rust]
 warnings = "deny"
 
+[features]
+default = []
+cuda = ["dep:cudarc", "cudarc/driver", "cudarc/runtime", "cudarc/nvrtc", "cudarc/cublas", "cudarc/cublaslt", "cudarc/cusparse", "cudarc/cusolver", "cudarc/cusolvermg", "cudarc/curand", "cudarc/nvtx", "cudarc/cupti", "cudarc/fallback-dynamic-loading", "cudarc/cuda-12080"]
+
 [dependencies]
 clap = { version = "4.6.0", features = ["derive"] }
 comfy-table = "7.2.2"
@@ -66,6 +70,7 @@ arrow = { version = "54", default-features = false, features = ["ffi"] }
 parquet = { version = "54", default-features = false, features = ["arrow", "snap", "zstd", "lz4"] }
 wide = "0.7"
 smallvec = "1"
+cudarc = { version = "0.19.6", default-features = false, optional = true }
 
 [dependencies.general-mcmc]
 package = "general-mcmc"

--- a/src/gpu/blas.rs
+++ b/src/gpu/blas.rs
@@ -1,0 +1,85 @@
+use super::cpu_traits::DeviceBlas;
+use super::profile::{OperationKind, record_cpu_fallback};
+use ndarray::{Array1, Array2};
+
+#[derive(Clone, Debug, Default)]
+pub struct CudaBlas;
+
+impl DeviceBlas for CudaBlas {
+    fn gemv(&self, a: &Array2<f64>, x: &Array1<f64>) -> Option<Array1<f64>> {
+        record_cpu_fallback(
+            "gpu.blas.gemv",
+            OperationKind::Gemv,
+            a.nrows(),
+            a.ncols(),
+            1,
+            0,
+        );
+        let _ = x;
+        None
+    }
+
+    fn gemv_transpose(&self, a: &Array2<f64>, x: &Array1<f64>) -> Option<Array1<f64>> {
+        record_cpu_fallback(
+            "gpu.blas.gemv_transpose",
+            OperationKind::GemvTranspose,
+            a.nrows(),
+            a.ncols(),
+            1,
+            0,
+        );
+        let _ = x;
+        None
+    }
+
+    fn xt_diag_x_signed(&self, x: &Array2<f64>, w: &Array1<f64>) -> Option<Array2<f64>> {
+        record_cpu_fallback(
+            "gpu.blas.xt_diag_x_signed",
+            OperationKind::XtDiagX,
+            x.nrows(),
+            x.ncols(),
+            x.ncols(),
+            0,
+        );
+        let _ = w;
+        None
+    }
+
+    fn xt_diag_y_signed(
+        &self,
+        x: &Array2<f64>,
+        w: &Array1<f64>,
+        y: &Array2<f64>,
+    ) -> Option<Array2<f64>> {
+        record_cpu_fallback(
+            "gpu.blas.xt_diag_y_signed",
+            OperationKind::XtDiagY,
+            x.nrows(),
+            x.ncols(),
+            y.ncols(),
+            0,
+        );
+        let _ = w;
+        None
+    }
+}
+
+pub fn try_fast_av(a: &Array2<f64>, v: &Array1<f64>) -> Option<Array1<f64>> {
+    CudaBlas.gemv(a, v)
+}
+
+pub fn try_fast_atv(a: &Array2<f64>, v: &Array1<f64>) -> Option<Array1<f64>> {
+    CudaBlas.gemv_transpose(a, v)
+}
+
+pub fn try_fast_xt_diag_x(x: &Array2<f64>, w: &Array1<f64>) -> Option<Array2<f64>> {
+    CudaBlas.xt_diag_x_signed(x, w)
+}
+
+pub fn try_fast_xt_diag_y(
+    x: &Array2<f64>,
+    w: &Array1<f64>,
+    y: &Array2<f64>,
+) -> Option<Array2<f64>> {
+    CudaBlas.xt_diag_y_signed(x, w, y)
+}

--- a/src/gpu/cpu_traits.rs
+++ b/src/gpu/cpu_traits.rs
@@ -1,0 +1,38 @@
+use ndarray::{Array1, Array2};
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ExecutionTarget {
+    Cpu,
+    Gpu,
+    Auto,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum MatrixLocation {
+    Host,
+    Device,
+    Unified,
+}
+
+pub trait DeviceBlas {
+    fn gemv(&self, a: &Array2<f64>, x: &Array1<f64>) -> Option<Array1<f64>>;
+    fn gemv_transpose(&self, a: &Array2<f64>, x: &Array1<f64>) -> Option<Array1<f64>>;
+    fn xt_diag_x_signed(&self, x: &Array2<f64>, w: &Array1<f64>) -> Option<Array2<f64>>;
+    fn xt_diag_y_signed(
+        &self,
+        x: &Array2<f64>,
+        w: &Array1<f64>,
+        y: &Array2<f64>,
+    ) -> Option<Array2<f64>>;
+}
+
+pub trait DeviceSolver {
+    fn potrf_solve(&self, h: &Array2<f64>, rhs: &Array2<f64>) -> Option<Array2<f64>>;
+    fn syevd(&self, h: &Array2<f64>) -> Option<(Array1<f64>, Array2<f64>)>;
+}
+
+pub trait DeviceDesignOperator {
+    fn rows(&self) -> usize;
+    fn cols(&self) -> usize;
+    fn location(&self) -> MatrixLocation;
+}

--- a/src/gpu/device.rs
+++ b/src/gpu/device.rs
@@ -1,0 +1,62 @@
+#[derive(Clone, Debug, Default)]
+pub struct GpuCapability {
+    pub compute_major: i32,
+    pub compute_minor: i32,
+    pub has_tensor_cores: bool,
+    pub has_fp64_tensor_cores: bool,
+    pub has_async_copy: bool,
+    pub cluster_launch: bool,
+    pub tma: bool,
+    pub min_warp_size: i32,
+}
+
+impl GpuCapability {
+    pub fn from_compute_capability(major: i32, minor: i32) -> Self {
+        Self {
+            compute_major: major,
+            compute_minor: minor,
+            has_tensor_cores: major >= 7,
+            has_fp64_tensor_cores: major >= 8,
+            has_async_copy: major >= 8,
+            cluster_launch: major >= 9,
+            tma: major >= 9,
+            min_warp_size: 32,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct GpuDeviceInfo {
+    pub ordinal: usize,
+    pub name: String,
+    pub capability: GpuCapability,
+    pub sm_count: i32,
+    pub max_threads_per_sm: i32,
+    pub shared_mem_per_block: usize,
+    pub l2_cache_bytes: usize,
+    pub total_mem_bytes: usize,
+    pub free_mem_bytes: usize,
+    pub ecc_enabled: bool,
+    pub integrated: bool,
+    pub mig_mode: bool,
+    pub peer_access: Vec<bool>,
+}
+
+impl GpuDeviceInfo {
+    pub fn score(&self) -> f64 {
+        let fp64_bonus = if self.capability.has_fp64_tensor_cores {
+            100.0
+        } else {
+            0.0
+        };
+        let async_bonus = if self.capability.has_async_copy {
+            50.0
+        } else {
+            0.0
+        };
+        self.sm_count as f64
+            + (self.free_mem_bytes as f64 / 1_073_741_824.0) * 4.0
+            + fp64_bonus
+            + async_bonus
+    }
+}

--- a/src/gpu/graph.rs
+++ b/src/gpu/graph.rs
@@ -1,0 +1,18 @@
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum GraphMode {
+    Auto,
+    Off,
+    Force,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct CudaGraphCache {
+    pub captured_iterations: usize,
+    pub stable_shape: Option<(usize, usize)>,
+}
+
+impl CudaGraphCache {
+    pub fn should_capture_after_iteration(&self, iter: usize) -> bool {
+        iter >= 2 && self.stable_shape.is_some()
+    }
+}

--- a/src/gpu/kernels/cell_moments.rs
+++ b/src/gpu/kernels/cell_moments.rs
@@ -1,0 +1,11 @@
+pub const GAUSS_LEGENDRE_NODES: usize = 384;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum CellMomentBranch {
+    RigidStandardNormal,
+    RigidEmpiricalGrid,
+    FlexibleQuartic,
+    FlexibleSextic,
+    TailLeft,
+    TailRight,
+}

--- a/src/gpu/kernels/fused_xtwx.rs
+++ b/src/gpu/kernels/fused_xtwx.rs
@@ -1,0 +1,16 @@
+#[derive(Clone, Debug)]
+pub struct FusedXtWxConfig {
+    pub tile_p: usize,
+    pub chunk_rows: usize,
+    pub signed_weights: bool,
+}
+
+impl Default for FusedXtWxConfig {
+    fn default() -> Self {
+        Self {
+            tile_p: 32,
+            chunk_rows: 32_768,
+            signed_weights: true,
+        }
+    }
+}

--- a/src/gpu/kernels/hutchpp.rs
+++ b/src/gpu/kernels/hutchpp.rs
@@ -1,0 +1,5 @@
+pub const DEFAULT_RADEMACHER_SEED: u64 = 0xCAFE_BABE;
+
+pub fn sketch_dim(dim: usize) -> usize {
+    (dim / 32).clamp(4, 16)
+}

--- a/src/gpu/kernels/irls_link.rs
+++ b/src/gpu/kernels/irls_link.rs
@@ -1,0 +1,19 @@
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum GpuLinkKernel {
+    Logit,
+    Probit,
+    CLogLog,
+    Identity,
+    Log,
+    Sas,
+    BetaLogistic,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct LinkKernelOutputs {
+    pub emits_mu: bool,
+    pub emits_w: bool,
+    pub emits_z: bool,
+    pub emits_derivative_jets: bool,
+    pub emits_deviance_loglik: bool,
+}

--- a/src/gpu/kernels/reductions.rs
+++ b/src/gpu/kernels/reductions.rs
@@ -1,0 +1,12 @@
+pub const DETERMINISTIC_TILE_SIZE: usize = 256;
+
+pub fn pairwise_sum_host(values: &[f64]) -> f64 {
+    if values.len() <= DETERMINISTIC_TILE_SIZE {
+        values.iter().copied().sum()
+    } else {
+        values
+            .chunks(DETERMINISTIC_TILE_SIZE)
+            .map(pairwise_sum_host)
+            .sum()
+    }
+}

--- a/src/gpu/kernels/row_scale.rs
+++ b/src/gpu/kernels/row_scale.rs
@@ -1,0 +1,6 @@
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum RowScaleMode {
+    Signed,
+    SqrtPositive,
+    AbsWithSign,
+}

--- a/src/gpu/kernels/spatial.rs
+++ b/src/gpu/kernels/spatial.rs
@@ -1,0 +1,25 @@
+#[derive(Clone, Debug)]
+pub enum SpatialKernel {
+    ThinPlate {
+        length_scale_sq: f64,
+        dim: usize,
+    },
+    Polyharmonic {
+        m: usize,
+        k_dim: usize,
+        c: f64,
+        power: f64,
+        is_log_case: bool,
+    },
+    Matern {
+        length_scale_sq: f64,
+        nu: f64,
+        dim: usize,
+    },
+    DuchonAnisotropic {
+        aniso_log_scales: Vec<f64>,
+        m: usize,
+        dim: usize,
+    },
+    GenericCpuOnly,
+}

--- a/src/gpu/memory.rs
+++ b/src/gpu/memory.rs
@@ -1,0 +1,86 @@
+use super::cpu_traits::MatrixLocation;
+
+#[derive(Clone, Debug)]
+pub struct DeviceBuffer<T> {
+    pub len: usize,
+    pub location: MatrixLocation,
+    pub host_shadow: Vec<T>,
+}
+
+impl<T: Clone + Default> DeviceBuffer<T> {
+    pub fn zeros(len: usize) -> Self {
+        Self {
+            len,
+            location: MatrixLocation::Host,
+            host_shadow: vec![T::default(); len],
+        }
+    }
+}
+
+pub type DeviceVector = DeviceBuffer<f64>;
+
+#[derive(Clone, Debug)]
+pub struct DeviceMatrix {
+    pub rows: usize,
+    pub cols: usize,
+    pub leading_dim: usize,
+    pub location: MatrixLocation,
+    pub host_shadow: Vec<f64>,
+}
+
+impl DeviceMatrix {
+    pub fn zeros(rows: usize, cols: usize) -> Self {
+        Self {
+            rows,
+            cols,
+            leading_dim: rows,
+            location: MatrixLocation::Host,
+            host_shadow: vec![0.0; rows.saturating_mul(cols)],
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct DeviceCsrMatrix {
+    pub rows: usize,
+    pub cols: usize,
+    pub rowptr: Vec<usize>,
+    pub colidx: Vec<usize>,
+    pub values: Vec<f64>,
+    pub location: MatrixLocation,
+}
+
+#[derive(Clone, Debug)]
+pub struct GpuFitSession {
+    pub target: super::cpu_traits::ExecutionTarget,
+    pub n: usize,
+    pub p: usize,
+    pub x_dense: Option<DeviceMatrix>,
+    pub x_sparse: Option<DeviceCsrMatrix>,
+    pub beta: DeviceVector,
+    pub eta: DeviceVector,
+    pub mu: DeviceVector,
+    pub w: DeviceVector,
+    pub z: DeviceVector,
+    pub gradient: DeviceVector,
+    pub hessian: DeviceMatrix,
+}
+
+impl GpuFitSession {
+    pub fn host_fallback(n: usize, p: usize) -> Self {
+        Self {
+            target: super::cpu_traits::ExecutionTarget::Cpu,
+            n,
+            p,
+            x_dense: None,
+            x_sparse: None,
+            beta: DeviceVector::zeros(p),
+            eta: DeviceVector::zeros(n),
+            mu: DeviceVector::zeros(n),
+            w: DeviceVector::zeros(n),
+            z: DeviceVector::zeros(n),
+            gradient: DeviceVector::zeros(p),
+            hessian: DeviceMatrix::zeros(p, p),
+        }
+    }
+}

--- a/src/gpu/mod.rs
+++ b/src/gpu/mod.rs
@@ -1,0 +1,38 @@
+//! GPU acceleration hardware-abstraction layer.
+//!
+//! The module is intentionally a thin, CPU-safe façade.  The `cuda` Cargo
+//! feature pulls in cudarc with dynamic loading, but all public entry points are
+//! allowed to return [`GpuUnavailable`] and fall back to the existing CPU path.
+//! This keeps default builds CUDA-free while giving solver/linalg call sites a
+//! stable routing contract for the device-resident pipeline.
+
+pub mod blas;
+pub mod cpu_traits;
+pub mod device;
+pub mod graph;
+pub mod memory;
+pub mod policy;
+pub mod profile;
+pub mod rand;
+pub mod runtime;
+pub mod solver;
+pub mod sparse;
+pub mod stream;
+pub mod validate;
+
+pub mod kernels {
+    pub mod cell_moments;
+    pub mod fused_xtwx;
+    pub mod hutchpp;
+    pub mod irls_link;
+    pub mod reductions;
+    pub mod row_scale;
+    pub mod spatial;
+}
+
+pub use cpu_traits::{ExecutionTarget, MatrixLocation};
+pub use device::{GpuCapability, GpuDeviceInfo};
+pub use memory::{DeviceBuffer, DeviceCsrMatrix, DeviceMatrix, DeviceVector, GpuFitSession};
+pub use policy::{GpuDispatchPolicy, GpuEnv, MixedPrecisionMode, ValidationMode};
+pub use profile::{KernelStat, OperationKind, record_cpu_fallback};
+pub use runtime::{GpuProbeStatus, GpuRuntime};

--- a/src/gpu/policy.rs
+++ b/src/gpu/policy.rs
@@ -1,0 +1,131 @@
+use std::env;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ValidationMode {
+    Off,
+    Every(usize),
+    Strict,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum MixedPrecisionMode {
+    Off,
+    Screening,
+    Never,
+}
+
+#[derive(Clone, Debug)]
+pub struct GpuEnv {
+    pub gpu: String,
+    pub device: Option<usize>,
+    pub mem_fraction: f64,
+    pub validate: ValidationMode,
+    pub graphs: String,
+    pub mixed_precision: MixedPrecisionMode,
+    pub profile: bool,
+    pub calibrate: String,
+    pub min_n_override: Option<usize>,
+    pub f32_operator_preconditioner: bool,
+    pub family_kernels: bool,
+}
+
+impl Default for GpuEnv {
+    fn default() -> Self {
+        Self::from_process_env()
+    }
+}
+
+impl GpuEnv {
+    pub fn from_process_env() -> Self {
+        let gpu = env::var("GAM_GPU").unwrap_or_else(|_| "auto".to_string());
+        let device = env::var("GAM_GPU_DEVICE").ok().and_then(|v| v.parse().ok());
+        let mem_fraction = env::var("GAM_GPU_MEM_FRACTION")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(0.85);
+        let validate = match env::var("GAM_GPU_VALIDATE")
+            .unwrap_or_else(|_| "0".to_string())
+            .as_str()
+        {
+            "1" => ValidationMode::Strict,
+            "0" => ValidationMode::Off,
+            v if v.starts_with("every:") => v[6..]
+                .parse()
+                .map(ValidationMode::Every)
+                .unwrap_or(ValidationMode::Off),
+            _ => ValidationMode::Off,
+        };
+        let graphs = env::var("GAM_GPU_GRAPHS").unwrap_or_else(|_| "auto".to_string());
+        let mixed_precision = match env::var("GAM_GPU_MIXED_PRECISION")
+            .unwrap_or_else(|_| "off".to_string())
+            .as_str()
+        {
+            "screening" => MixedPrecisionMode::Screening,
+            "never" => MixedPrecisionMode::Never,
+            _ => MixedPrecisionMode::Off,
+        };
+        let profile = env::var("GAM_GPU_PROFILE").is_ok_and(|v| v == "1");
+        let calibrate = env::var("GAM_GPU_CALIBRATE").unwrap_or_else(|_| "auto".to_string());
+        let min_n_override = env::var("GAM_GPU_MIN_N").ok().and_then(|v| v.parse().ok());
+        let f32_operator_preconditioner =
+            env::var("GAM_GPU_F32_OPERATOR_PRECONDITIONER").is_ok_and(|v| v == "1");
+        let family_kernels =
+            env::var("GAM_GPU_FAMILY_KERNELS").is_ok_and(|v| v == "on" || v == "1");
+        Self {
+            gpu,
+            device,
+            mem_fraction,
+            validate,
+            graphs,
+            mixed_precision,
+            profile,
+            calibrate,
+            min_n_override,
+            f32_operator_preconditioner,
+            family_kernels,
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct GpuDispatchPolicy {
+    pub xtwx_n_min: usize,
+    pub xtwx_flops_min: f64,
+    pub xtwx_use_fused_below_p: usize,
+    pub gemm_min_flops: f64,
+    pub potrf_min_p: usize,
+    pub syevd_min_p: usize,
+    pub sparse_min_nnz: usize,
+    pub fused_kernel_min_n: usize,
+    pub keep_design_resident_min_bytes: usize,
+    pub prefer_gpu_factorization_min_p: usize,
+    pub row_kernel_min_n: usize,
+}
+
+impl Default for GpuDispatchPolicy {
+    fn default() -> Self {
+        Self {
+            xtwx_n_min: 8_192,
+            xtwx_flops_min: 2.0e8,
+            xtwx_use_fused_below_p: 256,
+            gemm_min_flops: 5.0e7,
+            potrf_min_p: 256,
+            syevd_min_p: 256,
+            sparse_min_nnz: 100_000,
+            fused_kernel_min_n: 8_192,
+            keep_design_resident_min_bytes: 8 * 1024 * 1024,
+            prefer_gpu_factorization_min_p: 256,
+            row_kernel_min_n: 8_192,
+        }
+    }
+}
+
+impl GpuDispatchPolicy {
+    pub fn should_gpu_gemv(&self, n: usize, p: usize, resident: bool) -> bool {
+        resident || 2.0 * n as f64 * p as f64 >= self.gemm_min_flops
+    }
+
+    pub fn should_gpu_xtwx(&self, n: usize, p: usize, materialized: bool) -> bool {
+        materialized && n >= self.xtwx_n_min && n as f64 * (p * p) as f64 >= self.xtwx_flops_min
+    }
+}

--- a/src/gpu/profile.rs
+++ b/src/gpu/profile.rs
@@ -1,0 +1,123 @@
+use std::collections::VecDeque;
+use std::sync::{Mutex, OnceLock};
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum OperationKind {
+    Gemv,
+    GemvTranspose,
+    Gemm,
+    XtDiagX,
+    XtDiagY,
+    JointHessian2x2,
+    LinkKernel,
+    CandidateScreen,
+    Cholesky,
+    Syevd,
+    SparseXtWx,
+    Pcg,
+    SpatialKernel,
+    RemlTrace,
+    FamilyKernel,
+    CudaGraph,
+    MultiGpuReduce,
+}
+
+#[derive(Clone, Debug)]
+pub struct KernelStat {
+    pub name: &'static str,
+    pub kind: OperationKind,
+    pub n: usize,
+    pub p: usize,
+    pub k: usize,
+    pub nnz: usize,
+    pub flops_est: f64,
+    pub bytes_est: usize,
+    pub cpu_ms: Option<f64>,
+    pub gpu_ms: Option<f64>,
+    pub target: &'static str,
+}
+
+pub struct KernelStatRing {
+    capacity: usize,
+    entries: VecDeque<KernelStat>,
+}
+
+impl KernelStatRing {
+    pub fn new(capacity: usize) -> Self {
+        Self {
+            capacity,
+            entries: VecDeque::with_capacity(capacity),
+        }
+    }
+
+    pub fn push(&mut self, stat: KernelStat) {
+        if self.entries.len() == self.capacity {
+            self.entries.pop_front();
+        }
+        self.entries.push_back(stat);
+    }
+
+    pub fn snapshot(&self) -> Vec<KernelStat> {
+        self.entries.iter().cloned().collect()
+    }
+}
+
+pub fn global_kernel_stats() -> &'static Mutex<KernelStatRing> {
+    static STATS: OnceLock<Mutex<KernelStatRing>> = OnceLock::new();
+    STATS.get_or_init(|| Mutex::new(KernelStatRing::new(1024)))
+}
+
+pub fn record_cpu_fallback(
+    name: &'static str,
+    kind: OperationKind,
+    n: usize,
+    p: usize,
+    k: usize,
+    nnz: usize,
+) {
+    static ENABLED: OnceLock<bool> = OnceLock::new();
+    if !*ENABLED.get_or_init(|| std::env::var("GAM_GPU_PROFILE").is_ok_and(|v| v == "1")) {
+        return;
+    }
+    if let Ok(mut stats) = global_kernel_stats().lock() {
+        stats.push(KernelStat {
+            name,
+            kind,
+            n,
+            p,
+            k,
+            nnz,
+            flops_est: estimate_flops(kind, n, p, k, nnz),
+            bytes_est: estimate_bytes(n, p, k, nnz),
+            cpu_ms: None,
+            gpu_ms: None,
+            target: "cpu-fallback",
+        });
+    }
+}
+
+pub fn kernel_stats_snapshot() -> Vec<KernelStat> {
+    global_kernel_stats()
+        .lock()
+        .map(|stats| stats.snapshot())
+        .unwrap_or_default()
+}
+
+pub fn estimate_flops(kind: OperationKind, n: usize, p: usize, k: usize, nnz: usize) -> f64 {
+    match kind {
+        OperationKind::Gemv | OperationKind::GemvTranspose => 2.0 * n as f64 * p as f64,
+        OperationKind::Gemm => 2.0 * n as f64 * p as f64 * k as f64,
+        OperationKind::XtDiagX => n as f64 * p as f64 * p as f64,
+        OperationKind::XtDiagY => 2.0 * n as f64 * p as f64 * k as f64,
+        OperationKind::JointHessian2x2 => n as f64 * (p + k) as f64 * (p + k) as f64,
+        OperationKind::SparseXtWx | OperationKind::Pcg => 2.0 * nnz as f64,
+        _ => 0.0,
+    }
+}
+
+pub fn estimate_bytes(n: usize, p: usize, k: usize, nnz: usize) -> usize {
+    (n.saturating_mul(p)
+        .saturating_add(n.saturating_mul(k))
+        .saturating_add(nnz))
+    .saturating_mul(8)
+}

--- a/src/gpu/rand.rs
+++ b/src/gpu/rand.rs
@@ -1,0 +1,22 @@
+#[derive(Clone, Debug)]
+pub struct RademacherGenerator {
+    pub seed: u64,
+}
+
+impl Default for RademacherGenerator {
+    fn default() -> Self {
+        Self { seed: 0xCAFE_BABE }
+    }
+}
+
+impl RademacherGenerator {
+    pub fn fill_host(&self, out: &mut [f64]) {
+        let mut state = self.seed;
+        for value in out {
+            state ^= state << 13;
+            state ^= state >> 7;
+            state ^= state << 17;
+            *value = if state & 1 == 0 { -1.0 } else { 1.0 };
+        }
+    }
+}

--- a/src/gpu/runtime.rs
+++ b/src/gpu/runtime.rs
@@ -1,0 +1,74 @@
+use super::device::GpuDeviceInfo;
+use super::policy::{GpuDispatchPolicy, GpuEnv};
+use std::path::PathBuf;
+
+#[derive(Clone, Debug)]
+pub enum GpuProbeStatus {
+    Disabled,
+    Unavailable(String),
+    Available,
+}
+
+#[derive(Clone, Debug)]
+pub struct GpuRuntime {
+    pub status: GpuProbeStatus,
+    pub env: GpuEnv,
+    pub devices: Vec<GpuDeviceInfo>,
+    pub selected_device: Option<usize>,
+    pub memory_budget_bytes: usize,
+    pub policy: GpuDispatchPolicy,
+    pub calibration_cache_path: PathBuf,
+}
+
+impl GpuRuntime {
+    pub fn probe() -> Option<Self> {
+        let env = GpuEnv::from_process_env();
+        if env.gpu == "off" {
+            return None;
+        }
+        let cache = calibration_cache_path();
+        let runtime = Self {
+            status: GpuProbeStatus::Unavailable(cuda_backend_status().to_string()),
+            env,
+            devices: Vec::new(),
+            selected_device: None,
+            memory_budget_bytes: 0,
+            policy: GpuDispatchPolicy::default(),
+            calibration_cache_path: cache,
+        };
+        None.or(Some(runtime))
+            .filter(|rt| matches!(rt.env.gpu.as_str(), "force"))
+    }
+
+    pub fn cpu_fallback() -> Self {
+        Self {
+            status: GpuProbeStatus::Unavailable(cuda_backend_status().to_string()),
+            env: GpuEnv::from_process_env(),
+            devices: Vec::new(),
+            selected_device: None,
+            memory_budget_bytes: 0,
+            policy: GpuDispatchPolicy::default(),
+            calibration_cache_path: calibration_cache_path(),
+        }
+    }
+
+    pub fn is_available(&self) -> bool {
+        matches!(self.status, GpuProbeStatus::Available)
+    }
+}
+
+pub fn cuda_backend_status() -> &'static str {
+    if cfg!(feature = "cuda") {
+        "cuda feature enabled; cudarc dynamic backend is compiled but no device work is active in this routing layer"
+    } else {
+        "cuda feature disabled"
+    }
+}
+
+pub fn calibration_cache_path() -> PathBuf {
+    let base = std::env::var_os("XDG_CACHE_HOME")
+        .map(PathBuf::from)
+        .or_else(|| std::env::var_os("HOME").map(|home| PathBuf::from(home).join(".cache")))
+        .unwrap_or_else(|| PathBuf::from(".cache"));
+    base.join("gam").join("gpu_calib.json")
+}

--- a/src/gpu/solver.rs
+++ b/src/gpu/solver.rs
@@ -1,0 +1,32 @@
+use super::cpu_traits::DeviceSolver;
+use super::profile::{OperationKind, record_cpu_fallback};
+use ndarray::{Array1, Array2};
+
+#[derive(Clone, Debug, Default)]
+pub struct CudaSolver;
+
+impl DeviceSolver for CudaSolver {
+    fn potrf_solve(&self, h: &Array2<f64>, rhs: &Array2<f64>) -> Option<Array2<f64>> {
+        record_cpu_fallback(
+            "gpu.solver.potrf_solve",
+            OperationKind::Cholesky,
+            h.nrows(),
+            h.ncols(),
+            rhs.ncols(),
+            0,
+        );
+        None
+    }
+
+    fn syevd(&self, h: &Array2<f64>) -> Option<(Array1<f64>, Array2<f64>)> {
+        record_cpu_fallback(
+            "gpu.solver.syevd",
+            OperationKind::Syevd,
+            h.nrows(),
+            h.ncols(),
+            0,
+            0,
+        );
+        None
+    }
+}

--- a/src/gpu/sparse.rs
+++ b/src/gpu/sparse.rs
@@ -1,0 +1,26 @@
+use super::memory::DeviceCsrMatrix;
+use super::profile::{OperationKind, record_cpu_fallback};
+
+#[derive(Clone, Debug)]
+pub enum SparseGpuMode {
+    DenseOuterProduct,
+    CusparseSpGemm,
+    MatrixFreePcg,
+}
+
+pub fn try_sparse_xtwx(
+    csr: &DeviceCsrMatrix,
+    weights_len: usize,
+    mode: SparseGpuMode,
+) -> Option<super::memory::DeviceMatrix> {
+    let _ = (weights_len, mode);
+    record_cpu_fallback(
+        "gpu.sparse.xtwx",
+        OperationKind::SparseXtWx,
+        csr.rows,
+        csr.cols,
+        0,
+        csr.values.len(),
+    );
+    None
+}

--- a/src/gpu/stream.rs
+++ b/src/gpu/stream.rs
@@ -1,0 +1,18 @@
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum StreamRole {
+    Main,
+    LinkKernel,
+    XtWx,
+    Reduction,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct GpuStreamPool {
+    pub streams: usize,
+}
+
+impl GpuStreamPool {
+    pub fn new(streams: usize) -> Self {
+        Self { streams }
+    }
+}

--- a/src/gpu/validate.rs
+++ b/src/gpu/validate.rs
@@ -1,0 +1,39 @@
+#[derive(Clone, Debug)]
+pub struct ValidationTolerances {
+    pub beta_rel: f64,
+    pub gradient_rel: f64,
+    pub objective_rel: f64,
+    pub hessian_rel: f64,
+    pub trace_rel: f64,
+}
+
+impl Default for ValidationTolerances {
+    fn default() -> Self {
+        Self {
+            beta_rel: 1e-9,
+            gradient_rel: 1e-9,
+            objective_rel: 1e-12,
+            hessian_rel: 1e-9,
+            trace_rel: 1e-6,
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct ValidationReport {
+    pub passed: bool,
+    pub metric: &'static str,
+    pub observed: f64,
+    pub tolerance: f64,
+}
+
+pub fn compare_scalar(metric: &'static str, cpu: f64, gpu: f64, rel_tol: f64) -> ValidationReport {
+    let scale = cpu.abs().max(1.0);
+    let observed = (cpu - gpu).abs() / scale;
+    ValidationReport {
+        passed: observed <= rel_tol,
+        metric,
+        observed,
+        tolerance: rel_tol,
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,7 @@ pub fn init_parallelism() {
 }
 
 pub mod families;
+pub mod gpu;
 pub mod inference;
 pub mod linalg;
 pub mod report;

--- a/src/linalg/faer_ndarray.rs
+++ b/src/linalg/faer_ndarray.rs
@@ -309,6 +309,14 @@ pub fn fast_av<S1: Data<Elem = f64>, S2: Data<Elem = f64>>(
 
     let (n, p) = a.dim();
     debug_assert_eq!(p, v.len(), "A cols must match v length");
+    crate::gpu::record_cpu_fallback(
+        "linalg.fast_av",
+        crate::gpu::profile::OperationKind::Gemv,
+        n,
+        p,
+        1,
+        0,
+    );
 
     if !should_use_faer_matmul(n, 1, p) {
         return a.dot(v);
@@ -345,6 +353,14 @@ pub fn fast_av_into<S1: Data<Elem = f64>, S2: Data<Elem = f64>>(
     let (n, p) = a.dim();
     debug_assert_eq!(v.len(), p, "vector length must match A cols");
     debug_assert_eq!(out.len(), n, "output length must match A rows");
+    crate::gpu::record_cpu_fallback(
+        "linalg.fast_av_into",
+        crate::gpu::profile::OperationKind::Gemv,
+        n,
+        p,
+        1,
+        0,
+    );
 
     if !should_use_faer_matmul(n, 1, p) {
         out.assign(&a.dot(v));
@@ -379,6 +395,14 @@ pub fn fast_av_view_into<S1: Data<Elem = f64>, S2: Data<Elem = f64>>(
     let (n, p) = a.dim();
     debug_assert_eq!(v.len(), p, "vector length must match A cols");
     debug_assert_eq!(out.len(), n, "output length must match A rows");
+    crate::gpu::record_cpu_fallback(
+        "linalg.fast_av_view_into",
+        crate::gpu::profile::OperationKind::Gemv,
+        n,
+        p,
+        1,
+        0,
+    );
 
     if !should_use_faer_matmul(n, 1, p) {
         let prod = a.dot(v);
@@ -418,6 +442,14 @@ pub fn fast_atv<S1: Data<Elem = f64>, S2: Data<Elem = f64>>(
 
     let (n, p) = a.dim();
     debug_assert_eq!(n, v.len(), "A rows must match v length");
+    crate::gpu::record_cpu_fallback(
+        "linalg.fast_atv",
+        crate::gpu::profile::OperationKind::GemvTranspose,
+        n,
+        p,
+        1,
+        0,
+    );
 
     // For very small arrays, ndarray might be faster
     if !should_use_faer_matmul(p, 1, n) {
@@ -463,6 +495,14 @@ pub fn fast_atv_into<S: Data<Elem = f64>>(
     let (n, p) = a.dim();
     debug_assert_eq!(v.len(), n, "vector length must match A rows");
     debug_assert_eq!(out.len(), p, "output length must match A cols");
+    crate::gpu::record_cpu_fallback(
+        "linalg.fast_atv_into",
+        crate::gpu::profile::OperationKind::GemvTranspose,
+        n,
+        p,
+        1,
+        0,
+    );
 
     if !should_use_faer_matmul(p, 1, n) {
         out.assign(&a.t().dot(v));
@@ -510,6 +550,14 @@ pub fn fast_xt_diag_x_with_parallelism<S1: Data<Elem = f64>, S2: Data<Elem = f64
 
     let (n, p) = x.dim();
     debug_assert_eq!(n, w.len(), "X rows must match W length");
+    crate::gpu::record_cpu_fallback(
+        "linalg.fast_xt_diag_x",
+        crate::gpu::profile::OperationKind::XtDiagX,
+        n,
+        p,
+        p,
+        0,
+    );
     if n == 0 || p == 0 {
         return Array2::<f64>::zeros((p, p));
     }
@@ -577,6 +625,14 @@ pub fn fast_xt_diag_y<S1: Data<Elem = f64>, S2: Data<Elem = f64>, S3: Data<Elem 
     let (n, q) = y.dim();
     let px = x.ncols();
     debug_assert_eq!(n, w.len(), "Y rows must match W length");
+    crate::gpu::record_cpu_fallback(
+        "linalg.fast_xt_diag_y",
+        crate::gpu::profile::OperationKind::XtDiagY,
+        n,
+        px,
+        q,
+        0,
+    );
     debug_assert_eq!(n, x.nrows(), "X rows must match Y rows");
     if n == 0 || px == 0 || q == 0 {
         return Array2::<f64>::zeros((px, q));
@@ -655,6 +711,14 @@ pub fn fast_joint_hessian_2x2<
     let pa = x_a.ncols();
     let pb = x_b.ncols();
     let total = pa + pb;
+    crate::gpu::record_cpu_fallback(
+        "linalg.fast_joint_hessian_2x2",
+        crate::gpu::profile::OperationKind::JointHessian2x2,
+        n,
+        pa,
+        pb,
+        0,
+    );
     debug_assert_eq!(n, x_b.nrows());
     debug_assert_eq!(n, w_aa.len());
     debug_assert_eq!(n, w_ab.len());


### PR DESCRIPTION
### Motivation
- Prepare a non-invasive hardware abstraction layer for future CUDA acceleration (cudarc-backed) while keeping the CPU paths intact and the default build CUDA-free.
- Provide runtime/autodetect, dispatch policy, device/session memory types, kernel stubs and profiling hooks so solver and linalg call sites can be routed to device implementations later.
- Add small, deterministic profiling and validation scaffolding to record when CPU fallbacks occur and to gate NVRTC/driver work under a cargo feature and environment variables.

### Description
- Add a new `src/gpu/` module with multiple files implementing a thin HAL and stubs: `runtime.rs`, `device.rs`, `memory.rs`, `policy.rs`, `profile.rs`, `blas.rs`, `solver.rs`, `sparse.rs`, `stream.rs`, `graph.rs`, `rand.rs`, `validate.rs` and kernel descriptor stubs under `src/gpu/kernels/`.
- Introduce `DeviceBlas` / `DeviceSolver` / `DeviceDesignOperator` traits and `GpuFitSession`/`DeviceMatrix`/`DeviceBuffer` types as CPU-side placeholders that encapsulate future cudarc usage entirely within `src/gpu/`.
- Instrument hot linalg entry points in `src/linalg/faer_ndarray.rs` to call `crate::gpu::record_cpu_fallback(...)` so the policy/profiler can observe routing decisions for `fast_av`, `fast_atv`, `fast_xt_diag_x`, `fast_xt_diag_y`, and `fast_joint_hessian_2x2` without changing semantics.
- Add a `cuda` cargo feature (default off) and make `cudarc` an optional dependency with dynamic-loading features; set a concrete cudarc CUDA-version feature (`cudarc/cuda-12080`) so the crate builds predictably in CI/dev when the feature is selected.
- Wire simple environment parsing and profiling ring buffer (`KernelStat`) with `GAM_GPU_*` env overrides, and provide deterministic pairwise host reduction helper for later GPU reductions.

### Testing
- Built the crate: ran `cargo check` (default, no cuda feature) and it completed successfully.
- Tested CUDA-gated build: initially `cargo check --features cuda` failed due to `cudarc` requiring an explicit CUDA-version feature; after adding `cudarc/cuda-12080` to the `cuda` feature the `--features cuda` build succeeded.
- Ran the unit test suite via `cargo test --lib`; the repository's test run exercised the full unit test corpus (~1600 tests) and produced no failing unit tests in the observed run, with long-running integration/benchmark-style tests exercising the new instrumentation; several long tests were observed to run for extended time but completed without introducing regressions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0739b4b2b883249ef1e84407e5e7ad)