### PR TITLE
Add periodic/cylindrical B‑spline margins and wire into s()/te() construction

### DIFF
--- a/src/terms/basis.rs
+++ b/src/terms/basis.rs
@@ -1386,6 +1386,95 @@ pub enum BSplineKnotSpec {
         placement: BSplineKnotPlacement,
     },
     Provided(Array1<f64>),
+    /// Periodic/cyclic B-spline margin on `[origin, origin + period)`.
+    ///
+    /// The stored knot vector is the ordinary clamped knot vector used to
+    /// evaluate the wrapped coordinate; the builder folds the trailing
+    /// `degree` boundary columns into the leading columns and uses a cyclic
+    /// difference penalty.
+    Periodic {
+        origin: f64,
+        period: f64,
+        num_internal_knots: usize,
+        knots: Option<Array1<f64>>,
+    },
+}
+
+#[inline]
+pub fn wrap_periodic_value(x: f64, origin: f64, period: f64) -> f64 {
+    let mut y = (x - origin).rem_euclid(period) + origin;
+    let upper = origin + period;
+    if y >= upper {
+        y = origin;
+    }
+    y
+}
+
+fn wrap_periodic_array(
+    data: ArrayView1<'_, f64>,
+    origin: f64,
+    period: f64,
+) -> Result<Array1<f64>, BasisError> {
+    if !origin.is_finite() || !period.is_finite() || period <= 0.0 {
+        return Err(BasisError::InvalidInput(
+            "periodic B-spline requires finite origin and positive finite period".to_string(),
+        ));
+    }
+    let mut out = Array1::<f64>::zeros(data.len());
+    for (dst, &x) in out.iter_mut().zip(data.iter()) {
+        if !x.is_finite() {
+            return Err(BasisError::InvalidInput(
+                "periodic B-spline requires finite data".to_string(),
+            ));
+        }
+        *dst = wrap_periodic_value(x, origin, period);
+    }
+    Ok(out)
+}
+
+fn fold_periodic_bspline_columns(
+    raw: &Array2<f64>,
+    degree: usize,
+) -> Result<Array2<f64>, BasisError> {
+    let p_raw = raw.ncols();
+    if degree == 0 || p_raw <= degree {
+        return Ok(raw.clone());
+    }
+    let p = p_raw - degree;
+    let mut folded = Array2::<f64>::zeros((raw.nrows(), p));
+    folded.assign(&raw.slice(s![.., 0..p]));
+    for j in 0..degree {
+        let tail = raw.column(p + j);
+        let mut head = folded.column_mut(j);
+        head += &tail;
+    }
+    Ok(folded)
+}
+
+fn create_cyclic_difference_penalty_matrix(
+    num_basis_functions: usize,
+    order: usize,
+) -> Result<Array2<f64>, BasisError> {
+    if order == 0 || order >= num_basis_functions {
+        return Err(BasisError::InvalidPenaltyOrder {
+            order,
+            num_basis: num_basis_functions,
+        });
+    }
+    let mut d = Array2::<f64>::eye(num_basis_functions);
+    for _ in 0..order {
+        let rows = d.nrows();
+        let cols = d.ncols();
+        let mut next = Array2::<f64>::zeros((rows, cols));
+        for i in 0..rows {
+            let ip1 = (i + 1) % rows;
+            for j in 0..cols {
+                next[[i, j]] = d[[ip1, j]] - d[[i, j]];
+            }
+        }
+        d = next;
+    }
+    Ok(fast_ata(&d))
 }
 
 /// Internal-knot placement strategy when knots are automatically inferred.
