### PR TITLE
Add factor-smooth and `by=` support (fs/sz/re scaffolding)

### DIFF
--- a/docs/cookbook.md
+++ b/docs/cookbook.md
@@ -376,3 +376,38 @@ print(gs.best_params_, gs.best_score_)
 model.report("report.html")     # writes to disk
 html = model.report()           # returns string for Jupyter / inline display
 ```
+
+## Per-group trajectories (factor `by=` smooth)
+
+Use a factor `by=` smooth when each group should have its own unpooled curve:
+
+```text
+y ~ s(time, by=subject) + group(subject)
+```
+
+The smooth contribution for a previously unseen subject is zero at prediction
+time; include `group(subject)` when subject-level intercepts matter.
+
+## Hierarchical / partial-pooling smooths (`bs="fs"`)
+
+Use `bs="fs"` (or `fs(...)`) when group-specific curves should borrow strength:
+
+```text
+y ~ s(time, subject, bs="fs", k=8)
+y ~ fs(time, subject, k=8)
+```
+
+This term penalizes both wiggly components and low-order null-space components,
+so sparse groups shrink more strongly than dense groups.
+
+## Treatment vs control difference smooth (`bs="sz"`)
+
+Use `bs="sz"` with a main smooth to model deviations that sum to zero across
+factor levels:
+
+```text
+y ~ s(time) + s(treatment, time, bs="sz", k=10)
+```
+
+The main `s(time)` captures the population trajectory, while the `sz` term
+captures level-specific departures.

--- a/docs/formulas.md
+++ b/docs/formulas.md
@@ -70,15 +70,42 @@ Aliases for box constraints: `linear`, `constrain`, `constraint`, `box`.
 plus an optional Beta prior (parameterised by `target` / `strength`)
 rather than a quadratic ridge.
 
-## Random effects
+## Random effects and factor smooths
 
 ```
 y ~ x + group(site)
