### PR TITLE
Add periodic tensor-product smooth margins (torus support)

### DIFF
--- a/src/families/survival_construction.rs
+++ b/src/families/survival_construction.rs
@@ -906,6 +906,7 @@ pub fn build_survival_time_basis(
                         },
                         double_penalty: false,
                         identifiability: BSplineIdentifiability::None,
+                        boundary_condition: Default::default(),
                     },
                 )
                 .map_err(|e| format!("failed to infer survival time knots: {e}"))?;
@@ -1000,6 +1001,7 @@ pub fn build_survival_time_basis(
                     knotspec: BSplineKnotSpec::Provided(knotvec.clone()),
                     double_penalty: false,
                     identifiability: BSplineIdentifiability::None,
+                    boundary_condition: Default::default(),
                 },
             )
             .map_err(|e| format!("failed to build bspline entry basis: {e}"))?;
@@ -1011,6 +1013,7 @@ pub fn build_survival_time_basis(
                     knotspec: BSplineKnotSpec::Provided(knotvec.clone()),
                     double_penalty: false,
                     identifiability: BSplineIdentifiability::None,
+                    boundary_condition: Default::default(),
                 },
             )
             .map_err(|e| format!("failed to build bspline exit basis: {e}"))?;
@@ -1236,6 +1239,7 @@ pub fn build_survival_time_basis(
                     knotspec: BSplineKnotSpec::Provided(knotvec.clone()),
                     double_penalty: false,
                     identifiability: BSplineIdentifiability::None,
+                    boundary_condition: Default::default(),
                 },
             )
             .map_err(|e| format!("failed to build ispline smoothing penalty: {e}"))?;
@@ -1384,6 +1388,7 @@ pub fn evaluate_survival_time_basis_row(
                     knotspec: BSplineKnotSpec::Provided(knots.clone()),
                     double_penalty: false,
                     identifiability: BSplineIdentifiability::None,
+                    boundary_condition: Default::default(),
                 },
             )
             .map_err(|e| format!("failed to evaluate survival bspline anchor row: {e}"))?;
@@ -2779,6 +2784,7 @@ pub fn build_time_varying_survival_covariate_template(
         },
         double_penalty: false,
         identifiability: BSplineIdentifiability::None,
+        boundary_condition: Default::default(),
     };
 
     let time_build = build_bspline_basis_1d(log_exit.view(), &time_spec)
@@ -2802,6 +2808,7 @@ pub fn build_time_varying_survival_covariate_template(
             knotspec: BSplineKnotSpec::Provided(knots.clone()),
             double_penalty: false,
             identifiability: BSplineIdentifiability::None,
+            boundary_condition: Default::default(),
         },
     )
     .map_err(|e| format!("failed to evaluate {block_name} time-margin basis at entry: {e}"))?;

--- a/src/inference/formula_dsl.rs
+++ b/src/inference/formula_dsl.rs
@@ -26,7 +26,8 @@ mul_op = _{ "*" | "/" }
 unary = { unary_op* ~ primary }
 unary_op = _{ "+" | "-" }
 
-primary = { function_call | ident | number | string_lit | "(" ~ expr ~ ")" }
+primary = { function_call | list_lit | ident | number | string_lit | "(" ~ expr ~ ")" }
+list_lit = @{ "[" ~ (!"]" ~ ANY)* ~ "]" }
 function_call = { ident ~ "(" ~ arg_list? ~ ")" }
 arg_list = { arg ~ ("," ~ arg)* }
 arg = { named_arg | expr }