@@ -5493,6 +5582,94 @@ pub fn build_bspline_basis_1d(
     data: ArrayView1<'_, f64>,
     spec: &BSplineBasisSpec,
 ) -> Result<BasisBuildResult, BasisError> {
+    if let BSplineKnotSpec::Periodic {
+        origin,
+        period,
+        num_internal_knots,
+        knots,
+    } = &spec.knotspec
+    {
+        let wrapped = wrap_periodic_array(data, *origin, *period)?;
+        let base_knots = match knots {
+            Some(k) => k.clone(),
+            None => internal::generate_full_knot_vector(
+                (*origin, *origin + *period),
+                *num_internal_knots,
+                spec.degree,
+            )?,
+        };
+        let (raw_basis, used_knots) = create_basis::<Dense>(
+            wrapped.view(),
+            KnotSource::Provided(base_knots.view()),
+            spec.degree,
+            BasisOptions::value(),
+        )?;
+        let folded = fold_periodic_bspline_columns(raw_basis.as_ref(), spec.degree)?;
+        let p_cyclic = folded.ncols();
+        let s_bend_raw = create_cyclic_difference_penalty_matrix(p_cyclic, spec.penalty_order)?;
+        let mut penalties_raw = vec![PenaltyCandidate {
+            matrix: s_bend_raw.clone(),
+            nullspace_dim_hint: 0,
+            source: PenaltySource::Primary,
+            normalization_scale: 1.0,
+            kronecker_factors: None,
+            op: None,
+        }];
+        if spec.double_penalty {
+            penalties_raw.push(PenaltyCandidate {
+                matrix: build_nullspace_shrinkage_penalty(&s_bend_raw)?
+                    .map(|shrink| shrink.sym_penalty)
+                    .unwrap_or_else(|| Array2::<f64>::zeros(s_bend_raw.raw_dim())),
+                nullspace_dim_hint: 0,
+                source: PenaltySource::DoublePenaltyNullspace,
+                normalization_scale: 1.0,
+                kronecker_factors: None,
+                op: None,
+            });
+        }
+        let penalties_raw_mats = penalties_raw
+            .iter()
+            .map(|candidate| candidate.matrix.clone())
+            .collect::<Vec<_>>();
+        let (design_arr, penalties, identifiability_transform) =
+            apply_bspline_identifiability_policy(
+                folded,
+                penalties_raw_mats,
+                &used_knots,
+                spec.degree,
+                &spec.identifiability,
+            )?;
+        let transformed_candidates = penalties
+            .into_iter()
+            .zip(penalties_raw.into_iter())
+            .map(
+                |(matrix, candidate)| -> Result<PenaltyCandidate, BasisError> {
+                    Ok(PenaltyCandidate {
+                        nullspace_dim_hint: candidate.nullspace_dim_hint,
+                        matrix,
+                        source: candidate.source,
+                        normalization_scale: candidate.normalization_scale,
+                        kronecker_factors: None,
+                        op: None,
+                    })
+                },
+            )
+            .collect::<Result<Vec<_>, _>>()?;
+        let (penalties, nullspace_dims, penaltyinfo, ops) =
+            filter_active_penalty_candidates_with_ops(transformed_candidates)?;
+        return Ok(BasisBuildResult {
+            design: DesignMatrix::Dense(crate::matrix::DenseDesignMatrix::from(design_arr)),
+            penalties,
+            nullspace_dims,
+            penaltyinfo,
+            metadata: BasisMetadata::BSpline1D {
+                knots: used_knots,
+                identifiability_transform,
+            },
+            kronecker_factored: None,
+            ops,
+        });
+    }
     let prefer_sparse_design = matches!(
         spec.identifiability,
         BSplineIdentifiability::None | BSplineIdentifiability::WeightedSumToZero { .. }
@@ -5547,6 +5724,9 @@ pub fn build_bspline_basis_1d(
                 )?;
                 (Some(basis), None, knots)
             }
+            BSplineKnotSpec::Periodic { .. } => {
+                unreachable!("periodic B-spline handled before sparse/dense path")
+            }
         }
     } else {
         match &spec.knotspec {
@@ -5597,6 +5777,9 @@ pub fn build_bspline_basis_1d(
                     BasisOptions::value(),
                 )?;
                 (None, Some((*basis).clone()), knots)
+            }
+            BSplineKnotSpec::Periodic { .. } => {
+                unreachable!("periodic B-spline handled before sparse/dense path")
             }
         }
     };
