### PR TITLE
Add intrinsic S² (sphere) smooth using spherical harmonics

### DIFF
--- a/docs/formulas.md
+++ b/docs/formulas.md
@@ -8,7 +8,7 @@ response ~ term + term + ... + option(...)
 
 Terms are joined with `+`. `*` and `:` are not supported — interactions come
 from multivariate smooths (`s(x1, x2)`, `te(x1, x2)`, `matern(...)`,
-`duchon(...)`).
+`duchon(...)`), and intrinsic sphere smooths (`sphere(lat, lon)`).
 
 This page lists every right-hand-side term, its options, and the
 formula-level options (`link(...)`, `linkwiggle(...)`, `timewiggle(...)`,
@@ -101,7 +101,7 @@ second-order difference penalty. Options:
 | `knots` | auto | Number of interior knots. Cannot combine with `k`. |
 | `degree` | 3 | Polynomial degree of the B-spline. |
 | `penalty_order` | 2 | Derivative order penalised (1 = slope, 2 = curvature). |
-| `type` | `ps` (1-D), `tps` (2+D) | `ps`, `tps`, `matern`, `duchon`. |
+| `type` | `ps` (1-D), `tps` (2+D) | `ps`, `tps`, `matern`, `duchon`, `sphere`. |
 | `double_penalty` | `true` | Add a ridge penalty alongside the difference penalty. |
 
 Default `k`: `clamp(unique_values / 4, 4, max(20, cbrt(unique_values)))`.
@@ -114,6 +114,7 @@ y ~ tps(x1, x2)                     # alias
 y ~ thinplate(x1, x2)               # alias
 y ~ matern(x1, x2, x3)
 y ~ duchon(x1, x2, x3)
+y ~ sphere(lat, lon)                # intrinsic S² smooth
 y ~ te(x, z)                        # tensor product
 y ~ tensor(x, z)                    # alias
 ```
@@ -160,6 +161,22 @@ stiffness). Scale-free unless `length_scale` is given.
 Three independent penalties (mass, tension, stiffness) each get their own
 smoothing parameter under REML.
 
+### Sphere (`sphere`, `s2`, `sos`)
+
+Intrinsic S² smooth for latitude/longitude data on a sphere. The implementation
+uses real spherical harmonics through degree `L`, drops the global constant so
+the ordinary model intercept remains identifiable, and applies a diagonal
+curvature penalty proportional to `[l(l+1)]²` by harmonic degree. This makes the
+longitude seam periodic and removes artificial boundary conditions at the poles.
+
+| Option | Default | Meaning |
+| --- | --- | --- |
+| `degree` / `max_degree` | auto | Maximum spherical harmonic degree `L`; basis width is `L(L+2)`. |
+| `k` / `basis_dim` | auto | Alternative target basis dimension; resolved to the smallest `L` with `L(L+2) >= k`. |
+| `radians` | `false` | Treat latitude/longitude as radians instead of degrees. |
+| `units` | `degrees` | Set `units=radians` as an alias for `radians=true`. |
+| `double_penalty` | `true` | Add a ridge penalty alongside the curvature penalty. |
+
 ### Tensor product (`te`, `tensor`)
 
 Kronecker product of univariate B-spline bases. Each axis gets its own
@@ -182,7 +199,8 @@ the truth is reasonable, but they take different paths to get there:
 | You have... | Use... |
 | --- | --- |
 | One covariate | `s(x)` (P-spline). |
-| Two coordinates in the same units (lat, lon) | `s(x, y)` (thin-plate) or `matern(x, y)`. |
+| Two coordinates on a sphere (lat, lon) | `sphere(lat, lon)`. |
+| Two Euclidean coordinates in the same units | `s(x, y)` (thin-plate) or `matern(x, y)`. |
 | Coordinates in different units (space × time) | `te(x, t)`. |
 | 3+ coordinates, especially in different units | `duchon(...)` with `scale_dims=true`, or `matern(...)`. |
 | You want to control wiggliness directly | `matern(...)` with `nu`. |

--- a/src/families/survival_predict.rs
+++ b/src/families/survival_predict.rs
@@ -1209,7 +1209,8 @@ fn remap_term_collectionspec_columns(
             SmoothBasisSpec::ThinPlate { feature_cols, .. }
             | SmoothBasisSpec::Matern { feature_cols, .. }
             | SmoothBasisSpec::Duchon { feature_cols, .. }
-            | SmoothBasisSpec::TensorBSpline { feature_cols, .. } => {
+            | SmoothBasisSpec::TensorBSpline { feature_cols, .. }
+            | SmoothBasisSpec::Sphere { feature_cols, .. } => {
                 for feature_col in feature_cols.iter_mut() {
                     *feature_col = resolve_training_index(*feature_col)?;
                 }

--- a/src/inference/formula_dsl.rs
+++ b/src/inference/formula_dsl.rs
@@ -251,7 +251,7 @@ fn parse_call_pair(call: Pair<'_, Rule>) -> Result<FunctionCallSpec, String> {
 #[cfg(test)]
 mod tests {
     use super::{
-        CallArgSpec, parse_formula, parse_formula_dsl, parse_function_call,
+        CallArgSpec, ParsedTerm, parse_formula, parse_formula_dsl, parse_function_call,
         parsed_terms_reference_column, validate_marginal_slope_z_column_exclusion,
     };
 
@@ -265,6 +265,20 @@ mod tests {
         assert_eq!(parsed.rhs_terms[0], "x1");
         assert_eq!(parsed.rhs_terms[1], "s(log(x2 + 1), bs=\"tps\", k=10)");
         assert_eq!(parsed.rhs_terms[2], "te(x3, x4)");
+    }
+
+    #[test]
+    fn parses_sphere_smooth_aliases() {
+        let parsed = parse_formula("y ~ sphere(lat, lon, degree=6)").expect("sphere formula");
+        let ParsedTerm::Smooth { vars, options, .. } = &parsed.terms[0] else {
+            panic!("expected smooth term");
+        };
+        assert_eq!(vars, &vec!["lat".to_string(), "lon".to_string()]);
+        assert_eq!(options.get("type").map(String::as_str), Some("sphere"));
+        assert_eq!(options.get("degree").map(String::as_str), Some("6"));
+
+        let err = parse_formula("y ~ sphere(lat)").expect_err("arity");
+        assert!(err.contains("expects exactly two variables"));
     }
 
     #[test]
@@ -1223,6 +1237,20 @@ pub fn parse_term(raw: &str) -> Result<ParsedTerm, String> {
                         "smooth()/s() requires at least one variable: {raw}"
                     ));
                 }
+                return Ok(ParsedTerm::Smooth {
+                    label: raw.to_string(),
+                    vars,
+                    kind: SmoothKind::S,
+                    options,
+                });
+            }
+            "sphere" | "s2" | "sos" => {
+                if vars.len() != 2 {
+                    return Err(format!(
+                        "sphere()/s2()/sos() expects exactly two variables (lat, lon): {raw}"
+                    ));
+                }
+                options.insert("type".to_string(), "sphere".to_string());
                 return Ok(ParsedTerm::Smooth {
                     label: raw.to_string(),
                     vars,

--- a/src/main.rs
+++ b/src/main.rs
@@ -6843,7 +6843,8 @@ fn smooth_term_primary_column(term: &SmoothTermSpec) -> Option<usize> {
         SmoothBasisSpec::ThinPlate { feature_cols, .. }
         | SmoothBasisSpec::Matern { feature_cols, .. }
         | SmoothBasisSpec::Duchon { feature_cols, .. }
-        | SmoothBasisSpec::TensorBSpline { feature_cols, .. } => {
+        | SmoothBasisSpec::TensorBSpline { feature_cols, .. }
+        | SmoothBasisSpec::Sphere { feature_cols, .. } => {
             if feature_cols.len() == 1 {
                 Some(feature_cols[0])
             } else {
@@ -7608,7 +7609,9 @@ fn spatial_basiswarning_family_and_cols(term: &SmoothTermSpec) -> Option<(&'stat
         SmoothBasisSpec::ThinPlate { feature_cols, .. } => Some(("thinplate/tps", feature_cols)),
         SmoothBasisSpec::Matern { feature_cols, .. } => Some(("matern", feature_cols)),
         SmoothBasisSpec::Duchon { feature_cols, .. } => Some(("duchon", feature_cols)),
-        SmoothBasisSpec::BSpline1D { .. } | SmoothBasisSpec::TensorBSpline { .. } => None,
+        SmoothBasisSpec::BSpline1D { .. }
+        | SmoothBasisSpec::TensorBSpline { .. }
+        | SmoothBasisSpec::Sphere { .. } => None,
     }
 }
 
@@ -7678,7 +7681,8 @@ fn smooth_term_feature_cols(term: &SmoothTermSpec) -> Vec<usize> {
         SmoothBasisSpec::ThinPlate { feature_cols, .. }
         | SmoothBasisSpec::Matern { feature_cols, .. }
         | SmoothBasisSpec::Duchon { feature_cols, .. }
-        | SmoothBasisSpec::TensorBSpline { feature_cols, .. } => feature_cols.clone(),
+        | SmoothBasisSpec::TensorBSpline { feature_cols, .. }
+        | SmoothBasisSpec::Sphere { feature_cols, .. } => feature_cols.clone(),
     }
 }
 
@@ -7734,6 +7738,7 @@ fn smooth_basiswarning_family_rank(term: &SmoothTermSpec) -> u8 {
         SmoothBasisSpec::ThinPlate { .. } => 2,
         SmoothBasisSpec::Matern { .. } => 3,
         SmoothBasisSpec::Duchon { .. } => 4,
+        SmoothBasisSpec::Sphere { .. } => 5,
     }
 }
 

--- a/src/terms/basis.rs
+++ b/src/terms/basis.rs
@@ -2060,6 +2060,10 @@ pub enum BasisMetadata {
         degrees: Vec<usize>,
         identifiability_transform: Option<Array2<f64>>,
     },
+    Sphere {
+        max_degree: usize,
+        radians: bool,
+    },
 }
 
 /// Standardized basis build result for engine-level composition.

--- a/src/terms/smooth.rs
+++ b/src/terms/smooth.rs
@@ -146,6 +146,23 @@ pub enum SmoothBasisSpec {
         feature_cols: Vec<usize>,
         spec: TensorBSplineSpec,
     },
+    /// Intrinsic S² smooth using real spherical harmonics with a curvature penalty.
+    ///
+    /// The two feature columns are latitude and longitude. Inputs are degrees by
+    /// default (Earth/data-frame convention) and radians when `radians=true`.
+    Sphere {
+        feature_cols: Vec<usize>,
+        spec: SphereBasisSpec,
+    },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SphereBasisSpec {
+    pub max_degree: usize,
+    #[serde(default)]
+    pub radians: bool,
+    #[serde(default)]
+    pub double_penalty: bool,
 }
 
 /// Tensor-product B-spline smooth specification.
@@ -450,6 +467,14 @@ impl TermCollectionSpec {
                     ) {
                         return Err(format!(
                             "{label} term '{}' is not frozen: Duchon identifiability must be FrozenTransform or None",
+                            st.name
+                        ));
+                    }
+                }
+                SmoothBasisSpec::Sphere { spec, .. } => {
+                    if spec.max_degree == 0 {
+                        return Err(format!(
+                            "{label} term '{}' is not frozen: sphere max_degree must be positive",
                             st.name
                         ));
                     }
@@ -3087,6 +3112,150 @@ fn build_tensor_bspline_basis(
     })
 }
 
+fn build_sphere_basis(
+    data: ArrayView2<'_, f64>,
+    feature_cols: &[usize],
+    spec: &SphereBasisSpec,
+) -> Result<BasisBuildResult, BasisError> {
+    if feature_cols.len() != 2 {
+        return Err(BasisError::InvalidInput(format!(
+            "Sphere smooth requires exactly two feature columns (lat, lon), got {}",
+            feature_cols.len()
+        )));
+    }
+    if spec.max_degree == 0 {
+        return Err(BasisError::InvalidInput(
+            "Sphere smooth requires max_degree >= 1".to_string(),
+        ));
+    }
+    let p_data = data.ncols();
+    for &c in feature_cols {
+        if c >= p_data {
+            return Err(BasisError::DimensionMismatch(format!(
+                "sphere feature column {c} is out of bounds for data with {p_data} columns"
+            )));
+        }
+    }
+
+    let n = data.nrows();
+    let p = spec.max_degree * (spec.max_degree + 2); // sum_{l=1}^L (2l+1)
+    let mut design = Array2::<f64>::zeros((n, p));
+    for i in 0..n {
+        let mut lat = data[[i, feature_cols[0]]];
+        let mut lon = data[[i, feature_cols[1]]];
+        if !lat.is_finite() || !lon.is_finite() {
+            return Err(BasisError::InvalidInput(format!(
+                "sphere smooth encountered non-finite latitude/longitude at row {i}"
+            )));
+        }
+        if !spec.radians {
+            lat = lat.to_radians();
+            lon = lon.to_radians();
+        }
+        // Clamp tiny floating overshoots at the poles and wrap longitude only
+        // through sin/cos in the harmonic recurrence (no seam discontinuity).
+        if lat < -std::f64::consts::FRAC_PI_2 - 1e-10 || lat > std::f64::consts::FRAC_PI_2 + 1e-10 {
+            return Err(BasisError::InvalidInput(format!(
+                "sphere latitude at row {i} is outside [-90, 90] degrees / [-pi/2, pi/2] radians"
+            )));
+        }
+        lat = lat.clamp(-std::f64::consts::FRAC_PI_2, std::f64::consts::FRAC_PI_2);
+        fill_real_spherical_harmonics_row(lat, lon, spec.max_degree, design.row_mut(i));
+    }
+
+    let mut penalty = Array2::<f64>::zeros((p, p));
+    let mut col = 0usize;
+    for l in 1..=spec.max_degree {
+        let eig = (l as f64 * (l as f64 + 1.0)).powi(2);
+        for _ in 0..(2 * l + 1) {
+            penalty[[col, col]] = eig;
+            col += 1;
+        }
+    }
+    let mut candidates = vec![PenaltyCandidate {
+        matrix: penalty,
+        nullspace_dim_hint: 0,
+        source: PenaltySource::Primary,
+        normalization_scale: 1.0,
+        kronecker_factors: None,
+        op: None,
+    }];
+    if spec.double_penalty {
+        candidates.push(PenaltyCandidate {
+            matrix: Array2::<f64>::eye(p),
+            nullspace_dim_hint: 0,
+            source: PenaltySource::DoublePenaltyNullspace,
+            normalization_scale: 1.0,
+            kronecker_factors: None,
+            op: None,
+        });
+    }
+    let (penalties, nullspace_dims, penaltyinfo, ops) =
+        filter_active_penalty_candidates_with_ops(candidates)?;
+    Ok(BasisBuildResult {
+        design: DesignMatrix::Dense(crate::matrix::DenseDesignMatrix::from(design)),
+        penalties,
+        nullspace_dims,
+        penaltyinfo,
+        metadata: BasisMetadata::Sphere {
+            max_degree: spec.max_degree,
+            radians: spec.radians,
+        },
+        kronecker_factored: None,
+        ops,
+    })
+}
+
+fn fill_real_spherical_harmonics_row(
+    lat: f64,
+    lon: f64,
+    max_degree: usize,
+    mut row: ndarray::ArrayViewMut1<'_, f64>,
+) {
+    let x = lat.sin(); // cos(colatitude)
+    let mut p_lm = vec![vec![0.0; max_degree + 1]; max_degree + 1];
+    p_lm[0][0] = 1.0;
+    let somx2 = (1.0 - x * x).max(0.0).sqrt();
+    for m in 1..=max_degree {
+        p_lm[m][m] = -((2 * m - 1) as f64) * somx2 * p_lm[m - 1][m - 1];
+    }
+    for m in 0..max_degree {
+        p_lm[m + 1][m] = ((2 * m + 1) as f64) * x * p_lm[m][m];
+    }
+    for m in 0..=max_degree {
+        for l in (m + 2)..=max_degree {
+            p_lm[l][m] = (((2 * l - 1) as f64) * x * p_lm[l - 1][m]
+                - ((l + m - 1) as f64) * p_lm[l - 2][m])
+                / ((l - m) as f64);
+        }
+    }
+
+    let mut col = 0usize;
+    for l in 1..=max_degree {
+        for m_neg in (1..=l).rev() {
+            let m = m_neg;
+            let norm = spherical_harmonic_norm(l, m);
+            row[col] = (2.0f64).sqrt() * norm * p_lm[l][m] * (m as f64 * lon).sin();
+            col += 1;
+        }
+        row[col] = spherical_harmonic_norm(l, 0) * p_lm[l][0];
+        col += 1;
+        for m in 1..=l {
+            let norm = spherical_harmonic_norm(l, m);
+            row[col] = (2.0f64).sqrt() * norm * p_lm[l][m] * (m as f64 * lon).cos();
+            col += 1;
+        }
+    }
+}
+
+fn spherical_harmonic_norm(l: usize, m: usize) -> f64 {
+    let mut ratio = 1.0;
+    for k in (l - m + 1)..=(l + m) {
+        ratio /= k as f64;
+    }
+    (((2 * l + 1) as f64) / (4.0 * std::f64::consts::PI) * ratio).sqrt()
+}
+
 fn tensor_product_design_from_marginals(
     marginal_designs: &[Array2<f64>],
 ) -> Result<Array2<f64>, BasisError> {
@@ -3479,6 +3648,15 @@ fn build_single_local_smooth_term(
         }
         SmoothBasisSpec::TensorBSpline { feature_cols, spec } => {
             build_tensor_bspline_basis(data, feature_cols, spec)?
+        }
+        SmoothBasisSpec::Sphere { feature_cols, spec } => {
+            if term.shape != ShapeConstraint::None {
+                return Err(BasisError::InvalidInput(format!(
+                    "ShapeConstraint::{:?} is unsupported for intrinsic sphere term '{}'",
+                    term.shape, term.name
+                )));
+            }
+            build_sphere_basis(data, feature_cols, spec)?
         }
     };
 
@@ -4215,7 +4393,8 @@ fn smooth_term_feature_cols(term: &SmoothTermSpec) -> Vec<usize> {
         SmoothBasisSpec::ThinPlate { feature_cols, .. }
         | SmoothBasisSpec::Matern { feature_cols, .. }
         | SmoothBasisSpec::Duchon { feature_cols, .. }
-        | SmoothBasisSpec::TensorBSpline { feature_cols, .. } => feature_cols.clone(),
+        | SmoothBasisSpec::TensorBSpline { feature_cols, .. }
+        | SmoothBasisSpec::Sphere { feature_cols, .. } => feature_cols.clone(),
     }
 }
 
@@ -4226,6 +4405,7 @@ fn smooth_basis_family_rank(term: &SmoothTermSpec) -> u8 {
         SmoothBasisSpec::ThinPlate { .. } => 2,
         SmoothBasisSpec::Matern { .. } => 3,
         SmoothBasisSpec::Duchon { .. } => 4,
+        SmoothBasisSpec::Sphere { .. } => 5,
     }
 }
 
@@ -4253,6 +4433,7 @@ fn smooth_has_frozen_identifiability(term: &SmoothTermSpec) -> bool {
             spec.identifiability,
             TensorBSplineIdentifiability::FrozenTransform { .. }
         ),
+        SmoothBasisSpec::Sphere { .. } => false,
     }
 }
 
@@ -4980,6 +5161,13 @@ fn with_identifiability_transform(
                 identifiability_transform.as_ref(),
                 transform,
             )?,
+        }),
+        BasisMetadata::Sphere {
+            max_degree,
+            radians,
+        } => Ok(BasisMetadata::Sphere {
+            max_degree: *max_degree,
+            radians: *radians,
         }),
         BasisMetadata::TensorBSpline {
             feature_cols,
@@ -10569,7 +10757,9 @@ fn try_build_spatial_term_log_kappa_derivative(
             build_duchon_basis_log_kappa_derivatives(x.view(), spec)
                 .map_err(EstimationError::from)?
         }
-        SmoothBasisSpec::BSpline1D { .. } | SmoothBasisSpec::TensorBSpline { .. } => {
+        SmoothBasisSpec::BSpline1D { .. }
+        | SmoothBasisSpec::TensorBSpline { .. }
+        | SmoothBasisSpec::Sphere { .. } => {
             return Ok(None);
         }
     };
@@ -12086,6 +12276,16 @@ pub fn freeze_term_collection_from_design(
                 };
                 s.aniso_log_scales = meta_aniso.clone();
                 *input_scales = meta_scales.clone();
+            }
+            (
+                SmoothBasisSpec::Sphere { spec: s, .. },
+                BasisMetadata::Sphere {
+                    max_degree,
+                    radians,
+                },
+            ) => {
+                s.max_degree = *max_degree;
+                s.radians = *radians;
             }
             (
                 SmoothBasisSpec::TensorBSpline {
@@ -14003,6 +14203,109 @@ mod tests {
     use rand::RngExt;
     use rand::SeedableRng;
     use rand::rngs::StdRng;
+
+    fn sphere_term(max_degree: usize) -> SmoothTermSpec {
+        SmoothTermSpec {
+            name: "sphere(lat,lon)".to_string(),
+            basis: SmoothBasisSpec::Sphere {
+                feature_cols: vec![0, 1],
+                spec: SphereBasisSpec {
+                    max_degree,
+                    radians: false,
+                    double_penalty: true,
+                },
+            },
+            shape: ShapeConstraint::None,
+        }
+    }
+
+    #[test]
+    fn sphere_basis_has_expected_width_and_curvature_penalty() {
+        let data = array![[0.0, 0.0], [45.0, 90.0], [-30.0, 180.0]];
+        let sd = build_smooth_design(data.view(), &[sphere_term(3)]).expect("sphere design");
+        let term = &sd.terms[0];
+        assert_eq!(term.coeff_range.len(), 15); // L(L+2) for L=3, excluding the constant.
+        assert_eq!(term.penalties_local.len(), 2);
+        let primary = &term.penalties_local[0];
+        assert_eq!(primary.nrows(), 15);
+        for i in 0..15 {
+            for j in 0..15 {
+                if i != j {
+                    assert!(primary[[i, j]].abs() < 1e-12);
+                }
+            }
+        }
+        assert!(primary[[0, 0]] > 0.0);
+        assert!(primary[[3, 3]] > primary[[0, 0]]);
+        assert!(primary[[8, 8]] > primary[[3, 3]]);
+        assert_eq!(sd.penaltyinfo[0].penalty.source, PenaltySource::Primary);
+        assert_eq!(
+            sd.penaltyinfo[1].penalty.source,
+            PenaltySource::DoublePenaltyNullspace
+        );
+    }
+
+    #[test]
+    fn sphere_basis_is_periodic_in_longitude_and_well_defined_at_poles() {
+        let data = array![[10.0, 0.0], [10.0, 360.0], [90.0, 12.0], [90.0, 231.0]];
+        let sd = build_smooth_design(data.view(), &[sphere_term(4)]).expect("sphere design");
+        let dense = sd.term_designs[0]
+            .try_to_dense_by_chunks("sphere test")
+            .expect("dense sphere design");
+        let seam_diff = (&dense.row(0) - &dense.row(1))
+            .iter()
+            .map(|v| v.abs())
+            .fold(0.0_f64, f64::max);
+        assert!(seam_diff < 1e-12, "longitude seam diff {seam_diff}");
+        let pole_diff = (&dense.row(2) - &dense.row(3))
+            .iter()
+            .map(|v| v.abs())
+            .fold(0.0_f64, f64::max);
+        assert!(pole_diff < 1e-12, "north-pole longitude diff {pole_diff}");
+    }
+
+    #[test]
+    fn sphere_frozen_replay_matches_fit_design() {
+        let data = array![
+            [-60.0, -120.0],
+            [-20.0, 10.0],
+            [0.0, 85.0],
+            [35.0, 150.0],
+            [70.0, -45.0]
+        ];
+        let spec = TermCollectionSpec {
+            linear_terms: vec![],
+            smooth_terms: vec![sphere_term(3)],
+            random_effect_terms: vec![],
+        };
+        let fit_design = build_term_collection_design(data.view(), &spec).expect("fit design");
+        let frozen = freeze_term_collection_from_design(&spec, &fit_design).expect("freeze");
+        frozen
+            .validate_frozen("sphere")
+            .expect("frozen sphere spec");
+        let replay_design = build_term_collection_design(data.view(), &frozen).expect("replay");
+        let fit_dense = fit_design
+            .design
+            .try_to_dense_by_chunks("sphere fit dense")
+            .expect("fit dense");
+        let replay_dense = replay_design
+            .design
+            .try_to_dense_by_chunks("sphere replay dense")
+            .expect("replay dense");
+        let max_abs = (&fit_dense - &replay_dense)
+            .iter()
+            .map(|v| v.abs())
+            .fold(0.0_f64, f64::max);
+        assert!(max_abs < 1e-12, "frozen replay changed design by {max_abs}");
+    }
+
+    #[test]
+    fn sphere_rejects_bad_latitudes() {
+        let data = array![[91.0, 0.0]];
+        let err = build_smooth_design(data.view(), &[sphere_term(2)])
+            .expect_err("bad latitude should be rejected");
+        assert!(err.to_string().contains("outside"));
+    }
 
     fn assert_spatial_derivative_width(
         label: &str,

--- a/src/terms/term_builder.rs
+++ b/src/terms/term_builder.rs
@@ -23,8 +23,8 @@ use crate::inference::model::ColumnKindTag;
 use crate::resource::ResourcePolicy;
 use crate::smooth::{
     LinearCoefficientGeometry, LinearTermSpec, RandomEffectTermSpec, ShapeConstraint,
-    SmoothBasisSpec, SmoothTermSpec, TensorBSplineIdentifiability, TensorBSplineSpec,
-    TermCollectionSpec,
+    SmoothBasisSpec, SmoothTermSpec, SphereBasisSpec, TensorBSplineIdentifiability,
+    TensorBSplineSpec, TermCollectionSpec,
 };
 
 // ---------------------------------------------------------------------------
@@ -357,6 +357,44 @@ pub fn build_smooth_basis(
                 input_scales: None,
             })
         }
+        "sphere" | "s2" | "sos" => {
+            if cols.len() != 2 {
+                return Err(format!(
+                    "sphere smooth expects exactly two variables (lat, lon), got {}",
+                    cols.len()
+                ));
+            }
+            let max_degree =
+                option_usize_any(options, &["degree", "l", "max_degree", "max-degree"])
+                    .or_else(|| {
+                        option_usize_any(options, &["k", "basis_dim", "basis-dim", "basisdim"])
+                            .and_then(|k| (1..=128).find(|&l| l * (l + 2) >= k))
+                    })
+                    .unwrap_or_else(|| default_sphere_degree(ds.values.nrows()));
+            if max_degree == 0 {
+                return Err("sphere smooth requires degree/max_degree >= 1".to_string());
+            }
+            if max_degree > 32 {
+                return Err(format!(
+                    "sphere smooth max_degree={} is too large for the dense harmonic engine (limit 32)",
+                    max_degree
+                ));
+            }
+            let radians = option_bool(options, "radians").unwrap_or_else(|| {
+                options
+                    .get("units")
+                    .map(|u| u.eq_ignore_ascii_case("radian") || u.eq_ignore_ascii_case("radians"))
+                    .unwrap_or(false)
+            });
+            Ok(SmoothBasisSpec::Sphere {
+                feature_cols: cols.to_vec(),
+                spec: SphereBasisSpec {
+                    max_degree,
+                    radians,
+                    double_penalty: smooth_double_penalty,
+                },
+            })
+        }
         "matern" => {
             let plan = plan_spatial_basis(
                 ds.values.nrows(),
@@ -625,6 +663,18 @@ pub fn heuristic_knots_for_column(col: ArrayView1<'_, f64>) -> usize {
 
 pub fn heuristic_centers(n: usize, d: usize) -> usize {
     default_num_centers(n, d)
+}
+
+pub fn default_sphere_degree(n: usize) -> usize {
+    // Real spherical harmonics through degree L have L(L+2) non-constant
+    // columns. Keep the default comfortably below n while permitting enough
+    // angular detail for ordinary sample sizes.
+    let target = ((n as f64).sqrt() as usize).clamp(3, 12);
+    let mut l = 1usize;
+    while l < 12 && l * (l + 2) < target {
+        l += 1;
+    }
+    l
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/sphere_integration.rs
+++ b/tests/sphere_integration.rs
@@ -1,0 +1,49 @@
+use csv::StringRecord;
+use gam::{
+    FitConfig, FitResult, encode_recordswith_inferred_schema, fit_from_formula, init_parallelism,
+};
+
+fn sphere_dataset() -> gam::data::EncodedDataset {
+    let headers = vec!["lat".to_string(), "lon".to_string(), "y".to_string()];
+    let coords = [
+        (-75.0, -170.0),
+        (-55.0, -80.0),
+        (-35.0, 15.0),
+        (-15.0, 105.0),
+        (0.0, -130.0),
+        (10.0, -30.0),
+        (25.0, 60.0),
+        (40.0, 150.0),
+        (55.0, -100.0),
+        (65.0, 20.0),
+        (75.0, 115.0),
+        (5.0, 179.0),
+    ];
+    let records = coords
+        .into_iter()
+        .map(|(lat, lon)| {
+            let lat_rad = f64::to_radians(lat);
+            let lon_rad = f64::to_radians(lon);
+            let y = 1.0 + 0.6 * lat_rad.sin() + 0.4 * lat_rad.cos() * lon_rad.cos();
+            StringRecord::from(vec![lat.to_string(), lon.to_string(), y.to_string()])
+        })
+        .collect::<Vec<_>>();
+    encode_recordswith_inferred_schema(headers, records).expect("encode sphere dataset")
+}
+
+#[test]
+fn fit_from_formula_accepts_intrinsic_sphere_smooth() {
+    init_parallelism();
+    let data = sphere_dataset();
+    let config = FitConfig {
+        family: Some("gaussian".to_string()),
+        ..FitConfig::default()
+    };
+    let result = fit_from_formula("y ~ sphere(lat, lon, degree=2)", &data, &config)
+        .expect("sphere formula fit should succeed");
+    let FitResult::Standard(fit) = result else {
+        panic!("expected standard Gaussian fit");
+    };
+    assert!(fit.fit.beta.iter().all(|v| v.is_finite()));
+    assert_eq!(fit.design.smooth.terms[0].coeff_range.len(), 8);
+}


### PR DESCRIPTION
### Motivation
- Provide a first-class 2D intrinsic spherical smooth for latitude/longitude covariates so users can write `y ~ sphere(lat, lon)` instead of awkward Euclidean approximations. 
- Use a numerically-stable, compact engine based on real spherical harmonics and a natural curvature penalty so seams and poles are handled correctly. 
- Expose convenient options for degree/width selection and units (`degrees`/`radians`) while keeping the API consistent with existing smooth families. 

### Description
- Add `SmoothBasisSpec::Sphere` and `SphereBasisSpec` and wire parsing aliases `sphere(...)`, `s2(...)`, `sos(...)` into the formula DSL and term construction with degree/`k` resolution and `radians`/`units` handling. 
- Implement `build_sphere_basis` and harmonic utilities (`fill_real_spherical_harmonics_row`, `spherical_harmonic_norm`) to materialize a real-harmonic design through degree `L` (width `L(L+2)`), drop the global constant for identifiability, and build a diagonal curvature penalty with entries proportional to `[l(l+1)]^2` plus optional ridge. 
- Integrate sphere metadata into `BasisMetadata`, freeze/replay logic, prediction-column remapping, smooth-priority helpers, and the smooth-construction switch so sphere terms participate in the existing pipeline. 
- Document `sphere(lat, lon)` in `docs/formulas.md`, add a `default_sphere_degree` heuristic, and include unit + integration tests exercising parsing, basis shape/penalties, longitude seam periodicity, pole behavior, frozen-replay fidelity, invalid-latitude rejection, and `fit_from_formula` end-to-end. 

### Testing
- Ran `cargo fmt` to normalize formatting and it completed successfully. 
- Ran `cargo check` and the codebase type-checked successfully. 
- Ran the new unit tests via `cargo test sphere --lib` and all sphere-related unit tests passed. 
- Ran the integration test (`cargo test sphere --test sphere_integration`) exercising `fit_from_formula("y ~ sphere(lat, lon, degree=2)")` and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07c7ca68d883248e69cddd81ae51be)