@@ -281,6 +282,23 @@ mod tests {
             CallArgSpec::Named {
                 key: "type".to_string(),
                 value: "\"duchon\"".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn parses_tensor_periodic_list_options() {
+        let call = parse_function_call(
+            "te(day_of_week, hour, bc=['periodic', 'periodic'], period=[7, 24])",
+        )
+        .expect("call");
+        assert_eq!(call.name, "te");
+        assert_eq!(call.args.len(), 4);
+        assert_eq!(
+            call.args[2],
+            CallArgSpec::Named {
+                key: "bc".to_string(),
+                value: "['periodic', 'periodic']".to_string(),
             }
         );
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -11792,6 +11792,7 @@ mod tests {
                             },
                             double_penalty: false,
                             identifiability: BSplineIdentifiability::default(),
+                            boundary_condition: Default::default(),
                         },
                     },
                     shape: ShapeConstraint::None,

--- a/src/terms/basis.rs
+++ b/src/terms/basis.rs
@@ -1403,6 +1403,28 @@ pub struct BSplineBasisSpec {
     pub knotspec: BSplineKnotSpec,
     pub double_penalty: bool,
     pub identifiability: BSplineIdentifiability,
+    #[serde(default)]
+    pub boundary_condition: BSplineBoundaryCondition,
+}
+
+/// Boundary condition used by 1D B-spline-like bases.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum BSplineBoundaryCondition {
+    /// Ordinary open/clamped P-spline basis.
+    Open,
+    /// Fully cyclic margin with the supplied period and coordinate origin.
+    ///
+    /// Periodic margins are represented by a finite Fourier basis with a
+    /// diagonal derivative penalty. This gives exact value/derivative wrapping
+    /// under x -> origin + (x-origin) mod period and composes directly in
+    /// tensor-product smooths.
+    Periodic { period: f64, origin: f64 },
+}
+
+impl Default for BSplineBoundaryCondition {
+    fn default() -> Self {
+        Self::Open
+    }
 }
 
 /// Per-smooth identifiability policy for 1D B-spline bases.
@@ -5488,11 +5510,145 @@ pub fn select_centers_by_strategy(
     }
 }
 
