### PR TITLE
PeriodicSpline1D: multi-output periodic cubic splines (ellipsoid / anisotropic loops)

### DIFF
--- a/src/terms/basis.rs
+++ b/src/terms/basis.rs
@@ -1374,6 +1374,416 @@ struct DuchonBasisDesign {
     nullspace_order: DuchonNullspaceOrder,
 }
 
+/// Options for fitting a closed 1D periodic spline curve `u -> R^d`.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+pub struct PeriodicSpline1DOptions {
+    /// Period of the parameter.  For angles in radians this is usually `2π`.
+    pub period: f64,
+    /// Origin used for wrapping.  Values differing by integer multiples of
+    /// `period` are identified after subtracting this origin.
+    pub origin: f64,
+    /// Absolute tolerance used when coalescing duplicate periodic sites.
+    pub duplicate_tolerance: f64,
+}
+
+impl PeriodicSpline1DOptions {
+    pub fn new(period: f64) -> Self {
+        Self {
+            period,
+            origin: 0.0,
+            duplicate_tolerance: 1e-10,
+        }
+    }
+}
+
+/// A C² periodic cubic spline whose scalar parameter traces a curve in an
+/// arbitrary ambient dimension.
+///
+/// The coefficient solve is shared across output coordinates.  This means a
+/// single fit can represent circles, ellipses, ovals, and arbitrarily stretched
+/// or skewed closed loops in `R^d` without assuming a unit-radius embedding.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PeriodicSpline1D {
+    options: PeriodicSpline1DOptions,
+    /// Sorted periodic sites in `[origin, origin + period)`.
+    sites: Array1<f64>,
+    /// Function values at each site, shape `(n_sites, ambient_dim)`.
+    values: Array2<f64>,
+    /// Periodic cubic second derivatives at each site, shape `(n_sites, ambient_dim)`.
+    second_derivatives: Array2<f64>,
+}
+
+impl PeriodicSpline1D {
+    pub fn fit(
+        u: ArrayView1<'_, f64>,
+        y: ArrayView2<'_, f64>,
+        options: PeriodicSpline1DOptions,
+    ) -> Result<Self, BasisError> {
+        if !options.period.is_finite() || options.period <= 0.0 {
+            return Err(BasisError::InvalidInput(format!(
+                "periodic spline period must be finite and positive; got {}",
+                options.period
+            )));
+        }
+        if !options.origin.is_finite() {
+            return Err(BasisError::InvalidInput(
+                "periodic spline origin must be finite".to_string(),
+            ));
+        }
+        if !options.duplicate_tolerance.is_finite() || options.duplicate_tolerance < 0.0 {
+            return Err(BasisError::InvalidInput(
+                "periodic spline duplicate_tolerance must be finite and non-negative".to_string(),
+            ));
+        }
+        if y.nrows() != u.len() {
+            return Err(BasisError::DimensionMismatch(format!(
+                "periodic spline parameter length {} does not match output row count {}",
+                u.len(),
+                y.nrows()
+            )));
+        }
+        if u.len() < 3 {
+            return Err(BasisError::InvalidInput(
+                "periodic spline requires at least three samples".to_string(),
+            ));
+        }
+        if y.ncols() == 0 {
+            return Err(BasisError::InvalidInput(
+                "periodic spline requires at least one output/ambient dimension".to_string(),
+            ));
+        }
+        if u.iter().any(|v| !v.is_finite()) || y.iter().any(|v| !v.is_finite()) {
+            return Err(BasisError::InvalidInput(
+                "periodic spline inputs must be finite".to_string(),
+            ));
+        }
+
+        let (sites, values) = coalesce_periodic_samples(u, y, options)?;
+        let n = sites.len();
+        if n < 3 {
+            return Err(BasisError::InvalidInput(format!(
+                "periodic spline requires at least three distinct sites after wrapping; found {n}"
+            )));
+        }
+        let h = periodic_spacings(sites.view(), options)?;
+        if h.iter().any(|v| *v <= 0.0 || !v.is_finite()) {
+            return Err(BasisError::InvalidInput(
+                "periodic spline wrapped sites must be strictly increasing over one period"
+                    .to_string(),
+            ));
+        }
+        let second_derivatives = solve_periodic_cubic_second_derivatives(values.view(), &h)?;
+        Ok(Self {
+            options,
+            sites,
+            values,
+            second_derivatives,
+        })
+    }
+
+    pub fn period(&self) -> f64 {
+        self.options.period
+    }
+
+    pub fn origin(&self) -> f64 {
+        self.options.origin
+    }
+
+    pub fn ambient_dim(&self) -> usize {
+        self.values.ncols()
+    }
+
+    pub fn num_sites(&self) -> usize {
+        self.sites.len()
+    }
+
+    pub fn sites(&self) -> ArrayView1<'_, f64> {
+        self.sites.view()
+    }
+
+    pub fn values(&self) -> ArrayView2<'_, f64> {
+        self.values.view()
+    }
+
+    pub fn evaluate(&self, u: ArrayView1<'_, f64>) -> Result<Array2<f64>, BasisError> {
+        self.evaluate_with_derivative_order(u, 0)
+    }
+
+    pub fn evaluate_derivative(&self, u: ArrayView1<'_, f64>) -> Result<Array2<f64>, BasisError> {
+        self.evaluate_with_derivative_order(u, 1)
+    }
+
+    pub fn evaluate_second_derivative(
+        &self,
+        u: ArrayView1<'_, f64>,
+    ) -> Result<Array2<f64>, BasisError> {
+        self.evaluate_with_derivative_order(u, 2)
+    }
+
+    fn evaluate_with_derivative_order(
+        &self,
+        u: ArrayView1<'_, f64>,
+        derivative_order: usize,
+    ) -> Result<Array2<f64>, BasisError> {
+        if derivative_order > 2 {
+            return Err(BasisError::InvalidInput(format!(
+                "unsupported periodic spline derivative order {derivative_order}; only 0, 1, 2 are supported"
+            )));
+        }
+        if u.iter().any(|v| !v.is_finite()) {
+            return Err(BasisError::InvalidInput(
+                "periodic spline evaluation points must be finite".to_string(),
+            ));
+        }
+        let n = self.sites.len();
+        let d = self.ambient_dim();
+        let mut out = Array2::<f64>::zeros((u.len(), d));
+        for (row, &raw) in u.iter().enumerate() {
+            let x = wrap_periodic(raw, self.options);
+            let i = periodic_interval_index(self.sites.view(), x);
+            let j = if i + 1 == n { 0 } else { i + 1 };
+            let x_i = self.sites[i];
+            let h = if i + 1 == n {
+                self.sites[0] + self.options.period - x_i
+            } else {
+                self.sites[i + 1] - x_i
+            };
+            let x_eval = if i + 1 == n && x < x_i {
+                x + self.options.period
+            } else {
+                x
+            };
+            let a = (x_i + h - x_eval) / h;
+            let b = (x_eval - x_i) / h;
+            for col in 0..d {
+                let y_i = self.values[[i, col]];
+                let y_j = self.values[[j, col]];
+                let m_i = self.second_derivatives[[i, col]];
+                let m_j = self.second_derivatives[[j, col]];
+                out[[row, col]] = match derivative_order {
+                    0 => {
+                        a * y_i
+                            + b * y_j
+                            + ((a * a * a - a) * m_i + (b * b * b - b) * m_j) * h * h / 6.0
+                    }
+                    1 => {
+                        (y_j - y_i) / h
+                            + ((-3.0 * a * a + 1.0) * m_i + (3.0 * b * b - 1.0) * m_j) * h / 6.0
+                    }
+                    2 => a * m_i + b * m_j,
+                    _ => unreachable!(),
+                };
+            }
+        }
+        Ok(out)
+    }
+}
+
+pub fn fit_periodic_spline_1d(
+    u: ArrayView1<'_, f64>,
+    y: ArrayView2<'_, f64>,
+    options: PeriodicSpline1DOptions,
+) -> Result<PeriodicSpline1D, BasisError> {
+    PeriodicSpline1D::fit(u, y, options)
+}
+
+fn wrap_periodic(x: f64, options: PeriodicSpline1DOptions) -> f64 {
+    let shifted = (x - options.origin).rem_euclid(options.period);
+    let mut wrapped = options.origin + shifted;
+    let upper = options.origin + options.period;
+    if wrapped >= upper {
+        wrapped = options.origin;
+    }
+    wrapped
+}
+
+fn coalesce_periodic_samples(
+    u: ArrayView1<'_, f64>,
+    y: ArrayView2<'_, f64>,
+    options: PeriodicSpline1DOptions,
+) -> Result<(Array1<f64>, Array2<f64>), BasisError> {
+    let mut rows: Vec<(f64, Vec<f64>)> = u
+        .iter()
+        .enumerate()
+        .map(|(i, &ui)| (wrap_periodic(ui, options), y.row(i).to_vec()))
+        .collect();
+    rows.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap_or(std::cmp::Ordering::Equal));
+
+    let tol = options
+        .duplicate_tolerance
+        .max(64.0 * f64::EPSILON * options.period.abs());
+    let d = y.ncols();
+    let mut grouped_sites: Vec<f64> = Vec::new();
+    let mut grouped_values: Vec<Vec<f64>> = Vec::new();
+    let mut grouped_counts: Vec<usize> = Vec::new();
+
+    for (site, value) in rows {
+        if let Some(last) = grouped_sites.last_mut() {
+            if (site - *last).abs() <= tol {
+                let count = *grouped_counts.last().expect("group count exists") as f64;
+                let target = grouped_values.last_mut().expect("group value exists");
+                for col in 0..d {
+                    target[col] = (target[col] * count + value[col]) / (count + 1.0);
+                }
+                *last = (*last * count + site) / (count + 1.0);
+                *grouped_counts.last_mut().expect("group count exists") += 1;
+                continue;
+            }
+        }
+        grouped_sites.push(site);
+        grouped_values.push(value);
+        grouped_counts.push(1);
+    }
+
+    if grouped_sites.len() >= 2 {
+        let first = grouped_sites[0];
+        let last_idx = grouped_sites.len() - 1;
+        let last_equiv = grouped_sites[last_idx] - options.period;
+        if (first - last_equiv).abs() <= tol {
+            let first_count = grouped_counts[0] as f64;
+            let last_count = grouped_counts[last_idx] as f64;
+            let total = first_count + last_count;
+            for col in 0..d {
+                grouped_values[0][col] = (grouped_values[0][col] * first_count
+                    + grouped_values[last_idx][col] * last_count)
+                    / total;
+            }
+            grouped_counts[0] += grouped_counts[last_idx];
+            grouped_sites.remove(last_idx);
+            grouped_values.remove(last_idx);
+            grouped_counts.remove(last_idx);
+        }
+    }
+
+    let n = grouped_sites.len();
+    let sites = Array1::from_vec(grouped_sites);
+    let flat: Vec<f64> = grouped_values.into_iter().flatten().collect();
+    let values = Array2::from_shape_vec((n, d), flat).map_err(|e| {
+        BasisError::InvalidInput(format!("failed to construct periodic output matrix: {e}"))
+    })?;
+    Ok((sites, values))
+}
+
+fn periodic_spacings(
+    sites: ArrayView1<'_, f64>,
+    options: PeriodicSpline1DOptions,
+) -> Result<Vec<f64>, BasisError> {
+    let n = sites.len();
+    let mut h = Vec::with_capacity(n);
+    for i in 0..n {
+        let next = if i + 1 == n {
+            sites[0] + options.period
+        } else {
+            sites[i + 1]
+        };
+        h.push(next - sites[i]);
+    }
+    Ok(h)
+}
+
+fn periodic_interval_index(sites: ArrayView1<'_, f64>, x: f64) -> usize {
+    let n = sites.len();
+    match sites
+        .as_slice()
+        .expect("sites array is contiguous")
+        .binary_search_by(|v| v.partial_cmp(&x).unwrap_or(std::cmp::Ordering::Less))
+    {
+        Ok(idx) => idx.min(n - 1),
+        Err(0) => n - 1,
+        Err(idx) => idx - 1,
+    }
+}
+
+fn solve_periodic_cubic_second_derivatives(
+    values: ArrayView2<'_, f64>,
+    h: &[f64],
+) -> Result<Array2<f64>, BasisError> {
+    let n = values.nrows();
+    let d = values.ncols();
+    if h.len() != n {
+        return Err(BasisError::DimensionMismatch(
+            "periodic spacing count must match value rows".to_string(),
+        ));
+    }
+    let mut a = Array2::<f64>::zeros((n, n));
+    for i in 0..n {
+        let prev = if i == 0 { n - 1 } else { i - 1 };
+        let next = if i + 1 == n { 0 } else { i + 1 };
+        a[[i, prev]] = h[prev];
+        a[[i, i]] = 2.0 * (h[prev] + h[i]);
+        a[[i, next]] = h[i];
+    }
+    let mut rhs = Array2::<f64>::zeros((n, d));
+    for i in 0..n {
+        let prev = if i == 0 { n - 1 } else { i - 1 };
+        let next = if i + 1 == n { 0 } else { i + 1 };
+        for col in 0..d {
+            let slope_next = (values[[next, col]] - values[[i, col]]) / h[i];
+            let slope_prev = (values[[i, col]] - values[[prev, col]]) / h[prev];
+            rhs[[i, col]] = 6.0 * (slope_next - slope_prev);
+        }
+    }
+    solve_dense_linear_system_multi_rhs(a, rhs)
+}
+
+fn solve_dense_linear_system_multi_rhs(
+    mut a: Array2<f64>,
+    mut b: Array2<f64>,
+) -> Result<Array2<f64>, BasisError> {
+    let n = a.nrows();
+    if a.ncols() != n || b.nrows() != n {
+        return Err(BasisError::DimensionMismatch(
+            "dense linear solve shape mismatch".to_string(),
+        ));
+    }
+    let nrhs = b.ncols();
+    for k in 0..n {
+        let mut pivot = k;
+        let mut pivot_abs = a[[k, k]].abs();
+        for r in (k + 1)..n {
+            let candidate = a[[r, k]].abs();
+            if candidate > pivot_abs {
+                pivot = r;
+                pivot_abs = candidate;
+            }
+        }
+        if pivot_abs <= 1e-14 {
+            return Err(BasisError::InvalidInput(
+                "periodic cubic spline system is singular".to_string(),
+            ));
+        }
+        if pivot != k {
+            for c in k..n {
+                a.swap((k, c), (pivot, c));
+            }
+            for c in 0..nrhs {
+                b.swap((k, c), (pivot, c));
+            }
+        }
+        for r in (k + 1)..n {
+            let factor = a[[r, k]] / a[[k, k]];
+            a[[r, k]] = 0.0;
+            for c in (k + 1)..n {
+                a[[r, c]] -= factor * a[[k, c]];
+            }
+            for c in 0..nrhs {
+                b[[r, c]] -= factor * b[[k, c]];
+            }
+        }
+    }
+    let mut x = Array2::<f64>::zeros((n, nrhs));
+    for rhs_col in 0..nrhs {
+        for i_rev in 0..n {
+            let i = n - 1 - i_rev;
+            let mut sum = b[[i, rhs_col]];
+            for c in (i + 1)..n {
+                sum -= a[[i, c]] * x[[c, rhs_col]];
+            }
+            x[[i, rhs_col]] = sum / a[[i, i]];
+        }
+    }
+    Ok(x)
+}
 /// Which knot strategy to use for 1D B-spline bases.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum BSplineKnotSpec {