-y ~ x + re(site)            # alias
+y ~ x + re(site)                         # alias for random intercepts
+y ~ s(x, by=site) + site                 # separate smooth per factor level
+y ~ s(x, by=z)                           # numeric varying-coefficient smooth
+y ~ s(x, site, bs="fs")                  # partial-pooling random smooths
+y ~ fs(x, site)                          # alias for bs="fs"
+y ~ s(site, x, bs="sz") + s(x)           # sum-to-zero deviations from a main smooth
+y ~ sz(site, x)                          # alias for bs="sz"
+y ~ s(site, x, bs="re") + group(site)    # random intercepts plus random slopes
 ```
 
-Adds a random intercept per level of the grouping column. The column may be
-string- or integer-valued. Random slopes are not supported.
+`group()`/`re()` adds a random intercept per level of a string- or
+integer-valued grouping column.
+
+Factor and numeric `by=` smooths multiply an ordinary smooth basis by a
+numeric covariate or by per-level indicators. Factor `by=` smooths create a
+separate smooth for each kept level; include the factor main effect (for
+example `+ site` or `+ group(site)`) when level offsets should be identifiable.
+Ordered-factor style difference smooths can be requested with an ordered
+factor column name/convention and skip the reference level.
+
+`bs="fs"` builds random smooths: each group gets its own curve, including
+penalized null-space components such as intercept and linear trend, so small
+groups shrink toward zero contribution while larger groups can retain distinct
+curves. New/unseen groups at prediction time contribute zero for the factor
+smooth term. `m=1` reduces the number of null-space shrinkage penalties;
+`m=2` is the default.
+
+`bs="sz"` builds sum-to-zero factor-smooth deviations intended to be used with
+a population smooth such as `s(x)`. Deviations are constrained to sum to zero
+across factor levels at each spline coefficient. `bs="re"` with one grouping
+and one numeric variable builds random slopes as a factor-by-linear basis with
+an identity ridge penalty.
 
 ## Univariate smooths
 

--- a/src/families/survival_predict.rs
+++ b/src/families/survival_predict.rs
@@ -1215,6 +1215,41 @@ fn remap_term_collectionspec_columns(
                     *feature_col = resolve_training_index(*feature_col)?;
                 }
             }
+            SmoothBasisSpec::FactorSmooth { spec } => {
+                for feature_col in spec.continuous_cols.iter_mut() {
+                    *feature_col = resolve_training_index(*feature_col)?;
+                }
+                spec.group_col = resolve_training_index(spec.group_col)?;
+            }
+            SmoothBasisSpec::BySmooth { smooth, by_kind } => {
+                match smooth.as_mut() {
+                    SmoothBasisSpec::BSpline1D { feature_col, .. } => {
+                        *feature_col = resolve_training_index(*feature_col)?
+                    }
+                    SmoothBasisSpec::ThinPlate { feature_cols, .. }
+                    | SmoothBasisSpec::Sphere { feature_cols, .. }
+                    | SmoothBasisSpec::Matern { feature_cols, .. }
+                    | SmoothBasisSpec::Duchon { feature_cols, .. }
+                    | SmoothBasisSpec::TensorBSpline { feature_cols, .. } => {
+                        for feature_col in feature_cols.iter_mut() {
+                            *feature_col = resolve_training_index(*feature_col)?;
+                        }
+                    }
+                    SmoothBasisSpec::FactorSmooth { spec } => {
+                        for feature_col in spec.continuous_cols.iter_mut() {
+                            *feature_col = resolve_training_index(*feature_col)?;
+                        }
+                        spec.group_col = resolve_training_index(spec.group_col)?;
+                    }
+                    SmoothBasisSpec::BySmooth { .. } => {}
+                }
+                match by_kind {
+                    crate::smooth::ByVarKind::Numeric { feature_col }
+                    | crate::smooth::ByVarKind::Factor { feature_col, .. } => {
+                        *feature_col = resolve_training_index(*feature_col)?;
+                    }
+                }
+            }
         }
     }
     Ok(remapped)

--- a/src/inference/formula_dsl.rs
+++ b/src/inference/formula_dsl.rs
@@ -1406,6 +1406,18 @@ pub fn parse_term(raw: &str) -> Result<ParsedTerm, String> {
                     options,
                 });
             }
+            "fs" | "sz" => {
+                if vars.len() != 2 {
+                    return Err(format!("{}() expects exactly two variables: {raw}", name));
+                }
+                options.insert("bs".to_string(), name.clone());
+                return Ok(ParsedTerm::Smooth {
+                    label: raw.to_string(),
+                    vars,
+                    kind: SmoothKind::S,
+                    options,
+                });
+            }
             "thinplate" | "thin_plate" | "tps" => {
                 if vars.len() < 2 {
                     return Err(format!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -6360,6 +6360,12 @@ fn smooth_term_primary_column(term: &SmoothTermSpec) -> Option<usize> {
                 None
             }
         }
+        SmoothBasisSpec::FactorSmooth { spec } => spec.continuous_cols.first().copied(),
+        SmoothBasisSpec::BySmooth { smooth, .. } => smooth_term_primary_column(&SmoothTermSpec {
+            name: String::new(),
+            basis: (**smooth).clone(),
+            shape: gam::smooth::ShapeConstraint::None,
+        }),
     }
 }
 
@@ -7119,7 +7125,10 @@ fn spatial_basiswarning_family_and_cols(term: &SmoothTermSpec) -> Option<(&'stat
         SmoothBasisSpec::Sphere { feature_cols, .. } => Some(("sphere/sos", feature_cols)),
         SmoothBasisSpec::Matern { feature_cols, .. } => Some(("matern", feature_cols)),
         SmoothBasisSpec::Duchon { feature_cols, .. } => Some(("duchon", feature_cols)),
-        SmoothBasisSpec::BSpline1D { .. } | SmoothBasisSpec::TensorBSpline { .. } => None,
+        SmoothBasisSpec::BSpline1D { .. }
+        | SmoothBasisSpec::TensorBSpline { .. }
+        | SmoothBasisSpec::FactorSmooth { .. }
+        | SmoothBasisSpec::BySmooth { .. } => None,
     }
 }
 
@@ -7191,6 +7200,23 @@ fn smooth_term_feature_cols(term: &SmoothTermSpec) -> Vec<usize> {
         | SmoothBasisSpec::Matern { feature_cols, .. }
         | SmoothBasisSpec::Duchon { feature_cols, .. }
         | SmoothBasisSpec::TensorBSpline { feature_cols, .. } => feature_cols.clone(),
+        SmoothBasisSpec::FactorSmooth { spec } => {
+            let mut cols = spec.continuous_cols.clone();
+            cols.push(spec.group_col);
+            cols
+        }
+        SmoothBasisSpec::BySmooth { smooth, by_kind } => {
+            let mut cols = smooth_term_feature_cols(&SmoothTermSpec {
+                name: String::new(),
+                basis: (**smooth).clone(),
+                shape: gam::smooth::ShapeConstraint::None,
+            });
+            match by_kind {
+                gam::smooth::ByVarKind::Numeric { feature_col }
+                | gam::smooth::ByVarKind::Factor { feature_col, .. } => cols.push(*feature_col),
+            }
+            cols
+        }
     }
 }
 
@@ -7247,6 +7273,8 @@ fn smooth_basiswarning_family_rank(term: &SmoothTermSpec) -> u8 {
         SmoothBasisSpec::Sphere { .. } => 3,
         SmoothBasisSpec::Matern { .. } => 4,
         SmoothBasisSpec::Duchon { .. } => 5,
+        SmoothBasisSpec::FactorSmooth { .. } => 6,
+        SmoothBasisSpec::BySmooth { .. } => 7,
     }
 }
 
@@ -11028,7 +11056,7 @@ mod tests {
                         },
                         input_scales: None,
                     },
-                    shape: ShapeConstraint::None,
+                    shape: gam::smooth::ShapeConstraint::None,
                 },
                 SmoothTermSpec {
                     name: "pc2".to_string(),
@@ -11046,7 +11074,7 @@ mod tests {
                         },
                         input_scales: None,
                     },
-                    shape: ShapeConstraint::None,
+                    shape: gam::smooth::ShapeConstraint::None,
                 },
                 SmoothTermSpec {
                     name: "pc3".to_string(),
@@ -11064,7 +11092,7 @@ mod tests {
                         },
                         input_scales: None,
                     },
-                    shape: ShapeConstraint::None,
+                    shape: gam::smooth::ShapeConstraint::None,
                 },
             ],
         };
@@ -11102,7 +11130,7 @@ mod tests {
                     },
                     input_scales: None,
                 },
-                shape: ShapeConstraint::None,
+                shape: gam::smooth::ShapeConstraint::None,
             }],
         };
         let headers = vec!["pc1".to_string(), "pc2".to_string(), "pc3".to_string()];
@@ -11131,7 +11159,7 @@ mod tests {
                         },
                         input_scales: None,
                     },
-                    shape: ShapeConstraint::None,
+                    shape: gam::smooth::ShapeConstraint::None,
                 },
                 SmoothTermSpec {
                     name: "pc2".to_string(),
@@ -11146,7 +11174,7 @@ mod tests {
                         },
                         input_scales: None,
                     },
-                    shape: ShapeConstraint::None,
+                    shape: gam::smooth::ShapeConstraint::None,
                 },
             ],
         };
@@ -11188,7 +11216,7 @@ mod tests {
                     },
                     input_scales: None,
                 },
-                shape: ShapeConstraint::None,
+                shape: gam::smooth::ShapeConstraint::None,
             }],
         };
         let headers = vec!["pc1".to_string(), "pc2".to_string(), "pc3".to_string()];
@@ -11225,7 +11253,7 @@ mod tests {
                         },
                         input_scales: None,
                     },
-                    shape: ShapeConstraint::None,
+                    shape: gam::smooth::ShapeConstraint::None,
                 },
                 SmoothTermSpec {
                     name: "s(pc1)".to_string(),
@@ -11243,7 +11271,7 @@ mod tests {
                             boundary_conditions: Default::default(),
                         },
                     },
-                    shape: ShapeConstraint::None,
+                    shape: gam::smooth::ShapeConstraint::None,
                 },
             ],
         };

--- a/src/terms/smooth.rs
+++ b/src/terms/smooth.rs
@@ -31,7 +31,7 @@ use crate::estimate::{
     UnifiedFitResult, UnifiedFitResultParts, fit_gamwith_heuristic_lambdas,
     reml::DirectionalHyperParam,
 };
-use crate::faer_ndarray::{fast_atb, fast_atv};
+use crate::faer_ndarray::{FaerEigh, fast_atb, fast_atv};
 use crate::families::strategy::{FamilyStrategy, strategy_for_family};
 use crate::matrix::{
     BlockDesignOperator, CoefficientTransformOperator, DesignBlock, DesignMatrix,
@@ -44,6 +44,7 @@ use crate::pirls::LinearInequalityConstraints;
 use crate::types::{
     InverseLink, LatentCLogLogState, LikelihoodFamily, MixtureLinkState, SasLinkState,
 };
+use faer::Side;
 use faer::sparse::{SparseColMat, Triplet};
 use ndarray::{Array1, Array2, ArrayView1, ArrayView2, s};
 use serde::{Deserialize, Serialize};
@@ -150,6 +151,55 @@ pub enum SmoothBasisSpec {
     TensorBSpline {
         feature_cols: Vec<usize>,
         spec: TensorBSplineSpec,
+    },
+    FactorSmooth {
+        spec: FactorSmoothSpec,
+    },
+    BySmooth {
+        smooth: Box<SmoothBasisSpec>,
+        by_kind: ByVarKind,
+    },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum TensorMarginalSpec {
+    BSpline(BSplineBasisSpec),
+    Categorical {
+        feature_col_offset: usize,
+        drop_first_level: bool,
+        center_for_identifiability: bool,
+        #[serde(default)]
+        frozen_levels: Option<Vec<u64>>,
+    },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FactorSmoothSpec {
+    pub continuous_cols: Vec<usize>,
+    pub group_col: usize,
+    pub marginal: BSplineBasisSpec,
+    pub flavour: FactorSmoothFlavour,
+    #[serde(default)]
+    pub group_frozen_levels: Option<Vec<u64>>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum FactorSmoothFlavour {
+    Fs { m_null_penalty_orders: Vec<usize> },
+    Sz,
+    Re,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum ByVarKind {
+    Numeric {
+        feature_col: usize,
+    },
+    Factor {
+        feature_col: usize,
+        ordered: bool,
+        #[serde(default)]
+        frozen_levels: Option<Vec<u64>>,
     },
 }
 
@@ -491,6 +541,43 @@ impl TermCollectionSpec {
                             st.name
                         ));
                     }
+                }
+                SmoothBasisSpec::FactorSmooth { spec } => {
+                    if !matches!(
+                        spec.marginal.knotspec,
+                        BSplineKnotSpec::Provided(_) | BSplineKnotSpec::PeriodicUniform { .. }
+                    ) {
+                        return Err(format!(
+                            "{label} term '{}' is not frozen: factor-smooth marginal knotspec must be Provided or PeriodicUniform",
+                            st.name
+                        ));
+                    }
+                    if spec.group_frozen_levels.is_none() {
+                        return Err(format!(
+                            "{label} term '{}' is not frozen: factor smooth missing group_frozen_levels",
+                            st.name
+                        ));
+                    }
+                }
+                SmoothBasisSpec::BySmooth { smooth, by_kind } => {
+                    if let ByVarKind::Factor { frozen_levels, .. } = by_kind
+                        && frozen_levels.is_none()
+                    {
+                        return Err(format!(
+                            "{label} term '{}' is not frozen: factor by-smooth missing frozen_levels",
+                            st.name
+                        ));
+                    }
+                    let nested = TermCollectionSpec {
+                        linear_terms: vec![],
+                        random_effect_terms: vec![],
+                        smooth_terms: vec![SmoothTermSpec {
+                            name: st.name.clone(),
+                            basis: (**smooth).clone(),
+                            shape: st.shape,
+                        }],
+                    };
+                    nested.validate_frozen(label)?;
                 }
             }
         }
@@ -3108,6 +3195,387 @@ fn normalize_penalty_in_constrained_space(matrix: &Array2<f64>) -> (Array2<f64>,
     }
 }
 
+fn sorted_finite_levels_from_col(col: ArrayView1<'_, f64>) -> Result<Vec<u64>, BasisError> {
+    let mut levels = BTreeSet::<u64>::new();
+    for &v in col.iter() {
+        if !v.is_finite() {
+            return Err(BasisError::InvalidInput(
+                "factor smooth grouping column contains non-finite values".to_string(),
+            ));
+        }
+        levels.insert(v.to_bits());
+    }
+    Ok(levels.into_iter().collect())
+}
+
+fn indicator_design_for_levels(
+    data: ArrayView2<'_, f64>,
+    feature_col: usize,
+    levels: &[u64],
+) -> Result<Array2<f64>, BasisError> {
+    if feature_col >= data.ncols() {
+        return Err(BasisError::DimensionMismatch(format!(
+            "categorical feature column {feature_col} out of bounds for {} columns",
+            data.ncols()
+        )));
+    }
+    let n = data.nrows();
+    let mut out = Array2::<f64>::zeros((n, levels.len()));
+    let level_to_idx = levels
+        .iter()
+        .enumerate()
+        .map(|(i, &b)| (b, i))
+        .collect::<BTreeMap<_, _>>();
+    for i in 0..n {
+        let v = data[[i, feature_col]];
+        if !v.is_finite() {
+            return Err(BasisError::InvalidInput(
+                "categorical feature column contains non-finite values".to_string(),
+            ));
+        }
+        if let Some(&j) = level_to_idx.get(&v.to_bits()) {
+            out[[i, j]] = 1.0;
+        }
+    }
+    Ok(out)
+}
+
+fn dense_block_diag(blocks: &[Array2<f64>]) -> Array2<f64> {
+    let rows = blocks.iter().map(|b| b.nrows()).sum::<usize>();
+    let cols = blocks.iter().map(|b| b.ncols()).sum::<usize>();
+    let mut out = Array2::<f64>::zeros((rows, cols));
+    let mut r = 0usize;
+    let mut c = 0usize;
+    for b in blocks {
+        out.slice_mut(s![r..r + b.nrows(), c..c + b.ncols()])
+            .assign(b);
+        r += b.nrows();
+        c += b.ncols();
+    }
+    out
+}
+
+fn replicate_design_by_indicator(base: &Array2<f64>, indicator: &Array2<f64>) -> Array2<f64> {
+    let n = base.nrows();
+    let p = base.ncols();
+    let l = indicator.ncols();
+    let mut out = Array2::<f64>::zeros((n, p * l));
+    for lev in 0..l {
+        for j in 0..p {
+            let col = lev * p + j;
+            for i in 0..n {
+                out[[i, col]] = base[[i, j]] * indicator[[i, lev]];
+            }
+        }
+    }
+    out
+}
+
+fn sum_to_zero_level_contrast(levels: usize) -> Array2<f64> {
+    let mut c = Array2::<f64>::zeros((levels, levels.saturating_sub(1)));
+    if levels < 2 {
+        return c;
+    }
+    for j in 0..levels - 1 {
+        c[[j, j]] = 1.0;
+        c[[levels - 1, j]] = -1.0;
+    }
+    c
+}
+
+fn apply_level_contrast_to_replicated_design(
+    base_by_level: &Array2<f64>,
+    p_base: usize,
+    contrast: &Array2<f64>,
+) -> Array2<f64> {
+    let n = base_by_level.nrows();
+    let l = contrast.nrows();
+    let lc = contrast.ncols();
+    let mut out = Array2::<f64>::zeros((n, p_base * lc));
+    for i in 0..n {
+        for j in 0..p_base {
+            for cidx in 0..lc {
+                let mut v = 0.0;
+                for lev in 0..l {
+                    v += base_by_level[[i, lev * p_base + j]] * contrast[[lev, cidx]];
+                }
+                out[[i, cidx * p_base + j]] = v;
+            }
+        }
+    }
+    out
+}
+
+fn expand_penalty_by_levels(base_s: &Array2<f64>, levels: usize) -> Array2<f64> {
+    let blocks = (0..levels).map(|_| base_s.clone()).collect::<Vec<_>>();
+    dense_block_diag(&blocks)
+}
+
+fn build_by_smooth_basis(
+    data: ArrayView2<'_, f64>,
+    smooth: &SmoothBasisSpec,
+    by_kind: &ByVarKind,
+    workspace: &mut crate::basis::BasisWorkspace,
+) -> Result<BasisBuildResult, BasisError> {
+    let inner_term = SmoothTermSpec {
+        name: "by-inner".to_string(),
+        basis: smooth.clone(),
+        shape: ShapeConstraint::None,
+    };
+    let inner = build_single_local_smooth_term(data, &inner_term, workspace)?;
+    let base = inner.design.to_dense();
+    match by_kind {
+        ByVarKind::Numeric { feature_col } => {
+            if *feature_col >= data.ncols() {
+                return Err(BasisError::DimensionMismatch(
+                    "numeric by column out of bounds".to_string(),
+                ));
+            }
+            let mut out = base.clone();
+            for i in 0..out.nrows() {
+                let z = data[[i, *feature_col]];
+                if !z.is_finite() {
+                    return Err(BasisError::InvalidInput(
+                        "numeric by column contains non-finite values".to_string(),
+                    ));
+                }
+                for j in 0..out.ncols() {
+                    out[[i, j]] *= z;
+                }
+            }
+            Ok(BasisBuildResult {
+                design: DesignMatrix::Dense(crate::matrix::DenseDesignMatrix::from(out)),
+                penalties: inner.penalties,
+                nullspace_dims: inner.nullspaces,
+                penaltyinfo: inner.penaltyinfo,
+                ops: inner.ops,
+                metadata: inner.metadata,
+                kronecker_factored: None,
+            })
+        }
+        ByVarKind::Factor {
+            feature_col,
+            ordered,
+            frozen_levels,
+        } => {
+            let mut levels = frozen_levels.clone().unwrap_or_else(Vec::new);
+            if levels.is_empty() {
+                levels = sorted_finite_levels_from_col(data.column(*feature_col))?;
+            }
+            let kept = if *ordered && !levels.is_empty() {
+                levels[1..].to_vec()
+            } else {
+                levels
+            };
+            let ind = indicator_design_for_levels(data, *feature_col, &kept)?;
+            let design = replicate_design_by_indicator(&base, &ind);
+            let penalties = inner
+                .penalties
+                .iter()
+                .map(|s| expand_penalty_by_levels(s, kept.len()))
+                .collect::<Vec<_>>();
+            let candidates = penalties
+                .into_iter()
+                .enumerate()
+                .map(|(i, matrix)| PenaltyCandidate {
+                    matrix,
+                    nullspace_dim_hint: 0,
+                    source: PenaltySource::Other(format!("BySmoothPenalty({i})")),
+                    normalization_scale: 1.0,
+                    kronecker_factors: None,
+                    op: None,
+                })
+                .collect::<Vec<_>>();
+            let (penalties, nullspace_dims, penaltyinfo, ops) =
+                filter_active_penalty_candidates_with_ops(candidates)?;
+            Ok(BasisBuildResult {
+                design: DesignMatrix::Dense(crate::matrix::DenseDesignMatrix::from(design)),
+                penalties,
+                nullspace_dims,
+                penaltyinfo,
+                ops,
+                metadata: inner.metadata,
+                kronecker_factored: None,
+            })
+        }
+    }
+}
+
+fn bspline_base_design_and_penalty(
+    data: ArrayView2<'_, f64>,
+    col: usize,
+    spec: &BSplineBasisSpec,
+) -> Result<(Array2<f64>, Array2<f64>, BasisMetadata), BasisError> {
+    let mut local = spec.clone();
+    local.identifiability = BSplineIdentifiability::None;
+    let built = build_bspline_basis_1d(data.column(col), &local)?;
+    let design = built.design.to_dense();
+    let penalty =
+        built.penalties.first().cloned().ok_or_else(|| {
+            BasisError::InvalidInput("B-spline marginal missing penalty".to_string())
+        })?;
+    Ok((design, penalty, built.metadata))
+}
+
+fn natural_reparameterize_design_penalty(
+    x: &Array2<f64>,
+    s: &Array2<f64>,
+) -> Result<(Array2<f64>, usize, usize), BasisError> {
+    let sym = (s + &s.t().to_owned()) * 0.5;
+    let (evals, evecs) = FaerEigh::eigh(&sym, Side::Lower).map_err(BasisError::LinalgError)?;
+    let max_ev = evals.iter().copied().fold(0.0_f64, f64::max);
+    let tol = (max_ev.max(1.0)) * 1e-10;
+    let mut order = Vec::<usize>::new();
+    for (i, &ev) in evals.iter().enumerate() {
+        if ev <= tol {
+            order.push(i);
+        }
+    }
+    for (i, &ev) in evals.iter().enumerate() {
+        if ev > tol {
+            order.push(i);
+        }
+    }
+    let null_dim = order.iter().filter(|&&i| evals[i] <= tol).count();
+    let rank = order.len() - null_dim;
+    let mut transform = Array2::<f64>::zeros((evecs.nrows(), evecs.ncols()));
+    for (new_j, &old_j) in order.iter().enumerate() {
+        let scale = if evals[old_j] > tol {
+            evals[old_j].sqrt().recip()
+        } else {
+            1.0
+        };
+        for r in 0..evecs.nrows() {
+            transform[[r, new_j]] = evecs[[r, old_j]] * scale;
+        }
+    }
+    Ok((x.dot(&transform), null_dim, rank))
+}
+
+fn build_linear_margin(data: ArrayView2<'_, f64>, col: usize) -> Result<Array2<f64>, BasisError> {
+    if col >= data.ncols() {
+        return Err(BasisError::DimensionMismatch(
+            "random-slope continuous column out of bounds".to_string(),
+        ));
+    }
+    let n = data.nrows();
+    let mut x = Array2::<f64>::zeros((n, 2));
+    for i in 0..n {
+        let v = data[[i, col]];
+        if !v.is_finite() {
+            return Err(BasisError::InvalidInput(
+                "random-slope column contains non-finite values".to_string(),
+            ));
+        }
+        x[[i, 0]] = 1.0;
+        x[[i, 1]] = v;
+    }
+    Ok(x)
+}
+
+fn build_factor_smooth_basis(
+    data: ArrayView2<'_, f64>,
+    spec: &FactorSmoothSpec,
+) -> Result<BasisBuildResult, BasisError> {
+    if spec.group_col >= data.ncols() {
+        return Err(BasisError::DimensionMismatch(
+            "factor-smooth group column out of bounds".to_string(),
+        ));
+    }
+    let mut levels = spec.group_frozen_levels.clone().unwrap_or_else(Vec::new);
+    if levels.is_empty() {
+        levels = sorted_finite_levels_from_col(data.column(spec.group_col))?;
+    }
+    if levels.is_empty() {
+        return Err(BasisError::InvalidInput(
+            "factor smooth requires at least one group level".to_string(),
+        ));
+    }
+    let continuous_col = *spec.continuous_cols.first().ok_or_else(|| {
+        BasisError::InvalidInput("factor smooth requires one continuous margin".to_string())
+    })?;
+    let (base_x, base_s, metadata) = match spec.flavour {
+        FactorSmoothFlavour::Re => (
+            build_linear_margin(data, continuous_col)?,
+            Array2::<f64>::zeros((2, 2)),
+            BasisMetadata::TensorBSpline {
+                feature_cols: vec![continuous_col, spec.group_col],
+                knots: vec![],
+                degrees: vec![],
+                periodic: vec![],
+                identifiability_transform: None,
+            },
+        ),
+        _ => bspline_base_design_and_penalty(data, continuous_col, &spec.marginal)?,
+    };
+    let (base_x, null_dim, rank) = match spec.flavour {
+        FactorSmoothFlavour::Fs { .. } => natural_reparameterize_design_penalty(&base_x, &base_s)?,
+        FactorSmoothFlavour::Re => (base_x, 0, 2),
+        FactorSmoothFlavour::Sz => (base_x, 0, base_s.ncols()),
+    };
+    let p = base_x.ncols();
+    let ind = indicator_design_for_levels(data, spec.group_col, &levels)?;
+    let mut design = replicate_design_by_indicator(&base_x, &ind);
+    let mut penalties = Vec::<Array2<f64>>::new();
+    match &spec.flavour {
+        FactorSmoothFlavour::Fs {
+            m_null_penalty_orders,
+        } => {
+            let mut range = Array2::<f64>::zeros((p, p));
+            for j in null_dim..(null_dim + rank) {
+                range[[j, j]] = 1.0;
+            }
+            penalties.push(expand_penalty_by_levels(&range, levels.len()));
+            let null_count = if m_null_penalty_orders.len() == 1 && m_null_penalty_orders[0] == 1 {
+                null_dim.min(1)
+            } else {
+                null_dim
+            };
+            for j in 0..null_count {
+                let mut sj = Array2::<f64>::zeros((p, p));
+                sj[[j, j]] = 1.0;
+                penalties.push(expand_penalty_by_levels(&sj, levels.len()));
+            }
+        }
+        FactorSmoothFlavour::Sz => {
+            let contrast = sum_to_zero_level_contrast(levels.len());
+            design = apply_level_contrast_to_replicated_design(&design, p, &contrast);
+            let s_level = dense_block_diag(
+                &(0..contrast.ncols())
+                    .map(|_| base_s.clone())
+                    .collect::<Vec<_>>(),
+            );
+            penalties.push(s_level);
+        }
+        FactorSmoothFlavour::Re => {
+            penalties.push(Array2::<f64>::eye(design.ncols()));
+        }
+    }
+    let candidates = penalties
+        .into_iter()
+        .enumerate()
+        .map(|(i, matrix)| PenaltyCandidate {
+            matrix,
+            nullspace_dim_hint: 0,
+            source: PenaltySource::Other(format!("FactorSmoothPenalty({i})")),
+            normalization_scale: 1.0,
+            kronecker_factors: None,
+            op: None,
+        })
+        .collect::<Vec<_>>();
+    let (penalties, nullspace_dims, penaltyinfo, ops) =
+        filter_active_penalty_candidates_with_ops(candidates)?;
+    Ok(BasisBuildResult {
+        design: DesignMatrix::Dense(crate::matrix::DenseDesignMatrix::from(design)),
+        penalties,
+        nullspace_dims,
+        penaltyinfo,
+        ops,
+        metadata,
+        kronecker_factored: None,
+    })
+}
+
 fn build_tensor_bspline_basis(
     data: ArrayView2<'_, f64>,
     feature_cols: &[usize],
@@ -3905,6 +4373,10 @@ fn build_single_local_smooth_term(
         SmoothBasisSpec::TensorBSpline { feature_cols, spec } => {
             build_tensor_bspline_basis(data, feature_cols, spec)?
         }
+        SmoothBasisSpec::FactorSmooth { spec } => build_factor_smooth_basis(data, spec)?,
+        SmoothBasisSpec::BySmooth { smooth, by_kind } => {
+            build_by_smooth_basis(data, smooth, by_kind, workspace)?
+        }
     };
 
     match &term.basis {
@@ -4658,6 +5130,24 @@ fn smooth_term_feature_cols(term: &SmoothTermSpec) -> Vec<usize> {
         | SmoothBasisSpec::Matern { feature_cols, .. }
         | SmoothBasisSpec::Duchon { feature_cols, .. }
         | SmoothBasisSpec::TensorBSpline { feature_cols, .. } => feature_cols.clone(),
+        SmoothBasisSpec::FactorSmooth { spec } => {
+            let mut cols = spec.continuous_cols.clone();
+            cols.push(spec.group_col);
+            cols
+        }
+        SmoothBasisSpec::BySmooth { smooth, by_kind } => {
+            let mut cols = smooth_term_feature_cols(&SmoothTermSpec {
+                name: String::new(),
+                basis: (**smooth).clone(),
+                shape: ShapeConstraint::None,
+            });
+            match by_kind {
+                ByVarKind::Numeric { feature_col } | ByVarKind::Factor { feature_col, .. } => {
+                    cols.push(*feature_col)
+                }
+            }
+            cols
+        }
     }
 }
 
@@ -4669,6 +5159,8 @@ fn smooth_basis_family_rank(term: &SmoothTermSpec) -> u8 {
         SmoothBasisSpec::Sphere { .. } => 3,
         SmoothBasisSpec::Matern { .. } => 4,
         SmoothBasisSpec::Duchon { .. } => 5,
+        SmoothBasisSpec::FactorSmooth { .. } => 6,
+        SmoothBasisSpec::BySmooth { .. } => 7,
     }
 }
 
@@ -4699,6 +5191,15 @@ fn smooth_has_frozen_identifiability(term: &SmoothTermSpec) -> bool {
             spec.identifiability,
             TensorBSplineIdentifiability::FrozenTransform { .. }
         ),
+        SmoothBasisSpec::FactorSmooth { spec } => spec.group_frozen_levels.is_some(),
+        SmoothBasisSpec::BySmooth { by_kind, smooth } => match by_kind {
+            ByVarKind::Numeric { .. } => smooth_has_frozen_identifiability(&SmoothTermSpec {
+                name: String::new(),
+                basis: (**smooth).clone(),
+                shape: ShapeConstraint::None,
+            }),
+            ByVarKind::Factor { frozen_levels, .. } => frozen_levels.is_some(),
+        },
     }
 }
 
@@ -10839,7 +11340,10 @@ fn try_build_spatial_term_log_kappa_derivative(
             build_duchon_basis_log_kappa_derivatives(x.view(), spec)
                 .map_err(EstimationError::from)?
         }
-        SmoothBasisSpec::BSpline1D { .. } | SmoothBasisSpec::TensorBSpline { .. } => {
+        SmoothBasisSpec::BSpline1D { .. }
+        | SmoothBasisSpec::TensorBSpline { .. }
+        | SmoothBasisSpec::FactorSmooth { .. }
+        | SmoothBasisSpec::BySmooth { .. } => {
             return Ok(None);
         }
     };
@@ -12429,6 +12933,87 @@ pub fn freeze_term_collection_from_design(
                     },
                     None => TensorBSplineIdentifiability::None,
                 };
+            }
+            (
+                SmoothBasisSpec::FactorSmooth { spec: s },
+                BasisMetadata::BSpline1D {
+                    knots, periodic, ..
+                },
+            ) => {
+                s.marginal.knotspec = periodic
+                    .map(
+                        |(domain_start, period, num_basis)| BSplineKnotSpec::PeriodicUniform {
+                            data_range: (domain_start, domain_start + period),
+                            num_basis,
+                        },
+                    )
+                    .unwrap_or_else(|| BSplineKnotSpec::Provided(knots.clone()));
+                s.marginal.identifiability = BSplineIdentifiability::None;
+                s.marginal.boundary_conditions = Default::default();
+                if s.group_frozen_levels.is_none() {
+                    s.group_frozen_levels = Some(vec![]);
+                }
+            }
+            (SmoothBasisSpec::FactorSmooth { .. }, BasisMetadata::TensorBSpline { .. }) => {}
+            (SmoothBasisSpec::BySmooth { smooth, .. }, metadata) => {
+                // The by-smooth build carries the inner basis metadata through, so
+                // freeze the nested basis against that metadata while retaining the
+                // already-frozen by-level metadata captured in `ByVarKind`.
+                match (smooth.as_mut(), metadata) {
+                    (
+                        SmoothBasisSpec::BSpline1D { spec: s, .. },
+                        BasisMetadata::BSpline1D {
+                            knots,
+                            identifiability_transform,
+                            periodic,
+                        },
+                    ) => {
+                        s.knotspec = periodic
+                            .map(|(domain_start, period, num_basis)| {
+                                BSplineKnotSpec::PeriodicUniform {
+                                    data_range: (domain_start, domain_start + period),
+                                    num_basis,
+                                }
+                            })
+                            .unwrap_or_else(|| BSplineKnotSpec::Provided(knots.clone()));
+                        s.identifiability = match identifiability_transform {
+                            Some(z) => BSplineIdentifiability::FrozenTransform {
+                                transform: z.clone(),
+                            },
+                            None => BSplineIdentifiability::None,
+                        };
+                        s.boundary_conditions = Default::default();
+                    }
+                    (
+                        SmoothBasisSpec::TensorBSpline { spec: s, .. },
+                        BasisMetadata::TensorBSpline {
+                            knots,
+                            degrees,
+                            periodic,
+                            identifiability_transform,
+                            ..
+                        },
+                    ) => {
+                        for i in 0..s.marginalspecs.len().min(knots.len()).min(degrees.len()) {
+                            s.marginalspecs[i].degree = degrees[i];
+                            s.marginalspecs[i].knotspec = periodic[i]
+                                .map(|(domain_start, period, num_basis)| {
+                                    BSplineKnotSpec::PeriodicUniform {
+                                        data_range: (domain_start, domain_start + period),
+                                        num_basis,
+                                    }
+                                })
+                                .unwrap_or_else(|| BSplineKnotSpec::Provided(knots[i].clone()));
+                        }
+                        s.identifiability = match identifiability_transform {
+                            Some(z) => TensorBSplineIdentifiability::FrozenTransform {
+                                transform: z.clone(),
+                            },
+                            None => TensorBSplineIdentifiability::None,
+                        };
+                    }
+                    _ => {}
+                }
             }
             _ => {
                 return Err(EstimationError::InvalidInput(format!(

--- a/src/terms/term_builder.rs
+++ b/src/terms/term_builder.rs
@@ -24,9 +24,9 @@ use crate::inference::formula_dsl::{
 use crate::inference::model::ColumnKindTag;
 use crate::resource::ResourcePolicy;
 use crate::smooth::{
-    LinearCoefficientGeometry, LinearTermSpec, RandomEffectTermSpec, ShapeConstraint,
-    SmoothBasisSpec, SmoothTermSpec, TensorBSplineIdentifiability, TensorBSplineSpec,
-    TermCollectionSpec,
+    ByVarKind, FactorSmoothFlavour, FactorSmoothSpec, LinearCoefficientGeometry, LinearTermSpec,
+    RandomEffectTermSpec, ShapeConstraint, SmoothBasisSpec, SmoothTermSpec,
+    TensorBSplineIdentifiability, TensorBSplineSpec, TermCollectionSpec,
 };
 
 // ---------------------------------------------------------------------------
@@ -183,16 +183,54 @@ pub fn build_termspec(
                     .iter()
                     .map(|v| resolve_col(col_map, v))
                     .collect::<Result<Vec<_>, _>>()?;
-                let basis = build_smooth_basis(
+                let mut inner_options = options.clone();
+                let by_name = inner_options.remove("by");
+                let mut basis = build_smooth_basis(
                     *kind,
                     vars,
                     &cols,
-                    options,
+                    &inner_options,
                     ds,
                     inference_notes,
                     policy,
                     smooth_coordinate_count,
                 )?;
+                if let Some(by_name) = by_name {
+                    let by_col = resolve_col(col_map, &by_name)?;
+                    let by_kind_tag = ds.column_kinds.get(by_col).copied().ok_or_else(|| {
+                        format!("internal column-kind lookup failed for by variable '{by_name}'")
+                    })?;
+                    let by_kind = match by_kind_tag {
+                        ColumnKindTag::Categorical => {
+                            let levels = sorted_levels_for_column(ds.values.column(by_col))?;
+                            let ordered = inner_options
+                                .get("ordered")
+                                .map(|v| {
+                                    matches!(
+                                        v.trim().to_ascii_lowercase().as_str(),
+                                        "true" | "1" | "yes" | "ordered"
+                                    )
+                                })
+                                .unwrap_or(false)
+                                || by_name.to_ascii_lowercase().contains("ord");
+                            if !terms.iter().any(|t| matches!(t, ParsedTerm::Linear { name, .. } | ParsedTerm::RandomEffect { name } if name == &by_name)) {
+                                inference_notes.push(format!("factor by-smooth s(..., by={by_name}) is usually identifiable with an explicit main-effect term for '{by_name}' (for example '+ {by_name}' or '+ group({by_name})')."));
+                            }
+                            ByVarKind::Factor {
+                                feature_col: by_col,
+                                ordered,
+                                frozen_levels: Some(levels),
+                            }
+                        }
+                        ColumnKindTag::Continuous | ColumnKindTag::Binary => ByVarKind::Numeric {
+                            feature_col: by_col,
+                        },
+                    };
+                    basis = SmoothBasisSpec::BySmooth {
+                        smooth: Box::new(basis),
+                        by_kind,
+                    };
+                }
                 smooth_terms.push(SmoothTermSpec {
                     name: label.clone(),
                     basis,
@@ -218,6 +256,17 @@ pub fn build_termspec(
 // ---------------------------------------------------------------------------
 // Smooth basis spec construction
 // ---------------------------------------------------------------------------
+
+fn sorted_levels_for_column(col: ArrayView1<'_, f64>) -> Result<Vec<u64>, String> {
+    let mut levels = std::collections::BTreeSet::<u64>::new();
+    for &v in col.iter() {
+        if !v.is_finite() {
+            return Err("categorical column contains non-finite values".to_string());
+        }
+        levels.insert(v.to_bits());
+    }
+    Ok(levels.into_iter().collect())
+}
 
 /// Look up a per-side boundary-condition key under any of several names that
 /// users intuitively reach for, picking the first present. Aliases:
@@ -398,6 +447,106 @@ pub fn build_smooth_basis(
         });
 
     match type_opt.as_str() {
+        "fs" | "factor-smooth" | "factor_smooth" | "sz" | "re" => {
+            validate_known_options(
+                type_opt.as_str(),
+                options,
+                &[
+                    "type",
+                    "bs",
+                    "k",
+                    "basis_dim",
+                    "basis-dim",
+                    "basisdim",
+                    "knots",
+                    "degree",
+                    "penalty_order",
+                    "m",
+                    "double_penalty",
+                ],
+            )?;
+            if cols.len() != 2 {
+                return Err(format!(
+                    "{} smooth currently expects exactly two variables: one continuous and one categorical/group variable",
+                    type_opt
+                ));
+            }
+            let k0 = ds
+                .column_kinds
+                .get(cols[0])
+                .copied()
+                .ok_or_else(|| "column-kind lookup failed".to_string())?;
+            let k1 = ds
+                .column_kinds
+                .get(cols[1])
+                .copied()
+                .ok_or_else(|| "column-kind lookup failed".to_string())?;
+            let (group_idx, cont_idx) = match (k0, k1) {
+                (ColumnKindTag::Categorical, ColumnKindTag::Continuous | ColumnKindTag::Binary) => {
+                    (0usize, 1usize)
+                }
+                (ColumnKindTag::Continuous | ColumnKindTag::Binary, ColumnKindTag::Categorical) => {
+                    (1usize, 0usize)
+                }
+                _ => {
+                    return Err(format!(
+                        "{} smooth requires one categorical and one numeric variable",
+                        type_opt
+                    ));
+                }
+            };
+            let group_col = cols[group_idx];
+            let cont_col = cols[cont_idx];
+            let levels = sorted_levels_for_column(ds.values.column(group_col))?;
+            let degree = option_usize(options, "degree").unwrap_or(3);
+            let (minv, maxv) = col_minmax(ds.values.column(cont_col))?;
+            let default_internal = heuristic_knots_for_column(ds.values.column(cont_col));
+            let k = option_usize_any(options, &["k", "basis_dim", "basis-dim", "basisdim"]);
+            let n_knots = if let Some(k) = k {
+                if k < degree + 1 {
+                    return Err(format!(
+                        "factor smooth: k={} too small for degree {}; expected k >= {}",
+                        k,
+                        degree,
+                        degree + 1
+                    ));
+                }
+                k - degree - 1
+            } else {
+                default_internal
+            };
+            let marginal = BSplineBasisSpec {
+                degree,
+                penalty_order: option_usize(options, "penalty_order").unwrap_or(2),
+                knotspec: BSplineKnotSpec::Generate {
+                    data_range: (minv, maxv),
+                    num_internal_knots: n_knots,
+                },
+                double_penalty: true,
+                identifiability: BSplineIdentifiability::None,
+                boundary_conditions: Default::default(),
+            };
+            let flavour = match type_opt.as_str() {
+                "fs" | "factor-smooth" | "factor_smooth" => {
+                    let m = option_usize(options, "m").unwrap_or(2);
+                    FactorSmoothFlavour::Fs {
+                        m_null_penalty_orders: vec![m],
+                    }
+                }
+                "sz" => FactorSmoothFlavour::Sz,
+                "re" => FactorSmoothFlavour::Re,
+                _ => unreachable!(),
+            };
+            Ok(SmoothBasisSpec::FactorSmooth {
+                spec: FactorSmoothSpec {
+                    continuous_cols: vec![cont_col],
+                    group_col,
+                    marginal,
+                    flavour,
+                    group_frozen_levels: Some(levels),
+                },
+            })
+        }
         "tensor" | "te" | "tensor-bspline" => {
             validate_known_options(
                 "te",
@@ -405,6 +554,7 @@ pub fn build_smooth_basis(
                 &[
                     "type",
                     "bs",
+                    "by",
                     "k",
                     "basis_dim",
                     "basis-dim",
@@ -541,6 +691,7 @@ pub fn build_smooth_basis(
                 &[
                     "type",
                     "bs",
+                    "by",
                     "k",
                     "basis_dim",
                     "basis-dim",
@@ -605,6 +756,7 @@ pub fn build_smooth_basis(
                 &[
                     "type",
                     "bs",
+                    "by",
                     "k",
                     "basis_dim",
                     "basis-dim",
@@ -714,6 +866,7 @@ pub fn build_smooth_basis(
                 &[
                     "type",
                     "bs",
+                    "by",
                     "length_scale",
                     "centers",
                     "k",
@@ -767,6 +920,7 @@ pub fn build_smooth_basis(
                 &[
                     "type",
                     "bs",
+                    "by",
                     "method",
                     "m",
                     "order",
@@ -933,6 +1087,7 @@ pub fn build_smooth_basis(
                 &[
                     "type",
                     "bs",
+                    "by",
                     "nu",
                     "length_scale",
                     "centers",
@@ -1009,6 +1164,7 @@ pub fn build_smooth_basis(
                 &[
                     "type",
                     "bs",
+                    "by",
                     "length_scale",
                     "centers",
                     "k",

--- a/tests/factor_smooth_formula.rs
+++ b/tests/factor_smooth_formula.rs
@@ -1,0 +1,213 @@
+use ndarray::Array2;
+
+use gam::inference::data::EncodedDataset;
+use gam::inference::formula_dsl::{ParsedTerm, parse_formula};
+use gam::inference::model::{ColumnKindTag, DataSchema, SchemaColumn};
+use gam::resource::ResourcePolicy;
+use gam::smooth::{ByVarKind, FactorSmoothFlavour, SmoothBasisSpec};
+use gam::terms::term_builder::build_termspec;
+
+#[test]
+fn factor_smooth_aliases_and_by_options_parse() {
+    let cases = [
+        ("y ~ s(x, fac, bs=\"fs\")", Some("fs"), vec!["x", "fac"]),
+        ("y ~ fs(x, fac)", Some("fs"), vec!["x", "fac"]),
+        ("y ~ s(x, fac, bs=fs, k=10)", Some("fs"), vec!["x", "fac"]),
+        ("y ~ s(x, fac, bs=\"sz\")", Some("sz"), vec!["x", "fac"]),
+        ("y ~ sz(x, fac)", Some("sz"), vec!["x", "fac"]),
+        ("y ~ s(x, by=fac)", None, vec!["x"]),
+        ("y ~ s(x, by=group, k=8)", None, vec!["x"]),
+    ];
+    for (formula, bs, expected_vars) in cases {
+        let parsed = parse_formula(formula).unwrap_or_else(|e| panic!("{formula}: {e}"));
+        let ParsedTerm::Smooth { vars, options, .. } = &parsed.terms[0] else {
+            panic!("{formula} did not parse to a smooth");
+        };
+        assert_eq!(
+            vars,
+            &expected_vars
+                .iter()
+                .map(|s| s.to_string())
+                .collect::<Vec<_>>()
+        );
+        if let Some(bs) = bs {
+            assert_eq!(options.get("bs").map(String::as_str), Some(bs));
+        } else {
+            assert!(options.contains_key("by"));
+        }
+    }
+}
+
+fn tiny_dataset() -> EncodedDataset {
+    let rows = vec![
+        [0.0, 0.0, 0.0, 1.0],
+        [1.0, 0.2, 0.0, 2.0],
+        [0.0, 0.4, 1.0, 1.0],
+        [1.0, 0.6, 1.0, 2.0],
+        [0.0, 0.8, 0.0, 1.0],
+        [1.0, 1.0, 1.0, 2.0],
+    ];
+    EncodedDataset {
+        headers: vec!["y".into(), "x".into(), "fac".into(), "z".into()],
+        values: Array2::from_shape_vec((rows.len(), 4), rows.into_iter().flatten().collect())
+            .unwrap(),
+        schema: DataSchema {
+            columns: vec![
+                SchemaColumn {
+                    name: "y".into(),
+                    kind: ColumnKindTag::Continuous,
+                    levels: vec![],
+                },
+                SchemaColumn {
+                    name: "x".into(),
+                    kind: ColumnKindTag::Continuous,
+                    levels: vec![],
+                },
+                SchemaColumn {
+                    name: "fac".into(),
+                    kind: ColumnKindTag::Categorical,
+                    levels: vec!["a".into(), "b".into()],
+                },
+                SchemaColumn {
+                    name: "z".into(),
+                    kind: ColumnKindTag::Continuous,
+                    levels: vec![],
+                },
+            ],
+        },
+        column_kinds: vec![
+            ColumnKindTag::Continuous,
+            ColumnKindTag::Continuous,
+            ColumnKindTag::Categorical,
+            ColumnKindTag::Continuous,
+        ],
+    }
+}
+
+#[test]
+fn factor_smooth_forms_route_to_new_termspec_variants() {
+    let ds = tiny_dataset();
+    let cmap = ds.column_map();
+    let mut notes = Vec::new();
+
+    let parsed = parse_formula("y ~ s(x, by=fac) + fac").unwrap();
+    let spec = build_termspec(
+        &parsed.terms,
+        &ds,
+        &cmap,
+        &mut notes,
+        &ResourcePolicy::default_library(),
+    )
+    .unwrap();
+    match &spec.smooth_terms[0].basis {
+        SmoothBasisSpec::BySmooth {
+            by_kind: ByVarKind::Factor { frozen_levels, .. },
+            ..
+        } => {
+            assert_eq!(frozen_levels.as_ref().unwrap().len(), 2);
+        }
+        other => panic!("expected factor by smooth, got {other:?}"),
+    }
+
+    let parsed = parse_formula("y ~ s(x, by=z)").unwrap();
+    let spec = build_termspec(
+        &parsed.terms,
+        &ds,
+        &cmap,
+        &mut notes,
+        &ResourcePolicy::default_library(),
+    )
+    .unwrap();
+    assert!(matches!(
+        spec.smooth_terms[0].basis,
+        SmoothBasisSpec::BySmooth {
+            by_kind: ByVarKind::Numeric { .. },
+            ..
+        }
+    ));
+
+    let parsed = parse_formula("y ~ fs(x, fac, k=5)").unwrap();
+    let spec = build_termspec(
+        &parsed.terms,
+        &ds,
+        &cmap,
+        &mut notes,
+        &ResourcePolicy::default_library(),
+    )
+    .unwrap();
+    assert!(matches!(
+        spec.smooth_terms[0].basis,
+        SmoothBasisSpec::FactorSmooth {
+            spec: gam::smooth::FactorSmoothSpec {
+                flavour: FactorSmoothFlavour::Fs { .. },
+                ..
+            }
+        }
+    ));
+
+    let parsed = parse_formula("y ~ sz(fac, x, k=5)").unwrap();
+    let spec = build_termspec(
+        &parsed.terms,
+        &ds,
+        &cmap,
+        &mut notes,
+        &ResourcePolicy::default_library(),
+    )
+    .unwrap();
+    assert!(matches!(
+        spec.smooth_terms[0].basis,
+        SmoothBasisSpec::FactorSmooth {
+            spec: gam::smooth::FactorSmoothSpec {
+                flavour: FactorSmoothFlavour::Sz,
+                ..
+            }
+        }
+    ));
+
+    let parsed = parse_formula("y ~ s(fac, x, bs=re, k=5)").unwrap();
+    let spec = build_termspec(
+        &parsed.terms,
+        &ds,
+        &cmap,
+        &mut notes,
+        &ResourcePolicy::default_library(),
+    )
+    .unwrap();
+    assert!(matches!(
+        spec.smooth_terms[0].basis,
+        SmoothBasisSpec::FactorSmooth {
+            spec: gam::smooth::FactorSmoothSpec {
+                flavour: FactorSmoothFlavour::Re,
+                ..
+            }
+        }
+    ));
+}
+
+#[test]
+fn new_factor_smooth_terms_build_designs() {
+    let ds = tiny_dataset();
+    let cmap = ds.column_map();
+    for formula in [
+        "y ~ s(x, by=fac) + fac",
+        "y ~ s(x, by=z)",
+        "y ~ fs(x, fac, k=5)",
+        "y ~ sz(fac, x, k=5)",
+        "y ~ s(fac, x, bs=re, k=5) + group(fac)",
+    ] {
+        let parsed = parse_formula(formula).unwrap();
+        let mut notes = Vec::new();
+        let spec = build_termspec(
+            &parsed.terms,
+            &ds,
+            &cmap,
+            &mut notes,
+            &ResourcePolicy::default_library(),
+        )
+        .unwrap_or_else(|e| panic!("{formula}: {e}"));
+        let design = gam::smooth::build_term_collection_design(ds.values.view(), &spec)
+            .unwrap_or_else(|e| panic!("{formula} design build failed: {e}"));
+        assert_eq!(design.design.nrows(), ds.values.nrows(), "{formula}");
+        assert!(design.design.ncols() > 0, "{formula}");
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide mgcv-like factor interactions: support `s(x, by=...)` (numeric and factor `by=`), factor-smooth flavours `bs="fs"`/`bs="sz"`, and random-slope `bs="re"` semantics so users can fit per-group, partial-pooling, and deviation smooths.
- Extend the DSL and term-building pipeline so formula aliases like `fs(...)` and `sz(...)` parse naturally and round-trip into backend specs.
- Maintain frozen-spec/prediction robustness by capturing frozen factor levels and baking identifiability metadata for saved models.

### Description
- Added new types and spec variants: `FactorSmoothSpec`, `FactorSmoothFlavour::{Fs,Sz,Re}`, `ByVarKind::{Numeric,Factor}`, and `SmoothBasisSpec::FactorSmooth` / `SmoothBasisSpec::BySmooth` in `src/terms/smooth.rs` to represent the new term kinds and metadata.
- Implemented dense construction paths and helpers in `src/terms/smooth.rs`: `build_by_smooth_basis`, `build_factor_smooth_basis`, level indicator builders, sum-to-zero contrast application, natural reparameterisation via eigendecomposition (`FaerEigh`) for `bs="fs"`, and random-slope linear margin builder.
- Wired parser and term builder changes: accept `by=` in `build_termspec` and wrap inner smooths into `BySmooth`; added aliases `fs(...)` and `sz(...)` in `src/inference/formula_dsl.rs`; route `bs=

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ab3cfbbc8832499757e2e08cd2e71)