+fn build_periodic_fourier_basis_1d(
+    data: ArrayView1<'_, f64>,
+    spec: &BSplineBasisSpec,
+    period: f64,
+    origin: f64,
+) -> Result<BasisBuildResult, BasisError> {
+    if !period.is_finite() || period <= 0.0 || !origin.is_finite() {
+        return Err(BasisError::InvalidInput(format!(
+            "periodic B-spline margin requires finite origin and positive period, got origin={origin}, period={period}"
+        )));
+    }
+    let q = match &spec.knotspec {
+        BSplineKnotSpec::Generate {
+            num_internal_knots, ..
+        } => num_internal_knots + spec.degree + 1,
+        BSplineKnotSpec::Automatic {
+            num_internal_knots, ..
+        } => {
+            num_internal_knots
+                .unwrap_or_else(|| default_internal_knot_count_for_data(data.len(), spec.degree))
+                + spec.degree
+                + 1
+        }
+        BSplineKnotSpec::Provided(knots) => knots.len().saturating_sub(spec.degree + 1),
+    };
+    if q < 3 {
+        return Err(BasisError::InvalidInput(
+            "periodic margin requires at least three basis coefficients".to_string(),
+        ));
+    }
+
+    let n = data.len();
+    let mut design = Array2::<f64>::zeros((n, q));
+    for (i, &x) in data.iter().enumerate() {
+        if !x.is_finite() {
+            return Err(BasisError::InvalidInput(
+                "periodic margin contains non-finite data".to_string(),
+            ));
+        }
+        let u = (x - origin).rem_euclid(period) / period;
+        design[[i, 0]] = 1.0;
+        let mut col = 1usize;
+        let mut harmonic = 1usize;
+        while col < q {
+            let angle = std::f64::consts::TAU * (harmonic as f64) * u;
+            design[[i, col]] = angle.sin();
+            col += 1;
+            if col < q {
+                design[[i, col]] = angle.cos();
+                col += 1;
+            }
+            harmonic += 1;
+        }
+    }
+
+    let mut s_bend = Array2::<f64>::zeros((q, q));
+    let mut col = 1usize;
+    let mut harmonic = 1usize;
+    while col < q {
+        let omega = std::f64::consts::TAU * (harmonic as f64) / period;
+        let weight = omega.powi((2 * spec.penalty_order) as i32);
+        s_bend[[col, col]] = weight;
+        col += 1;
+        if col < q {
+            s_bend[[col, col]] = weight;
+            col += 1;
+        }
+        harmonic += 1;
+    }
+
+    let mut penalties_raw = vec![PenaltyCandidate {
+        matrix: s_bend.clone(),
+        nullspace_dim_hint: 1,
+        source: PenaltySource::Primary,
+        normalization_scale: 1.0,
+        kronecker_factors: None,
+        op: None,
+    }];
+    if spec.double_penalty {
+        let mut shrink = Array2::<f64>::zeros((q, q));
+        shrink[[0, 0]] = 1.0;
+        penalties_raw.push(PenaltyCandidate {
+            matrix: shrink,
+            nullspace_dim_hint: 0,
+            source: PenaltySource::DoublePenaltyNullspace,
+            normalization_scale: 1.0,
+            kronecker_factors: None,
+            op: None,
+        });
+    }
+
+    let knots = Array1::linspace(origin, origin + period, q + spec.degree + 1);
+    let penalties_raw_mats: Vec<Array2<f64>> = penalties_raw
+        .iter()
+        .map(|candidate| candidate.matrix.clone())
+        .collect();
+    let (design, penalties, identifiability_transform) = apply_bspline_identifiability_policy(
+        design,
+        penalties_raw_mats,
+        &knots,
+        spec.degree,
+        &spec.identifiability,
+    )?;
+    let transformed_candidates = penalties
+        .into_iter()
+        .zip(penalties_raw.into_iter())
+        .map(|(matrix, candidate)| PenaltyCandidate {
+            nullspace_dim_hint: candidate.nullspace_dim_hint,
+            matrix,
+            source: candidate.source,
+            normalization_scale: candidate.normalization_scale,
+            kronecker_factors: None,
+            op: None,
+        })
+        .collect::<Vec<_>>();
+    let (penalties, nullspace_dims, penaltyinfo, ops) =
+        filter_active_penalty_candidates_with_ops(transformed_candidates)?;
+    Ok(BasisBuildResult {
+        design: DesignMatrix::Dense(crate::matrix::DenseDesignMatrix::from(design)),
+        penalties,
+        nullspace_dims,
+        penaltyinfo,
+        metadata: BasisMetadata::BSpline1D {
+            knots,
+            identifiability_transform,
+        },
+        kronecker_factored: None,
+        ops,
+    })
+}
+
 /// Generic 1D B-spline builder returning design + penalty list.
 pub fn build_bspline_basis_1d(
     data: ArrayView1<'_, f64>,
     spec: &BSplineBasisSpec,
 ) -> Result<BasisBuildResult, BasisError> {
+    if let BSplineBoundaryCondition::Periodic { period, origin } = spec.boundary_condition {
+        return build_periodic_fourier_basis_1d(data, spec, period, origin);
+    }
     let prefer_sparse_design = matches!(
         spec.identifiability,
         BSplineIdentifiability::None | BSplineIdentifiability::WeightedSumToZero { .. }
@@ -22658,6 +22814,7 @@ mod tests {
             },
             double_penalty: true,
             identifiability: BSplineIdentifiability::default(),
+            boundary_condition: Default::default(),
         };
         let result = build_bspline_basis_1d(x.view(), &spec).unwrap();
         assert_eq!(result.penalties.len(), 2);
@@ -22684,6 +22841,7 @@ mod tests {
             },
             double_penalty: false,
             identifiability: BSplineIdentifiability::default(),
+            boundary_condition: Default::default(),
         };
 
         let result = build_bspline_basis_1d(x.view(), &spec).unwrap();
@@ -22708,6 +22866,7 @@ mod tests {
             },
             double_penalty: false,
             identifiability: BSplineIdentifiability::default(),
+            boundary_condition: Default::default(),
         };
 
         let result = build_bspline_basis_1d(x.view(), &spec).unwrap();