--- a/tests/periodic_spline_1d.rs
+++ b/tests/periodic_spline_1d.rs
@@ -1,0 +1,125 @@
+use gam::basis::{PeriodicSpline1DOptions, fit_periodic_spline_1d};
+use ndarray::{Array1, Array2, array};
+
+const TWO_PI: f64 = std::f64::consts::TAU;
+
+fn max_abs(a: &Array2<f64>, b: &Array2<f64>) -> f64 {
+    a.iter()
+        .zip(b.iter())
+        .map(|(x, y)| (x - y).abs())
+        .fold(0.0, f64::max)
+}
+
+#[test]
+fn periodic_spline_interpolates_anisotropic_ellipse_in_multi_output_space() {
+    let n = 33;
+    let mut u = Array1::<f64>::zeros(n);
+    let mut y = Array2::<f64>::zeros((n, 2));
+    for i in 0..n {
+        let t = i as f64 * TWO_PI / n as f64;
+        u[i] = t;
+        // Strong anisotropic stretching: not a unit circle.
+        y[[i, 0]] = 4.0 * t.cos();
+        y[[i, 1]] = 0.35 * t.sin();
+    }
+
+    let spline = fit_periodic_spline_1d(u.view(), y.view(), PeriodicSpline1DOptions::new(TWO_PI))
+        .expect("periodic ellipse fit");
+    let fitted = spline.evaluate(u.view()).expect("ellipse eval at knots");
+
+    assert_eq!(spline.ambient_dim(), 2);
+    assert_eq!(spline.num_sites(), n);
+    assert!(max_abs(&fitted, &y) < 1e-10);
+
+    let seam = array![0.0, TWO_PI, -TWO_PI, 11.0 * TWO_PI];
+    let seam_y = spline.evaluate(seam.view()).expect("seam eval");
+    for row in 1..seam_y.nrows() {
+        for col in 0..seam_y.ncols() {
+            assert!((seam_y[[row, col]] - seam_y[[0, col]]).abs() < 1e-10);
+        }
+    }
+
+    let deriv = spline
+        .evaluate_derivative(array![0.0, TWO_PI].view())
+        .expect("seam derivative");
+    for col in 0..deriv.ncols() {
+        assert!((deriv[[0, col]] - deriv[[1, col]]).abs() < 1e-10);
+    }
+}
+
+#[test]
+fn periodic_spline_handles_skewed_oval_embedded_in_3d() {
+    let n = 48;
+    let mut u = Array1::<f64>::zeros(n);
+    let mut y = Array2::<f64>::zeros((n, 3));
+    for i in 0..n {
+        let t = i as f64 * TWO_PI / n as f64;
+        u[i] = t;
+        // A distorted loop with mixed harmonics and a non-axis-aligned ambient embedding.
+        let x = 2.0 * t.cos() + 0.22 * (3.0 * t).cos();
+        let z = 0.8 * t.sin() - 0.15 * (2.0 * t).sin();
+        y[[i, 0]] = x + 0.4 * z;
+        y[[i, 1]] = -0.3 * x + 1.7 * z;
+        y[[i, 2]] = 0.25 * (t + 0.3).sin() + 0.1 * (4.0 * t).cos();
+    }
+
+    let spline = fit_periodic_spline_1d(u.view(), y.view(), PeriodicSpline1DOptions::new(TWO_PI))
+        .expect("periodic 3d oval fit");
+    let fitted = spline.evaluate(u.view()).expect("oval eval at knots");
+    assert_eq!(spline.ambient_dim(), 3);
+    assert!(max_abs(&fitted, &y) < 1e-10);
+
+    let dense_m = 97;
+    let mut dense_u = Array1::<f64>::zeros(dense_m);
+    for i in 0..dense_m {
+        dense_u[i] = -1.2 * TWO_PI + i as f64 * 3.4 * TWO_PI / (dense_m - 1) as f64;
+    }
+    let dense_y = spline.evaluate(dense_u.view()).expect("dense wrapped eval");
+    let shifted = dense_u.mapv(|v| v + 5.0 * TWO_PI);
+    let shifted_y = spline.evaluate(shifted.view()).expect("shifted eval");
+    assert!(max_abs(&dense_y, &shifted_y) < 1e-10);
+}
+
+#[test]
+fn periodic_spline_accepts_unsorted_samples_and_duplicate_endpoint() {
+    let u = array![TWO_PI, 0.5 * TWO_PI, 0.0, 1.5 * TWO_PI, 0.25 * TWO_PI];
+    let mut y = Array2::<f64>::zeros((u.len(), 2));
+    for i in 0..u.len() {
+        let t = u[i];
+        y[[i, 0]] = 1.5 * t.cos();
+        y[[i, 1]] = 0.25 * t.sin();
+    }
+
+    let spline = fit_periodic_spline_1d(u.view(), y.view(), PeriodicSpline1DOptions::new(TWO_PI))
+        .expect("fit with duplicate endpoint");
+    assert_eq!(spline.num_sites(), 3);
+
+    let at_zero = spline.evaluate(array![0.0].view()).expect("zero eval");
+    let at_period = spline.evaluate(array![TWO_PI].view()).expect("period eval");
+    assert!(max_abs(&at_zero, &at_period) < 1e-12);
+    assert!((at_zero[[0, 0]] - 1.5).abs() < 1e-12);
+    assert!(at_zero[[0, 1]].abs() < 1e-12);
+}
+
+#[test]
+fn periodic_spline_rejects_scalar_only_or_degenerate_inputs() {
+    let u = array![0.0, 1.0];
+    let y = Array2::<f64>::zeros((2, 2));
+    let err = fit_periodic_spline_1d(u.view(), y.view(), PeriodicSpline1DOptions::new(2.0))
+        .expect_err("too few samples should fail");
+    assert!(err.to_string().contains("at least three samples"));
+
+    let u3 = array![0.0, 1.0, 2.0];
+    let y_bad = Array2::<f64>::zeros((2, 2));
+    let err = fit_periodic_spline_1d(u3.view(), y_bad.view(), PeriodicSpline1DOptions::new(3.0))
+        .expect_err("row mismatch should fail");
+    assert!(err.to_string().contains("does not match output row count"));
+
+    let y3 = Array2::<f64>::zeros((3, 1));
+    let err = fit_periodic_spline_1d(u3.view(), y3.view(), PeriodicSpline1DOptions::new(f64::NAN))
+        .expect_err("bad period should fail");
+    assert!(
+        err.to_string()
+            .contains("period must be finite and positive")
+    );
+}


