### PR TITLE
Add cylinder (one-periodic-dim) support for spatial smooths and tensor margins

### DIFF
--- a/src/families/custom_family.rs
+++ b/src/families/custom_family.rs
@@ -17378,6 +17378,7 @@ mod tests {
                 basis: SmoothBasisSpec::Matern {
                     feature_cols: vec![0, 1],
                     spec: MaternBasisSpec {
+                        periodic: None,
                         center_strategy: CenterStrategy::EqualMass { num_centers: 6 },
                         length_scale: 0.8,
                         nu: MaternNu::ThreeHalves,
@@ -17593,6 +17594,7 @@ mod tests {
                 basis: SmoothBasisSpec::Matern {
                     feature_cols: vec![0, 1, 2],
                     spec: MaternBasisSpec {
+                        periodic: None,
                         center_strategy: CenterStrategy::EqualMass { num_centers: 6 },
                         length_scale: 0.45,
                         nu: MaternNu::ThreeHalves,

--- a/src/families/gamlss.rs
+++ b/src/families/gamlss.rs
@@ -23736,6 +23736,7 @@ mod tests {
                 basis: SmoothBasisSpec::Matern {
                     feature_cols: feature_cols.to_vec(),
                     spec: MaternBasisSpec {
+                        periodic: None,
                         center_strategy: CenterStrategy::EqualMass { num_centers: 6 },
                         length_scale,
                         nu: MaternNu::ThreeHalves,

--- a/src/inference/formula_dsl.rs
+++ b/src/inference/formula_dsl.rs
@@ -26,7 +26,8 @@ mul_op = _{ "*" | "/" }
 unary = { unary_op* ~ primary }
 unary_op = _{ "+" | "-" }
 
-primary = { function_call | ident | number | string_lit | "(" ~ expr ~ ")" }
+primary = { function_call | list_lit | ident | number | string_lit | "(" ~ expr ~ ")" }
+list_lit = { "[" ~ (expr ~ ("," ~ expr)* ~ ","?)? ~ "]" }
 function_call = { ident ~ "(" ~ arg_list? ~ ")" }
 arg_list = { arg ~ ("," ~ arg)* }
 arg = { named_arg | expr }

--- a/src/terms/basis.rs
+++ b/src/terms/basis.rs
@@ -1735,6 +1735,8 @@ pub fn center_strategy_with_num_centers(
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ThinPlateBasisSpec {
     pub center_strategy: CenterStrategy,
+    #[serde(default)]
+    pub periodic: Option<Vec<Option<f64>>>,
     pub length_scale: f64,
     pub double_penalty: bool,
     #[serde(default)]
@@ -1781,6 +1783,8 @@ impl Default for SpatialIdentifiability {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct MaternBasisSpec {
     pub center_strategy: CenterStrategy,
+    #[serde(default)]
+    pub periodic: Option<Vec<Option<f64>>>,
     pub length_scale: f64,
     pub nu: MaternNu,
     #[serde(default)]
@@ -1846,6 +1850,8 @@ pub enum DuchonNullspaceOrder {
 #[serde(deny_unknown_fields)]
 pub struct DuchonBasisSpec {
     pub center_strategy: CenterStrategy,
+    #[serde(default)]
+    pub periodic: Option<Vec<Option<f64>>>,
     /// Optional hybrid Matérn width. `None` means pure scale-free Duchon with
     /// spectrum `||w||^(2p + 2s)`. `Some(length_scale)` enables the hybrid
     /// spectrum `||w||^(2p) * (kappa^2 + ||w||^2)^s`, `kappa = 1/length_scale`.
@@ -2023,6 +2029,7 @@ pub enum BasisMetadata {
     ThinPlate {
         centers: Array2<f64>,
         length_scale: f64,
+        periodic: Option<Vec<Option<f64>>>,
         identifiability_transform: Option<Array2<f64>>,
         /// Per-column standard deviations used for input standardization (d > 1).
         input_scales: Option<Vec<f64>>,
@@ -2034,6 +2041,7 @@ pub enum BasisMetadata {
     Matern {
         centers: Array2<f64>,
         length_scale: f64,
+        periodic: Option<Vec<Option<f64>>>,
         nu: MaternNu,
         include_intercept: bool,
         identifiability_transform: Option<Array2<f64>>,
@@ -2046,6 +2054,7 @@ pub enum BasisMetadata {
     Duchon {
         centers: Array2<f64>,
         length_scale: Option<f64>,
+        periodic: Option<Vec<Option<f64>>>,
         power: usize,
         nullspace_order: DuchonNullspaceOrder,
         identifiability_transform: Option<Array2<f64>>,
@@ -2058,6 +2067,7 @@ pub enum BasisMetadata {
         feature_cols: Vec<usize>,
         knots: Vec<Array1<f64>>,
         degrees: Vec<usize>,
+        periods: Vec<Option<f64>>,
         identifiability_transform: Option<Array2<f64>>,
     },
 }
@@ -6159,6 +6169,60 @@ fn finite_data_range(data: ArrayView1<'_, f64>) -> Result<(f64, f64), BasisError
     Ok((minv, maxv))
 }
 
+pub(crate) fn expand_periodic_centers(
+    centers: &Array2<f64>,
+    periodic: Option<&[Option<f64>]>,
+) -> Result<Array2<f64>, BasisError> {
+    let Some(periodic) = periodic else {
+        return Ok(centers.clone());
+    };
+    if periodic.len() != centers.ncols() {
+        return Err(BasisError::DimensionMismatch(format!(
+            "period vector length {} does not match smooth dimension {}",
+            periodic.len(),
+            centers.ncols()
+        )));
+    }
+    let active: Vec<(usize, f64)> = periodic
+        .iter()
+        .enumerate()
+        .filter_map(|(i, p)| p.map(|v| (i, v)))
+        .collect();
+    if active.is_empty() {
+        return Ok(centers.clone());
+    }
+    for (axis, period) in &active {
+        if !period.is_finite() || *period <= 0.0 {
+            return Err(BasisError::InvalidInput(format!(
+                "period for axis {axis} must be finite and positive, got {period}"
+            )));
+        }
+    }
+    let shifts = 3usize.pow(active.len() as u32);
+    let mut out = Array2::<f64>::zeros((centers.nrows() * shifts, centers.ncols()));
+    let mut row_out = 0usize;
+    for code in 0..shifts {
+        let mut tmp = code;
+        let mut offsets = vec![0.0; centers.ncols()];
+        for &(axis, period) in &active {
+            let digit = tmp % 3;
+            tmp /= 3;
+            offsets[axis] = match digit {
+                0 => -period,
+                1 => 0.0,
+                _ => period,
+            };
+        }
+        for r in 0..centers.nrows() {
+            for c in 0..centers.ncols() {
+                out[[row_out, c]] = centers[[r, c]] + offsets[c];
+            }
+            row_out += 1;
+        }
+    }
+    Ok(out)
+}
+
 /// Generic thin-plate builder returning design + penalty list.
 pub fn build_thin_plate_basis(
     data: ArrayView2<'_, f64>,
@@ -6173,7 +6237,8 @@ pub fn build_thin_plate_basiswithworkspace(
     spec: &ThinPlateBasisSpec,
     workspace: &mut BasisWorkspace,
 ) -> Result<BasisBuildResult, BasisError> {
-    let centers = select_centers_by_strategy(data, &spec.center_strategy)?;
+    let original_centers = select_centers_by_strategy(data, &spec.center_strategy)?;
+    let centers = expand_periodic_centers(&original_centers, spec.periodic.as_deref())?;
     // Canonical TPS in dimension d uses penalty order m = ⌊d/2⌋+1 and a
     // polynomial nullspace of size M(d) = C(d+m-1, d). For d=16 this is
     // 735_471, well above any practical knot count. When the requested
@@ -6193,7 +6258,8 @@ pub fn build_thin_plate_basiswithworkspace(
     {
         let d = data.ncols();
         let duchon_spec = DuchonBasisSpec {
-            center_strategy: CenterStrategy::UserProvided(centers.clone()),
+            center_strategy: CenterStrategy::UserProvided(original_centers.clone()),
+            periodic: spec.periodic.clone(),
             length_scale: Some(spec.length_scale),
             power: s,
             nullspace_order,
@@ -6365,8 +6431,9 @@ pub fn build_thin_plate_basiswithworkspace(
         penaltyinfo,
         ops,
         metadata: BasisMetadata::ThinPlate {
-            centers,
+            centers: original_centers,
             length_scale: spec.length_scale,
+            periodic: spec.periodic.clone(),
             identifiability_transform,
             input_scales: None,
             radial_reparam: radial_reparam_meta,
@@ -12413,7 +12480,8 @@ pub fn build_matern_basiswithworkspace(
     spec: &MaternBasisSpec,
     workspace: &mut BasisWorkspace,
 ) -> Result<BasisBuildResult, BasisError> {
-    let centers = select_centers_by_strategy(data, &spec.center_strategy)?;
+    let original_centers = select_centers_by_strategy(data, &spec.center_strategy)?;
+    let centers = expand_periodic_centers(&original_centers, spec.periodic.as_deref())?;
     // Initialize anisotropy contrasts from knot cloud geometry when the caller
     // enabled scale-dimensions but left η at the zero default.
     let aniso = maybe_initialize_aniso_contrasts(centers.view(), spec.aniso_log_scales.as_deref());
@@ -12555,8 +12623,9 @@ pub fn build_matern_basiswithworkspace(
         nullspace_dims,
         penaltyinfo,
         metadata: BasisMetadata::Matern {
-            centers,
+            centers: original_centers,
             length_scale: spec.length_scale,
+            periodic: spec.periodic.clone(),
             nu: spec.nu,
             include_intercept: spec.include_intercept,
             identifiability_transform,
@@ -13538,7 +13607,8 @@ fn prepare_duchon_derivative_contextwithworkspace(
     spec: &DuchonBasisSpec,
     workspace: &mut BasisWorkspace,
 ) -> Result<(Array2<f64>, Option<Array2<f64>>), BasisError> {
-    let centers = select_centers_by_strategy(data, &spec.center_strategy)?;
+    let original_centers = select_centers_by_strategy(data, &spec.center_strategy)?;
+    let centers = expand_periodic_centers(&original_centers, spec.periodic.as_deref())?;
     assert_spatial_centers_below_biobank_cap(data.nrows(), data.ncols(), centers.view());
     let raw_design = build_duchon_basis_designwithworkspace(
         data,
@@ -16103,7 +16173,8 @@ pub fn build_duchon_basiswithworkspace(
     spec: &DuchonBasisSpec,
     workspace: &mut BasisWorkspace,
 ) -> Result<BasisBuildResult, BasisError> {
-    let centers = select_centers_by_strategy(data, &spec.center_strategy)?;
+    let original_centers = select_centers_by_strategy(data, &spec.center_strategy)?;
+    let centers = expand_periodic_centers(&original_centers, spec.periodic.as_deref())?;
     assert_spatial_centers_below_biobank_cap(data.nrows(), data.ncols(), centers.view());
     // Auto-degrade the requested null-space order to Zero when the selected
     // centers cannot span the requested polynomial block. Every downstream
@@ -16341,8 +16412,9 @@ pub fn build_duchon_basiswithworkspace(
         penaltyinfo,
         ops,
         metadata: BasisMetadata::Duchon {
-            centers,
+            centers: original_centers,
             length_scale: spec.length_scale,
+            periodic: spec.periodic.clone(),
             power: spec.power,
             nullspace_order: effective_nullspace_order,
             identifiability_transform,
@@ -22396,6 +22468,7 @@ mod tests {
             [0.5, 0.0]
         ];
         let spec = ThinPlateBasisSpec {
+            periodic: None,
             center_strategy: CenterStrategy::FarthestPoint { num_centers: 4 },
             length_scale: 1.0,
             double_penalty: true,
@@ -22428,6 +22501,7 @@ mod tests {
             [0.5, 0.0]
         ];
         let spec = ThinPlateBasisSpec {
+            periodic: None,
             center_strategy: CenterStrategy::FarthestPoint { num_centers: 4 },
             length_scale: 1.0,
             double_penalty: false,
@@ -22458,6 +22532,7 @@ mod tests {
             centers[[j, 0]] = j as f64 / (k - 1) as f64;
         }
         let spec = ThinPlateBasisSpec {
+            periodic: None,
             center_strategy: CenterStrategy::UserProvided(centers),
             length_scale: 1.0,
             double_penalty: false,
@@ -22484,6 +22559,7 @@ mod tests {
             [0.2, 0.35]
         ];
         let spec = ThinPlateBasisSpec {
+            periodic: None,
             center_strategy: CenterStrategy::FarthestPoint { num_centers: 4 },
             length_scale: 1.0,
             double_penalty: false,
@@ -22519,6 +22595,7 @@ mod tests {
         let data = array![[-1.5], [-0.7], [0.2], [0.8], [1.6]];
         let centers = array![[-1.5], [0.2], [1.6]];
         let spec = ThinPlateBasisSpec {
+            periodic: None,
             center_strategy: CenterStrategy::UserProvided(centers),
             length_scale: 1.0,
             double_penalty: false,
@@ -22555,6 +22632,7 @@ mod tests {
         ];
         let specs = vec![
             ThinPlateBasisSpec {
+                periodic: None,
                 center_strategy: CenterStrategy::EqualMass { num_centers: 4 },
                 length_scale: 1.0,
                 double_penalty: false,
@@ -22562,6 +22640,7 @@ mod tests {
                 radial_reparam: None,
             },
             ThinPlateBasisSpec {
+                periodic: None,
                 center_strategy: CenterStrategy::KMeans {
                     num_centers: 4,
                     max_iter: 5,
@@ -22572,6 +22651,7 @@ mod tests {
                 radial_reparam: None,
             },
             ThinPlateBasisSpec {
+                periodic: None,
                 center_strategy: CenterStrategy::UniformGrid { points_per_dim: 2 },
                 length_scale: 1.0,
                 double_penalty: false,
@@ -22579,6 +22659,7 @@ mod tests {
                 radial_reparam: None,
             },
             ThinPlateBasisSpec {
+                periodic: None,
                 center_strategy: CenterStrategy::UserProvided(array![
                     [0.0, 0.0],
                     [1.0, 0.0],
@@ -24570,6 +24651,7 @@ mod tests {
     fn test_build_duchon_basisfreezes_default_spatial_identifiability() {
         let data = array![[0.0, 0.0], [1.0, 0.0], [0.0, 1.0], [1.0, 1.0], [0.5, 0.5]];
         let spec = DuchonBasisSpec {
+            periodic: None,
             center_strategy: CenterStrategy::FarthestPoint { num_centers: 4 },
             length_scale: Some(1.0),
             power: 2,
@@ -24614,6 +24696,7 @@ mod tests {
             [0.25, 0.75]
         ];
         let spec = DuchonBasisSpec {
+            periodic: None,
             center_strategy: CenterStrategy::FarthestPoint { num_centers: 4 },
             length_scale: Some(1.0),
             power: 2,
@@ -24656,6 +24739,7 @@ mod tests {
             [1.0, 1.0, 1.0]
         ];
         let spec = DuchonBasisSpec {
+            periodic: None,
             center_strategy: CenterStrategy::FarthestPoint { num_centers: 5 },
             length_scale: None,
             power: 1,
@@ -25275,6 +25359,7 @@ mod tests {
     fn test_build_duchon_basis_linear_nullspace_uses_operator_penalty_triplet() {
         let data = array![[0.0, 0.0], [1.0, 0.0], [0.0, 1.0], [1.0, 1.0], [0.5, 0.5]];
         let spec = DuchonBasisSpec {
+            periodic: None,
             center_strategy: CenterStrategy::FarthestPoint { num_centers: 4 },
             length_scale: Some(1.0),
             power: 2,
@@ -25316,6 +25401,7 @@ mod tests {
             [0.5, 0.0],
         ];
         let spec = DuchonBasisSpec {
+            periodic: None,
             center_strategy: CenterStrategy::FarthestPoint { num_centers: 6 },
             length_scale: Some(1.0),
             power: 2,
@@ -25339,6 +25425,7 @@ mod tests {
         // three penalties stay active and PSD.
         let data = array![[0.0, 0.0], [1.0, 0.0], [0.0, 1.0], [1.0, 1.0], [0.5, 0.5]];
         let spec = DuchonBasisSpec {
+            periodic: None,
             center_strategy: CenterStrategy::FarthestPoint { num_centers: 4 },
             length_scale: Some(1.0),
             power: 2,
@@ -25750,6 +25837,7 @@ mod tests {
         let data = array![[0.0, 0.0], [1.0, 0.0], [0.0, 1.0], [1.0, 1.0], [0.5, 0.5]];
         let centers = array![[0.0, 0.0], [1.0, 0.0], [0.0, 1.0], [1.0, 1.0]];
         let spec = MaternBasisSpec {
+            periodic: None,
             center_strategy: CenterStrategy::UserProvided(centers.clone()),
             length_scale: 0.7,
             nu: MaternNu::FiveHalves,
@@ -25783,6 +25871,7 @@ mod tests {
         let data = array![[0.0, 0.0], [1.0, 0.0], [0.0, 1.0], [1.0, 1.0], [0.4, 0.7]];
         let centers = array![[0.0, 0.0], [1.0, 0.0], [0.0, 1.0], [1.0, 1.0]];
         let spec = MaternBasisSpec {
+            periodic: None,
             center_strategy: CenterStrategy::UserProvided(centers.clone()),
             length_scale: 1.1,
             nu: MaternNu::ThreeHalves,
@@ -25803,6 +25892,7 @@ mod tests {
         let data = array![[0.0, 0.0], [1.0, 0.0], [0.0, 1.0], [1.0, 1.0], [0.4, 0.7]];
         let centers = array![[0.0, 0.0], [1.0, 0.0], [0.0, 1.0], [1.0, 1.0]];
         let spec = MaternBasisSpec {
+            periodic: None,
             center_strategy: CenterStrategy::UserProvided(centers),
             length_scale: 1.1,
             nu: MaternNu::ThreeHalves,
@@ -25824,6 +25914,7 @@ mod tests {
         let data = array![[0.0, 0.0], [1.0, 0.0], [0.0, 1.0], [1.0, 1.0], [0.4, 0.7]];
         let centers = array![[0.0, 0.0], [1.0, 0.0], [0.0, 1.0], [1.0, 1.0]];
         let spec = MaternBasisSpec {
+            periodic: None,
             center_strategy: CenterStrategy::UserProvided(centers),
             length_scale: 1.1,
             nu: MaternNu::ThreeHalves,
@@ -25849,6 +25940,7 @@ mod tests {
         let data = array![[0.0, 0.0], [1.0, 0.2], [0.3, 1.1], [0.9, 0.8]];
         let centers = array![[0.0, 0.0], [1.0, 0.0], [0.0, 1.0]];
         let spec = MaternBasisSpec {
+            periodic: None,
             center_strategy: CenterStrategy::UserProvided(centers),
             length_scale: 0.9,
             nu: MaternNu::FiveHalves,
@@ -25918,6 +26010,7 @@ mod tests {
         let data = array![[0.0, 0.0], [1.0, 0.2], [0.3, 1.1], [0.9, 0.8]];
         let centers = array![[0.0, 0.0], [1.0, 0.0], [0.0, 1.0]];
         let spec = MaternBasisSpec {
+            periodic: None,
             center_strategy: CenterStrategy::UserProvided(centers),
             length_scale: 0.9,
             nu: MaternNu::FiveHalves,
@@ -25965,6 +26058,7 @@ mod tests {
         let data = array![[0.0, 0.0], [1.0, 0.2], [0.3, 1.1], [0.9, 0.8]];
         let centers = array![[0.0, 0.0], [1.0, 0.0], [0.0, 1.0], [1.0, 1.0]];
         let mut spec = ThinPlateBasisSpec {
+            periodic: None,
             center_strategy: CenterStrategy::UserProvided(centers),
             length_scale: 0.9,
             double_penalty: true,
@@ -26027,6 +26121,7 @@ mod tests {
         let data = array![[0.0, 0.0], [1.0, 0.2], [0.3, 1.1], [0.9, 0.8]];
         let centers = array![[0.0, 0.0], [1.0, 0.0], [0.0, 1.0], [1.0, 1.0]];
         let mut spec = ThinPlateBasisSpec {
+            periodic: None,
             center_strategy: CenterStrategy::UserProvided(centers),
             length_scale: 0.9,
             double_penalty: true,
@@ -26284,6 +26379,7 @@ mod tests {
         let data = array![[0.0, 0.0], [1.0, 0.2], [0.3, 1.1], [0.9, 0.8]];
         let centers = array![[0.0, 0.0], [1.0, 0.0], [0.0, 1.0]];
         let spec = DuchonBasisSpec {
+            periodic: None,
             center_strategy: CenterStrategy::UserProvided(centers),
             length_scale: Some(1.0),
             power: 2,
@@ -26327,6 +26423,7 @@ mod tests {
             data[[i, 0]] = i as f64 / (n as f64 - 1.0);
         }
         let mut spec = DuchonBasisSpec {
+            periodic: None,
             center_strategy: CenterStrategy::FarthestPoint { num_centers: 8 },
             length_scale: Some(1.0),
             power: 1,
@@ -26407,6 +26504,7 @@ mod tests {
             data[[i, 0]] = i as f64 / (n as f64 - 1.0);
         }
         let mut spec = DuchonBasisSpec {
+            periodic: None,
             center_strategy: CenterStrategy::FarthestPoint { num_centers: 8 },
             length_scale: Some(1.0),
             power: 1,
@@ -26469,6 +26567,7 @@ mod tests {
             data[[i, 0]] = i as f64 / (n as f64 - 1.0);
         }
         let spec = DuchonBasisSpec {
+            periodic: None,
             center_strategy: CenterStrategy::FarthestPoint { num_centers: 8 },
             length_scale: Some(1.0),
             power: 1,
@@ -26514,6 +26613,7 @@ mod tests {
             data[[i, 0]] = i as f64 / (n as f64 - 1.0);
         }
         let spec = DuchonBasisSpec {
+            periodic: None,
             center_strategy: CenterStrategy::FarthestPoint { num_centers: 8 },
             length_scale: Some(1.0),
             power: 1,
@@ -26591,6 +26691,7 @@ mod tests {
         let data = array![[0.0, 0.0], [1.0, 0.2], [0.3, 1.1], [0.9, 0.8]];
         let centers = array![[0.0, 0.0], [1.0, 0.0], [0.0, 1.0]];
         let spec = DuchonBasisSpec {
+            periodic: None,
             center_strategy: CenterStrategy::UserProvided(centers),
             length_scale: Some(0.9),
             power: 2,
@@ -26671,6 +26772,7 @@ mod tests {
         let data = array![[0.0, 0.0], [1.0, 0.2], [0.3, 1.1], [0.9, 0.8]];
         let centers = array![[0.0, 0.0], [1.0, 0.0], [0.0, 1.0]];
         let spec = DuchonBasisSpec {
+            periodic: None,
             center_strategy: CenterStrategy::UserProvided(centers),
             length_scale: Some(0.9),
             power: 2,
@@ -27415,6 +27517,7 @@ mod tests {
         let data = array![[0.0, 0.0], [1.0, 0.2], [0.3, 1.1], [0.9, 0.8]];
         let centers = array![[0.0, 0.0], [1.0, 0.0], [0.0, 1.0]];
         let spec = MaternBasisSpec {
+            periodic: None,
             center_strategy: CenterStrategy::UserProvided(centers),
             length_scale: 0.9,
             nu: MaternNu::FiveHalves,
@@ -27475,6 +27578,7 @@ mod tests {
         ];
         let centers = array![[0.0, 0.0], [1.0, 0.0], [0.0, 1.0], [1.0, 1.0]];
         let spec = MaternBasisSpec {
+            periodic: None,
             center_strategy: CenterStrategy::UserProvided(centers),
             length_scale: 0.9,
             nu: MaternNu::FiveHalves,
@@ -27508,6 +27612,7 @@ mod tests {
         let data = array![[0.0, 0.0], [1.0, 0.2], [0.3, 1.1], [0.9, 0.8]];
         let centers = array![[0.0, 0.0], [1.0, 0.0], [0.0, 1.0]];
         let spec = DuchonBasisSpec {
+            periodic: None,
             center_strategy: CenterStrategy::UserProvided(centers),
             length_scale: Some(0.9),
             power: 2,
@@ -27568,6 +27673,7 @@ mod tests {
         ];
         let centers = array![[0.0, 0.0], [1.0, 0.0], [0.0, 1.0], [1.0, 1.0]];
         let spec = DuchonBasisSpec {
+            periodic: None,
             center_strategy: CenterStrategy::UserProvided(centers),
             length_scale: Some(0.9),
             power: 1,
@@ -27628,6 +27734,7 @@ mod tests {
         ];
         let centers = data.clone();
         let spec = DuchonBasisSpec {
+            periodic: None,
             center_strategy: CenterStrategy::UserProvided(centers),
             length_scale: None,
             power: 1,
@@ -27667,6 +27774,7 @@ mod tests {
         eta: Vec<f64>,
     ) -> Array2<f64> {
         let spec = DuchonBasisSpec {
+            periodic: None,
             center_strategy: CenterStrategy::UserProvided(centers.clone()),
             length_scale: None,
             power: 1,
@@ -27710,6 +27818,7 @@ mod tests {
         eta: Vec<f64>,
     ) {
         let spec = DuchonBasisSpec {
+            periodic: None,
             center_strategy: CenterStrategy::UserProvided(centers.clone()),
             length_scale: None,
             power: 1,
@@ -27825,6 +27934,7 @@ mod tests {
             [0.5, 0.6, 1.2]
         ];
         let spec = DuchonBasisSpec {
+            periodic: None,
             center_strategy: CenterStrategy::UserProvided(centers),
             length_scale: None,
             power: 1,
@@ -27956,6 +28066,7 @@ mod tests {
         let data = array![[0.0, 0.1], [0.2, 0.0], [0.4, 0.2], [0.6, 0.4], [0.8, 0.5]];
         let centers = data.slice(s![0..4, ..]).to_owned();
         let spec = DuchonBasisSpec {
+            periodic: None,
             center_strategy: CenterStrategy::UserProvided(centers),
             length_scale: None,
             power: 2,
@@ -27988,6 +28099,7 @@ mod tests {
         );
 
         let spec = DuchonBasisSpec {
+            periodic: None,
             center_strategy: CenterStrategy::UserProvided(centers.clone()),
             length_scale: None,
             power: 2,

--- a/src/terms/smooth.rs
+++ b/src/terms/smooth.rs
@@ -156,6 +156,8 @@ pub enum SmoothBasisSpec {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TensorBSplineSpec {
     pub marginalspecs: Vec<BSplineBasisSpec>,
+    #[serde(default)]
+    pub periods: Vec<Option<f64>>,
     pub double_penalty: bool,
     #[serde(default)]
     pub identifiability: TensorBSplineIdentifiability,
@@ -2456,12 +2458,14 @@ fn freeze_raw_spatial_metadata(metadata: BasisMetadata, raw_cols: usize) -> Basi
         BasisMetadata::ThinPlate {
             centers,
             length_scale,
+            periodic,
             identifiability_transform: None,
             input_scales,
             radial_reparam,
         } => BasisMetadata::ThinPlate {
             centers,
             length_scale,
+            periodic,
             identifiability_transform: Some(Array2::eye(raw_cols)),
             input_scales,
             radial_reparam,
@@ -2469,6 +2473,7 @@ fn freeze_raw_spatial_metadata(metadata: BasisMetadata, raw_cols: usize) -> Basi
         BasisMetadata::Duchon {
             centers,
             length_scale,
+            periodic,
             power,
             nullspace_order,
             identifiability_transform: None,
@@ -2477,6 +2482,7 @@ fn freeze_raw_spatial_metadata(metadata: BasisMetadata, raw_cols: usize) -> Basi
         } => BasisMetadata::Duchon {
             centers,
             length_scale,
+            periodic,
             power,
             nullspace_order,
             identifiability_transform: Some(Array2::eye(raw_cols)),
@@ -2493,6 +2499,7 @@ fn matern_operator_penalty_triplet_from_metadata(
     let BasisMetadata::Matern {
         centers,
         length_scale,
+        periodic,
         nu,
         include_intercept,
         identifiability_transform,
@@ -2504,8 +2511,9 @@ fn matern_operator_penalty_triplet_from_metadata(
             "Matérn operator penalties require Matérn metadata".to_string(),
         ));
     };
+    let penalty_centers = crate::basis::expand_periodic_centers(centers, periodic.as_deref())?;
     let ops = build_matern_collocation_operator_matrices(
-        centers.view(),
+        penalty_centers.view(),
         None,
         *length_scale,
         *nu,
@@ -2641,6 +2649,7 @@ fn build_shape_constraint_design_1d(
             },
         ) => {
             let evalspec = ThinPlateBasisSpec {
+                periodic: None,
                 center_strategy: crate::basis::CenterStrategy::UserProvided(centers.clone()),
                 length_scale: *length_scale,
                 double_penalty: false,
@@ -2675,6 +2684,7 @@ fn build_shape_constraint_design_1d(
                 })
                 .unwrap_or(MaternIdentifiability::None);
             let evalspec = MaternBasisSpec {
+                periodic: None,
                 center_strategy: crate::basis::CenterStrategy::UserProvided(centers.clone()),
                 length_scale: *length_scale,
                 nu: *nu,
@@ -2700,6 +2710,7 @@ fn build_shape_constraint_design_1d(
             },
         ) => {
             let evalspec = DuchonBasisSpec {
+                periodic: None,
                 center_strategy: crate::basis::CenterStrategy::UserProvided(centers.clone()),
                 length_scale: *length_scale,
                 power: *power,
@@ -2876,6 +2887,62 @@ fn normalize_penalty_in_constrained_space(matrix: &Array2<f64>) -> (Array2<f64>,
     }
 }
 
+fn build_periodic_fourier_margin(
+    x: ArrayView1<'_, f64>,
+    period: f64,
+    requested_cols: usize,
+    penalty_order: usize,
+) -> Result<(Array2<f64>, Array2<f64>, Array1<f64>), BasisError> {
+    if !period.is_finite() || period <= 0.0 {
+        return Err(BasisError::InvalidInput(format!(
+            "periodic tensor margin requires finite positive period, got {period}"
+        )));
+    }
+    let q = requested_cols.max(3);
+    let harmonics = q / 2;
+    let has_nyquist_cos = q % 2 == 0;
+    let mut basis = Array2::<f64>::zeros((x.len(), q));
+    basis.column_mut(0).fill(1.0);
+    for (i, &xi) in x.iter().enumerate() {
+        let angle = 2.0 * std::f64::consts::PI * xi / period;
+        let mut col = 1usize;
+        for h in 1..=harmonics {
+            if col >= q {
+                break;
+            }
+            basis[[i, col]] = (h as f64 * angle).cos();
+            col += 1;
+            if col >= q {
+                break;
+            }
+            basis[[i, col]] = (h as f64 * angle).sin();
+            col += 1;
+        }
+        if has_nyquist_cos && q > 1 {
+            basis[[i, q - 1]] = (harmonics as f64 * angle).cos();
+        }
+    }
+    let mut penalty = Array2::<f64>::zeros((q, q));
+    let order = penalty_order.max(1) as i32;
+    let mut col = 1usize;
+    for h in 1..=harmonics {
+        let w = (h as f64).powi(2 * order);
+        if col < q {
+            penalty[[col, col]] = w;
+            col += 1;
+        }
+        if col < q {
+            penalty[[col, col]] = w;
+            col += 1;
+        }
+    }
+    if has_nyquist_cos && q > 1 {
+        penalty[[q - 1, q - 1]] = (harmonics as f64).powi(2 * order);
+    }
+    let knots = Array1::linspace(0.0, period, q + 1);
+    Ok((basis, penalty, knots))
+}
+
 fn build_tensor_bspline_basis(
     data: ArrayView2<'_, f64>,
     feature_cols: &[usize],
@@ -2891,6 +2958,13 @@ fn build_tensor_bspline_basis(
             "TensorBSpline feature/spec mismatch: feature_cols={}, marginalspecs={}",
             feature_cols.len(),
             spec.marginalspecs.len()
+        )));
+    }
+    if !spec.periods.is_empty() && spec.periods.len() != feature_cols.len() {
+        return Err(BasisError::DimensionMismatch(format!(
+            "TensorBSpline periods length {} does not match feature count {}",
+            spec.periods.len(),
+            feature_cols.len()
         )));
     }
     let p = data.ncols();
@@ -2919,37 +2993,62 @@ fn build_tensor_bspline_basis(
         // identifiability constraints here would change marginal penalty sizes
         // without changing the tensor design construction, causing dimension
         // mismatch. Keep marginal builders unconstrained at this stage.
-        let mut marginal_unconstrained = marginalspec.clone();
-        marginal_unconstrained.identifiability = BSplineIdentifiability::None;
-        let built = build_bspline_basis_1d(data.column(col), &marginal_unconstrained)?;
-        let knots = match built.metadata {
-            BasisMetadata::BSpline1D { knots, .. } => knots,
-            _ => {
-                return Err(BasisError::InvalidInput(format!(
-                    "internal TensorBSpline error at dim {dim}: expected BSpline1D metadata"
-                )));
-            }
-        };
-        marginal_knots.push(knots);
-        marginal_degrees.push(marginalspec.degree);
-        marginalnum_basis.push(built.design.ncols());
-        marginal_designs.push(built.design.to_dense());
-        marginal_penalties.push(
-            built
-                .penalties
-                .first()
-                .ok_or_else(|| {
-                    BasisError::InvalidInput(format!(
-                        "internal TensorBSpline error at dim {dim}: missing marginal penalty"
-                    ))
-                })?
-                .clone(),
-        );
-        built.nullspace_dims.first().ok_or_else(|| {
-            BasisError::InvalidInput(format!(
-                "internal TensorBSpline error at dim {dim}: missing marginal nullspace dim"
-            ))
-        })?;
+        if let Some(period) = spec.periods.get(dim).and_then(|p| *p) {
+            let requested_cols = match marginalspec.knotspec {
+                BSplineKnotSpec::Generate {
+                    num_internal_knots, ..
+                } => num_internal_knots + marginalspec.degree + 1,
+                BSplineKnotSpec::Provided(ref knots) => {
+                    knots.len().saturating_sub(marginalspec.degree + 1)
+                }
+                BSplineKnotSpec::Automatic {
+                    num_internal_knots, ..
+                } => num_internal_knots.unwrap_or(8) + marginalspec.degree + 1,
+            };
+            let (basis, penalty, knots) = build_periodic_fourier_margin(
+                data.column(col),
+                period,
+                requested_cols,
+                marginalspec.penalty_order,
+            )?;
+            marginal_knots.push(knots);
+            marginal_degrees.push(marginalspec.degree);
+            marginalnum_basis.push(basis.ncols());
+            marginal_designs.push(basis);
+            marginal_penalties.push(penalty);
+        } else {
+            let mut marginal_unconstrained = marginalspec.clone();
+            marginal_unconstrained.identifiability = BSplineIdentifiability::None;
+            let built = build_bspline_basis_1d(data.column(col), &marginal_unconstrained)?;
+            let knots = match built.metadata {
+                BasisMetadata::BSpline1D { knots, .. } => knots,
+                _ => {
+                    return Err(BasisError::InvalidInput(format!(
+                        "internal TensorBSpline error at dim {dim}: expected BSpline1D metadata"
+                    )));
+                }
+            };
+            marginal_knots.push(knots);
+            marginal_degrees.push(marginalspec.degree);
+            marginalnum_basis.push(built.design.ncols());
+            marginal_designs.push(built.design.to_dense());
+            marginal_penalties.push(
+                built
+                    .penalties
+                    .first()
+                    .ok_or_else(|| {
+                        BasisError::InvalidInput(format!(
+                            "internal TensorBSpline error at dim {dim}: missing marginal penalty"
+                        ))
+                    })?
+                    .clone(),
+            );
+            built.nullspace_dims.first().ok_or_else(|| {
+                BasisError::InvalidInput(format!(
+                    "internal TensorBSpline error at dim {dim}: missing marginal nullspace dim"
+                ))
+            })?;
+        }
     }
 
     let total_cols: usize = marginalnum_basis.iter().product();
@@ -3072,6 +3171,11 @@ fn build_tensor_bspline_basis(
             feature_cols: feature_cols.to_vec(),
             knots: marginal_knots,
             degrees: marginal_degrees,
+            periods: if spec.periods.is_empty() {
+                vec![None; feature_cols.len()]
+            } else {
+                spec.periods.clone()
+            },
             identifiability_transform: z_opt,
         },
         kronecker_factored: if matches!(spec.identifiability, TensorBSplineIdentifiability::None) {
@@ -4928,12 +5032,14 @@ fn with_identifiability_transform(
         BasisMetadata::ThinPlate {
             centers,
             length_scale,
+            periodic,
             identifiability_transform,
             input_scales,
             radial_reparam,
         } => Ok(BasisMetadata::ThinPlate {
             centers: centers.clone(),
             length_scale: *length_scale,
+            periodic: periodic.clone(),
             identifiability_transform: compose_identifiability_transforms(
                 identifiability_transform.as_ref(),
                 transform,
@@ -4944,6 +5050,7 @@ fn with_identifiability_transform(
         BasisMetadata::Matern {
             centers,
             length_scale,
+            periodic,
             nu,
             include_intercept,
             identifiability_transform,
@@ -4952,6 +5059,7 @@ fn with_identifiability_transform(
         } => Ok(BasisMetadata::Matern {
             centers: centers.clone(),
             length_scale: *length_scale,
+            periodic: periodic.clone(),
             nu: *nu,
             include_intercept: *include_intercept,
             identifiability_transform: compose_identifiability_transforms(
@@ -4964,6 +5072,7 @@ fn with_identifiability_transform(
         BasisMetadata::Duchon {
             centers,
             length_scale,
+            periodic,
             power,
             nullspace_order,
             identifiability_transform,
@@ -4972,6 +5081,7 @@ fn with_identifiability_transform(
         } => Ok(BasisMetadata::Duchon {
             centers: centers.clone(),
             length_scale: *length_scale,
+            periodic: periodic.clone(),
             power: *power,
             nullspace_order: *nullspace_order,
             input_scales: input_scales.clone(),
@@ -4985,11 +5095,13 @@ fn with_identifiability_transform(
             feature_cols,
             knots,
             degrees,
+            periods,
             identifiability_transform,
         } => Ok(BasisMetadata::TensorBSpline {
             feature_cols: feature_cols.clone(),
             knots: knots.clone(),
             degrees: degrees.clone(),
+            periods: periods.clone(),
             identifiability_transform: compose_identifiability_transforms(
                 identifiability_transform.as_ref(),
                 transform,
@@ -11929,6 +12041,7 @@ pub fn freeze_term_collection_from_design(
                     // overwrites them with the frozen values from the metadata
                     // captured during the actual basis build.
                     center_strategy: CenterStrategy::FarthestPoint { num_centers: 0 },
+                    periodic: None,
                     length_scale: None,
                     power: 0,
                     nullspace_order: DuchonNullspaceOrder::Zero,
@@ -11964,10 +12077,10 @@ pub fn freeze_term_collection_from_design(
                 BasisMetadata::ThinPlate {
                     centers,
                     length_scale,
+                    periodic: meta_periodic,
                     identifiability_transform,
                     input_scales: meta_scales,
                     radial_reparam,
-                    ..
                 },
             ) => {
                 s.center_strategy = crate::basis::CenterStrategy::UserProvided(centers.clone());
@@ -11982,6 +12095,7 @@ pub fn freeze_term_collection_from_design(
                     },
                 };
                 s.radial_reparam = radial_reparam.clone();
+                s.periodic = meta_periodic.clone();
                 *input_scales = meta_scales.clone();
             }
             (
@@ -11989,6 +12103,7 @@ pub fn freeze_term_collection_from_design(
                 BasisMetadata::Duchon {
                     centers,
                     length_scale,
+                    periodic: meta_periodic,
                     power,
                     nullspace_order,
                     identifiability_transform,
@@ -12009,6 +12124,7 @@ pub fn freeze_term_collection_from_design(
                 term.basis = SmoothBasisSpec::Duchon {
                     feature_cols: feature_cols.clone(),
                     spec: DuchonBasisSpec {
+                        periodic: meta_periodic.clone(),
                         center_strategy: crate::basis::CenterStrategy::UserProvided(
                             centers.clone(),
                         ),
@@ -12031,12 +12147,12 @@ pub fn freeze_term_collection_from_design(
                 BasisMetadata::Matern {
                     centers,
                     length_scale,
+                    periodic: meta_periodic,
                     nu,
                     include_intercept,
                     identifiability_transform,
                     input_scales: meta_scales,
                     aniso_log_scales: meta_aniso,
-                    ..
                 },
             ) => {
                 s.center_strategy = crate::basis::CenterStrategy::UserProvided(centers.clone());
@@ -12050,6 +12166,7 @@ pub fn freeze_term_collection_from_design(
                     None => MaternIdentifiability::None,
                 };
                 s.aniso_log_scales = meta_aniso.clone();
+                s.periodic = meta_periodic.clone();
                 *input_scales = meta_scales.clone();
             }
             (
@@ -12061,6 +12178,7 @@ pub fn freeze_term_collection_from_design(
                 BasisMetadata::Duchon {
                     centers,
                     length_scale,
+                    periodic: meta_periodic,
                     power,
                     nullspace_order,
                     identifiability_transform,
@@ -12085,6 +12203,7 @@ pub fn freeze_term_collection_from_design(
                     },
                 };
                 s.aniso_log_scales = meta_aniso.clone();
+                s.periodic = meta_periodic.clone();
                 *input_scales = meta_scales.clone();
             }
             (
@@ -12096,6 +12215,7 @@ pub fn freeze_term_collection_from_design(
                     feature_cols: fitted_cols,
                     knots,
                     degrees,
+                    periods,
                     identifiability_transform,
                 },
             ) => {
@@ -12113,6 +12233,7 @@ pub fn freeze_term_collection_from_design(
                     s.marginalspecs[i].degree = degrees[i];
                     s.marginalspecs[i].knotspec = BSplineKnotSpec::Provided(knots[i].clone());
                 }
+                s.periods = periods.clone();
                 s.identifiability = match identifiability_transform {
                     Some(z) => TensorBSplineIdentifiability::FrozenTransform {
                         transform: z.clone(),
@@ -14399,6 +14520,7 @@ mod tests {
                 basis: SmoothBasisSpec::ThinPlate {
                     feature_cols: vec![1, 2],
                     spec: ThinPlateBasisSpec {
+                        periodic: None,
                         center_strategy: CenterStrategy::FarthestPoint { num_centers: 4 },
                         length_scale: 1.0,
                         double_penalty: true,
@@ -14443,6 +14565,7 @@ mod tests {
             basis: SmoothBasisSpec::ThinPlate {
                 feature_cols: vec![0, 1],
                 spec: ThinPlateBasisSpec {
+                    periodic: None,
                     center_strategy: CenterStrategy::FarthestPoint { num_centers: 3 },
                     length_scale: 1.0,
                     double_penalty: false,
@@ -14474,6 +14597,7 @@ mod tests {
             basis: SmoothBasisSpec::ThinPlate {
                 feature_cols: vec![0],
                 spec: ThinPlateBasisSpec {
+                    periodic: None,
                     center_strategy: CenterStrategy::FarthestPoint { num_centers: 4 },
                     length_scale: 1.0,
                     double_penalty: false,
@@ -14513,6 +14637,7 @@ mod tests {
             basis: SmoothBasisSpec::ThinPlate {
                 feature_cols: vec![0, 1, 2],
                 spec: ThinPlateBasisSpec {
+                    periodic: None,
                     center_strategy: CenterStrategy::FarthestPoint { num_centers: 3 },
                     length_scale: 1.0,
                     double_penalty: false,
@@ -14565,6 +14690,7 @@ mod tests {
                 basis: SmoothBasisSpec::ThinPlate {
                     feature_cols: vec![0, 1, 2, 3, 4],
                     spec: ThinPlateBasisSpec {
+                        periodic: None,
                         center_strategy: CenterStrategy::FarthestPoint { num_centers: 10 },
                         length_scale: 1.0,
                         double_penalty: false,
@@ -14624,6 +14750,7 @@ mod tests {
             basis: SmoothBasisSpec::Matern {
                 feature_cols: vec![0],
                 spec: MaternBasisSpec {
+                    periodic: None,
                     center_strategy: CenterStrategy::FarthestPoint { num_centers: 4 },
                     length_scale: 0.7,
                     nu: MaternNu::FiveHalves,
@@ -14655,6 +14782,7 @@ mod tests {
             basis: SmoothBasisSpec::Duchon {
                 feature_cols: vec![0],
                 spec: DuchonBasisSpec {
+                    periodic: None,
                     center_strategy: CenterStrategy::FarthestPoint { num_centers: 4 },
                     length_scale: Some(0.9),
                     power: 5,
@@ -14735,6 +14863,7 @@ mod tests {
                 basis: SmoothBasisSpec::ThinPlate {
                     feature_cols: vec![1, 2],
                     spec: ThinPlateBasisSpec {
+                        periodic: None,
                         center_strategy: CenterStrategy::FarthestPoint { num_centers: 4 },
                         length_scale: 1.0,
                         double_penalty: true,
@@ -14818,6 +14947,7 @@ mod tests {
                 basis: SmoothBasisSpec::ThinPlate {
                     feature_cols: vec![0, 1],
                     spec: ThinPlateBasisSpec {
+                        periodic: None,
                         center_strategy: CenterStrategy::FarthestPoint { num_centers: 4 },
                         length_scale: 1.0,
                         double_penalty: false,
@@ -14873,6 +15003,7 @@ mod tests {
                 basis: SmoothBasisSpec::ThinPlate {
                     feature_cols: vec![0, 1],
                     spec: ThinPlateBasisSpec {
+                        periodic: None,
                         center_strategy: CenterStrategy::FarthestPoint { num_centers: 4 },
                         length_scale: 1.0,
                         double_penalty: false,
@@ -14933,6 +15064,7 @@ mod tests {
                 basis: SmoothBasisSpec::ThinPlate {
                     feature_cols: vec![0, 1],
                     spec: ThinPlateBasisSpec {
+                        periodic: None,
                         center_strategy: CenterStrategy::FarthestPoint { num_centers: 4 },
                         length_scale: 1.0,
                         double_penalty: false,
@@ -15007,6 +15139,7 @@ mod tests {
                     basis: SmoothBasisSpec::ThinPlate {
                         feature_cols: vec![feature],
                         spec: ThinPlateBasisSpec {
+                            periodic: None,
                             center_strategy: CenterStrategy::EqualMass { num_centers: 4 },
                             length_scale: 1.0,
                             double_penalty: false,
@@ -15074,6 +15207,7 @@ mod tests {
                     basis: SmoothBasisSpec::ThinPlate {
                         feature_cols: vec![1],
                         spec: ThinPlateBasisSpec {
+                            periodic: None,
                             center_strategy: CenterStrategy::FarthestPoint { num_centers: 12 },
                             length_scale: 1.0,
                             double_penalty: true,
@@ -15089,6 +15223,7 @@ mod tests {
                     basis: SmoothBasisSpec::ThinPlate {
                         feature_cols: vec![2],
                         spec: ThinPlateBasisSpec {
+                            periodic: None,
                             center_strategy: CenterStrategy::FarthestPoint { num_centers: 12 },
                             length_scale: 1.0,
                             double_penalty: true,
@@ -15176,6 +15311,7 @@ mod tests {
             basis: SmoothBasisSpec::ThinPlate {
                 feature_cols: vec![0],
                 spec: ThinPlateBasisSpec {
+                    periodic: None,
                     center_strategy: CenterStrategy::UserProvided(centers),
                     length_scale: 1.0,
                     double_penalty: false,
@@ -15215,6 +15351,7 @@ mod tests {
             basis: SmoothBasisSpec::ThinPlate {
                 feature_cols: vec![0, 1],
                 spec: ThinPlateBasisSpec {
+                    periodic: None,
                     center_strategy: CenterStrategy::EqualMass { num_centers: 4 },
                     length_scale: 1.0,
                     double_penalty: false,
@@ -15280,6 +15417,7 @@ mod tests {
             basis: SmoothBasisSpec::Duchon {
                 feature_cols: vec![0, 1],
                 spec: DuchonBasisSpec {
+                    periodic: None,
                     center_strategy: CenterStrategy::FarthestPoint { num_centers: 6 },
                     length_scale: Some(1.0),
                     power: 5,
@@ -15390,6 +15528,7 @@ mod tests {
                     basis: SmoothBasisSpec::Duchon {
                         feature_cols: vec![0, 1],
                         spec: DuchonBasisSpec {
+                            periodic: None,
                             center_strategy: CenterStrategy::FarthestPoint { num_centers: 6 },
                             length_scale: Some(1.0),
                             power: 1,
@@ -15469,6 +15608,7 @@ mod tests {
                 basis: SmoothBasisSpec::ThinPlate {
                     feature_cols: vec![0],
                     spec: ThinPlateBasisSpec {
+                        periodic: None,
                         center_strategy: CenterStrategy::UserProvided(centers),
                         length_scale: 1.0,
                         double_penalty: false,
@@ -15521,6 +15661,7 @@ mod tests {
                 basis: SmoothBasisSpec::ThinPlate {
                     feature_cols: vec![0, 1],
                     spec: ThinPlateBasisSpec {
+                        periodic: None,
                         center_strategy: CenterStrategy::FarthestPoint { num_centers: 4 },
                         length_scale: 1.0,
                         double_penalty: false,
@@ -15558,6 +15699,7 @@ mod tests {
                 basis: SmoothBasisSpec::ThinPlate {
                     feature_cols: vec![0, 1],
                     spec: ThinPlateBasisSpec {
+                        periodic: None,
                         center_strategy: CenterStrategy::UserProvided(centers),
                         length_scale,
                         double_penalty: false,
@@ -15616,6 +15758,7 @@ mod tests {
                 basis: SmoothBasisSpec::ThinPlate {
                     feature_cols: vec![0, 1],
                     spec: ThinPlateBasisSpec {
+                        periodic: None,
                         center_strategy: CenterStrategy::FarthestPoint { num_centers: 6 },
                         length_scale: 1.3,
                         double_penalty: true,
@@ -15637,6 +15780,7 @@ mod tests {
                 basis: SmoothBasisSpec::Matern {
                     feature_cols: vec![0, 1],
                     spec: MaternBasisSpec {
+                        periodic: None,
                         center_strategy: CenterStrategy::FarthestPoint { num_centers: 6 },
                         length_scale: 1.1,
                         nu: MaternNu::FiveHalves,
@@ -15660,6 +15804,7 @@ mod tests {
                 basis: SmoothBasisSpec::Duchon {
                     feature_cols: vec![0, 1],
                     spec: DuchonBasisSpec {
+                        periodic: None,
                         center_strategy: CenterStrategy::FarthestPoint { num_centers: 6 },
                         length_scale: Some(1.4),
                         power: 5,
@@ -15727,6 +15872,7 @@ mod tests {
             basis: SmoothBasisSpec::Matern {
                 feature_cols: (0..d).collect(),
                 spec: MaternBasisSpec {
+                    periodic: None,
                     center_strategy: CenterStrategy::FarthestPoint { num_centers: 5 },
                     length_scale: 0.75,
                     nu: MaternNu::FiveHalves,
@@ -15780,6 +15926,7 @@ mod tests {
             basis: SmoothBasisSpec::Duchon {
                 feature_cols: (0..d).collect(),
                 spec: DuchonBasisSpec {
+                    periodic: None,
                     center_strategy: CenterStrategy::FarthestPoint { num_centers: 12 },
                     length_scale: Some(0.9),
                     power: 5,
@@ -15816,6 +15963,7 @@ mod tests {
             basis: SmoothBasisSpec::Duchon {
                 feature_cols: (0..d).collect(),
                 spec: DuchonBasisSpec {
+                    periodic: None,
                     center_strategy: CenterStrategy::FarthestPoint { num_centers: 4 },
                     length_scale: Some(1.0),
                     power: 3,
@@ -15864,6 +16012,7 @@ mod tests {
                 basis: SmoothBasisSpec::Duchon {
                     feature_cols: (0..d).collect(),
                     spec: DuchonBasisSpec {
+                        periodic: None,
                         center_strategy: CenterStrategy::FarthestPoint { num_centers: 4 },
                         length_scale: Some(1.0),
                         power: 3,
@@ -15916,6 +16065,7 @@ mod tests {
                 basis: SmoothBasisSpec::Duchon {
                     feature_cols: (0..d).collect(),
                     spec: DuchonBasisSpec {
+                        periodic: None,
                         center_strategy: CenterStrategy::FarthestPoint { num_centers: 4 },
                         length_scale: Some(1.0),
                         power: 3,
@@ -15960,6 +16110,7 @@ mod tests {
                 basis: SmoothBasisSpec::Duchon {
                     feature_cols: (0..d).collect(),
                     spec: DuchonBasisSpec {
+                        periodic: None,
                         center_strategy: CenterStrategy::FarthestPoint { num_centers: 4 },
                         length_scale: Some(1.0),
                         power: 3,
@@ -16002,6 +16153,7 @@ mod tests {
                 basis: SmoothBasisSpec::Matern {
                     feature_cols: (0..d).collect(),
                     spec: MaternBasisSpec {
+                        periodic: None,
                         center_strategy: CenterStrategy::FarthestPoint { num_centers: 6 },
                         length_scale: 1.0,
                         nu: MaternNu::FiveHalves,
@@ -16062,6 +16214,7 @@ mod tests {
             basis: SmoothBasisSpec::TensorBSpline {
                 feature_cols: vec![0, 1],
                 spec: TensorBSplineSpec {
+                    periods: Vec::new(),
                     marginalspecs: vec![spec_x, spec_y],
                     double_penalty: true,
                     identifiability: TensorBSplineIdentifiability::default(),
@@ -16126,6 +16279,7 @@ mod tests {
             basis: SmoothBasisSpec::TensorBSpline {
                 feature_cols: vec![0, 1],
                 spec: TensorBSplineSpec {
+                    periods: Vec::new(),
                     marginalspecs: vec![spec_x, spec_y],
                     double_penalty: false,
                     identifiability: TensorBSplineIdentifiability::None,
@@ -16163,6 +16317,7 @@ mod tests {
             basis: SmoothBasisSpec::TensorBSpline {
                 feature_cols: vec![0, 1],
                 spec: TensorBSplineSpec {
+                    periods: Vec::new(),
                     marginalspecs: vec![
                         BSplineBasisSpec {
                             degree: 3,
@@ -16244,6 +16399,7 @@ mod tests {
                 basis: SmoothBasisSpec::Matern {
                     feature_cols: vec![0, 1, 2],
                     spec: MaternBasisSpec {
+                        periodic: None,
                         center_strategy: CenterStrategy::FarthestPoint { num_centers: 12 },
                         length_scale: 20.0,
                         nu: MaternNu::FiveHalves,
@@ -16349,6 +16505,7 @@ mod tests {
             basis: SmoothBasisSpec::Matern {
                 feature_cols: vec![0, 1],
                 spec: MaternBasisSpec {
+                    periodic: None,
                     center_strategy: CenterStrategy::FarthestPoint { num_centers: 8 },
                     length_scale,
                     nu: MaternNu::FiveHalves,
@@ -16525,6 +16682,7 @@ mod tests {
                 basis: SmoothBasisSpec::Matern {
                     feature_cols: vec![0, 1],
                     spec: MaternBasisSpec {
+                        periodic: None,
                         center_strategy: CenterStrategy::FarthestPoint { num_centers: 5 },
                         length_scale: 0.85,
                         nu: MaternNu::FiveHalves,
@@ -16683,6 +16841,7 @@ mod tests {
                 basis: SmoothBasisSpec::Duchon {
                     feature_cols: vec![0],
                     spec: DuchonBasisSpec {
+                        periodic: None,
                         center_strategy: CenterStrategy::FarthestPoint { num_centers: 8 },
                         length_scale: Some(1.0),
                         power: 1,
@@ -16920,6 +17079,7 @@ mod tests {
             SmoothBasisSpec::ThinPlate {
                 feature_cols: vec![0],
                 spec: ThinPlateBasisSpec {
+                    periodic: None,
                     center_strategy: CenterStrategy::FarthestPoint { num_centers: 8 },
                     length_scale: 1.0,
                     double_penalty: false,
@@ -16932,6 +17092,7 @@ mod tests {
             SmoothBasisSpec::Duchon {
                 feature_cols: vec![0],
                 spec: DuchonBasisSpec {
+                    periodic: None,
                     center_strategy: CenterStrategy::FarthestPoint { num_centers: 8 },
                     length_scale: Some(1.0),
                     power: 1,
@@ -17237,6 +17398,7 @@ mod tests {
                 basis: SmoothBasisSpec::Duchon {
                     feature_cols: vec![0],
                     spec: DuchonBasisSpec {
+                        periodic: None,
                         center_strategy: CenterStrategy::FarthestPoint { num_centers: 8 },
                         length_scale: Some(1.0),
                         power: 1,
@@ -17442,6 +17604,7 @@ mod tests {
                 basis: SmoothBasisSpec::Duchon {
                     feature_cols: vec![0],
                     spec: DuchonBasisSpec {
+                        periodic: None,
                         center_strategy: CenterStrategy::FarthestPoint { num_centers: 8 },
                         length_scale: Some(1.0),
                         power: 1,
@@ -17675,6 +17838,7 @@ mod tests {
                 basis: SmoothBasisSpec::Duchon {
                     feature_cols: vec![0],
                     spec: DuchonBasisSpec {
+                        periodic: None,
                         center_strategy: CenterStrategy::FarthestPoint { num_centers: 8 },
                         length_scale: Some(1.0),
                         power: 1,
@@ -17849,6 +18013,7 @@ mod tests {
                 basis: SmoothBasisSpec::Duchon {
                     feature_cols: vec![0],
                     spec: DuchonBasisSpec {
+                        periodic: None,
                         center_strategy: CenterStrategy::FarthestPoint { num_centers: 8 },
                         length_scale: Some(1.0),
                         power: 1,
@@ -18024,6 +18189,7 @@ mod tests {
             basis: SmoothBasisSpec::Matern {
                 feature_cols: vec![0, 1],
                 spec: MaternBasisSpec {
+                    periodic: None,
                     center_strategy: CenterStrategy::Auto(Box::new(
                         CenterStrategy::FarthestPoint { num_centers: 8 },
                     )),
@@ -18254,6 +18420,7 @@ mod tests {
                     basis: SmoothBasisSpec::Matern {
                         feature_cols: vec![0, 1],
                         spec: MaternBasisSpec {
+                            periodic: None,
                             center_strategy: CenterStrategy::FarthestPoint { num_centers: 6 },
                             length_scale: 0.8,
                             nu: MaternNu::FiveHalves,
@@ -18386,6 +18553,7 @@ mod tests {
             basis: SmoothBasisSpec::Matern {
                 feature_cols: vec![0, 1],
                 spec: MaternBasisSpec {
+                    periodic: None,
                     center_strategy: CenterStrategy::FarthestPoint { num_centers: 5 },
                     length_scale,
                     nu: MaternNu::FiveHalves,
@@ -18522,6 +18690,7 @@ mod tests {
                 basis: SmoothBasisSpec::Matern {
                     feature_cols: vec![0, 1],
                     spec: MaternBasisSpec {
+                        periodic: None,
                         center_strategy: CenterStrategy::FarthestPoint { num_centers: 6 },
                         length_scale: 0.9,
                         nu: MaternNu::FiveHalves,
@@ -18625,6 +18794,7 @@ mod tests {
                 basis: SmoothBasisSpec::Matern {
                     feature_cols: vec![0, 1],
                     spec: MaternBasisSpec {
+                        periodic: None,
                         center_strategy: CenterStrategy::FarthestPoint { num_centers: 6 },
                         length_scale: 0.85,
                         nu: MaternNu::FiveHalves,
@@ -18841,6 +19011,7 @@ mod tests {
                 basis: SmoothBasisSpec::Matern {
                     feature_cols: vec![0],
                     spec: MaternBasisSpec {
+                        periodic: None,
                         center_strategy: CenterStrategy::FarthestPoint { num_centers: 6 },
                         length_scale: 0.4,
                         nu: MaternNu::FiveHalves,
@@ -18907,6 +19078,7 @@ mod tests {
                 basis: SmoothBasisSpec::ThinPlate {
                     feature_cols: vec![0, 1],
                     spec: ThinPlateBasisSpec {
+                        periodic: None,
                         center_strategy: CenterStrategy::FarthestPoint { num_centers: 7 },
                         length_scale: 0.7,
                         double_penalty: true,
@@ -19013,6 +19185,7 @@ mod tests {
                 basis: SmoothBasisSpec::Duchon {
                     feature_cols: vec![0, 1],
                     spec: DuchonBasisSpec {
+                        periodic: None,
                         center_strategy: CenterStrategy::FarthestPoint { num_centers: 7 },
                         length_scale: Some(0.7),
                         power: 1,
@@ -19124,6 +19297,7 @@ mod tests {
                 basis: SmoothBasisSpec::Matern {
                     feature_cols: vec![0, 1],
                     spec: MaternBasisSpec {
+                        periodic: None,
                         center_strategy: CenterStrategy::FarthestPoint { num_centers: 12 },
                         length_scale: 12.0,
                         nu: MaternNu::FiveHalves,
@@ -19238,6 +19412,7 @@ mod tests {
                 basis: SmoothBasisSpec::Matern {
                     feature_cols: vec![0, 1],
                     spec: MaternBasisSpec {
+                        periodic: None,
                         center_strategy: CenterStrategy::FarthestPoint { num_centers: 10 },
                         length_scale: 1.8,
                         nu: MaternNu::FiveHalves,
@@ -19347,6 +19522,7 @@ mod tests {
                 basis: SmoothBasisSpec::Duchon {
                     feature_cols: vec![0, 1],
                     spec: DuchonBasisSpec {
+                        periodic: None,
                         center_strategy: CenterStrategy::FarthestPoint { num_centers: 4 },
                         length_scale: Some(0.9),
                         power: 1,
@@ -19440,6 +19616,7 @@ mod tests {
                 basis: SmoothBasisSpec::Duchon {
                     feature_cols: vec![0, 1],
                     spec: DuchonBasisSpec {
+                        periodic: None,
                         center_strategy: CenterStrategy::FarthestPoint { num_centers: 4 },
                         length_scale: None,
                         power: 1,
@@ -19475,6 +19652,7 @@ mod tests {
                 basis: SmoothBasisSpec::Duchon {
                     feature_cols: vec![0, 1],
                     spec: DuchonBasisSpec {
+                        periodic: None,
                         center_strategy: CenterStrategy::UserProvided(array![
                             [0.0, 0.0],
                             [1.0, 0.0],
@@ -19522,6 +19700,7 @@ mod tests {
                 basis: SmoothBasisSpec::Duchon {
                     feature_cols: vec![0, 1, 2],
                     spec: DuchonBasisSpec {
+                        periodic: None,
                         center_strategy: CenterStrategy::UserProvided(array![
                             [0.0, 0.0, 0.0],
                             [1.0, 0.0, 0.0],
@@ -19565,6 +19744,7 @@ mod tests {
                     basis: SmoothBasisSpec::Matern {
                         feature_cols: vec![0, 1],
                         spec: MaternBasisSpec {
+                            periodic: None,
                             center_strategy: CenterStrategy::UserProvided(array![
                                 [0.0, 0.0],
                                 [1.0, 0.0],
@@ -19586,6 +19766,7 @@ mod tests {
                     basis: SmoothBasisSpec::Matern {
                         feature_cols: vec![0, 1],
                         spec: MaternBasisSpec {
+                            periodic: None,
                             center_strategy: CenterStrategy::UserProvided(array![
                                 [0.0, 0.0],
                                 [1.0, 0.0],
@@ -19631,6 +19812,7 @@ mod tests {
                 basis: SmoothBasisSpec::Matern {
                     feature_cols: vec![0, 1],
                     spec: MaternBasisSpec {
+                        periodic: None,
                         center_strategy: CenterStrategy::UserProvided(array![
                             [0.0, 0.0],
                             [1.0, 0.0],
@@ -19714,6 +19896,7 @@ mod tests {
                 basis: SmoothBasisSpec::Duchon {
                     feature_cols: vec![0, 1, 2],
                     spec: DuchonBasisSpec {
+                        periodic: None,
                         center_strategy: CenterStrategy::FarthestPoint { num_centers: 5 },
                         length_scale: None,
                         power: 1,
@@ -19788,6 +19971,7 @@ mod tests {
                 basis: SmoothBasisSpec::Matern {
                     feature_cols: vec![0, 1],
                     spec: MaternBasisSpec {
+                        periodic: None,
                         center_strategy: CenterStrategy::UserProvided(array![
                             [0.0, 0.0],
                             [1.0, 0.0],
@@ -19908,6 +20092,7 @@ mod tests {
                 basis: SmoothBasisSpec::Duchon {
                     feature_cols: vec![0, 1, 2],
                     spec: DuchonBasisSpec {
+                        periodic: None,
                         center_strategy: CenterStrategy::FarthestPoint { num_centers: 5 },
                         length_scale: None,
                         power: 1,
@@ -20056,6 +20241,7 @@ mod tests {
             basis: SmoothBasisSpec::Duchon {
                 feature_cols: vec![0, 1],
                 spec: DuchonBasisSpec {
+                    periodic: None,
                     center_strategy: CenterStrategy::FarthestPoint { num_centers: 8 },
                     length_scale: Some(length_scale),
                     power: 3,
@@ -20193,6 +20379,7 @@ mod tests {
             basis: SmoothBasisSpec::Duchon {
                 feature_cols: (0..d).collect(),
                 spec: DuchonBasisSpec {
+                    periodic: None,
                     center_strategy: CenterStrategy::FarthestPoint { num_centers: 24 },
                     length_scale: None,
                     power: 2,
@@ -20894,6 +21081,7 @@ mod tests {
                 basis: SmoothBasisSpec::Matern {
                     feature_cols: vec![0, 1],
                     spec: MaternBasisSpec {
+                        periodic: None,
                         center_strategy: CenterStrategy::FarthestPoint { num_centers: 10 },
                         length_scale: 0.7,
                         nu: MaternNu::FiveHalves,
@@ -20981,6 +21169,7 @@ mod tests {
                 basis: SmoothBasisSpec::Matern {
                     feature_cols: vec![0, 1],
                     spec: MaternBasisSpec {
+                        periodic: None,
                         center_strategy: CenterStrategy::FarthestPoint { num_centers: 10 },
                         length_scale: 0.7,
                         nu: MaternNu::FiveHalves,
@@ -21066,6 +21255,7 @@ mod tests {
                 basis: SmoothBasisSpec::Matern {
                     feature_cols: vec![0, 1],
                     spec: MaternBasisSpec {
+                        periodic: None,
                         center_strategy: CenterStrategy::FarthestPoint { num_centers: 8 },
                         length_scale: 0.6,
                         nu: MaternNu::FiveHalves,
@@ -21288,6 +21478,7 @@ mod tests {
                 basis: SmoothBasisSpec::Duchon {
                     feature_cols: vec![0],
                     spec: DuchonBasisSpec {
+                        periodic: None,
                         center_strategy: CenterStrategy::FarthestPoint { num_centers: 31 },
                         length_scale: Some(1.0),
                         power: 2,
@@ -21466,6 +21657,7 @@ mod tests {
                 basis: SmoothBasisSpec::Duchon {
                     feature_cols: vec![0],
                     spec: DuchonBasisSpec {
+                        periodic: None,
                         center_strategy: CenterStrategy::FarthestPoint { num_centers: 120 },
                         length_scale: Some(1.0),
                         power: 2,
@@ -21631,6 +21823,7 @@ mod tests {
                 basis: SmoothBasisSpec::Matern {
                     feature_cols: vec![0, 1],
                     spec: MaternBasisSpec {
+                        periodic: None,
                         center_strategy: CenterStrategy::FarthestPoint { num_centers: 7 },
                         length_scale: 0.8,
                         nu: MaternNu::FiveHalves,
@@ -21716,6 +21909,7 @@ mod tests {
                 basis: SmoothBasisSpec::Duchon {
                     feature_cols: vec![0],
                     spec: DuchonBasisSpec {
+                        periodic: None,
                         center_strategy: CenterStrategy::FarthestPoint { num_centers: 11 },
                         length_scale: Some(0.8),
                         power: 2,

--- a/src/terms/term_builder.rs
+++ b/src/terms/term_builder.rs
@@ -17,7 +17,7 @@ use crate::basis::{
 };
 use crate::inference::data::{EncodedDataset as Dataset, missing_column_message};
 use crate::inference::formula_dsl::{
-    ParsedTerm, SmoothKind, option_bool, option_f64, option_usize, option_usize_any,
+    ParsedTerm, SmoothKind, option_bool, option_f64, option_usize, option_usize_any, strip_quotes,
 };
 use crate::inference::model::ColumnKindTag;
 use crate::resource::ResourcePolicy;
@@ -213,6 +213,143 @@ pub fn build_termspec(
     })
 }
 
+fn split_list_option(raw: &str) -> Vec<String> {
+    let t = raw.trim();
+    let inner = t
+        .strip_prefix('[')
+        .and_then(|u| u.strip_suffix(']'))
+        .unwrap_or(t);
+    inner
+        .split(',')
+        .map(|v| v.trim().to_string())
+        .filter(|v| !v.is_empty())
+        .collect()
+}
+
+fn parse_numeric_expr(raw: &str) -> Result<f64, String> {
+    let mut acc = 1.0f64;
+    let normalized = raw.replace(' ', "");
+    if normalized.eq_ignore_ascii_case("none") {
+        return Err("None is not numeric".to_string());
+    }
+    for factor in normalized.split('*') {
+        if factor.is_empty() {
+            return Err(format!("invalid numeric expression '{raw}'"));
+        }
+        let value = if factor.eq_ignore_ascii_case("pi") {
+            std::f64::consts::PI
+        } else {
+            factor
+                .parse::<f64>()
+                .map_err(|_| format!("invalid numeric expression '{raw}'"))?
+        };
+        acc *= value;
+    }
+    Ok(acc)
+}
+
+fn parse_periods_option(
+    options: &BTreeMap<String, String>,
+    dim: usize,
+) -> Result<Option<Vec<Option<f64>>>, String> {
+    let Some(raw) = options.get("period") else {
+        return Ok(None);
+    };
+    let values = split_list_option(raw);
+    let mut periods = vec![None; dim];
+    if values.len() == 1 && dim == 1 {
+        periods[0] = Some(parse_numeric_expr(&values[0])?);
+    } else {
+        if values.len() != dim {
+            return Err(format!(
+                "period list length {} must match smooth dimension {}",
+                values.len(),
+                dim
+            ));
+        }
+        for (i, v) in values.iter().enumerate() {
+            if v.eq_ignore_ascii_case("none") {
+                continue;
+            }
+            periods[i] = Some(parse_numeric_expr(v)?);
+        }
+    }
+    Ok(Some(periods))
+}
+
+fn parse_periodic_axes_option(
+    options: &BTreeMap<String, String>,
+    dim: usize,
+) -> Result<Option<Vec<Option<f64>>>, String> {
+    let Some(raw_axes) = options.get("periodic") else {
+        return Ok(None);
+    };
+    let mut periods = parse_periods_option(options, dim)?.unwrap_or_else(|| vec![None; dim]);
+    let axes = split_list_option(raw_axes);
+    if axes.is_empty() {
+        return Ok(Some(periods));
+    }
+    for a in axes {
+        let axis = a
+            .parse::<usize>()
+            .map_err(|_| format!("invalid periodic axis '{a}'"))?;
+        if axis >= dim {
+            return Err(format!(
+                "periodic axis {axis} out of range for {dim}D smooth"
+            ));
+        }
+        if periods[axis].is_none() {
+            return Err(format!(
+                "periodic axis {axis} requires period[{axis}] to be finite"
+            ));
+        }
+    }
+    // Axes not listed are non-periodic even if period list has a finite placeholder.
+    let listed: std::collections::BTreeSet<usize> = split_list_option(raw_axes)
+        .into_iter()
+        .filter_map(|a| a.parse::<usize>().ok())
+        .collect();
+    for i in 0..dim {
+        if !listed.contains(&i) {
+            periods[i] = None;
+        }
+    }
+    Ok(Some(periods))
+}
+
+fn parse_bc_periods_option(
+    options: &BTreeMap<String, String>,
+    dim: usize,
+) -> Result<Vec<Option<f64>>, String> {
+    let mut periods = vec![None; dim];
+    if let Some(raw_bc) = options.get("bc") {
+        let bc = split_list_option(raw_bc);
+        if bc.len() != dim {
+            return Err(format!(
+                "bc list length {} must match tensor dimension {}",
+                bc.len(),
+                dim
+            ));
+        }
+        let period_values = parse_periods_option(options, dim)?.unwrap_or_else(|| vec![None; dim]);
+        for (i, b) in bc.iter().enumerate() {
+            let b = strip_quotes(b).trim().to_ascii_lowercase();
+            match b.as_str() {
+                "periodic" | "cyclic" | "cc" => {
+                    periods[i] =
+                        period_values[i].or_else(|| if dim == 1 { period_values[0] } else { None });
+                    if periods[i].is_none() {
+                        return Err(format!("periodic tensor margin {i} requires period[{i}]"));
+                    }
+                }
+                "natural" | "cr" | "bspline" | "p-spline" | "ps" | "none" => {}
+                other => return Err(format!("unsupported tensor bc '{other}' at margin {i}")),
+            }
+        }
+    }
+    Ok(periods)
+}
+
 // ---------------------------------------------------------------------------
 // Smooth basis spec construction
 // ---------------------------------------------------------------------------
@@ -283,6 +420,7 @@ pub fn build_smooth_basis(
                 feature_cols: cols.to_vec(),
                 spec: TensorBSplineSpec {
                     marginalspecs: specs,
+                    periods: parse_bc_periods_option(options, cols.len())?,
                     double_penalty: smooth_double_penalty,
                     identifiability: parse_tensor_identifiability(options)?,
                 },
@@ -349,6 +487,7 @@ pub fn build_smooth_basis(
                 feature_cols: cols.to_vec(),
                 spec: ThinPlateBasisSpec {
                     center_strategy,
+                    periodic: parse_periodic_axes_option(options, cols.len())?,
                     length_scale: option_f64(options, "length_scale").unwrap_or(1.0),
                     double_penalty: smooth_double_penalty,
                     identifiability: parse_spatial_identifiability(options)?,
@@ -383,6 +522,7 @@ pub fn build_smooth_basis(
                 feature_cols: cols.to_vec(),
                 spec: MaternBasisSpec {
                     center_strategy,
+                    periodic: parse_periodic_axes_option(options, cols.len())?,
                     length_scale: option_f64(options, "length_scale").unwrap_or(1.0),
                     nu,
                     include_intercept: option_bool(options, "include_intercept").unwrap_or(false),
@@ -518,6 +658,7 @@ pub fn build_smooth_basis(
                 feature_cols: cols.to_vec(),
                 spec: DuchonBasisSpec {
                     center_strategy,
+                    periodic: parse_periodic_axes_option(options, cols.len())?,
                     length_scale,
                     power,
                     nullspace_order,

--- a/tests/cylinder_periodic.rs
+++ b/tests/cylinder_periodic.rs
@@ -1,0 +1,120 @@
+use gam::inference::formula_dsl::parse_formula;
+use gam::terms::basis::{
+    BSplineBasisSpec, BSplineIdentifiability, BSplineKnotSpec, CenterStrategy, MaternBasisSpec,
+    MaternIdentifiability, MaternNu,
+};
+use gam::terms::smooth::{
+    ShapeConstraint, SmoothBasisSpec, SmoothTermSpec, TensorBSplineIdentifiability,
+    TensorBSplineSpec, TermCollectionSpec, build_term_collection_design,
+};
+use ndarray::{Array2, array};
+
+#[test]
+fn formula_parser_accepts_cylinder_periodic_options() {
+    let s = parse_formula("y ~ s(theta, h, periodic=[0], period=[2*pi, None])")
+        .expect("parse periodic radial smooth");
+    assert_eq!(s.terms.len(), 1);
+
+    let te = parse_formula("y ~ te(theta, h, bc=['periodic', 'natural'], period=[2*pi, None])")
+        .expect("parse periodic tensor smooth");
+    assert_eq!(te.terms.len(), 1);
+}
+
+#[test]
+fn tensor_periodic_margin_is_exactly_cyclic_at_period_boundary() {
+    let two_pi = 2.0 * std::f64::consts::PI;
+    let data = array![[0.0, 0.25], [two_pi, 0.25], [std::f64::consts::PI, 0.75]];
+    let marginal = |range| BSplineBasisSpec {
+        degree: 3,
+        penalty_order: 2,
+        knotspec: BSplineKnotSpec::Generate {
+            data_range: range,
+            num_internal_knots: 4,
+        },
+        double_penalty: false,
+        identifiability: BSplineIdentifiability::None,
+    };
+    let spec = TermCollectionSpec {
+        linear_terms: vec![],
+        random_effect_terms: vec![],
+        smooth_terms: vec![SmoothTermSpec {
+            name: "te(theta,h)".to_string(),
+            basis: SmoothBasisSpec::TensorBSpline {
+                feature_cols: vec![0, 1],
+                spec: TensorBSplineSpec {
+                    marginalspecs: vec![marginal((0.0, two_pi)), marginal((0.0, 1.0))],
+                    periods: vec![Some(two_pi), None],
+                    double_penalty: false,
+                    identifiability: TensorBSplineIdentifiability::None,
+                },
+            },
+            shape: ShapeConstraint::None,
+        }],
+    };
+
+    let design = build_term_collection_design(data.view(), &spec).expect("tensor periodic design");
+    let dense = design.smooth.term_designs[0].to_dense();
+    assert_eq!(dense.nrows(), 3);
+    for col in 0..dense.ncols() {
+        assert!(
+            (dense[[0, col]] - dense[[1, col]]).abs() < 1e-12,
+            "tensor cyclic seam mismatch at col {col}: {} vs {}",
+            dense[[0, col]],
+            dense[[1, col]]
+        );
+    }
+}
+
+#[test]
+fn radial_periodic_smooth_uses_ghost_centers_but_freezes_original_centers() {
+    let two_pi = 2.0 * std::f64::consts::PI;
+    let data = array![[0.0, 0.0], [two_pi / 2.0, 0.5], [two_pi, 1.0]];
+    let centers: Array2<f64> = data.clone();
+    let spec = TermCollectionSpec {
+        linear_terms: vec![],
+        random_effect_terms: vec![],
+        smooth_terms: vec![SmoothTermSpec {
+            name: "s(theta,h)".to_string(),
+            basis: SmoothBasisSpec::Matern {
+                feature_cols: vec![0, 1],
+                spec: MaternBasisSpec {
+                    center_strategy: CenterStrategy::UserProvided(centers.clone()),
+                    periodic: Some(vec![Some(two_pi), None]),
+                    length_scale: 1.0,
+                    nu: MaternNu::FiveHalves,
+                    include_intercept: false,
+                    double_penalty: true,
+                    identifiability: MaternIdentifiability::None,
+                    aniso_log_scales: None,
+                },
+                input_scales: None,
+            },
+            shape: ShapeConstraint::None,
+        }],
+    };
+
+    let design = build_term_collection_design(data.view(), &spec).expect("radial periodic design");
+    let dense = design.smooth.term_designs[0].to_dense();
+    assert_eq!(dense.nrows(), 3);
+    assert_eq!(
+        dense.ncols(),
+        centers.nrows() * 3,
+        "one periodic axis should add ±period ghosts"
+    );
+
+    match &design.smooth.terms[0].metadata {
+        gam::terms::basis::BasisMetadata::Matern {
+            centers: frozen,
+            periodic,
+            ..
+        } => {
+            assert_eq!(
+                frozen.nrows(),
+                centers.nrows(),
+                "metadata stores unexpanded centers"
+            );
+            assert_eq!(periodic.as_ref().unwrap()[0], Some(two_pi));
+        }
+        other => panic!("expected Matern metadata, got {other:?}"),
+    }
+}


### PR DESCRIPTION
### Motivation
- Support 2D smooths with one periodic axis (cylinder / ICLR cylinder case) so users can write `s(theta, h, periodic=[0], period=[2*pi, None])` and `te(theta, h, bc=['periodic','natural'], period=[2*pi, None])`.

### Description
- Formula DSL: accept list literals and wire `period` / `periodic` option parsing into the term builder, including helpers `parse_periods_option`, `parse_periodic_axes_option`, and `parse_bc_periods_option` so `period=[...]` and `periodic=[...]` are recognized.
- Term builder: parse `period`/`periodic` into smooth specs and pass them through `SmoothBasisSpec` constructors.
- Basis & metadata: add `periodic: Option<Vec<Option<f64>>>` to `ThinPlateBasisSpec`, `MaternBasisSpec`, `DuchonBasisSpec` and `periods: Vec<Option<f64>>` to `TensorBSplineSpec`; extend `BasisMetadata` to carry original (unexpanded) center list and periodic info so predict-time rebuilds use the same frozen centers.
- Ghost-centers for radial kernels: implement `expand_periodic_centers` (duplicate centers shifted by ±period in active periodic axes) and use the expanded centers for kernel evaluation / operator construction while preserving the original centers in metadata.
- Periodic tensor margins: add `build_periodic_fourier_margin` to synthesize Fourier-like periodic marginal bases (and simple diagonal penalties) for periodic `te()` margins and integrate into `build_tensor_bspline_basis` when a margin period is specified.
- Integrations and plumbing: wire periodic expansion into `build_thin_plate_basiswithworkspace`, `build_matern_basiswithworkspace`, and `build_duchon_basiswithworkspace`; ensure operator-penalty construction uses expanded (ghost) centers while metadata retains original centers; update identifiability/freeze paths to carry periodic info.
- Tests: add `tests/cylinder_periodic.rs` exercising formula parsing, periodic tensor seam equality, and radial ghost-centers + metadata freeze behavior.

### Testing
- Ran `cargo check` during development and after each change; the project built successfully (`cargo check` succeeded).
- Added `tests/cylinder_periodic.rs` and executed it via `cargo test --test cylinder_periodic`; all tests in that suite passed (3 passed, 0 failed).
- Ran targeted library tests used during development (formula parsing unit tests) and they passed after fixes. All automated checks run in this rollout succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07c77e8a008324b0467db4bf2a5b4c)