@@ -22745,6 +22904,7 @@ mod tests {
             },
             double_penalty: false,
             identifiability: BSplineIdentifiability::None,
+            boundary_condition: Default::default(),
         };
 
         let built = build_bspline_basis_1d(x.view(), &spec).unwrap();
@@ -22788,6 +22948,7 @@ mod tests {
             },
             double_penalty: false,
             identifiability: BSplineIdentifiability::None,
+            boundary_condition: Default::default(),
         };
 
         let built = build_bspline_basis_1d(x.view(), &spec).expect("build sparse bspline");
@@ -22806,6 +22967,7 @@ mod tests {
             },
             double_penalty: false,
             identifiability: BSplineIdentifiability::default(),
+            boundary_condition: Default::default(),
         };
 
         let built = build_bspline_basis_1d(x.view(), &spec).expect("build centered sparse bspline");
@@ -22824,6 +22986,7 @@ mod tests {
             },
             double_penalty: false,
             identifiability: BSplineIdentifiability::None,
+            boundary_condition: Default::default(),
         };
 
         match build_bspline_basis_1d(x.view(), &spec).unwrap_err() {
@@ -22876,6 +23039,7 @@ mod tests {
             },
             double_penalty: false,
             identifiability: BSplineIdentifiability::default(),
+            boundary_condition: Default::default(),
         };
 
         let built = build_bspline_basis_1d(x.view(), &spec).unwrap();
@@ -22929,6 +23093,7 @@ mod tests {
             identifiability: BSplineIdentifiability::WeightedSumToZero {
                 weights: Some(weights.clone()),
             },
+            boundary_condition: Default::default(),
         };
 
         let built = build_bspline_basis_1d(x.view(), &spec).unwrap();
@@ -22955,9 +23120,11 @@ mod tests {
             },
             double_penalty: false,
             identifiability: BSplineIdentifiability::None,
+            boundary_condition: Default::default(),
         };
         let constrained = BSplineBasisSpec {
             identifiability: BSplineIdentifiability::RemoveLinearTrend,
+            boundary_condition: Default::default(),
             ..raw.clone()
         };
 
@@ -22985,6 +23152,7 @@ mod tests {
                 columns: constraints.clone(),
                 weights: None,
             },
+            boundary_condition: Default::default(),
         };
 
         let built = build_bspline_basis_1d(x.view(), &spec).unwrap();

--- a/src/terms/smooth.rs
+++ b/src/terms/smooth.rs
@@ -2625,6 +2625,7 @@ fn build_shape_constraint_design_1d(
                         transform: z.clone(),
                     })
                     .unwrap_or(BSplineIdentifiability::None),
+                boundary_condition: spec.boundary_condition.clone(),
             };
             build_bspline_basis_1d(x_grid.view(), &evalspec)?
                 .design
@@ -14390,6 +14391,7 @@ mod tests {
                         },
                         double_penalty: true,
                         identifiability: BSplineIdentifiability::default(),
+                        boundary_condition: Default::default(),
                     },
                 },
                 shape: ShapeConstraint::None,
@@ -14694,6 +14696,7 @@ mod tests {
                     },
                     double_penalty: false,
                     identifiability: BSplineIdentifiability::default(),
+                    boundary_condition: Default::default(),
                 },
             },
             shape: ShapeConstraint::MonotoneIncreasing,
@@ -14785,6 +14788,7 @@ mod tests {
                         },
                         double_penalty: false,
                         identifiability: BSplineIdentifiability::default(),
+                        boundary_condition: Default::default(),
                     },
                 },
                 shape: ShapeConstraint::None,
@@ -15148,6 +15152,7 @@ mod tests {
                         },
                         double_penalty: false,
                         identifiability: BSplineIdentifiability::default(),
+                        boundary_condition: Default::default(),
                     },
                 },
                 shape: ShapeConstraint::None,
@@ -15271,6 +15276,7 @@ mod tests {
                     },
                     double_penalty: false,
                     identifiability: BSplineIdentifiability::default(),