@@ -31308,5 +31491,59 @@ mod tests {
                 }
             }
         }
+    }
+    #[test]
+    fn test_periodic_bspline_wraps_design_at_cylinder_seam() {
+        let x = array![0.0, 0.25, 0.5, 0.75, 1.0, 1.25];
+        let spec = BSplineBasisSpec {
+            degree: 3,
+            penalty_order: 2,
+            knotspec: BSplineKnotSpec::Periodic {
+                origin: 0.0,
+                period: 1.0,
+                num_internal_knots: 6,
+                knots: None,
+            },
+            double_penalty: false,
+            identifiability: BSplineIdentifiability::None,
+        };
+        let built = build_bspline_basis_1d(x.view(), &spec).expect("periodic basis");
+        let design = built.design.to_dense();
+        assert_eq!(design.nrows(), x.len());
+        assert_eq!(design.ncols(), 7);
+        for col in 0..design.ncols() {
+            assert_abs_diff_eq!(design[[0, col]], design[[4, col]], epsilon = 1e-12);
+            assert_abs_diff_eq!(design[[1, col]], design[[5, col]], epsilon = 1e-12);
+        }
+        assert_eq!(built.penalties.len(), 1);
+        assert_eq!(built.penalties[0].nrows(), design.ncols());
+        assert_eq!(built.penalties[0].ncols(), design.ncols());
+    }
+
+    #[test]
+    fn test_periodic_bspline_with_sum_to_zero_keeps_wrapped_rows_equal() {
+        let x = array![0.0, 0.2, 0.4, 0.6, 0.8, 1.0];
+        let spec = BSplineBasisSpec {
+            degree: 3,
+            penalty_order: 2,
+            knotspec: BSplineKnotSpec::Periodic {
+                origin: 0.0,
+                period: 1.0,
+                num_internal_knots: 5,
+                knots: None,
+            },
+            double_penalty: true,
+            identifiability: BSplineIdentifiability::WeightedSumToZero { weights: None },
+        };
+        let built = build_bspline_basis_1d(x.view(), &spec).expect("periodic centered basis");
+        let design = built.design.to_dense();
+        for col in 0..design.ncols() {
+            assert_abs_diff_eq!(design[[0, col]], design[[5, col]], epsilon = 1e-12);
+        }
+        let col_sums = design.sum_axis(Axis(0));
+        for sum in col_sums.iter() {
+            assert_abs_diff_eq!(*sum, 0.0, epsilon = 1e-10);
+        }
+        assert_eq!(built.penalties.len(), 2);
     }
 }

