### PR TITLE
Implement boundary-conditioned 1D smooths

### DIFF
--- a/docs/formulas.md
+++ b/docs/formulas.md
@@ -90,6 +90,8 @@ y ~ s(x, knots=10)          # 10 interior knots
 y ~ s(x, degree=3, penalty_order=2)
 y ~ s(x, type=ps)           # explicit P-spline
 y ~ s(x, double_penalty=true)
+y ~ s(x, bc_left=anchored, anchor_left=0)  # start at a known value only
+y ~ s(x, bc=clamped)        # zero slope at both endpoints
 ```
 
 For a single covariate, `s(x)` defaults to a cubic P-spline with a
@@ -103,6 +105,11 @@ second-order difference penalty. Options:
 | `penalty_order` | 2 | Derivative order penalised (1 = slope, 2 = curvature). |
 | `type` | `ps` (1-D), `tps` (2+D) | `ps`, `tps`, `matern`, `duchon`. |
 | `double_penalty` | `true` | Add a ridge penalty alongside the difference penalty. |
+| `bc` | `none` | Boundary condition for both endpoints: `none`, `clamped` (zero first derivative), or `anchored` (fixed value). Combine with `side=left`/`right` for half-open smooths. |
+| `bc_left`, `bc_right` | inherit from `bc` | Per-endpoint overrides, with aliases `start_bc`/`end_bc`. |
+| `anchor`, `anchor_left`, `anchor_right` | `0` for anchored endpoints | Fixed endpoint value(s) when an endpoint uses `anchored`. |
+
+Boundary conditions are available for 1-D P-spline smooths. They are useful for trajectories with a known start or end: `bc_left=anchored, anchor_left=0` fixes only the left endpoint, while leaving the right endpoint open; `bc_right=clamped` forces a flat terminal slope.
 
 Default `k`: `clamp(unique_values / 4, 4, max(20, cbrt(unique_values)))`.
 

--- a/src/families/survival_construction.rs
+++ b/src/families/survival_construction.rs
@@ -906,6 +906,7 @@ pub fn build_survival_time_basis(
                         },
                         double_penalty: false,
                         identifiability: BSplineIdentifiability::None,
+                        boundary_condition: Default::default(),
                     },
                 )
                 .map_err(|e| format!("failed to infer survival time knots: {e}"))?;
@@ -1000,6 +1001,7 @@ pub fn build_survival_time_basis(
                     knotspec: BSplineKnotSpec::Provided(knotvec.clone()),
                     double_penalty: false,
                     identifiability: BSplineIdentifiability::None,
+                    boundary_condition: Default::default(),
                 },
             )
             .map_err(|e| format!("failed to build bspline entry basis: {e}"))?;
@@ -1011,6 +1013,7 @@ pub fn build_survival_time_basis(
                     knotspec: BSplineKnotSpec::Provided(knotvec.clone()),
                     double_penalty: false,
                     identifiability: BSplineIdentifiability::None,
+                    boundary_condition: Default::default(),
                 },
             )
             .map_err(|e| format!("failed to build bspline exit basis: {e}"))?;
@@ -1236,6 +1239,7 @@ pub fn build_survival_time_basis(
                     knotspec: BSplineKnotSpec::Provided(knotvec.clone()),
                     double_penalty: false,
                     identifiability: BSplineIdentifiability::None,
+                    boundary_condition: Default::default(),
                 },
             )
             .map_err(|e| format!("failed to build ispline smoothing penalty: {e}"))?;
@@ -1384,6 +1388,7 @@ pub fn evaluate_survival_time_basis_row(
                     knotspec: BSplineKnotSpec::Provided(knots.clone()),
                     double_penalty: false,
                     identifiability: BSplineIdentifiability::None,
+                    boundary_condition: Default::default(),
                 },
             )
             .map_err(|e| format!("failed to evaluate survival bspline anchor row: {e}"))?;
@@ -2779,6 +2784,7 @@ pub fn build_time_varying_survival_covariate_template(
         },
         double_penalty: false,
         identifiability: BSplineIdentifiability::None,
+        boundary_condition: Default::default(),
     };
 
     let time_build = build_bspline_basis_1d(log_exit.view(), &time_spec)
@@ -2802,6 +2808,7 @@ pub fn build_time_varying_survival_covariate_template(
             knotspec: BSplineKnotSpec::Provided(knots.clone()),
             double_penalty: false,
             identifiability: BSplineIdentifiability::None,
+            boundary_condition: Default::default(),
         },
     )
     .map_err(|e| format!("failed to evaluate {block_name} time-margin basis at entry: {e}"))?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -11792,6 +11792,7 @@ mod tests {
                             },
                             double_penalty: false,
                             identifiability: BSplineIdentifiability::default(),
+                            boundary_condition: Default::default(),
                         },
                     },
                     shape: ShapeConstraint::None,

--- a/src/terms/basis.rs
+++ b/src/terms/basis.rs
@@ -1403,6 +1403,47 @@ pub struct BSplineBasisSpec {
     pub knotspec: BSplineKnotSpec,
     pub double_penalty: bool,
     pub identifiability: BSplineIdentifiability,
+    /// Optional endpoint value/slope constraints for 1D B-spline smooths.
+    ///
+    /// These are enforced by the smooth-term builder as linear equality
+    /// constraints (represented internally as paired inequalities) in the
+    /// final coefficient coordinates, after identifiability and shape
+    /// reparameterizations have been applied.
+    #[serde(default)]
+    pub boundary_condition: BSplineBoundaryCondition,
+}
+
+/// Per-endpoint boundary condition for a 1D B-spline smooth.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+pub enum BSplineEndpointCondition {
+    /// Do not constrain this endpoint.
+    None,
+    /// Force the first derivative to zero at this endpoint.
+    Clamped,
+    /// Force the smooth value to the supplied value at this endpoint.
+    Anchored { value: f64 },
+}
+
+impl Default for BSplineEndpointCondition {
+    fn default() -> Self {
+        Self::None
+    }
+}
+
+/// Boundary conditions for the left and right endpoints of a 1D B-spline smooth.
+#[derive(Debug, Clone, Copy, PartialEq, Default, Serialize, Deserialize)]
+pub struct BSplineBoundaryCondition {
+    #[serde(default)]
+    pub left: BSplineEndpointCondition,
+    #[serde(default)]
+    pub right: BSplineEndpointCondition,
+}
+
+impl BSplineBoundaryCondition {
+    pub fn is_unconstrained(self) -> bool {
+        matches!(self.left, BSplineEndpointCondition::None)
+            && matches!(self.right, BSplineEndpointCondition::None)
+    }
 }
 
 /// Per-smooth identifiability policy for 1D B-spline bases.
@@ -22658,6 +22699,7 @@ mod tests {
             },
             double_penalty: true,
             identifiability: BSplineIdentifiability::default(),
+            boundary_condition: Default::default(),
         };
         let result = build_bspline_basis_1d(x.view(), &spec).unwrap();
         assert_eq!(result.penalties.len(), 2);
@@ -22684,6 +22726,7 @@ mod tests {
             },
             double_penalty: false,
             identifiability: BSplineIdentifiability::default(),
+            boundary_condition: Default::default(),
         };
 
         let result = build_bspline_basis_1d(x.view(), &spec).unwrap();
@@ -22708,6 +22751,7 @@ mod tests {
             },
             double_penalty: false,
             identifiability: BSplineIdentifiability::default(),
+            boundary_condition: Default::default(),
         };
 
         let result = build_bspline_basis_1d(x.view(), &spec).unwrap();
@@ -22745,6 +22789,7 @@ mod tests {
             },
             double_penalty: false,
             identifiability: BSplineIdentifiability::None,
+            boundary_condition: Default::default(),
         };
 
         let built = build_bspline_basis_1d(x.view(), &spec).unwrap();
@@ -22788,6 +22833,7 @@ mod tests {
             },
             double_penalty: false,
             identifiability: BSplineIdentifiability::None,
+            boundary_condition: Default::default(),
         };
 
         let built = build_bspline_basis_1d(x.view(), &spec).expect("build sparse bspline");
@@ -22806,6 +22852,7 @@ mod tests {
             },
             double_penalty: false,
             identifiability: BSplineIdentifiability::default(),
+            boundary_condition: Default::default(),
         };
 
         let built = build_bspline_basis_1d(x.view(), &spec).expect("build centered sparse bspline");
@@ -22824,6 +22871,7 @@ mod tests {
             },
             double_penalty: false,
             identifiability: BSplineIdentifiability::None,
+            boundary_condition: Default::default(),
         };
 
         match build_bspline_basis_1d(x.view(), &spec).unwrap_err() {
@@ -22876,6 +22924,7 @@ mod tests {
             },
             double_penalty: false,
             identifiability: BSplineIdentifiability::default(),
+            boundary_condition: Default::default(),
         };
 
         let built = build_bspline_basis_1d(x.view(), &spec).unwrap();
@@ -22929,6 +22978,7 @@ mod tests {
             identifiability: BSplineIdentifiability::WeightedSumToZero {
                 weights: Some(weights.clone()),
             },
+            boundary_condition: Default::default(),
         };
 
         let built = build_bspline_basis_1d(x.view(), &spec).unwrap();
@@ -22955,9 +23005,11 @@ mod tests {
             },
             double_penalty: false,
             identifiability: BSplineIdentifiability::None,
+            boundary_condition: Default::default(),
         };
         let constrained = BSplineBasisSpec {
             identifiability: BSplineIdentifiability::RemoveLinearTrend,
+            boundary_condition: Default::default(),
             ..raw.clone()
         };
 
@@ -22985,6 +23037,7 @@ mod tests {
                 columns: constraints.clone(),
                 weights: None,
             },
+            boundary_condition: Default::default(),
         };
 
         let built = build_bspline_basis_1d(x.view(), &spec).unwrap();

--- a/src/terms/smooth.rs
+++ b/src/terms/smooth.rs
@@ -1,7 +1,8 @@
 use crate::basis::{
-    BSplineBasisSpec, BSplineIdentifiability, BSplineKnotSpec, BasisBuildResult, BasisError,
-    BasisMetadata, BasisPsiDerivativeResult, BasisPsiSecondDerivativeResult, CenterStrategy,
-    CenterStrategyKind, DuchonBasisSpec, DuchonNullspaceOrder, DuchonOperatorPenaltySpec,
+    BSplineBasisSpec, BSplineBoundaryCondition, BSplineEndpointCondition, BSplineIdentifiability,
+    BSplineKnotSpec, BasisBuildResult, BasisError, BasisMetadata, BasisOptions,
+    BasisPsiDerivativeResult, BasisPsiSecondDerivativeResult, CenterStrategy, CenterStrategyKind,
+    Dense, DuchonBasisSpec, DuchonNullspaceOrder, DuchonOperatorPenaltySpec, KnotSource,
     KroneckerFactoredBasis, MaternBasisSpec, MaternIdentifiability, PenaltyCandidate, PenaltyInfo,
     PenaltySource, SpatialIdentifiability, ThinPlateBasisSpec, apply_sum_to_zero_constraint,
     build_bspline_basis_1d, build_duchon_basis, build_duchon_basis_log_kappa_aniso_derivatives,
@@ -2625,6 +2626,7 @@ fn build_shape_constraint_design_1d(
                         transform: z.clone(),
                     })
                     .unwrap_or(BSplineIdentifiability::None),
+                boundary_condition: Default::default(),
             };
             build_bspline_basis_1d(x_grid.view(), &evalspec)?
                 .design
@@ -3231,6 +3233,137 @@ impl SmoothDesign {
     }
 }
 
+fn bspline_boundary_endpoint(
+    knots: &Array1<f64>,
+    degree: usize,
+    right: bool,
+) -> Result<f64, BasisError> {
+    if knots.len() <= degree + 1 {
+        return Err(BasisError::InvalidInput(
+            "B-spline boundary condition requires a valid knot vector".to_string(),
+        ));
+    }
+    let n_basis = knots.len() - degree - 1;
+    Ok(if right { knots[n_basis] } else { knots[degree] })
+}
+
+fn bspline_endpoint_row(
+    knots: &Array1<f64>,
+    degree: usize,
+    condition: BSplineEndpointCondition,
+    right: bool,
+    identifiability_transform: Option<&Array2<f64>>,
+    coefficient_transform: Option<&Array2<f64>>,
+) -> Result<Option<(Array1<f64>, f64)>, BasisError> {
+    let derivative_order = match condition {
+        BSplineEndpointCondition::None => return Ok(None),
+        BSplineEndpointCondition::Clamped => 1,
+        BSplineEndpointCondition::Anchored { .. } => 0,
+    };
+    let target = match condition {
+        BSplineEndpointCondition::None | BSplineEndpointCondition::Clamped => 0.0,
+        BSplineEndpointCondition::Anchored { value } => value,
+    };
+    if !target.is_finite() {
+        return Err(BasisError::InvalidInput(
+            "anchored B-spline boundary value must be finite".to_string(),
+        ));
+    }
+    let endpoint = bspline_boundary_endpoint(knots, degree, right)?;
+    let point = Array1::from_vec(vec![endpoint]);
+    let options = if derivative_order == 1 {
+        BasisOptions::first_derivative()
+    } else {
+        BasisOptions::value()
+    };
+    let (raw, _) = crate::basis::create_basis::<Dense>(
+        point.view(),
+        KnotSource::Provided(knots.view()),
+        degree,
+        options,
+    )?;
+    let mut row = raw.row(0).to_owned();
+    if let Some(z) = identifiability_transform {
+        if row.len() != z.nrows() {
+            return Err(BasisError::DimensionMismatch(format!(
+                "B-spline boundary constraint transform mismatch: row has {} columns but transform has {} rows",
+                row.len(),
+                z.nrows()
+            )));
+        }
+        row = row.dot(z);
+    }
+    if let Some(t) = coefficient_transform {
+        if row.len() != t.nrows() {
+            return Err(BasisError::DimensionMismatch(format!(
+                "B-spline boundary constraint coefficient transform mismatch: row has {} columns but transform has {} rows",
+                row.len(),
+                t.nrows()
+            )));
+        }
+        row = row.dot(t);
+    }
+    Ok(Some((row, target)))
+}
+
+fn bspline_boundary_linear_constraints(
+    boundary: BSplineBoundaryCondition,
+    metadata: &BasisMetadata,
+    degree: usize,
+    coefficient_transform: Option<&Array2<f64>>,
+) -> Result<Option<LinearInequalityConstraints>, BasisError> {
+    if boundary.is_unconstrained() {
+        return Ok(None);
+    }
+    let BasisMetadata::BSpline1D {
+        knots,
+        identifiability_transform,
+    } = metadata
+    else {
+        return Err(BasisError::InvalidInput(
+            "B-spline boundary constraints require B-spline metadata".to_string(),
+        ));
+    };
+
+    let mut eq_rows = Vec::<Array1<f64>>::new();
+    let mut eq_targets = Vec::<f64>::new();
+    for (cond, right) in [(boundary.left, false), (boundary.right, true)] {
+        if let Some((row, target)) = bspline_endpoint_row(
+            knots,
+            degree,
+            cond,
+            right,
+            identifiability_transform.as_ref(),
+            coefficient_transform,
+        )? {
+            let norm = row.dot(&row).sqrt();
+            if norm <= 1e-12 {
+                if target.abs() > 1e-12 {
+                    return Err(BasisError::InvalidInput(format!(
+                        "anchored B-spline boundary value {target} is infeasible because the endpoint row is zero"
+                    )));
+                }
+                continue;
+            }
+            eq_rows.push(row);
+            eq_targets.push(target);
+        }
+    }
+    if eq_rows.is_empty() {
+        return Ok(None);
+    }
+    let p = eq_rows[0].len();
+    let mut a = Array2::<f64>::zeros((2 * eq_rows.len(), p));
+    let mut b = Array1::<f64>::zeros(2 * eq_rows.len());
+    for (i, (row, &target)) in eq_rows.iter().zip(eq_targets.iter()).enumerate() {
+        a.row_mut(2 * i).assign(row);
+        b[2 * i] = target;
+        a.row_mut(2 * i + 1).assign(&row.mapv(|v| -v));
+        b[2 * i + 1] = -target;
+    }
+    Ok(Some(LinearInequalityConstraints { a, b }))
+}
+
 struct LocalSmoothTermBuild {
     dim: usize,
     design: DesignMatrix,
@@ -3530,10 +3663,12 @@ fn build_single_local_smooth_term(
         .collect::<Vec<_>>();
     let use_box_reparam =
         term.shape != ShapeConstraint::None && shape_uses_box_reparameterization(&term.basis);
+    let mut coefficient_transform_for_constraints: Option<Array2<f64>> = None;
     if let Some((order, sign)) = shape_order_and_sign(term.shape)
         && use_box_reparam
     {
         let t = cumulative_sum_transform_matrix(p_local, order, sign);
+        coefficient_transform_for_constraints = Some(t.clone());
         // Coefficient-side transform: wrap the design in an operator that
         // applies T on the coefficient side, preserving sparsity/operator
         // structure of the inner design.
@@ -3603,7 +3738,7 @@ fn build_single_local_smooth_term(
         .collect::<Result<Vec<_>, _>>()?;
     let (penalties_t, nullspaces_t, penaltyinfo_t, ops_t) =
         crate::terms::basis::filter_active_penalty_candidates_with_ops(penalty_candidates)?;
-    let linear_constraints_local = if term.shape != ShapeConstraint::None && !use_box_reparam {
+    let shape_linear_constraints = if term.shape != ShapeConstraint::None && !use_box_reparam {
         let axis = shape_axis_col.ok_or_else(|| {
             BasisError::InvalidInput(format!(
                 "internal shape-constraint axis missing for term '{}'",
@@ -3620,6 +3755,17 @@ fn build_single_local_smooth_term(
     } else {
         None
     };
+    let boundary_linear_constraints = match &term.basis {
+        SmoothBasisSpec::BSpline1D { spec, .. } => bspline_boundary_linear_constraints(
+            spec.boundary_condition,
+            &metadata,
+            spec.degree,
+            coefficient_transform_for_constraints.as_ref(),
+        )?,
+        _ => None,
+    };
+    let linear_constraints_local =
+        merge_linear_constraints_global(shape_linear_constraints, boundary_linear_constraints);
 
     Ok(LocalSmoothTermBuild {
         dim: p_local,
@@ -13993,16 +14139,134 @@ pub fn fit_term_collectionwith_spatial_length_scale_optimization(
 mod tests {
     use super::*;
     use crate::basis::{
-        BSplineBasisSpec, BSplineIdentifiability, BSplineKnotSpec, CenterStrategy, DuchonBasisSpec,
+        BSplineBasisSpec, BSplineBoundaryCondition, BSplineEndpointCondition,
+        BSplineIdentifiability, BSplineKnotSpec, CenterStrategy, DuchonBasisSpec,
         DuchonNullspaceOrder, DuchonOperatorPenaltySpec, MaternBasisSpec, MaternIdentifiability,
         MaternNu, SpatialIdentifiability, ThinPlateBasisSpec,
     };
     use crate::estimate::AdaptiveRegularizationOptions;
     use crate::faer_ndarray::{FaerEigh, FaerSvd};
-    use ndarray::array;
+    use ndarray::{Axis, array};
     use rand::RngExt;
     use rand::SeedableRng;
     use rand::rngs::StdRng;
+
+    #[test]
+    fn bspline_boundary_conditions_emit_paired_equality_constraints() {
+        let x = Array1::linspace(0.0, 1.0, 25);
+        let data = x.clone().insert_axis(Axis(1));
+        let spec = SmoothTermSpec {
+            name: "s(x, bc_left=anchored, anchor_left=2, bc_right=clamped)".to_string(),
+            basis: SmoothBasisSpec::BSpline1D {
+                feature_col: 0,
+                spec: BSplineBasisSpec {
+                    degree: 3,
+                    penalty_order: 2,
+                    knotspec: BSplineKnotSpec::Generate {
+                        data_range: (0.0, 1.0),
+                        num_internal_knots: 4,
+                    },
+                    double_penalty: false,
+                    identifiability: BSplineIdentifiability::None,
+                    boundary_condition: BSplineBoundaryCondition {
+                        left: BSplineEndpointCondition::Anchored { value: 2.0 },
+                        right: BSplineEndpointCondition::Clamped,
+                    },
+                },
+            },
+            shape: ShapeConstraint::None,
+        };
+        let design = build_smooth_design(data.view(), &[spec]).expect("boundary design");
+        let constraints = design
+            .linear_constraints
+            .as_ref()
+            .expect("boundary constraints");
+        assert_eq!(constraints.a.nrows(), 4);
+        assert_eq!(constraints.a.ncols(), design.total_smooth_cols());
+        assert_eq!(constraints.b.to_vec(), vec![2.0, -2.0, 0.0, -0.0]);
+
+        let metadata = &design.terms[0].metadata;
+        let BasisMetadata::BSpline1D { knots, .. } = metadata else {
+            panic!("expected B-spline metadata");
+        };
+        let (left_value, _) = crate::basis::create_basis::<Dense>(
+            array![0.0].view(),
+            KnotSource::Provided(knots.view()),
+            3,
+            BasisOptions::value(),
+        )
+        .expect("left endpoint basis");
+        let (right_slope, _) = crate::basis::create_basis::<Dense>(
+            array![1.0].view(),
+            KnotSource::Provided(knots.view()),
+            3,
+            BasisOptions::first_derivative(),
+        )
+        .expect("right endpoint derivative");
+        for j in 0..constraints.a.ncols() {
+            assert!((constraints.a[[0, j]] - left_value[[0, j]]).abs() < 1e-12);
+            assert!((constraints.a[[1, j]] + left_value[[0, j]]).abs() < 1e-12);
+            assert!((constraints.a[[2, j]] - right_slope[[0, j]]).abs() < 1e-12);
+            assert!((constraints.a[[3, j]] + right_slope[[0, j]]).abs() < 1e-12);
+        }
+    }
+
+    #[test]
+    fn bspline_boundary_conditions_follow_frozen_identifiability_transform() {
+        let x = Array1::linspace(0.0, 1.0, 20);
+        let data = x.insert_axis(Axis(1));
+        let raw_cols = 8;
+        let mut z = Array2::<f64>::zeros((raw_cols, raw_cols - 1));
+        for j in 0..(raw_cols - 1) {
+            z[[j, j]] = 1.0;
+            z[[raw_cols - 1, j]] = -1.0;
+        }
+        let spec = SmoothTermSpec {
+            name: "half-open anchored smooth".to_string(),
+            basis: SmoothBasisSpec::BSpline1D {
+                feature_col: 0,
+                spec: BSplineBasisSpec {
+                    degree: 3,
+                    penalty_order: 2,
+                    knotspec: BSplineKnotSpec::Generate {
+                        data_range: (0.0, 1.0),
+                        num_internal_knots: 4,
+                    },
+                    double_penalty: false,
+                    identifiability: BSplineIdentifiability::FrozenTransform {
+                        transform: z.clone(),
+                    },
+                    boundary_condition: BSplineBoundaryCondition {
+                        left: BSplineEndpointCondition::Anchored { value: 0.0 },
+                        right: BSplineEndpointCondition::None,
+                    },
+                },
+            },
+            shape: ShapeConstraint::None,
+        };
+        let design = build_smooth_design(data.view(), &[spec]).expect("boundary design");
+        let constraints = design
+            .linear_constraints
+            .as_ref()
+            .expect("boundary constraints");
+        assert_eq!(constraints.a.nrows(), 2);
+        assert_eq!(constraints.a.ncols(), raw_cols - 1);
+        let BasisMetadata::BSpline1D { knots, .. } = &design.terms[0].metadata else {
+            panic!("expected B-spline metadata");
+        };
+        let (left_value, _) = crate::basis::create_basis::<Dense>(
+            array![0.0].view(),
+            KnotSource::Provided(knots.view()),
+            3,
+            BasisOptions::value(),
+        )
+        .expect("left endpoint basis");
+        let expected = left_value.row(0).to_owned().dot(&z);
+        for j in 0..expected.len() {
+            assert!((constraints.a[[0, j]] - expected[j]).abs() < 1e-12);
+            assert!((constraints.a[[1, j]] + expected[j]).abs() < 1e-12);
+        }
+    }
 
     fn assert_spatial_derivative_width(
         label: &str,
@@ -14390,6 +14654,7 @@ mod tests {
                         },
                         double_penalty: true,
                         identifiability: BSplineIdentifiability::default(),
+                        boundary_condition: Default::default(),
                     },
                 },
                 shape: ShapeConstraint::None,
@@ -14694,6 +14959,7 @@ mod tests {
                     },
                     double_penalty: false,
                     identifiability: BSplineIdentifiability::default(),
+                    boundary_condition: Default::default(),
                 },
             },
             shape: ShapeConstraint::MonotoneIncreasing,
@@ -14785,6 +15051,7 @@ mod tests {
                         },
                         double_penalty: false,
                         identifiability: BSplineIdentifiability::default(),
+                        boundary_condition: Default::default(),
                     },
                 },
                 shape: ShapeConstraint::None,
@@ -15148,6 +15415,7 @@ mod tests {
                         },
                         double_penalty: false,
                         identifiability: BSplineIdentifiability::default(),
+                        boundary_condition: Default::default(),
                     },
                 },
                 shape: ShapeConstraint::None,
@@ -15271,6 +15539,7 @@ mod tests {
                     },
                     double_penalty: false,
                     identifiability: BSplineIdentifiability::default(),
+                    boundary_condition: Default::default(),
                 },
             },
             shape: ShapeConstraint::None,
@@ -15415,6 +15684,7 @@ mod tests {
                             },
                             double_penalty: false,
                             identifiability: BSplineIdentifiability::default(),
+                            boundary_condition: Default::default(),
                         },
                     },
                     shape: ShapeConstraint::None,
@@ -16045,6 +16315,7 @@ mod tests {
             },
             double_penalty: false,
             identifiability: BSplineIdentifiability::default(),
+            boundary_condition: Default::default(),
         };
         let spec_y = BSplineBasisSpec {
             degree: 3,
@@ -16055,6 +16326,7 @@ mod tests {
             },
             double_penalty: false,
             identifiability: BSplineIdentifiability::default(),
+            boundary_condition: Default::default(),
         };
 
         let terms = vec![SmoothTermSpec {
@@ -16100,6 +16372,7 @@ mod tests {
             },
             double_penalty: false,
             identifiability: BSplineIdentifiability::None,
+            boundary_condition: Default::default(),
         };
         let spec_y = BSplineBasisSpec {
             degree: 3,
@@ -16110,6 +16383,7 @@ mod tests {
             },
             double_penalty: false,
             identifiability: BSplineIdentifiability::None,
+            boundary_condition: Default::default(),
         };
         let mx = build_bspline_basis_1d(data.column(0), &spec_x)
             .unwrap()
@@ -16173,6 +16447,7 @@ mod tests {
                             },
                             double_penalty: false,
                             identifiability: BSplineIdentifiability::default(),
+                            boundary_condition: Default::default(),
                         },
                         BSplineBasisSpec {
                             degree: 3,
@@ -16183,6 +16458,7 @@ mod tests {
                             },
                             double_penalty: false,
                             identifiability: BSplineIdentifiability::default(),
+                            boundary_condition: Default::default(),
                         },
                     ],
                     double_penalty: false,
@@ -17818,6 +18094,7 @@ mod tests {
                         },
                         double_penalty: false,
                         identifiability: BSplineIdentifiability::default(),
+                        boundary_condition: Default::default(),
                     },
                 },
                 shape: ShapeConstraint::None,
@@ -18104,6 +18381,7 @@ mod tests {
                     },
                     double_penalty: true,
                     identifiability: BSplineIdentifiability::None,
+                    boundary_condition: Default::default(),
                 },
             },
             shape: ShapeConstraint::None,
@@ -18279,6 +18557,7 @@ mod tests {
                             },
                             double_penalty: false,
                             identifiability: BSplineIdentifiability::None,
+                            boundary_condition: Default::default(),
                         },
                     },
                     shape: ShapeConstraint::MonotoneIncreasing,
@@ -19986,6 +20265,7 @@ mod tests {
                         },
                         double_penalty: true,
                         identifiability: BSplineIdentifiability::None,
+                        boundary_condition: Default::default(),
                     },
                 },
                 shape: ShapeConstraint::None,

--- a/src/terms/term_builder.rs
+++ b/src/terms/term_builder.rs
@@ -9,11 +9,11 @@ use std::collections::{BTreeMap, HashMap};
 use ndarray::ArrayView1;
 
 use crate::basis::{
-    BSplineBasisSpec, BSplineIdentifiability, BSplineKnotSpec, CenterCountRequest, CenterStrategy,
-    DuchonBasisSpec, DuchonNullspaceOrder, DuchonOperatorPenaltySpec, MaternBasisSpec,
-    MaternIdentifiability, MaternNu, SpatialIdentifiability, ThinPlateBasisSpec,
-    auto_spatial_center_strategy, default_num_centers, default_spatial_center_strategy,
-    plan_spatial_basis, resolve_duchon_orders,
+    BSplineBasisSpec, BSplineBoundaryCondition, BSplineEndpointCondition, BSplineIdentifiability,
+    BSplineKnotSpec, CenterCountRequest, CenterStrategy, DuchonBasisSpec, DuchonNullspaceOrder,
+    DuchonOperatorPenaltySpec, MaternBasisSpec, MaternIdentifiability, MaternNu,
+    SpatialIdentifiability, ThinPlateBasisSpec, auto_spatial_center_strategy, default_num_centers,
+    default_spatial_center_strategy, plan_spatial_basis, resolve_duchon_orders,
 };
 use crate::inference::data::{EncodedDataset as Dataset, missing_column_message};
 use crate::inference::formula_dsl::{
@@ -276,6 +276,7 @@ pub fn build_smooth_basis(
                         },
                         double_penalty: smooth_double_penalty,
                         identifiability: BSplineIdentifiability::None,
+                        boundary_condition: Default::default(),
                     })
                 })
                 .collect::<Result<Vec<_>, String>>()?;
@@ -326,6 +327,7 @@ pub fn build_smooth_basis(
                     },
                     double_penalty: smooth_double_penalty,
                     identifiability: BSplineIdentifiability::default(),
+                    boundary_condition: parse_bspline_boundary_condition(options)?,
                 },
             })
         }
@@ -631,6 +633,108 @@ pub fn heuristic_centers(n: usize, d: usize) -> usize {
 // Smooth option parsers
 // ---------------------------------------------------------------------------
 
+fn parse_endpoint_side(value: &str, context: &str) -> Result<BSplineEndpointCondition, String> {
+    match value.trim().to_ascii_lowercase().as_str() {
+        "" | "none" | "open" | "unconstrained" => Ok(BSplineEndpointCondition::None),
+        "clamped" | "clamp" | "zero_derivative" | "zero-derivative" => {
+            Ok(BSplineEndpointCondition::Clamped)
+        }
+        "anchored" | "anchor" => Ok(BSplineEndpointCondition::Anchored { value: 0.0 }),
+        other => Err(format!(
+            "unsupported {context} boundary condition '{other}'; expected none, clamped, or anchored"
+        )),
+    }
+}
+
+fn boundary_anchor_value(
+    options: &BTreeMap<String, String>,
+    side: &str,
+    fallback: Option<f64>,
+) -> Option<f64> {
+    [
+        format!("anchor_{side}"),
+        format!("{side}_anchor"),
+        format!("anchor-value-{side}"),
+    ]
+    .iter()
+    .find_map(|key| option_f64(options, key))
+    .or(fallback)
+}
+
+fn apply_anchor_value(
+    cond: BSplineEndpointCondition,
+    value: Option<f64>,
+) -> BSplineEndpointCondition {
+    match cond {
+        BSplineEndpointCondition::Anchored { .. } => BSplineEndpointCondition::Anchored {
+            value: value.unwrap_or(0.0),
+        },
+        other => other,
+    }
+}
+
+fn parse_bspline_boundary_condition(
+    options: &BTreeMap<String, String>,
+) -> Result<BSplineBoundaryCondition, String> {
+    let fallback_anchor = option_f64(options, "anchor")
+        .or_else(|| option_f64(options, "anchor_value"))
+        .or_else(|| option_f64(options, "value"));
+    let global_bc = options
+        .get("bc")
+        .or_else(|| options.get("boundary_condition"));
+    let mut boundary = BSplineBoundaryCondition::default();
+
+    if let Some(raw_bc) = global_bc {
+        let cond = parse_endpoint_side(raw_bc, "bc")?;
+        let side = options
+            .get("side")
+            .or_else(|| options.get("boundary"))
+            .map(|s| s.trim().to_ascii_lowercase())
+            .unwrap_or_else(|| "both".to_string());
+        match side.as_str() {
+            "both" | "all" | "endpoints" => {
+                boundary.left = cond;
+                boundary.right = cond;
+            }
+            "left" | "start" | "lower" => boundary.left = cond,
+            "right" | "end" | "upper" => boundary.right = cond,
+            other => {
+                return Err(format!(
+                    "unsupported B-spline boundary side '{other}'; expected left, right, or both"
+                ));
+            }
+        }
+    }
+
+    if let Some(raw) = options
+        .get("bc_left")
+        .or_else(|| options.get("left_bc"))
+        .or_else(|| options.get("bc_start"))
+        .or_else(|| options.get("start_bc"))
+    {
+        boundary.left = parse_endpoint_side(raw, "left endpoint")?;
+    }
+    if let Some(raw) = options
+        .get("bc_right")
+        .or_else(|| options.get("right_bc"))
+        .or_else(|| options.get("bc_end"))
+        .or_else(|| options.get("end_bc"))
+    {
+        boundary.right = parse_endpoint_side(raw, "right endpoint")?;
+    }
+
+    boundary.left = apply_anchor_value(
+        boundary.left,
+        boundary_anchor_value(options, "left", fallback_anchor),
+    );
+    boundary.right = apply_anchor_value(
+        boundary.right,
+        boundary_anchor_value(options, "right", fallback_anchor),
+    );
+
+    Ok(boundary)
+}
+
 pub fn parse_ps_internal_knots(
     options: &BTreeMap<String, String>,
     degree: usize,
@@ -807,5 +911,41 @@ fn parse_tensor_identifiability(
         other => Err(format!(
             "invalid tensor identifiability '{other}'; expected one of: none, sum_tozero"
         )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_half_open_anchored_boundary_options() {
+        let mut options = BTreeMap::new();
+        options.insert("bc_left".to_string(), "anchored".to_string());
+        options.insert("anchor_left".to_string(), "1.5".to_string());
+        options.insert("bc_right".to_string(), "none".to_string());
+        let parsed = parse_bspline_boundary_condition(&options).expect("boundary options");
+        assert_eq!(
+            parsed,
+            BSplineBoundaryCondition {
+                left: BSplineEndpointCondition::Anchored { value: 1.5 },
+                right: BSplineEndpointCondition::None,
+            }
+        );
+    }
+
+    #[test]
+    fn parses_global_clamped_with_side_selector() {
+        let mut options = BTreeMap::new();
+        options.insert("bc".to_string(), "clamped".to_string());
+        options.insert("side".to_string(), "right".to_string());
+        let parsed = parse_bspline_boundary_condition(&options).expect("boundary options");
+        assert_eq!(
+            parsed,
+            BSplineBoundaryCondition {
+                left: BSplineEndpointCondition::None,
+                right: BSplineEndpointCondition::Clamped,
+            }
+        );
     }
 }


### PR DESCRIPTION
### Motivation
- Add explicit support for half-open and endpoint-conditioned 1‑D P-spline smooths (zero endpoint slope "clamped" and fixed-value "anchored") so users can express known start/end behaviour for trajectories and monotone fits.

### Description
- Introduce serialisable boundary types `BSplineBoundaryCondition` / `BSplineEndpointCondition` and a `boundary_condition` field on `BSplineBasisSpec`, with defaults and serde handling (`src/terms/basis.rs`).
- Parse formula options (`bc`, `bc_left`, `bc_right`, `side`, `anchor*`) into the spec via `parse_bspline_boundary_condition` and helper parsers used from `term_builder` so `s(...)` can declare endpoint behaviour (`src/terms/term_builder.rs`).
- Enforce endpoint constraints by generating paired linear-equality rows represented as inequalities (`A * β >= b`) in the smooth assembly pipeline, including correct handling after frozen identifiability transforms and shape-side coefficient transforms (`src/terms/smooth.rs`).
- Add helper builders to evaluate endpoint basis/derivative rows (`create_basis` usage) and produce constraint rows with consistency checks and infeasibility diagnostics (`src/terms/smooth.rs`, `src/terms/basis.rs`).
- Wire through default `boundary_condition` in codepaths that construct `BSplineBasisSpec` (survival, term templates, tests) and update docs to document `bc` usage and examples (`docs/formulas.md`, `src/families/survival_construction.rs`, `src/main.rs`).
- Add unit tests for option parsing and constraint-generation + frozen-transform behaviour and small refactors to preserve coefficient-transform / box-reparam compatibility (`src/terms/smooth.rs`, `src/terms/term_builder.rs`).

### Testing
- Ran `cargo test bspline_boundary --lib` and the new boundary-focused unit tests passed (2 tests) and returned `ok`.
- Ran `cargo test parses_ --lib` covering the option parsing tests and they passed (4 tests `ok`).
- Ran `cargo check` / full crate build and `cargo test` subsets during development; compilation and the exercised test suites completed successfully.
- All automated checks above succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07c75b162c83248618bec565009b29)