+                    boundary_condition: Default::default(),
                 },
             },
             shape: ShapeConstraint::None,
@@ -15415,6 +15421,7 @@ mod tests {
                             },
                             double_penalty: false,
                             identifiability: BSplineIdentifiability::default(),
+                            boundary_condition: Default::default(),
                         },
                     },
                     shape: ShapeConstraint::None,
@@ -16045,6 +16052,7 @@ mod tests {
             },
             double_penalty: false,
             identifiability: BSplineIdentifiability::default(),
+            boundary_condition: Default::default(),
         };
         let spec_y = BSplineBasisSpec {
             degree: 3,
@@ -16055,6 +16063,7 @@ mod tests {
             },
             double_penalty: false,
             identifiability: BSplineIdentifiability::default(),
+            boundary_condition: Default::default(),
         };
 
         let terms = vec![SmoothTermSpec {
@@ -16100,6 +16109,7 @@ mod tests {
             },
             double_penalty: false,
             identifiability: BSplineIdentifiability::None,
+            boundary_condition: Default::default(),
         };
         let spec_y = BSplineBasisSpec {
             degree: 3,
@@ -16110,6 +16120,7 @@ mod tests {
             },
             double_penalty: false,
             identifiability: BSplineIdentifiability::None,
+            boundary_condition: Default::default(),
         };
         let mx = build_bspline_basis_1d(data.column(0), &spec_x)
             .unwrap()
@@ -16149,6 +16160,63 @@ mod tests {
     }
 
     #[test]
+    fn tensor_bspline_periodic_margins_wrap_as_torus() {
+        let data = array![[1.25, 3.5], [8.25, 27.5], [-5.75, -20.5], [1.25, 27.5]];
+        let periodic_day = BSplineBasisSpec {
+            degree: 3,
+            penalty_order: 2,
+            knotspec: BSplineKnotSpec::Generate {
+                data_range: (0.0, 7.0),
+                num_internal_knots: 4,
+            },
+            double_penalty: false,
+            identifiability: BSplineIdentifiability::None,
+            boundary_condition: crate::basis::BSplineBoundaryCondition::Periodic {
+                period: 7.0,
+                origin: 0.0,
+            },
+        };
+        let periodic_hour = BSplineBasisSpec {
+            degree: 3,
+            penalty_order: 2,
+            knotspec: BSplineKnotSpec::Generate {
+                data_range: (0.0, 24.0),
+                num_internal_knots: 4,
+            },
+            double_penalty: false,
+            identifiability: BSplineIdentifiability::None,
+            boundary_condition: crate::basis::BSplineBoundaryCondition::Periodic {
+                period: 24.0,
+                origin: 0.0,
+            },
+        };
+        let term = SmoothTermSpec {
+            name: "te_day_hour".to_string(),
+            basis: SmoothBasisSpec::TensorBSpline {
+                feature_cols: vec![0, 1],
+                spec: TensorBSplineSpec {
+                    marginalspecs: vec![periodic_day, periodic_hour],
+                    double_penalty: false,
+                    identifiability: TensorBSplineIdentifiability::None,
+                },
+            },
+            shape: ShapeConstraint::None,
+        };
+
+        let design = build_smooth_design(data.view(), &[term])
+            .unwrap()
+            .term_designs
+            .into_iter()
+            .next()
+            .unwrap()
+            .to_dense();
+        for j in 0..design.ncols() {
+            assert!((design[[0, j]] - design[[1, j]]).abs() < 1e-12);
+            assert!((design[[0, j]] - design[[2, j]]).abs() < 1e-12);
+        }
+    }
+
+    #[test]
     fn tensor_bspline_design_is_identifiable_against_global_intercept() {
         let n = 120usize;
         let mut data = Array2::<f64>::zeros((n, 2));
@@ -16173,6 +16241,7 @@ mod tests {
                             },
                             double_penalty: false,
                             identifiability: BSplineIdentifiability::default(),
+                            boundary_condition: Default::default(),
                         },
                         BSplineBasisSpec {
                             degree: 3,
@@ -16183,6 +16252,7 @@ mod tests {
                             },
                             double_penalty: false,
                             identifiability: BSplineIdentifiability::default(),
+                            boundary_condition: Default::default(),
                         },
                     ],
                     double_penalty: false,
