### PR TITLE
Add periodic (cyclic) B-spline margins and toroidal tensor-spline support

### DIFF
--- a/src/inference/formula_dsl.rs
+++ b/src/inference/formula_dsl.rs
@@ -26,7 +26,8 @@ mul_op = _{ "*" | "/" }
 unary = { unary_op* ~ primary }
 unary_op = _{ "+" | "-" }
 
-primary = { function_call | ident | number | string_lit | "(" ~ expr ~ ")" }
+primary = { function_call | list_lit | ident | number | string_lit | "(" ~ expr ~ ")" }
+list_lit = { "[" ~ (expr ~ ("," ~ expr)*)? ~ "]" }
 function_call = { ident ~ "(" ~ arg_list? ~ ")" }
 arg_list = { arg ~ ("," ~ arg)* }
 arg = { named_arg | expr }
@@ -281,6 +282,30 @@ mod tests {
             CallArgSpec::Named {
                 key: "type".to_string(),
                 value: "\"duchon\"".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn parses_list_options_for_periodic_tensor_smooths() {
+        let call = parse_function_call(
+            "te(day_of_week, hour, bc=['periodic', 'periodic'], period=[7, 24])",
+        )
+        .expect("call");
+        assert_eq!(call.name, "te");
+        assert_eq!(call.args.len(), 4);
+        assert_eq!(
+            call.args[2],
+            CallArgSpec::Named {
+                key: "bc".to_string(),
+                value: "['periodic', 'periodic']".to_string(),
+            }
+        );
+        assert_eq!(
+            call.args[3],
+            CallArgSpec::Named {
+                key: "period".to_string(),
+                value: "[7, 24]".to_string(),
             }
         );
     }

--- a/src/terms/basis.rs
+++ b/src/terms/basis.rs
@@ -1381,6 +1381,17 @@ pub enum BSplineKnotSpec {
         data_range: (f64, f64),
         num_internal_knots: usize,
     },
+    /// Uniform cyclic B-spline basis on [domain_start, domain_start + period).
+    ///
+    /// The basis is built by evaluating an unclamped uniform B-spline basis on
+    /// an extended knot vector and folding columns whose indices differ by the
+    /// number of cyclic coefficients. The resulting columns are exactly
+    /// periodic at the seam, and the associated difference penalty is cyclic.
+    Periodic {
+        domain_start: f64,
+        period: f64,
+        num_basis: usize,
+    },
     Automatic {
         num_internal_knots: Option<usize>,
         placement: BSplineKnotPlacement,
@@ -2019,6 +2030,7 @@ pub enum BasisMetadata {
     BSpline1D {
         knots: Array1<f64>,
         identifiability_transform: Option<Array2<f64>>,
+        periodic: Option<(f64, f64, usize)>,
     },
     ThinPlate {
         centers: Array2<f64>,
@@ -2058,6 +2070,7 @@ pub enum BasisMetadata {
         feature_cols: Vec<usize>,
         knots: Vec<Array1<f64>>,
         degrees: Vec<usize>,
+        periodic: Vec<Option<(f64, f64, usize)>>,
         identifiability_transform: Option<Array2<f64>>,
     },
 }
@@ -5488,11 +5501,166 @@ pub fn select_centers_by_strategy(
     }
 }
 
+fn wrap_periodic_value(x: f64, start: f64, period: f64) -> f64 {
+    let r = (x - start).rem_euclid(period);
+    // Keep exact seam evaluations stable: start + period maps to start.
+    start
+        + if (period - r).abs() <= 16.0 * f64::EPSILON * period.abs().max(1.0) {
+            0.0
+        } else {
+            r
+        }
+}
+
+fn periodic_uniform_extended_knots(
+    domain_start: f64,
+    period: f64,
+    num_basis: usize,
+    degree: usize,
+) -> Result<Array1<f64>, BasisError> {
+    if !domain_start.is_finite() || !period.is_finite() || period <= 0.0 {
+        return Err(BasisError::InvalidInput(format!(
+            "periodic B-spline requires finite positive period, got start={domain_start}, period={period}"
+        )));
+    }
+    if num_basis <= degree {
+        return Err(BasisError::InvalidInput(format!(
+            "periodic B-spline requires num_basis > degree, got num_basis={num_basis}, degree={degree}"
+        )));
+    }
+    let h = period / num_basis as f64;
+    let count = num_basis + 2 * degree + 1;
+    let knots = (0..count)
+        .map(|i| domain_start - degree as f64 * h + i as f64 * h)
+        .collect::<Vec<_>>();
+    Ok(Array1::from_vec(knots))
+}
+
+fn create_cyclic_difference_penalty_matrix(
+    num_basis: usize,
+    order: usize,
+) -> Result<Array2<f64>, BasisError> {
+    if order == 0 {
+        return Ok(Array2::<f64>::eye(num_basis));
+    }
+    if num_basis < 2 {
+        return Err(BasisError::InvalidInput(
+            "cyclic difference penalty requires at least two coefficients".to_string(),
+        ));
+    }
+    let mut d = Array2::<f64>::eye(num_basis);
+    for _ in 0..order {
+        let rows = d.nrows();
+        let mut next = Array2::<f64>::zeros((rows, num_basis));
+        for r in 0..rows {
+            for c in 0..num_basis {
+                next[[r, c]] = d[[r, c]] - d[[r, (c + 1) % num_basis]];
+            }
+        }
+        d = next;
+    }
+    Ok(d.t().dot(&d))
+}
+
+fn build_periodic_bspline_basis_1d(
+    data: ArrayView1<'_, f64>,
+    domain_start: f64,
+    period: f64,
+    num_basis: usize,
+    spec: &BSplineBasisSpec,
+) -> Result<BasisBuildResult, BasisError> {
+    let knots = periodic_uniform_extended_knots(domain_start, period, num_basis, spec.degree)?;
+    let wrapped = data.mapv(|x| wrap_periodic_value(x, domain_start, period));
+    let (extended, knots) = create_basis::<Dense>(
+        wrapped.view(),
+        KnotSource::Provided(knots.view()),
+        spec.degree,
+        BasisOptions::value(),
+    )?;
+    let ext = extended.as_ref();
+    let mut design_raw = Array2::<f64>::zeros((ext.nrows(), num_basis));
+    for j in 0..ext.ncols() {
+        let target = j % num_basis;
+        for i in 0..ext.nrows() {
+            design_raw[[i, target]] += ext[[i, j]];
+        }
+    }
+
+    let s_bend_raw = create_cyclic_difference_penalty_matrix(num_basis, spec.penalty_order)?;
+    let mut penalties_raw = vec![PenaltyCandidate {
+        matrix: s_bend_raw.clone(),
+        nullspace_dim_hint: 1,
+        source: PenaltySource::Primary,
+        normalization_scale: 1.0,
+        kronecker_factors: None,
+        op: None,
+    }];
+    if spec.double_penalty {
+        penalties_raw.push(PenaltyCandidate {
+            matrix: build_nullspace_shrinkage_penalty(&s_bend_raw)?
+                .map(|shrink| shrink.sym_penalty)
+                .unwrap_or_else(|| Array2::<f64>::zeros(s_bend_raw.raw_dim())),
+            nullspace_dim_hint: 0,
+            source: PenaltySource::DoublePenaltyNullspace,
+            normalization_scale: 1.0,
+            kronecker_factors: None,
+            op: None,
+        });
+    }
+
+    let penalties_raw_mats = penalties_raw
+        .iter()
+        .map(|c| c.matrix.clone())
+        .collect::<Vec<_>>();
+    let (design, penalties, identifiability_transform) = apply_bspline_identifiability_policy(
+        design_raw,
+        penalties_raw_mats,
+        &knots,
+        spec.degree,
+        &spec.identifiability,
+    )?;
+    let transformed_candidates = penalties
+        .into_iter()
+        .zip(penalties_raw.into_iter())
+        .map(|(matrix, candidate)| PenaltyCandidate {
+            nullspace_dim_hint: candidate.nullspace_dim_hint,
+            matrix,
+            source: candidate.source,
+            normalization_scale: candidate.normalization_scale,
+            kronecker_factors: None,
+            op: None,
+        })
+        .collect::<Vec<_>>();
+    let (penalties, nullspace_dims, penaltyinfo, ops) =
+        filter_active_penalty_candidates_with_ops(transformed_candidates)?;
+    Ok(BasisBuildResult {
+        design: DesignMatrix::Dense(crate::matrix::DenseDesignMatrix::from(design)),
+        penalties,
+        nullspace_dims,
+        penaltyinfo,
+        metadata: BasisMetadata::BSpline1D {
+            knots,
+            identifiability_transform,
+            periodic: Some((domain_start, period, num_basis)),
+        },
+        kronecker_factored: None,
+        ops,
+    })
+}
+
 /// Generic 1D B-spline builder returning design + penalty list.
 pub fn build_bspline_basis_1d(
     data: ArrayView1<'_, f64>,
     spec: &BSplineBasisSpec,
 ) -> Result<BasisBuildResult, BasisError> {
+    if let BSplineKnotSpec::Periodic {
+        domain_start,
+        period,
+        num_basis,
+    } = spec.knotspec
+    {
+        return build_periodic_bspline_basis_1d(data, domain_start, period, num_basis, spec);
+    }
     let prefer_sparse_design = matches!(
         spec.identifiability,
         BSplineIdentifiability::None | BSplineIdentifiability::WeightedSumToZero { .. }
@@ -5522,6 +5690,9 @@ pub fn build_bspline_basis_1d(
                     BasisOptions::value(),
                 )?;
                 (Some(basis), None, knots)
+            }
+            BSplineKnotSpec::Periodic { .. } => {
+                unreachable!("periodic B-spline handled before storage selection")
             }
             BSplineKnotSpec::Automatic {
                 num_internal_knots,
@@ -5573,6 +5744,9 @@ pub fn build_bspline_basis_1d(
                     BasisOptions::value(),
                 )?;
                 (None, Some((*basis).clone()), knots)
+            }
+            BSplineKnotSpec::Periodic { .. } => {
+                unreachable!("periodic B-spline handled before storage selection")
             }
             BSplineKnotSpec::Automatic {
                 num_internal_knots,
@@ -5728,6 +5902,7 @@ pub fn build_bspline_basis_1d(
         metadata: BasisMetadata::BSpline1D {
             knots,
             identifiability_transform,
+            periodic: None,
         },
         kronecker_factored: None,
         ops,

--- a/src/terms/smooth.rs
+++ b/src/terms/smooth.rs
@@ -2612,12 +2612,21 @@ fn build_shape_constraint_design_1d(
             BasisMetadata::BSpline1D {
                 knots,
                 identifiability_transform,
+                periodic,
             },
         ) => {
             let evalspec = BSplineBasisSpec {
                 degree: spec.degree,
                 penalty_order: spec.penalty_order,
-                knotspec: BSplineKnotSpec::Provided(knots.clone()),
+                knotspec: periodic
+                    .map(
+                        |(domain_start, period, num_basis)| BSplineKnotSpec::Periodic {
+                            domain_start,
+                            period,
+                            num_basis,
+                        },
+                    )
+                    .unwrap_or_else(|| BSplineKnotSpec::Provided(knots.clone())),
                 double_penalty: false,
                 identifiability: identifiability_transform
                     .as_ref()
@@ -2907,6 +2916,7 @@ fn build_tensor_bspline_basis(
     let mut marginalnum_basis = Vec::<usize>::with_capacity(feature_cols.len());
     let mut marginal_penalties = Vec::<Array2<f64>>::with_capacity(feature_cols.len());
     let mut marginal_designs = Vec::<Array2<f64>>::with_capacity(feature_cols.len());
+    let mut marginal_periodic = Vec::<Option<(f64, f64, usize)>>::with_capacity(feature_cols.len());
 
     // Reuse the robust 1D builder to ensure the same knot validation and
     // marginal difference-penalty construction as standalone smooth terms.
@@ -2922,8 +2932,10 @@ fn build_tensor_bspline_basis(
         let mut marginal_unconstrained = marginalspec.clone();
         marginal_unconstrained.identifiability = BSplineIdentifiability::None;
         let built = build_bspline_basis_1d(data.column(col), &marginal_unconstrained)?;
-        let knots = match built.metadata {
-            BasisMetadata::BSpline1D { knots, .. } => knots,
+        let (knots, periodic) = match built.metadata {
+            BasisMetadata::BSpline1D {
+                knots, periodic, ..
+            } => (knots, periodic),
             _ => {
                 return Err(BasisError::InvalidInput(format!(
                     "internal TensorBSpline error at dim {dim}: expected BSpline1D metadata"
@@ -2931,6 +2943,7 @@ fn build_tensor_bspline_basis(
             }
         };
         marginal_knots.push(knots);
+        marginal_periodic.push(periodic);
         marginal_degrees.push(marginalspec.degree);
         marginalnum_basis.push(built.design.ncols());
         marginal_designs.push(built.design.to_dense());
@@ -3072,6 +3085,7 @@ fn build_tensor_bspline_basis(
             feature_cols: feature_cols.to_vec(),
             knots: marginal_knots,
             degrees: marginal_degrees,
+            periodic: marginal_periodic,
             identifiability_transform: z_opt,
         },
         kronecker_factored: if matches!(spec.identifiability, TensorBSplineIdentifiability::None) {
@@ -4918,8 +4932,10 @@ fn with_identifiability_transform(
         BasisMetadata::BSpline1D {
             knots,
             identifiability_transform,
+            periodic,
         } => Ok(BasisMetadata::BSpline1D {
             knots: knots.clone(),
+            periodic: *periodic,
             identifiability_transform: compose_identifiability_transforms(
                 identifiability_transform.as_ref(),
                 transform,
@@ -4985,11 +5001,13 @@ fn with_identifiability_transform(
             feature_cols,
             knots,
             degrees,
+            periodic,
             identifiability_transform,
         } => Ok(BasisMetadata::TensorBSpline {
             feature_cols: feature_cols.clone(),
             knots: knots.clone(),
             degrees: degrees.clone(),
+            periodic: periodic.clone(),
             identifiability_transform: compose_identifiability_transforms(
                 identifiability_transform.as_ref(),
                 transform,
@@ -11945,9 +11963,18 @@ pub fn freeze_term_collection_from_design(
                 BasisMetadata::BSpline1D {
                     knots,
                     identifiability_transform,
+                    periodic,
                 },
             ) => {
-                s.knotspec = BSplineKnotSpec::Provided(knots.clone());
+                s.knotspec = periodic
+                    .map(
+                        |(domain_start, period, num_basis)| BSplineKnotSpec::Periodic {
+                            domain_start,
+                            period,
+                            num_basis,
+                        },
+                    )
+                    .unwrap_or_else(|| BSplineKnotSpec::Provided(knots.clone()));
                 s.identifiability = match identifiability_transform {
                     Some(z) => BSplineIdentifiability::FrozenTransform {
                         transform: z.clone(),
@@ -12096,6 +12123,7 @@ pub fn freeze_term_collection_from_design(
                     feature_cols: fitted_cols,
                     knots,
                     degrees,
+                    periodic,
                     identifiability_transform,
                 },
             ) => {
@@ -12111,7 +12139,15 @@ pub fn freeze_term_collection_from_design(
                 *feature_cols = fitted_cols.clone();
                 for i in 0..s.marginalspecs.len() {
                     s.marginalspecs[i].degree = degrees[i];
-                    s.marginalspecs[i].knotspec = BSplineKnotSpec::Provided(knots[i].clone());
+                    s.marginalspecs[i].knotspec = periodic[i]
+                        .map(
+                            |(domain_start, period, num_basis)| BSplineKnotSpec::Periodic {
+                                domain_start,
+                                period,
+                                num_basis,
+                            },
+                        )
+                        .unwrap_or_else(|| BSplineKnotSpec::Provided(knots[i].clone()));
                 }
                 s.identifiability = match identifiability_transform {
                     Some(z) => TensorBSplineIdentifiability::FrozenTransform {
@@ -16086,6 +16122,114 @@ mod tests {
                 .iter()
                 .all(|bp| bp.col_range.end <= sd.total_smooth_cols())
         );
+    }
+
+    #[test]
+    fn periodic_bspline_margin_wraps_exactly_at_period() {
+        let x = array![0.0, 1.25, 2.5, 3.75, 7.0, 8.25];
+        let spec = BSplineBasisSpec {
+            degree: 3,
+            penalty_order: 2,
+            knotspec: BSplineKnotSpec::Periodic {
+                domain_start: 0.0,
+                period: 7.0,
+                num_basis: 8,
+            },
+            double_penalty: false,
+            identifiability: BSplineIdentifiability::None,
+        };
+        let built = build_bspline_basis_1d(x.view(), &spec).expect("periodic bspline");
+        let dense = built.design.to_dense();
+        assert_eq!(dense.ncols(), 8);
+        for j in 0..dense.ncols() {
+            assert!(
+                (dense[[0, j]] - dense[[4, j]]).abs() < 1e-12,
+                "seam row differs at column {j}: {} vs {}",
+                dense[[0, j]],
+                dense[[4, j]]
+            );
+            assert!(
+                (dense[[1, j]] - dense[[5, j]]).abs() < 1e-12,
+                "wrapped row differs at column {j}: {} vs {}",
+                dense[[1, j]],
+                dense[[5, j]]
+            );
+        }
+        for row in dense.rows() {
+            assert!((row.sum() - 1.0).abs() < 1e-12);
+        }
+        assert_eq!(built.nullspace_dims[0], 1);
+    }
+
+    #[test]
+    fn tensor_bspline_supports_two_periodic_margins_as_torus() {
+        let data = array![[0.0, 0.0], [7.0, 0.0], [0.0, 24.0], [7.0, 24.0], [1.5, 6.0]];
+        let spec_day = BSplineBasisSpec {
+            degree: 3,
+            penalty_order: 2,
+            knotspec: BSplineKnotSpec::Periodic {
+                domain_start: 0.0,
+                period: 7.0,
+                num_basis: 7,
+            },
+            double_penalty: false,
+            identifiability: BSplineIdentifiability::None,
+        };
+        let spec_hour = BSplineBasisSpec {
+            degree: 3,
+            penalty_order: 2,
+            knotspec: BSplineKnotSpec::Periodic {
+                domain_start: 0.0,
+                period: 24.0,
+                num_basis: 8,
+            },
+            double_penalty: false,
+            identifiability: BSplineIdentifiability::None,
+        };
+        let spec_collection = TermCollectionSpec {
+            linear_terms: vec![],
+            random_effect_terms: vec![],
+            smooth_terms: vec![SmoothTermSpec {
+                name: "te_day_hour".to_string(),
+                basis: SmoothBasisSpec::TensorBSpline {
+                    feature_cols: vec![0, 1],
+                    spec: TensorBSplineSpec {
+                        marginalspecs: vec![spec_day, spec_hour],
+                        double_penalty: false,
+                        identifiability: TensorBSplineIdentifiability::None,
+                    },
+                },
+                shape: ShapeConstraint::None,
+            }],
+        };
+        let design = build_term_collection_design(data.view(), &spec_collection)
+            .expect("periodic tensor design");
+        let sd = &design.smooth;
+        let dense = sd.term_designs[0].to_dense();
+        assert_eq!(dense.ncols(), 56);
+        for j in 0..dense.ncols() {
+            assert!((dense[[0, j]] - dense[[1, j]]).abs() < 1e-12);
+            assert!((dense[[0, j]] - dense[[2, j]]).abs() < 1e-12);
+            assert!((dense[[0, j]] - dense[[3, j]]).abs() < 1e-12);
+        }
+        assert_eq!(sd.penalties.len(), 2);
+        assert!(sd.penalties.iter().all(|p| p.local.nrows() == 56));
+
+        let frozen = freeze_term_collection_from_design(&spec_collection, &design)
+            .expect("freeze periodic tensor");
+        match &frozen.smooth_terms[0].basis {
+            SmoothBasisSpec::TensorBSpline { spec, .. } => {
+                assert!(matches!(
+                    spec.marginalspecs[0].knotspec,
+                    BSplineKnotSpec::Periodic { period: 7.0, .. }
+                ));
+                assert!(matches!(
+                    spec.marginalspecs[1].knotspec,
+                    BSplineKnotSpec::Periodic { period: 24.0, .. }
+                ));
+            }
+            _ => panic!("expected tensor spec"),
+        }
     }
 
     #[test]

--- a/src/terms/term_builder.rs
+++ b/src/terms/term_builder.rs
@@ -263,17 +263,44 @@ pub fn build_smooth_basis(
                     vars.join(",")
                 ));
             }
+            let bc = parse_boundary_conditions(options, cols.len())?;
+            let periods = parse_periods(options, cols.len())?;
             let specs = cols
                 .iter()
-                .map(|&c| {
+                .enumerate()
+                .map(|(dim, &c)| {
                     let (minv, maxv) = col_minmax(ds.values.column(c))?;
+                    let knotspec = if bc[dim].as_deref() == Some("periodic") {
+                        let period = periods
+                            .as_ref()
+                            .and_then(|p| p.get(dim).copied())
+                            .ok_or_else(|| {
+                                format!(
+                                    "periodic tensor margin '{}' requires period=[...] with one positive period per margin",
+                                    vars[dim]
+                                )
+                            })?;
+                        if !period.is_finite() || period <= 0.0 {
+                            return Err(format!(
+                                "periodic tensor margin '{}' requires a finite positive period, got {}",
+                                vars[dim], period
+                            ));
+                        }
+                        BSplineKnotSpec::Periodic {
+                            domain_start: minv,
+                            period,
+                            num_basis: n_knots + degree + 1,
+                        }
+                    } else {
+                        BSplineKnotSpec::Generate {
+                            data_range: (minv, maxv),
+                            num_internal_knots: n_knots,
+                        }
+                    };
                     Ok(BSplineBasisSpec {
                         degree,
                         penalty_order: 2,
-                        knotspec: BSplineKnotSpec::Generate {
-                            data_range: (minv, maxv),
-                            num_internal_knots: n_knots,
-                        },
+                        knotspec,
                         double_penalty: smooth_double_penalty,
                         identifiability: BSplineIdentifiability::None,
                     })
@@ -625,6 +652,73 @@ pub fn heuristic_knots_for_column(col: ArrayView1<'_, f64>) -> usize {
 
 pub fn heuristic_centers(n: usize, d: usize) -> usize {
     default_num_centers(n, d)
+}
+
+fn split_option_list(raw: &str) -> Vec<String> {
+    let trimmed = raw.trim();
+    let inner = trimmed
+        .strip_prefix('[')
+        .and_then(|v| v.strip_suffix(']'))
+        .unwrap_or(trimmed);
+    inner
+        .split(',')
+        .map(|part| {
+            part.trim()
+                .trim_matches(|c| c == '\'' || c == '"')
+                .to_ascii_lowercase()
+        })
+        .filter(|part| !part.is_empty())
+        .collect()
+}
+
+fn parse_boundary_conditions(
+    options: &BTreeMap<String, String>,
+    dims: usize,
+) -> Result<Vec<Option<String>>, String> {
+    let Some(raw) = options.get("bc").or_else(|| options.get("boundary")) else {
+        return Ok(vec![None; dims]);
+    };
+    let values = split_option_list(raw);
+    if values.len() != dims {
+        return Err(format!(
+            "bc must provide one boundary condition per tensor margin (expected {dims}, got {})",
+            values.len()
+        ));
+    }
+    values
+        .into_iter()
+        .map(|v| match v.as_str() {
+            "periodic" | "cyclic" | "cycle" => Ok(Some("periodic".to_string())),
+            "none" | "open" | "natural" => Ok(None),
+            other => Err(format!(
+                "unsupported tensor boundary condition '{other}'; supported values are 'periodic' and 'none'"
+            )),
+        })
+        .collect()
+}
+
+fn parse_periods(
+    options: &BTreeMap<String, String>,
+    dims: usize,
+) -> Result<Option<Vec<f64>>, String> {
+    let Some(raw) = options.get("period").or_else(|| options.get("periods")) else {
+        return Ok(None);
+    };
+    let values = split_option_list(raw);
+    if values.len() != dims {
+        return Err(format!(
+            "period must provide one numeric period per tensor margin (expected {dims}, got {})",
+            values.len()
+        ));
+    }
+    values
+        .into_iter()
+        .map(|v| {
+            v.parse::<f64>()
+                .map_err(|_| format!("invalid period value '{v}'; expected a number"))
+        })
+        .collect::<Result<Vec<_>, _>>()
+        .map(Some)
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
### Motivation
- Enable fully-periodic 2D tensor smooths (torus) by making each tensor margin optionally periodic so `te(..., bc=['periodic','periodic'], period=[...])` composes a tensor-product of cyclic 1D bases. 
- Keep the implementation local to existing tensor-product machinery by reusing the 1D B-spline builder and per-margin penalties so no new mathematics or penalty theory is required. 

### Description
- Parse list literals in the formula DSL so calls like `te(day_of_week, hour, bc=['periodic','periodic'], period=[7,24])` are accepted (`src/inference/formula_dsl.rs`).
- Add `BSplineKnotSpec::Periodic` and implement periodic 1D B-spline construction, input wrapping, and a cyclic difference penalty generator (`wrap_periodic_value`, `periodic_uniform_extended_knots`, `create_cyclic_difference_penalty_matrix`, `build_periodic_bspline_basis_1d`) and preserve periodic metadata (`src/terms/basis.rs`).
- Wire `bc` and `period` tensor options into `build_smooth_basis` so tensor marginal specs can request periodic 1D margins (compute `num_basis = internal_knots + degree + 1`) and fall back to existing generation for non-periodic margins (`src/terms/term_builder.rs`).
- Propagate and preserve periodic margin metadata through tensor assembly and freezing so saved/frozen models re-create periodic margins at predict-time (`src/terms/smooth.rs`).
- Add unit tests covering parsing of list options, exact seam wrapping and partition-of-unity for periodic 1D margins, and a 2D tensor with two periodic margins (torus behavior) (`src/terms/smooth.rs` tests and `src/inference/formula_dsl.rs` test).

### Testing
- Ran `cargo check -q` which completed successfully. 
- Ran focused unit tests with `cargo test -q --lib periodic -- --nocapture` and the periodic-related test subset passed (`3 passed`).
- A full `cargo test -q periodic -- --nocapture` attempt initially hit an environment disk space linking error during integration test builds, `cargo clean` was executed and the focused lib tests above succeeded afterward.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07c79ba868832498da1d49f406f8df)