### PR DESCRIPTION
### Motivation
- Provide a native 1D periodic spline that maps `u -> R^d` so closed curves (circles, ellipses, ovals, skewed/distorted loops) can be represented without assuming a unit-radius embedding. 
- Support robust user inputs: unsorted samples, duplicate endpoints (wrapped), and arbitrary periodic parameter ranges. 
- Expose a small, serializable API for fitting and evaluating periodic spline curves including derivatives for downstream usage and testing.

### Description
- Add `PeriodicSpline1DOptions` and `PeriodicSpline1D` (serializable) plus public constructor `fit_periodic_spline_1d` and accessors `period`, `origin`, `ambient_dim`, `num_sites`, `sites`, `values`. 
- Implement fitting pipeline that wraps parameters into one period, coalesces duplicate/near-duplicate periodic sites, sorts sites, validates spacings, and builds a shared cyclic cubic solve to compute second derivatives for all output coordinates. 
- Implement evaluation helpers for value/first/second derivatives and lower-level helpers `wrap_periodic`, `coalesce_periodic_samples`, `periodic_spacings`, `periodic_interval_index`, `solve_periodic_cubic_second_derivatives`, and a dense multi-RHS linear solver. 
- Add integration tests in `tests/periodic_spline_1d.rs` exercising anisotropic ellipses, skewed 3D ovals, seam/derivative closure, wrapped-evaluation invariance, unsorted/duplicate endpoints, and invalid-input diagnostics.

### Testing
- Ran `cargo test --test periodic_spline_1d` which executed the new integration tests and all tests passed (4 passed, 0 failed). 
- Ran `cargo check` (build check) which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07c744619c8324954fbbb61c00dbe1)