@@ -17818,6 +17888,7 @@ mod tests {
                         },
                         double_penalty: false,
                         identifiability: BSplineIdentifiability::default(),
+                        boundary_condition: Default::default(),
                     },
                 },
                 shape: ShapeConstraint::None,
@@ -18104,6 +18175,7 @@ mod tests {
                     },
                     double_penalty: true,
                     identifiability: BSplineIdentifiability::None,
+                    boundary_condition: Default::default(),
                 },
             },
             shape: ShapeConstraint::None,
@@ -18279,6 +18351,7 @@ mod tests {
                             },
                             double_penalty: false,
                             identifiability: BSplineIdentifiability::None,
+                            boundary_condition: Default::default(),
                         },
                     },
                     shape: ShapeConstraint::MonotoneIncreasing,
@@ -19986,6 +20059,7 @@ mod tests {
                         },
                         double_penalty: true,
                         identifiability: BSplineIdentifiability::None,
+                        boundary_condition: Default::default(),
                     },
                 },
                 shape: ShapeConstraint::None,

--- a/src/terms/term_builder.rs
+++ b/src/terms/term_builder.rs
@@ -9,11 +9,11 @@ use std::collections::{BTreeMap, HashMap};
 use ndarray::ArrayView1;
 
 use crate::basis::{
-    BSplineBasisSpec, BSplineIdentifiability, BSplineKnotSpec, CenterCountRequest, CenterStrategy,
-    DuchonBasisSpec, DuchonNullspaceOrder, DuchonOperatorPenaltySpec, MaternBasisSpec,
-    MaternIdentifiability, MaternNu, SpatialIdentifiability, ThinPlateBasisSpec,
-    auto_spatial_center_strategy, default_num_centers, default_spatial_center_strategy,
-    plan_spatial_basis, resolve_duchon_orders,
+    BSplineBasisSpec, BSplineBoundaryCondition, BSplineIdentifiability, BSplineKnotSpec,
+    CenterCountRequest, CenterStrategy, DuchonBasisSpec, DuchonNullspaceOrder,
+    DuchonOperatorPenaltySpec, MaternBasisSpec, MaternIdentifiability, MaternNu,
+    SpatialIdentifiability, ThinPlateBasisSpec, auto_spatial_center_strategy, default_num_centers,
+    default_spatial_center_strategy, plan_spatial_basis, resolve_duchon_orders,
 };
 use crate::inference::data::{EncodedDataset as Dataset, missing_column_message};
 use crate::inference::formula_dsl::{
@@ -217,6 +217,86 @@ pub fn build_termspec(
 // Smooth basis spec construction
 // ---------------------------------------------------------------------------
 
+fn parse_option_list(raw: &str) -> Vec<String> {
+    let trimmed = raw.trim();
+    let inner = trimmed
+        .strip_prefix('[')
+        .and_then(|v| v.strip_suffix(']'))
+        .unwrap_or(trimmed);
+    inner
+        .split(',')
+        .map(|v| {
+            v.trim()
+                .trim_matches('"')
+                .trim_matches('\'')
+                .to_ascii_lowercase()
+        })
+        .filter(|v| !v.is_empty())
+        .collect()
+}
+
+fn parse_f64_option_list(raw: &str) -> Vec<f64> {
+    parse_option_list(raw)
+        .into_iter()
+        .filter_map(|v| v.parse::<f64>().ok())
+        .collect()
+}
+
+fn tensor_margin_boundary_conditions(
+    options: &BTreeMap<String, String>,
+    cols: &[usize],
+    ds: &Dataset,
+) -> Result<Vec<BSplineBoundaryCondition>, String> {
+    let mut out = vec![BSplineBoundaryCondition::Open; cols.len()];
+    let Some(raw_bc) = options.get("bc").or_else(|| options.get("boundary")) else {
+        return Ok(out);
+    };
+    let bc = parse_option_list(raw_bc);
+    if bc.len() != cols.len() {
+        return Err(format!(
+            "te()/tensor() bc must have one entry per margin: got {} for {} variables",
+            bc.len(),
+            cols.len()
+        ));
+    }
+    let periods = options
+        .get("period")
+        .or_else(|| options.get("periods"))
+        .map(|raw| parse_f64_option_list(raw))
+        .unwrap_or_default();
+    let origins = options
+        .get("origin")
+        .or_else(|| options.get("origins"))
+        .map(|raw| parse_f64_option_list(raw))
+        .unwrap_or_default();
+    for (i, boundary) in bc.iter().enumerate() {
+        match boundary.as_str() {
+            "periodic" | "cyclic" | "cc" => {
+                let origin = origins.get(i).copied().map(Ok).unwrap_or_else(|| {
+                    col_minmax(ds.values.column(cols[i])).map(|(minv, _)| minv)
+                })?;
+                let period = periods.get(i).copied().ok_or_else(|| {
+                    "te()/tensor() periodic margins require period=[...] with one positive period per margin".to_string()
+                })?;
+                if !period.is_finite() || period <= 0.0 {
+                    return Err(format!(
+                        "te()/tensor() period for margin {} must be finite and positive, got {}",
+                        i, period
+                    ));
+                }
+                out[i] = BSplineBoundaryCondition::Periodic { period, origin };
+            }
+            "open" | "none" | "natural" => {}
+            other => {
+                return Err(format!(
+                    "unsupported te()/tensor() boundary condition '{other}'; supported values are open and periodic"
+                ));
+            }
+        }
+    }
+    Ok(out)
+}
+
 pub fn build_smooth_basis(
     kind: SmoothKind,
     vars: &[String],
@@ -263,10 +343,17 @@ pub fn build_smooth_basis(
                     vars.join(",")
                 ));
             }
+            let boundary_conditions = tensor_margin_boundary_conditions(options, cols, ds)?;
             let specs = cols
                 .iter()
-                .map(|&c| {
-                    let (minv, maxv) = col_minmax(ds.values.column(c))?;
+                .enumerate()
+                .map(|(i, &c)| {
+                    let (minv, maxv) = match boundary_conditions[i] {
+                        BSplineBoundaryCondition::Periodic { period, origin } => {
+                            (origin, origin + period)
+                        }
+                        BSplineBoundaryCondition::Open => col_minmax(ds.values.column(c))?,
+                    };
                     Ok(BSplineBasisSpec {
                         degree,
                         penalty_order: 2,
@@ -276,6 +363,7 @@ pub fn build_smooth_basis(
                         },
                         double_penalty: smooth_double_penalty,
                         identifiability: BSplineIdentifiability::None,
+                        boundary_condition: boundary_conditions[i].clone(),
                     })
                 })
                 .collect::<Result<Vec<_>, String>>()?;
@@ -326,6 +414,7 @@ pub fn build_smooth_basis(
                     },
                     double_penalty: smooth_double_penalty,
                     identifiability: BSplineIdentifiability::default(),
+                    boundary_condition: Default::default(),
                 },
             })
         }