--- a/src/terms/smooth.rs
+++ b/src/terms/smooth.rs
@@ -405,7 +405,11 @@ impl TermCollectionSpec {
         for st in &self.smooth_terms {
             match &st.basis {
                 SmoothBasisSpec::BSpline1D { spec, .. } => {
-                    if !matches!(spec.knotspec, BSplineKnotSpec::Provided(_)) {
+                    if !matches!(
+                        spec.knotspec,
+                        BSplineKnotSpec::Provided(_)
+                            | BSplineKnotSpec::Periodic { knots: Some(_), .. }
+                    ) {
                         return Err(format!(
                             "{label} term '{}' is not frozen: BSpline knotspec must be Provided",
                             st.name
@@ -456,7 +460,11 @@ impl TermCollectionSpec {
                 }
                 SmoothBasisSpec::TensorBSpline { spec, .. } => {
                     for (dim, marginal) in spec.marginalspecs.iter().enumerate() {
-                        if !matches!(marginal.knotspec, BSplineKnotSpec::Provided(_)) {
+                        if !matches!(
+                            marginal.knotspec,
+                            BSplineKnotSpec::Provided(_)
+                                | BSplineKnotSpec::Periodic { knots: Some(_), .. }
+                        ) {
                             return Err(format!(
                                 "{label} term '{}' dim {} is not frozen: tensor marginal knotspec must be Provided",
                                 st.name, dim
@@ -11947,7 +11955,20 @@ pub fn freeze_term_collection_from_design(
                     identifiability_transform,
                 },
             ) => {
-                s.knotspec = BSplineKnotSpec::Provided(knots.clone());
+                s.knotspec = match &s.knotspec {
+                    BSplineKnotSpec::Periodic {
+                        origin,
+                        period,
+                        num_internal_knots,
+                        ..
+                    } => BSplineKnotSpec::Periodic {
+                        origin: *origin,
+                        period: *period,
+                        num_internal_knots: *num_internal_knots,
+                        knots: Some(knots.clone()),
+                    },
+                    _ => BSplineKnotSpec::Provided(knots.clone()),
+                };
                 s.identifiability = match identifiability_transform {
                     Some(z) => BSplineIdentifiability::FrozenTransform {
                         transform: z.clone(),
@@ -12111,7 +12132,20 @@ pub fn freeze_term_collection_from_design(
                 *feature_cols = fitted_cols.clone();
                 for i in 0..s.marginalspecs.len() {
                     s.marginalspecs[i].degree = degrees[i];
-                    s.marginalspecs[i].knotspec = BSplineKnotSpec::Provided(knots[i].clone());
+                    s.marginalspecs[i].knotspec = match &s.marginalspecs[i].knotspec {
+                        BSplineKnotSpec::Periodic {
+                            origin,
+                            period,
+                            num_internal_knots,
+                            ..
+                        } => BSplineKnotSpec::Periodic {
+                            origin: *origin,
+                            period: *period,
+                            num_internal_knots: *num_internal_knots,
+                            knots: Some(knots[i].clone()),
+                        },
+                        _ => BSplineKnotSpec::Provided(knots[i].clone()),
+                    };
                 }
                 s.identifiability = match identifiability_transform {
                     Some(z) => TensorBSplineIdentifiability::FrozenTransform {

--- a/src/terms/term_builder.rs
+++ b/src/terms/term_builder.rs
@@ -228,12 +228,25 @@ pub fn build_smooth_basis(
     smooth_coordinate_count: usize,
 ) -> Result<SmoothBasisSpec, String> {
     let smooth_double_penalty = option_bool(options, "double_penalty").unwrap_or(true);
+    let has_periodic_option = options.contains_key("periodic")
+        || options.contains_key("cyclic")
+        || options
+            .get("bc")
+            .map(|bc| {
+                bc.to_ascii_lowercase().contains("periodic")
+                    || bc.to_ascii_lowercase().contains("cyclic")
+            })
+            .unwrap_or(false);
     let type_opt = options
         .get("type")
         .map(|s| s.to_ascii_lowercase())
         .unwrap_or_else(|| match kind {
             SmoothKind::Te => "tensor".to_string(),
             SmoothKind::S if cols.len() == 1 => "bspline".to_string(),
+            // Mixed periodic Euclidean radial kernels are not separable on the
+            // cylinder. Use a tensor product with a cyclic margin so s(theta,h)
+            // honors seam continuity while preserving the formula-level s(...).
+            SmoothKind::S if has_periodic_option => "tensor".to_string(),
             SmoothKind::S => "tps".to_string(),
         });
 
@@ -263,17 +276,36 @@ pub fn build_smooth_basis(
                     vars.join(",")
                 ));
             }
+            let periodic_axes = parse_periodic_axes(options, cols.len())?;
+            let periods = parse_periods(options, &periodic_axes)?;
             let specs = cols
                 .iter()
-                .map(|&c| {
+                .enumerate()
+                .map(|(dim, &c)| {
                     let (minv, maxv) = col_minmax(ds.values.column(c))?;
+                    let knotspec = if periodic_axes[dim] {
+                        let period = periods[dim].ok_or_else(|| {
+                            format!(
+                                "periodic tensor margin {} ('{}') requires period=[...] entry",
+                                dim, vars[dim]
+                            )
+                        })?;
+                        BSplineKnotSpec::Periodic {
+                            origin: minv,
+                            period,
+                            num_internal_knots: n_knots,
+                            knots: None,
+                        }
+                    } else {
+                        BSplineKnotSpec::Generate {
+                            data_range: (minv, maxv),
+                            num_internal_knots: n_knots,
+                        }
+                    };
                     Ok(BSplineBasisSpec {
                         degree,
                         penalty_order: 2,
-                        knotspec: BSplineKnotSpec::Generate {
-                            data_range: (minv, maxv),
-                            num_internal_knots: n_knots,
-                        },
+                        knotspec,
                         double_penalty: smooth_double_penalty,
                         identifiability: BSplineIdentifiability::None,
                     })
@@ -315,15 +347,32 @@ pub fn build_smooth_basis(
                     ceiling,
                 ));
             }
+            let periodic_axes = parse_periodic_axes(options, 1)?;
+            let periods = parse_periods(options, &periodic_axes)?;
+            let knotspec = if periodic_axes[0] {
+                BSplineKnotSpec::Periodic {
+                    origin: minv,
+                    period: periods[0].ok_or_else(|| {
+                        format!(
+                            "periodic smooth '{}' requires period=<value> or period=[value]",
+                            vars.join(",")
+                        )
+                    })?,
+                    num_internal_knots: n_knots,
+                    knots: None,
+                }
+            } else {
+                BSplineKnotSpec::Generate {
+                    data_range: (minv, maxv),
+                    num_internal_knots: n_knots,
+                }
+            };
             Ok(SmoothBasisSpec::BSpline1D {
                 feature_col: c,
                 spec: BSplineBasisSpec {
                     degree,
                     penalty_order: option_usize(options, "penalty_order").unwrap_or(2),
-                    knotspec: BSplineKnotSpec::Generate {
-                        data_range: (minv, maxv),
-                        num_internal_knots: n_knots,
-                    },
+                    knotspec,
                     double_penalty: smooth_double_penalty,
                     identifiability: BSplineIdentifiability::default(),
                 },
@@ -627,6 +676,138 @@ pub fn heuristic_centers(n: usize, d: usize) -> usize {
     default_num_centers(n, d)
 }
 
+fn parse_math_f64(raw: &str) -> Result<f64, String> {
+    let t = raw.trim().trim_matches('"').trim_matches('\'').trim();
+    if t.eq_ignore_ascii_case("none") || t.eq_ignore_ascii_case("null") {
+        return Err("None/null is not a number".to_string());
+    }
+    let lower = t.to_ascii_lowercase().replace(' ', "");
+    match lower.as_str() {
+        "pi" => return Ok(std::f64::consts::PI),
+        "tau" | "2pi" | "2*pi" => return Ok(2.0 * std::f64::consts::PI),
+        _ => {}
+    }
+    if let Some(rest) = lower.strip_suffix("*pi") {
+        let coef = if rest.is_empty() {
+            1.0
+        } else {
+            rest.parse::<f64>()
+                .map_err(|_| format!("invalid numeric expression '{raw}'"))?
+        };
+        return Ok(coef * std::f64::consts::PI);
+    }
+    if let Some(rest) = lower.strip_prefix("pi*") {
+        let coef = rest
+            .parse::<f64>()
+            .map_err(|_| format!("invalid numeric expression '{raw}'"))?;
+        return Ok(coef * std::f64::consts::PI);
+    }
+    lower
+        .parse::<f64>()
+        .map_err(|_| format!("invalid numeric expression '{raw}'"))
+}
+
+fn split_list_option(raw: &str) -> Vec<String> {
+    let t = raw.trim();
+    let inner = t
+        .strip_prefix('[')
+        .and_then(|u| u.strip_suffix(']'))
+        .unwrap_or(t);
+    inner.split(',').map(|v| v.trim().to_string()).collect()
+}
+
+fn parse_periodic_axes(
+    options: &BTreeMap<String, String>,
+    ndim: usize,
+) -> Result<Vec<bool>, String> {
+    let mut out = vec![false; ndim];
+    let Some(raw) = options.get("periodic").or_else(|| options.get("cyclic")) else {
+        if let Some(raw_bc) = options.get("bc") {
+            let vals = split_list_option(raw_bc);
+            if vals.len() != ndim {
+                return Err(format!(
+                    "bc must have one entry per margin ({ndim}), got {}",
+                    vals.len()
+                ));
+            }
+            for (i, v) in vals.iter().enumerate() {
+                let l = v.trim_matches('"').trim_matches('\'').to_ascii_lowercase();
+                out[i] = matches!(l.as_str(), "periodic" | "cyclic" | "cc");
+            }
+        }
+        return Ok(out);
+    };
+    let vals = split_list_option(raw);
+    if vals.len() == ndim
+        && vals.iter().all(|v| {
+            matches!(
+                v.to_ascii_lowercase().as_str(),
+                "true" | "false" | "yes" | "no"
+            )
+        })
+    {
+        for (i, v) in vals.iter().enumerate() {
+            out[i] = matches!(v.to_ascii_lowercase().as_str(), "true" | "yes");
+        }
+    } else {
+        for v in vals {
+            if v.is_empty() {
+                continue;
+            }
+            let axis = v
+                .parse::<usize>()
+                .map_err(|_| format!("periodic axes must be zero-based integers, got '{v}'"))?;
+            if axis >= ndim {
+                return Err(format!(
+                    "periodic axis {axis} out of range for {ndim}D smooth"
+                ));
+            }
+            out[axis] = true;
+        }
+    }
+    Ok(out)
+}
+
+fn parse_periods(
+    options: &BTreeMap<String, String>,
+    periodic: &[bool],
+) -> Result<Vec<Option<f64>>, String> {
+    let ndim = periodic.len();
+    let mut out = vec![None; ndim];
+    let Some(raw) = options.get("period") else {
+        return Ok(out);
+    };
+    let vals = split_list_option(raw);
+    if vals.len() == 1 && periodic.iter().filter(|&&b| b).count() == 1 {
+        let value = parse_math_f64(&vals[0])?;
+        if value <= 0.0 || !value.is_finite() {
+            return Err("period entries must be positive finite values".to_string());
+        }
+        if let Some(axis) = periodic.iter().position(|&b| b) {
+            out[axis] = Some(value);
+        }
+        return Ok(out);
+    }
+    if vals.len() != ndim {
+        return Err(format!(
+            "period must have one entry per margin ({ndim}), got {}",
+            vals.len()
+        ));
+    }
+    for (i, v) in vals.iter().enumerate() {
+        let l = v.to_ascii_lowercase();
+        if matches!(l.as_str(), "none" | "null" | "na" | "") {
+            continue;
+        }
+        let value = parse_math_f64(v)?;
+        if value <= 0.0 || !value.is_finite() {
+            return Err("period entries must be positive finite values".to_string());
+        }
+        out[i] = Some(value);
+    }
+    Ok(out)
+}
+
 // ---------------------------------------------------------------------------
 // Smooth option parsers
 // ---------------------------------------------------------------------------
@@ -807,5 +988,43 @@ fn parse_tensor_identifiability(
         other => Err(format!(
             "invalid tensor identifiability '{other}'; expected one of: none, sum_tozero"
         )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::BTreeMap;
+
+    #[test]
+    fn parse_cylinder_periodic_options_match_requested_forms() {
+        let mut opts = BTreeMap::new();
+        opts.insert("periodic".to_string(), "[0]".to_string());
+        opts.insert("period".to_string(), "[2*pi, None]".to_string());
+        let axes = parse_periodic_axes(&opts, 2).expect("axes");
+        let periods = parse_periods(&opts, &axes).expect("periods");
+        assert_eq!(axes, vec![true, false]);
+        assert!((periods[0].unwrap() - 2.0 * std::f64::consts::PI).abs() < 1e-12);
+        assert_eq!(periods[1], None);
+
+        let mut bc_opts = BTreeMap::new();
+        bc_opts.insert("bc".to_string(), "['periodic', 'natural']".to_string());
+        bc_opts.insert("period".to_string(), "[2*pi, None]".to_string());
+        let bc_axes = parse_periodic_axes(&bc_opts, 2).expect("bc axes");
+        let bc_periods = parse_periods(&bc_opts, &bc_axes).expect("bc periods");
+        assert_eq!(bc_axes, vec![true, false]);
+        assert!((bc_periods[0].unwrap() - 2.0 * std::f64::consts::PI).abs() < 1e-12);
+        assert_eq!(bc_periods[1], None);
+    }
+
+    #[test]
+    fn parse_single_axis_periodic_zero_as_axis_not_false() {
+        let mut opts = BTreeMap::new();
+        opts.insert("periodic".to_string(), "[0]".to_string());
+        opts.insert("period".to_string(), "2*pi".to_string());
+        let axes = parse_periodic_axes(&opts, 1).expect("axes");
+        let periods = parse_periods(&opts, &axes).expect("periods");
+        assert_eq!(axes, vec![true]);
+        assert!((periods[0].unwrap() - 2.0 * std::f64::consts::PI).abs() < 1e-12);
     }
 }


### PR DESCRIPTION
### Motivation

- Add support for mixed Euclidean × periodic (cylinder) smooths so users can specify cylindrical smooths like `s(theta, h, periodic=[0], period=[2*pi, None])` and `te(theta, h, bc=['periodic','natural'], period=[2*pi, None])`.
- Provide a principled builder path for periodic 1‑D B‑spline margins (wrap/evaluate/fold seam columns + cyclic penalty) that composes with tensor and radial kernels.

### Description

- Introduce `BSplineKnotSpec::Periodic` and helper routines (`wrap_periodic_value`, `wrap_periodic_array`, `fold_periodic_bspline_columns`, `create_cyclic_difference_penalty_matrix`) to evaluate wrapped coordinates, fold seam columns, and create cyclic difference penalties in `src/terms/basis.rs`.
- Extend `build_bspline_basis_1d` to handle `BSplineKnotSpec::Periodic` by building on the wrapped coordinates and returning a folded design + cyclic penalty, and keep the old sparse/dense path for non‑periodic cases.
- Add parsing utilities `parse_math_f64`, `split_list_option`, `parse_periodic_axes`, and `parse_periods` and integrate `periodic`/`cyclic`/`bc`/`period` options into `build_smooth_basis` so tensor and 1‑D B‑spline construction can be requested from the formula; route mixed `s(...)` with a periodic margin into a tensor BSpline construction to ensure seam continuity (`src/terms/term_builder.rs`).
- Preserve periodic specification through freeze/serialization by storing fit-time knots back into `BSplineKnotSpec::Periodic { knots: Some(...) }` and accepting `Periodic` with `knots: Some` as frozen in relevant validators and freeze logic (`src/terms/smooth.rs`).
- Update tensor construction to accept periodic marginal specs and adjust identifiability/validation to accept `Periodic { knots: Some(..) }` as frozen; add focused unit tests verifying seam equality, sum-to-zero compatibility, and option parsing.

### Testing

- Ran `cargo check` (build) and it completed successfully.
- Ran `cargo test test_periodic_bspline --lib` and the periodic B‑spline seam/sum‑to‑zero unit tests passed.
- Ran `cargo test parse_cylinder_periodic_options_match_requested_forms --lib` and `cargo test parse_single_axis_periodic_zero_as_axis_not_false --lib` and both parsing tests passed.
- All automated checks above succeeded (no failing tests reported).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07c77e8a008324b0467db4bf2a5b4c)