--- a/tests/biobank_margslope_repro.rs
+++ b/tests/biobank_margslope_repro.rs
@@ -101,6 +101,7 @@ fn age_smooth(feature_col: usize, name: &str) -> SmoothTermSpec {
                 },
                 double_penalty: false,
                 identifiability: Default::default(),
+                boundary_condition: Default::default(),
             },
         },
         shape: ShapeConstraint::None,

--- a/tests/margslope_inner_pirls_scaling.rs
+++ b/tests/margslope_inner_pirls_scaling.rs
@@ -127,6 +127,7 @@ fn build_problem(n: usize, flex: bool) -> Problem {
                 },
                 double_penalty: false,
                 identifiability: Default::default(),
+                boundary_condition: Default::default(),
             },
         },
         shape: ShapeConstraint::None,

--- a/tests/margslope_smallcondition_smoke.rs
+++ b/tests/margslope_smallcondition_smoke.rs
@@ -94,6 +94,7 @@ fn build_problem(n: usize, flex: bool) -> (Array2<f64>, BernoulliMarginalSlopeTe
                 },
                 double_penalty: false,
                 identifiability: Default::default(),
+                boundary_condition: Default::default(),
             },
         },
         shape: ShapeConstraint::None,

--- a/tests/test_support/margslope_flex_equivalence.rs
+++ b/tests/test_support/margslope_flex_equivalence.rs
@@ -102,6 +102,7 @@ fn age_smooth(feature_col: usize, name: &str) -> SmoothTermSpec {
                 },
                 double_penalty: false,
                 identifiability: Default::default(),
+                boundary_condition: Default::default(),
             },
         },
         shape: ShapeConstraint::None,


### PR DESCRIPTION
### Motivation
- Support fully-periodic 2D smooths (torus) by composing two periodic 1D margins so users can write `te(day_of_week, hour, bc=['periodic','periodic'], period=[7,24])` and get exact wraparound behavior. 
- Keep math minimal: use a Fourier-style finite basis per periodic margin plus a derivative-weighted diagonal penalty so it composes cleanly with the existing tensor-product machinery.
- Expose a simple user-facing syntax for per-margin boundary conditions and periods that integrates with existing `te()`/`tensor()` and formula parsing.

### Description
- Parser: accept list-valued formula options by adding a `list_lit` token and a unit test for `te(..., bc=[...], period=[...])` in `src/inference/formula_dsl.rs` and `parse_function_call` tests. (`list_lit` grammar, parse test). 
- Spec: add `BSplineBoundaryCondition` and a new `boundary_condition` field to `BSplineBasisSpec` with `Open` and `Periodic { period, origin }` variants in `src/terms/basis.rs` and a `Default::default()` helper. 
- Periodic 1D builder: implement `build_periodic_fourier_basis_1d` that builds a finite Fourier basis for a periodic margin, constructs a diagonal derivative penalty (weights ~ ω^(2*penalty_order)), and returns a `BasisBuildResult`; route periodic specs through this early in `build_bspline_basis_1d`. (changes in `src/terms/basis.rs`). 
- Tensor wiring: add `tensor_margin_boundary_conditions` option parsing in `src/terms/term_builder.rs` to read `bc`, `period` and optional `origin` lists, validate one entry per margin, and build marginal `BSplineBasisSpec` entries with per-margin `boundary_condition` that `te()`/`tensor()` uses. 
- Integration: propagate `boundary_condition` through `smooth.rs` when evaluating/building marginal evaluation/spec replay so periodic margins get the periodic design ranges (origin..origin+period) and the periodic builder is used for per-margin designs. (`src/terms/smooth.rs`, `src/terms/term_builder.rs`). 
- Tests: add `parses_tensor_periodic_list_options` (formula parsing) and `tensor_bspline_periodic_margins_wrap_as_torus` (design equality under wrap shifts) in `src/terms/smooth.rs` and adjust many test initializers to specify `boundary_condition: Default::default()` where needed. 

### Testing
- Ran `cargo fmt` — succeeded. 
- Ran `cargo check --message-format=short` — succeeded (project compiles). 
- Ran the new parser unit test via `cargo test -q parses_tensor_periodic_list_options` — the parse test completed successfully. 
- Added `tensor_bspline_periodic_margins_wrap_as_torus` (design-level torus test); full `cargo test` for that target was not completed in this interactive run because the lib/test harness compilation exceeded the interactive window, but `cargo check` and the targeted parser test verify the integration points and compile-time wiring.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07c79ba868832498da1d49f406f8df)