### PR TITLE
Add factor-smooth support: `by=`, `bs="fs"`/`sz` and random-slope scaffolding

### DIFF
--- a/docs/cookbook.md
+++ b/docs/cookbook.md
@@ -376,3 +376,53 @@ print(gs.best_params_, gs.best_score_)
 model.report("report.html")     # writes to disk
 html = model.report()           # returns string for Jupyter / inline display
 ```
+
+## Per-group trajectories (factor `by=` smooth)
+
+Use a factor `by=` smooth when each group should have its own curve without
+partial pooling between groups:
+
+```python
+model = gamfit.fit(train, formula="y ~ group(subject) + s(time, by=subject)")
+```
+
+The `group(subject)` term estimates per-subject mean offsets; the `by=` smooth
+then captures per-subject nonlinear departures. Prediction rows with subject
+levels not seen during fitting contribute zero from the factor-smooth block.
+
+## Hierarchical / partial-pooling smooths (`bs="fs"`)
+
+Use `bs="fs"` (or the `fs()` alias) when every group has a trajectory but
+small groups should shrink toward zero contribution:
+
+```python
+model = gamfit.fit(train, formula="y ~ s(time) + s(time, subject, bs='fs', k=8)")
+# same factor-smooth term: fs(time, subject, k=8)
+```
+
+The term includes ridge penalties for the spline range and low-order components,
+so it can recover subject-specific intercept and slope variation while still
+regularizing sparse subjects.
+
+## Treatment vs control difference smooth (`bs="sz"`)
+
+Use `bs="sz"` for identifiable deviations around a population smooth:
+
+```python
+model = gamfit.fit(train, formula="y ~ treatment + s(time) + s(treatment, time, bs='sz')")
+```
+
+The deviation curves are constrained to sum to zero across factor levels at each
+spline coefficient, making the `s(time)` term the population curve and the `sz`
+term the level-specific differences.
+
+## Random slopes
+
+Random slopes are available as the linear factor-smooth special case:
+
+```python
+model = gamfit.fit(train, formula="y ~ group(subject) + s(subject, time, bs='re')")
+```
+
+`group(subject)` supplies random intercepts; the `bs='re'` smooth contributes
+per-subject linear slopes in `time` with a shared ridge penalty.

--- a/docs/formulas.md
+++ b/docs/formulas.md
@@ -70,15 +70,36 @@ Aliases for box constraints: `linear`, `constrain`, `constraint`, `box`.
 plus an optional Beta prior (parameterised by `target` / `strength`)
 rather than a quadratic ridge.
 
-## Random effects
+## Random effects and factor smooths
 
 ```
 y ~ x + group(site)
-y ~ x + re(site)            # alias
+y ~ x + re(site)                         # random-intercept alias
+y ~ s(time, by=treatment) + treatment    # separate smooth per factor level
+y ~ s(time, by=dose)                     # numeric varying-coefficient smooth
+y ~ s(time, subject, bs="fs")           # partial-pooling random smooths
+y ~ fs(time, subject)                    # alias for bs="fs"
+y ~ s(time) + s(subject, time, bs="sz") # sum-to-zero factor deviations
+y ~ sz(subject, time)                    # alias for bs="sz"
+y ~ group(subject) + s(subject, time, bs="re")  # random intercept + slope
 ```
 
-Adds a random intercept per level of the grouping column. The column may be
-string- or integer-valued. Random slopes are not supported.
+`group()` / `re()` adds a random intercept per level of the grouping column.
+The column may be string- or integer-valued, and saved models freeze the observed
+level set so unseen prediction levels contribute zero.
+
+`by=` smooths multiply an ordinary smooth by a numeric column or by factor-level
+indicators. Numeric `by=` terms are a single varying-coefficient smooth. Factor
+`by=` terms create one smooth block per retained level; include the factor main
+effect (for example `+ treatment` or `+ group(subject)`) when level means should
+be estimated separately.
+
+`bs="fs"` builds factor-smooth interactions for hierarchical trajectories: each
+level gets its own curve and the whole block is ridge-penalized, including the
+low-order/null-space components, so per-level intercepts and slopes shrink.
+`bs="sz"` builds sum-to-zero deviations that pair naturally with a population
+main-effect smooth. `bs="re"` on a factor/numeric pair is the random-slope
+special case.
 
 ## Univariate smooths
 

--- a/src/families/survival_predict.rs
+++ b/src/families/survival_predict.rs
@@ -1215,6 +1215,35 @@ fn remap_term_collectionspec_columns(
                     *feature_col = resolve_training_index(*feature_col)?;
                 }
             }
+            SmoothBasisSpec::BySmooth { smooth, by_kind } => {
+                match by_kind {
+                    crate::terms::smooth::ByVarKind::Numeric { feature_col }
+                    | crate::terms::smooth::ByVarKind::Factor { feature_col, .. } => {
+                        *feature_col = resolve_training_index(*feature_col)?;
+                    }
+                }
+                match smooth.as_mut() {
+                    SmoothBasisSpec::BSpline1D { feature_col, .. } => {
+                        *feature_col = resolve_training_index(*feature_col)?;
+                    }
+                    SmoothBasisSpec::ThinPlate { feature_cols, .. }
+                    | SmoothBasisSpec::Sphere { feature_cols, .. }
+                    | SmoothBasisSpec::Matern { feature_cols, .. }
+                    | SmoothBasisSpec::Duchon { feature_cols, .. }
+                    | SmoothBasisSpec::TensorBSpline { feature_cols, .. } => {
+                        for feature_col in feature_cols.iter_mut() {
+                            *feature_col = resolve_training_index(*feature_col)?;
+                        }
+                    }
+                    SmoothBasisSpec::BySmooth { .. } | SmoothBasisSpec::FactorSmooth { .. } => {}
+                }
+            }
+            SmoothBasisSpec::FactorSmooth { spec } => {
+                for feature_col in spec.continuous_cols.iter_mut() {
+                    *feature_col = resolve_training_index(*feature_col)?;
+                }
+                spec.group_col = resolve_training_index(spec.group_col)?;
+            }
         }
     }
     Ok(remapped)

--- a/src/inference/formula_dsl.rs
+++ b/src/inference/formula_dsl.rs
@@ -1420,7 +1420,7 @@ pub fn parse_term(raw: &str) -> Result<ParsedTerm, String> {
                     options,
                 });
             }
-            "smooth" | "s" | "cyclic" | "periodic" | "cc" | "cp" => {
+            "smooth" | "s" | "cyclic" | "periodic" | "cc" | "cp" | "fs" | "sz" => {
                 if vars.is_empty() {
                     return Err(format!(
                         "smooth()/s() requires at least one variable: {raw}"
@@ -1428,6 +1428,9 @@ pub fn parse_term(raw: &str) -> Result<ParsedTerm, String> {
                 }
                 if matches!(name.as_str(), "cyclic" | "periodic" | "cc" | "cp") {
                     options.insert("type".to_string(), "cyclic".to_string());
+                }
+                if matches!(name.as_str(), "fs" | "sz") {
+                    options.insert("bs".to_string(), name.clone());
                 }
                 return Ok(ParsedTerm::Smooth {
                     label: raw.to_string(),
@@ -1528,7 +1531,7 @@ pub fn parse_term(raw: &str) -> Result<ParsedTerm, String> {
             }
             _ => {
                 return Err(format!(
-                    "unknown term function in '{raw}'. Supported: bounded(), linear(), constrain(), nonnegative(), nonpositive(), smooth() / s(), cyclic() / periodic() / cc() / cp(), thinplate() / tps(), tensor() / te(), group() / re(), sphere() / sos() / spherical(), matern(), duchon(), linkwiggle(), timewiggle(), link(), survmodel()"
+                    "unknown term function in '{raw}'. Supported: bounded(), linear(), constrain(), nonnegative(), nonpositive(), smooth() / s(), fs(), sz(), cyclic() / periodic() / cc() / cp(), thinplate() / tps(), tensor() / te(), group() / re(), sphere() / sos() / spherical(), matern(), duchon(), linkwiggle(), timewiggle(), link(), survmodel()"
                 ));
             }
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -6360,6 +6360,11 @@ fn smooth_term_primary_column(term: &SmoothTermSpec) -> Option<usize> {
                 None
             }
         }
+        SmoothBasisSpec::BySmooth { smooth, .. } => match smooth.as_ref() {
+            SmoothBasisSpec::BSpline1D { feature_col, .. } => Some(*feature_col),
+            _ => None,
+        },
+        SmoothBasisSpec::FactorSmooth { spec } => spec.continuous_cols.first().copied(),
     }
 }
 
@@ -7119,7 +7124,10 @@ fn spatial_basiswarning_family_and_cols(term: &SmoothTermSpec) -> Option<(&'stat
         SmoothBasisSpec::Sphere { feature_cols, .. } => Some(("sphere/sos", feature_cols)),
         SmoothBasisSpec::Matern { feature_cols, .. } => Some(("matern", feature_cols)),
         SmoothBasisSpec::Duchon { feature_cols, .. } => Some(("duchon", feature_cols)),
-        SmoothBasisSpec::BSpline1D { .. } | SmoothBasisSpec::TensorBSpline { .. } => None,
+        SmoothBasisSpec::BSpline1D { .. }
+        | SmoothBasisSpec::TensorBSpline { .. }
+        | SmoothBasisSpec::BySmooth { .. }
+        | SmoothBasisSpec::FactorSmooth { .. } => None,
     }
 }
 
@@ -7191,6 +7199,27 @@ fn smooth_term_feature_cols(term: &SmoothTermSpec) -> Vec<usize> {
         | SmoothBasisSpec::Matern { feature_cols, .. }
         | SmoothBasisSpec::Duchon { feature_cols, .. }
         | SmoothBasisSpec::TensorBSpline { feature_cols, .. } => feature_cols.clone(),
+        SmoothBasisSpec::BySmooth { smooth, by_kind } => {
+            let mut cols = match smooth.as_ref() {
+                SmoothBasisSpec::BSpline1D { feature_col, .. } => vec![*feature_col],
+                SmoothBasisSpec::ThinPlate { feature_cols, .. }
+                | SmoothBasisSpec::Sphere { feature_cols, .. }
+                | SmoothBasisSpec::Matern { feature_cols, .. }
+                | SmoothBasisSpec::Duchon { feature_cols, .. }
+                | SmoothBasisSpec::TensorBSpline { feature_cols, .. } => feature_cols.clone(),
+                SmoothBasisSpec::BySmooth { .. } | SmoothBasisSpec::FactorSmooth { .. } => vec![],
+            };
+            match by_kind {
+                gam::smooth::ByVarKind::Numeric { feature_col }
+                | gam::smooth::ByVarKind::Factor { feature_col, .. } => cols.push(*feature_col),
+            }
+            cols
+        }
+        SmoothBasisSpec::FactorSmooth { spec } => {
+            let mut cols = spec.continuous_cols.clone();
+            cols.push(spec.group_col);
+            cols
+        }
     }
 }
 
@@ -7247,6 +7276,8 @@ fn smooth_basiswarning_family_rank(term: &SmoothTermSpec) -> u8 {
         SmoothBasisSpec::Sphere { .. } => 3,
         SmoothBasisSpec::Matern { .. } => 4,
         SmoothBasisSpec::Duchon { .. } => 5,
+        SmoothBasisSpec::BySmooth { .. } => 6,
+        SmoothBasisSpec::FactorSmooth { .. } => 7,
     }
 }
 

--- a/src/terms/basis.rs
+++ b/src/terms/basis.rs
@@ -3016,6 +3016,15 @@ pub enum BasisMetadata {
         periodic: Vec<Option<(f64, f64, usize)>>,
         identifiability_transform: Option<Array2<f64>>,
     },
+    FactorSmooth {
+        continuous_cols: Vec<usize>,
+        group_col: usize,
+        knots: Array1<f64>,
+        degree: usize,
+        periodic: Option<(f64, f64, usize)>,
+        group_levels: Vec<u64>,
+        flavour: String,
+    },
 }
 
 /// Standardized basis build result for engine-level composition.

--- a/src/terms/smooth.rs
+++ b/src/terms/smooth.rs
@@ -118,6 +118,15 @@ pub enum SmoothBasisSpec {
         feature_col: usize,
         spec: BSplineBasisSpec,
     },
+    /// A smooth modulated by a `by=` variable. Numeric `by` scales one inner
+    /// smooth; factor `by` replicates the inner smooth by level.
+    BySmooth {
+        smooth: Box<SmoothBasisSpec>,
+        by_kind: ByVarKind,
+    },
+    /// Factor-smooth interaction families (`bs="fs"`, `bs="sz"`) and
+    /// random slopes (`bs="re"`).
+    FactorSmooth { spec: FactorSmoothSpec },
     ThinPlate {
         feature_cols: Vec<usize>,
         spec: ThinPlateBasisSpec,
@@ -150,6 +159,52 @@ pub enum SmoothBasisSpec {
     TensorBSpline {
         feature_cols: Vec<usize>,
         spec: TensorBSplineSpec,
+    },
+}
+
+/// General tensor marginal building block for future mixed continuous/categorical tensors.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum TensorMarginalSpec {
+    BSpline(BSplineBasisSpec),
+    Categorical {
+        feature_col_offset: usize,
+        drop_first_level: bool,
+        center_for_identifiability: bool,
+        #[serde(default)]
+        frozen_levels: Option<Vec<u64>>,
+    },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FactorSmoothSpec {
+    pub continuous_cols: Vec<usize>,
+    pub group_col: usize,
+    pub marginal: BSplineBasisSpec,
+    pub flavour: FactorSmoothFlavour,
+    #[serde(default)]
+    pub group_frozen_levels: Option<Vec<u64>>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum FactorSmoothFlavour {
+    /// Fully penalized per-level smooths.
+    Fs { m_null_penalty_orders: Vec<usize> },
+    /// Sum-to-zero deviations across factor levels.
+    Sz,
+    /// Random intercept/slope block for `s(g, x, bs="re")`.
+    Re,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum ByVarKind {
+    Numeric {
+        feature_col: usize,
+    },
+    Factor {
+        feature_col: usize,
+        ordered: bool,
+        #[serde(default)]
+        frozen_levels: Option<Vec<u64>>,
     },
 }
 
@@ -488,6 +543,45 @@ impl TermCollectionSpec {
                     ) {
                         return Err(format!(
                             "{label} term '{}' is not frozen: tensor identifiability must be FrozenTransform or None",
+                            st.name
+                        ));
+                    }
+                }
+                SmoothBasisSpec::BySmooth { smooth, by_kind } => {
+                    match by_kind {
+                        ByVarKind::Numeric { .. } => {}
+                        ByVarKind::Factor { frozen_levels, .. } if frozen_levels.is_none() => {
+                            return Err(format!(
+                                "{label} term '{}' is not frozen: by-factor levels must be frozen",
+                                st.name
+                            ));
+                        }
+                        ByVarKind::Factor { .. } => {}
+                    }
+                    let nested = TermCollectionSpec {
+                        linear_terms: vec![],
+                        random_effect_terms: vec![],
+                        smooth_terms: vec![SmoothTermSpec {
+                            name: st.name.clone(),
+                            basis: (**smooth).clone(),
+                            shape: st.shape,
+                        }],
+                    };
+                    nested.validate_frozen(label)?;
+                }
+                SmoothBasisSpec::FactorSmooth { spec } => {
+                    if spec.group_frozen_levels.is_none() {
+                        return Err(format!(
+                            "{label} term '{}' is not frozen: factor-smooth group levels must be frozen",
+                            st.name
+                        ));
+                    }
+                    if !matches!(
+                        spec.marginal.knotspec,
+                        BSplineKnotSpec::Provided(_) | BSplineKnotSpec::PeriodicUniform { .. }
+                    ) {
+                        return Err(format!(
+                            "{label} term '{}' is not frozen: factor-smooth marginal knotspec must be Provided or PeriodicUniform",
                             st.name
                         ));
                     }
@@ -3623,6 +3717,318 @@ fn build_random_effect_block(
     })
 }
 
+fn sorted_factor_levels(
+    data: ArrayView2<'_, f64>,
+    feature_col: usize,
+    frozen: Option<&Vec<u64>>,
+    drop_first: bool,
+) -> Result<Vec<u64>, BasisError> {
+    if feature_col >= data.ncols() {
+        return Err(BasisError::DimensionMismatch(format!(
+            "factor column {feature_col} out of bounds for {} columns",
+            data.ncols()
+        )));
+    }
+    let mut levels = if let Some(levels) = frozen {
+        levels.clone()
+    } else {
+        let mut set = BTreeSet::<u64>::new();
+        for &v in data.column(feature_col) {
+            if !v.is_finite() {
+                return Err(BasisError::InvalidInput(
+                    "factor smooth contains non-finite group values".to_string(),
+                ));
+            }
+            set.insert(v.to_bits());
+        }
+        let all: Vec<u64> = set.into_iter().collect();
+        if drop_first && all.len() > 1 {
+            all[1..].to_vec()
+        } else {
+            all
+        }
+    };
+    levels.sort_unstable();
+    levels.dedup();
+    if levels.is_empty() {
+        return Err(BasisError::InvalidInput(
+            "factor smooth has no retained levels".to_string(),
+        ));
+    }
+    Ok(levels)
+}
+
+fn block_diag_penalty(base: &Array2<f64>, blocks: usize) -> Array2<f64> {
+    let p = base.nrows();
+    let mut out = Array2::<f64>::zeros((p * blocks, p * blocks));
+    for b in 0..blocks {
+        let off = b * p;
+        out.slice_mut(s![off..off + p, off..off + p]).assign(base);
+    }
+    out
+}
+
+fn dense_by_factor_design(
+    inner: &Array2<f64>,
+    groups: &[Option<usize>],
+    levels: usize,
+) -> Array2<f64> {
+    let n = inner.nrows();
+    let p = inner.ncols();
+    let mut out = Array2::<f64>::zeros((n, p * levels));
+    for i in 0..n {
+        if let Some(g) = groups[i] {
+            let off = g * p;
+            for j in 0..p {
+                out[[i, off + j]] = inner[[i, j]];
+            }
+        }
+    }
+    out
+}
+
+fn build_by_smooth_basis(
+    data: ArrayView2<'_, f64>,
+    term_name: &str,
+    smooth: &SmoothBasisSpec,
+    by_kind: &ByVarKind,
+    workspace: &mut crate::basis::BasisWorkspace,
+) -> Result<BasisBuildResult, BasisError> {
+    let inner_term = SmoothTermSpec {
+        name: format!("{term_name}:inner"),
+        basis: smooth.clone(),
+        shape: ShapeConstraint::None,
+    };
+    let inner = build_single_local_smooth_term(data, &inner_term, workspace)?;
+    let inner_dense = inner.design.to_dense();
+    match by_kind {
+        ByVarKind::Numeric { feature_col } => {
+            if *feature_col >= data.ncols() {
+                return Err(BasisError::DimensionMismatch(
+                    "numeric by column out of bounds".to_string(),
+                ));
+            }
+            let by = data.column(*feature_col);
+            let mut design = inner_dense.clone();
+            for i in 0..design.nrows() {
+                let z = by[i];
+                if !z.is_finite() {
+                    return Err(BasisError::InvalidInput(
+                        "numeric by smooth contains non-finite by values".to_string(),
+                    ));
+                }
+                for j in 0..design.ncols() {
+                    design[[i, j]] *= z;
+                }
+            }
+            Ok(BasisBuildResult {
+                design: DesignMatrix::Dense(crate::matrix::DenseDesignMatrix::from(design)),
+                penalties: inner.penalties,
+                nullspace_dims: inner.nullspaces,
+                penaltyinfo: inner.penaltyinfo,
+                metadata: inner.metadata,
+                kronecker_factored: None,
+                ops: vec![None; inner.ops.len()],
+            })
+        }
+        ByVarKind::Factor {
+            feature_col,
+            ordered,
+            frozen_levels,
+        } => {
+            let levels =
+                sorted_factor_levels(data, *feature_col, frozen_levels.as_ref(), *ordered)?;
+            let groups = data
+                .column(*feature_col)
+                .iter()
+                .map(|v| levels.binary_search(&v.to_bits()).ok())
+                .collect::<Vec<_>>();
+            let design = dense_by_factor_design(&inner_dense, &groups, levels.len());
+            let mut candidates = Vec::<PenaltyCandidate>::new();
+            for (pi, pen) in inner.penalties.iter().enumerate() {
+                for lev in 0..levels.len() {
+                    let p = inner_dense.ncols();
+                    let mut mat = Array2::<f64>::zeros((p * levels.len(), p * levels.len()));
+                    let off = lev * p;
+                    mat.slice_mut(s![off..off + p, off..off + p]).assign(pen);
+                    candidates.push(PenaltyCandidate {
+                        matrix: mat,
+                        nullspace_dim_hint: 0,
+                        source: PenaltySource::Other(format!("BySmoothLevel{lev}Penalty{pi}")),
+                        normalization_scale: 1.0,
+                        kronecker_factors: None,
+                        op: None,
+                    });
+                }
+            }
+            let (penalties, nullspace_dims, penaltyinfo, ops) =
+                filter_active_penalty_candidates_with_ops(candidates)?;
+            let metadata = match inner.metadata {
+                BasisMetadata::BSpline1D {
+                    knots, periodic, ..
+                } => BasisMetadata::FactorSmooth {
+                    continuous_cols: smooth_term_feature_cols(&SmoothTermSpec {
+                        name: term_name.to_string(),
+                        basis: smooth.clone(),
+                        shape: ShapeConstraint::None,
+                    }),
+                    group_col: *feature_col,
+                    knots,
+                    degree: inner_dense.ncols().saturating_sub(1),
+                    periodic,
+                    group_levels: levels.clone(),
+                    flavour: "by".to_string(),
+                },
+                other => other,
+            };
+            Ok(BasisBuildResult {
+                design: DesignMatrix::Dense(crate::matrix::DenseDesignMatrix::from(design)),
+                penalties,
+                nullspace_dims,
+                penaltyinfo,
+                metadata,
+                kronecker_factored: None,
+                ops,
+            })
+        }
+    }
+}
+
+fn build_factor_smooth_basis(
+    data: ArrayView2<'_, f64>,
+    spec: &FactorSmoothSpec,
+) -> Result<BasisBuildResult, BasisError> {
+    if spec.continuous_cols.len() != 1 {
+        return Err(BasisError::InvalidInput(
+            "factor smooth currently supports one continuous variable".to_string(),
+        ));
+    }
+    let c = spec.continuous_cols[0];
+    let mut marginal = spec.marginal.clone();
+    marginal.identifiability = BSplineIdentifiability::None;
+    let base = build_bspline_basis_1d(data.column(c), &marginal)?;
+    let mut x = base.design.to_dense();
+    let base_pen = base
+        .penalties
+        .first()
+        .cloned()
+        .unwrap_or_else(|| Array2::<f64>::eye(x.ncols()));
+    let (knots, periodic) = match base.metadata {
+        BasisMetadata::BSpline1D {
+            knots, periodic, ..
+        } => (knots, periodic),
+        _ => unreachable!(),
+    };
+    if matches!(spec.flavour, FactorSmoothFlavour::Re) {
+        x = Array2::<f64>::zeros((data.nrows(), 2));
+        for i in 0..data.nrows() {
+            x[[i, 0]] = 1.0;
+            x[[i, 1]] = data[[i, c]];
+        }
+    }
+    let mut levels = sorted_factor_levels(
+        data,
+        spec.group_col,
+        spec.group_frozen_levels.as_ref(),
+        false,
+    )?;
+    let groups = data
+        .column(spec.group_col)
+        .iter()
+        .map(|v| levels.binary_search(&v.to_bits()).ok())
+        .collect::<Vec<_>>();
+    let mut design = dense_by_factor_design(&x, &groups, levels.len());
+    if matches!(spec.flavour, FactorSmoothFlavour::Sz) && levels.len() > 1 {
+        let n = design.nrows();
+        let p = x.ncols();
+        let l = levels.len();
+        let mut contrasted = Array2::<f64>::zeros((n, p * (l - 1)));
+        for i in 0..n {
+            if let Some(g) = groups[i] {
+                for j in 0..p {
+                    if g < l - 1 {
+                        contrasted[[i, g * p + j]] += x[[i, j]];
+                    } else {
+                        for h in 0..l - 1 {
+                            contrasted[[i, h * p + j]] -= x[[i, j]];
+                        }
+                    }
+                }
+            }
+        }
+        design = contrasted;
+        levels.pop();
+    }
+    let l = levels.len();
+    let p = x.ncols();
+    let mut candidates = Vec::<PenaltyCandidate>::new();
+    match spec.flavour {
+        FactorSmoothFlavour::Fs { .. } => {
+            candidates.push(PenaltyCandidate {
+                matrix: block_diag_penalty(&base_pen, l),
+                nullspace_dim_hint: 0,
+                source: PenaltySource::Other("FactorSmoothFsRange".to_string()),
+                normalization_scale: 1.0,
+                kronecker_factors: None,
+                op: None,
+            });
+            candidates.push(PenaltyCandidate {
+                matrix: Array2::<f64>::eye(p * l),
+                nullspace_dim_hint: 0,
+                source: PenaltySource::Other("FactorSmoothFsRidge".to_string()),
+                normalization_scale: 1.0,
+                kronecker_factors: None,
+                op: None,
+            });
+        }
+        FactorSmoothFlavour::Sz => {
+            candidates.push(PenaltyCandidate {
+                matrix: block_diag_penalty(&base_pen, l),
+                nullspace_dim_hint: 0,
+                source: PenaltySource::Other("FactorSmoothSz".to_string()),
+                normalization_scale: 1.0,
+                kronecker_factors: None,
+                op: None,
+            });
+        }
+        FactorSmoothFlavour::Re => {
+            candidates.push(PenaltyCandidate {
+                matrix: Array2::<f64>::eye(p * l),
+                nullspace_dim_hint: 0,
+                source: PenaltySource::Other("RandomSlopeRidge".to_string()),
+                normalization_scale: 1.0,
+                kronecker_factors: None,
+                op: None,
+            });
+        }
+    }
+    let (penalties, nullspace_dims, penaltyinfo, ops) =
+        filter_active_penalty_candidates_with_ops(candidates)?;
+    let flavour = match spec.flavour {
+        FactorSmoothFlavour::Fs { .. } => "fs",
+        FactorSmoothFlavour::Sz => "sz",
+        FactorSmoothFlavour::Re => "re",
+    }
+    .to_string();
+    Ok(BasisBuildResult {
+        design: DesignMatrix::Dense(crate::matrix::DenseDesignMatrix::from(design)),
+        penalties,
+        nullspace_dims,
+        penaltyinfo,
+        metadata: BasisMetadata::FactorSmooth {
+            continuous_cols: spec.continuous_cols.clone(),
+            group_col: spec.group_col,
+            knots,
+            degree: marginal.degree,
+            periodic,
+            group_levels: levels,
+            flavour,
+        },
+        kronecker_factored: None,
+        ops,
+    })
+}
+
 impl SmoothDesign {
     /// Map an unconstrained term coefficient vector to its constrained shape space.
     /// This is useful for nonlinear fits that optimize unconstrained parameters.
@@ -3905,6 +4311,10 @@ fn build_single_local_smooth_term(
         SmoothBasisSpec::TensorBSpline { feature_cols, spec } => {
             build_tensor_bspline_basis(data, feature_cols, spec)?
         }
+        SmoothBasisSpec::BySmooth { smooth, by_kind } => {
+            build_by_smooth_basis(data, &term.name, smooth, by_kind, workspace)?
+        }
+        SmoothBasisSpec::FactorSmooth { spec } => build_factor_smooth_basis(data, spec)?,
     };
 
     match &term.basis {
@@ -4658,6 +5068,28 @@ fn smooth_term_feature_cols(term: &SmoothTermSpec) -> Vec<usize> {
         | SmoothBasisSpec::Matern { feature_cols, .. }
         | SmoothBasisSpec::Duchon { feature_cols, .. }
         | SmoothBasisSpec::TensorBSpline { feature_cols, .. } => feature_cols.clone(),
+        SmoothBasisSpec::BySmooth { smooth, by_kind } => {
+            let mut cols = match smooth.as_ref() {
+                SmoothBasisSpec::BSpline1D { feature_col, .. } => vec![*feature_col],
+                SmoothBasisSpec::ThinPlate { feature_cols, .. }
+                | SmoothBasisSpec::Sphere { feature_cols, .. }
+                | SmoothBasisSpec::Matern { feature_cols, .. }
+                | SmoothBasisSpec::Duchon { feature_cols, .. }
+                | SmoothBasisSpec::TensorBSpline { feature_cols, .. } => feature_cols.clone(),
+                SmoothBasisSpec::BySmooth { .. } | SmoothBasisSpec::FactorSmooth { .. } => vec![],
+            };
+            match by_kind {
+                ByVarKind::Numeric { feature_col } | ByVarKind::Factor { feature_col, .. } => {
+                    cols.push(*feature_col)
+                }
+            }
+            cols
+        }
+        SmoothBasisSpec::FactorSmooth { spec } => {
+            let mut cols = spec.continuous_cols.clone();
+            cols.push(spec.group_col);
+            cols
+        }
     }
 }
 
@@ -4669,6 +5101,8 @@ fn smooth_basis_family_rank(term: &SmoothTermSpec) -> u8 {
         SmoothBasisSpec::Sphere { .. } => 3,
         SmoothBasisSpec::Matern { .. } => 4,
         SmoothBasisSpec::Duchon { .. } => 5,
+        SmoothBasisSpec::BySmooth { .. } => 6,
+        SmoothBasisSpec::FactorSmooth { .. } => 7,
     }
 }
 
@@ -4699,6 +5133,7 @@ fn smooth_has_frozen_identifiability(term: &SmoothTermSpec) -> bool {
             spec.identifiability,
             TensorBSplineIdentifiability::FrozenTransform { .. }
         ),
+        SmoothBasisSpec::BySmooth { .. } | SmoothBasisSpec::FactorSmooth { .. } => true,
     }
 }
 
@@ -5460,6 +5895,23 @@ fn with_identifiability_transform(
                 identifiability_transform.as_ref(),
                 transform,
             )?,
+        }),
+        BasisMetadata::FactorSmooth {
+            continuous_cols,
+            group_col,
+            knots,
+            degree,
+            periodic,
+            group_levels,
+            flavour,
+        } => Ok(BasisMetadata::FactorSmooth {
+            continuous_cols: continuous_cols.clone(),
+            group_col: *group_col,
+            knots: knots.clone(),
+            degree: *degree,
+            periodic: *periodic,
+            group_levels: group_levels.clone(),
+            flavour: flavour.clone(),
         }),
     }
 }
@@ -10839,7 +11291,10 @@ fn try_build_spatial_term_log_kappa_derivative(
             build_duchon_basis_log_kappa_derivatives(x.view(), spec)
                 .map_err(EstimationError::from)?
         }
-        SmoothBasisSpec::BSpline1D { .. } | SmoothBasisSpec::TensorBSpline { .. } => {
+        SmoothBasisSpec::BSpline1D { .. }
+        | SmoothBasisSpec::TensorBSpline { .. }
+        | SmoothBasisSpec::BySmooth { .. }
+        | SmoothBasisSpec::FactorSmooth { .. } => {
             return Ok(None);
         }
     };
@@ -12429,6 +12884,73 @@ pub fn freeze_term_collection_from_design(
                     },
                     None => TensorBSplineIdentifiability::None,
                 };
+            }
+            (
+                SmoothBasisSpec::FactorSmooth { spec: s },
+                BasisMetadata::FactorSmooth {
+                    knots,
+                    periodic,
+                    group_levels,
+                    ..
+                },
+            ) => {
+                s.marginal.knotspec = periodic
+                    .map(
+                        |(domain_start, period, num_basis)| BSplineKnotSpec::PeriodicUniform {
+                            data_range: (domain_start, domain_start + period),
+                            num_basis,
+                        },
+                    )
+                    .unwrap_or_else(|| BSplineKnotSpec::Provided(knots.clone()));
+                s.group_frozen_levels = Some(group_levels.clone());
+            }
+            (
+                SmoothBasisSpec::BySmooth { smooth, by_kind },
+                BasisMetadata::FactorSmooth {
+                    knots,
+                    periodic,
+                    group_levels,
+                    ..
+                },
+            ) => {
+                if let ByVarKind::Factor { frozen_levels, .. } = by_kind {
+                    *frozen_levels = Some(group_levels.clone());
+                }
+                if let SmoothBasisSpec::BSpline1D { spec: inner, .. } = smooth.as_mut() {
+                    inner.knotspec = periodic
+                        .map(
+                            |(domain_start, period, num_basis)| BSplineKnotSpec::PeriodicUniform {
+                                data_range: (domain_start, domain_start + period),
+                                num_basis,
+                            },
+                        )
+                        .unwrap_or_else(|| BSplineKnotSpec::Provided(knots.clone()));
+                    inner.identifiability = BSplineIdentifiability::None;
+                }
+            }
+            (SmoothBasisSpec::BySmooth { smooth, .. }, metadata) => {
+                if let SmoothBasisSpec::BSpline1D { spec: inner, .. } = smooth.as_mut()
+                    && let BasisMetadata::BSpline1D {
+                        knots,
+                        periodic,
+                        identifiability_transform,
+                    } = metadata
+                {
+                    inner.knotspec = periodic
+                        .map(
+                            |(domain_start, period, num_basis)| BSplineKnotSpec::PeriodicUniform {
+                                data_range: (domain_start, domain_start + period),
+                                num_basis,
+                            },
+                        )
+                        .unwrap_or_else(|| BSplineKnotSpec::Provided(knots.clone()));
+                    inner.identifiability = match identifiability_transform {
+                        Some(z) => BSplineIdentifiability::FrozenTransform {
+                            transform: z.clone(),
+                        },
+                        None => BSplineIdentifiability::None,
+                    };
+                }
             }
             _ => {
                 return Err(EstimationError::InvalidInput(format!(

--- a/src/terms/term_builder.rs
+++ b/src/terms/term_builder.rs
@@ -24,9 +24,9 @@ use crate::inference::formula_dsl::{
 use crate::inference::model::ColumnKindTag;
 use crate::resource::ResourcePolicy;
 use crate::smooth::{
-    LinearCoefficientGeometry, LinearTermSpec, RandomEffectTermSpec, ShapeConstraint,
-    SmoothBasisSpec, SmoothTermSpec, TensorBSplineIdentifiability, TensorBSplineSpec,
-    TermCollectionSpec,
+    ByVarKind, FactorSmoothFlavour, FactorSmoothSpec, LinearCoefficientGeometry, LinearTermSpec,
+    RandomEffectTermSpec, ShapeConstraint, SmoothBasisSpec, SmoothTermSpec,
+    TensorBSplineIdentifiability, TensorBSplineSpec, TermCollectionSpec,
 };
 
 // ---------------------------------------------------------------------------
@@ -183,11 +183,21 @@ pub fn build_termspec(
                     .iter()
                     .map(|v| resolve_col(col_map, v))
                     .collect::<Result<Vec<_>, _>>()?;
+                let mut options_resolved = options.clone();
+                if let Some(by_name) = options.get("by") {
+                    let by_col = resolve_col(col_map, by_name)?;
+                    options_resolved.insert("__by_col".to_string(), by_col.to_string());
+                    if !terms.iter().any(|term| matches!(term, ParsedTerm::Linear { name, .. } | ParsedTerm::RandomEffect { name } if name == by_name)) {
+                        inference_notes.push(format!(
+                            "factor/numeric by-smooth `by={by_name}` is used without an explicit `{by_name}` main-effect term; add `{by_name}` or `group({by_name})` if level means should be identifiable."
+                        ));
+                    }
+                }
                 let basis = build_smooth_basis(
                     *kind,
                     vars,
                     &cols,
-                    options,
+                    &options_resolved,
                     ds,
                     inference_notes,
                     policy,
@@ -365,6 +375,9 @@ pub fn build_smooth_basis(
     // ("smooth basis collapses onto the parametric block"); this lift makes
     // the same diagnosis explicit and uniform across smooth families.
     for (var, &col) in vars.iter().zip(cols.iter()) {
+        if matches!(ds.column_kinds.get(col), Some(ColumnKindTag::Categorical)) {
+            continue;
+        }
         if unique_count_column(ds.values.column(col)) <= 1 {
             return Err(format!(
                 "smooth term over '{var}' has only one unique value in the training data \
@@ -373,6 +386,47 @@ pub fn build_smooth_basis(
             ));
         }
     }
+    if let Some(by_name) = options.get("by").cloned() {
+        let by_col = options
+            .get("__by_col")
+            .and_then(|raw| raw.parse::<usize>().ok())
+            .or_else(|| vars.iter().position(|v| v == &by_name).map(|idx| cols[idx]))
+            .ok_or_else(|| format!("unknown by= column '{by_name}'"))?;
+        let mut inner_options = options.clone();
+        inner_options.remove("by");
+        inner_options.remove("__by_col");
+        inner_options.remove("id");
+        let inner = build_smooth_basis(
+            kind,
+            vars,
+            cols,
+            &inner_options,
+            ds,
+            inference_notes,
+            policy,
+            smooth_coordinate_count,
+        )?;
+        let by_kind = match ds.column_kinds.get(by_col).copied() {
+            Some(ColumnKindTag::Categorical) => ByVarKind::Factor {
+                feature_col: by_col,
+                ordered: option_bool(options, "ordered").unwrap_or(false),
+                frozen_levels: None,
+            },
+            Some(ColumnKindTag::Continuous | ColumnKindTag::Binary) => ByVarKind::Numeric {
+                feature_col: by_col,
+            },
+            None => {
+                return Err(format!(
+                    "internal column-kind lookup failed for by='{by_name}'"
+                ));
+            }
+        };
+        return Ok(SmoothBasisSpec::BySmooth {
+            smooth: Box::new(inner),
+            by_kind,
+        });
+    }
+
     let smooth_double_penalty = option_bool(options, "double_penalty").unwrap_or(true);
     let has_periodic_option = options.contains_key("periodic")
         || options.contains_key("cyclic")
@@ -396,6 +450,97 @@ pub fn build_smooth_basis(
             SmoothKind::S if has_periodic_option => "tensor".to_string(),
             SmoothKind::S => "tps".to_string(),
         });
+
+    if matches!(type_opt.as_str(), "fs" | "sz" | "re") {
+        validate_known_options(
+            type_opt.as_str(),
+            options,
+            &[
+                "type",
+                "bs",
+                "k",
+                "basis_dim",
+                "basis-dim",
+                "basisdim",
+                "knots",
+                "degree",
+                "penalty_order",
+                "m",
+                "double_penalty",
+                "ordered",
+            ],
+        )?;
+        if cols.len() != 2 {
+            return Err(format!(
+                "{} factor-smooth currently expects exactly two variables (one numeric, one categorical)",
+                type_opt
+            ));
+        }
+        let kinds = cols
+            .iter()
+            .map(|&c| ds.column_kinds.get(c).copied())
+            .collect::<Vec<_>>();
+        let (cont_idx, group_idx) = if type_opt == "re" {
+            // mgcv random-slope examples are often s(g, x, bs="re").
+            match (kinds[0], kinds[1]) {
+                (Some(ColumnKindTag::Categorical), _) => (1usize, 0usize),
+                (_, Some(ColumnKindTag::Categorical)) => (0usize, 1usize),
+                _ => (1usize, 0usize),
+            }
+        } else {
+            match (kinds[0], kinds[1]) {
+                (_, Some(ColumnKindTag::Categorical)) => (0usize, 1usize),
+                (Some(ColumnKindTag::Categorical), _) => (1usize, 0usize),
+                _ => {
+                    return Err(format!(
+                        "{} factor-smooth requires one categorical factor variable",
+                        type_opt
+                    ));
+                }
+            }
+        };
+        let c = cols[cont_idx];
+        let (minv, maxv) = col_minmax(ds.values.column(c))?;
+        let degree = if type_opt == "re" {
+            1
+        } else {
+            option_usize(options, "degree").unwrap_or(3)
+        };
+        let default_internal = heuristic_knots_for_column(ds.values.column(c));
+        let (n_knots, _) = parse_ps_internal_knots(options, degree, default_internal)?;
+        let marginal = BSplineBasisSpec {
+            degree,
+            penalty_order: option_usize(options, "penalty_order").unwrap_or(if degree > 1 {
+                2
+            } else {
+                1
+            }),
+            knotspec: BSplineKnotSpec::Generate {
+                data_range: (minv, maxv),
+                num_internal_knots: n_knots,
+            },
+            double_penalty: true,
+            identifiability: BSplineIdentifiability::None,
+            boundary_conditions: Default::default(),
+        };
+        let flavour = match type_opt.as_str() {
+            "fs" => FactorSmoothFlavour::Fs {
+                m_null_penalty_orders: vec![option_usize(options, "m").unwrap_or(2)],
+            },
+            "sz" => FactorSmoothFlavour::Sz,
+            "re" => FactorSmoothFlavour::Re,
+            _ => unreachable!(),
+        };
+        return Ok(SmoothBasisSpec::FactorSmooth {
+            spec: FactorSmoothSpec {
+                continuous_cols: vec![c],
+                group_col: cols[group_idx],
+                marginal,
+                flavour,
+                group_frozen_levels: None,
+            },
+        });
+    }
 
     match type_opt.as_str() {
         "tensor" | "te" | "tensor-bspline" => {
@@ -424,6 +569,9 @@ pub fn build_smooth_basis(
                     "period-origin",
                     "domain_origin",
                     "double_penalty",
+                    "by",
+                    "id",
+                    "__by_col",
                     "identifiability",
                 ],
             )?;
@@ -556,6 +704,9 @@ pub fn build_smooth_basis(
                     "period-origin",
                     "domain_origin",
                     "double_penalty",
+                    "by",
+                    "id",
+                    "__by_col",
                 ],
             )?;
             if cols.len() != 1 {
@@ -633,6 +784,9 @@ pub fn build_smooth_basis(
                     "period_end",
                     "origin",
                     "double_penalty",
+                    "by",
+                    "id",
+                    "__by_col",
                     "identifiability",
                 ],
             )?;
@@ -723,6 +877,9 @@ pub fn build_smooth_basis(
                     "knots",
                     "include_intercept",
                     "double_penalty",
+                    "by",
+                    "id",
+                    "__by_col",
                     "identifiability",
                     "scale_dims",
                 ],
@@ -943,6 +1100,9 @@ pub fn build_smooth_basis(
                     "knots",
                     "include_intercept",
                     "double_penalty",
+                    "by",
+                    "id",
+                    "__by_col",
                     "identifiability",
                     "scale_dims",
                 ],
@@ -1027,6 +1187,9 @@ pub fn build_smooth_basis(
                     "period_end",
                     "scale_dims",
                     "double_penalty",
+                    "by",
+                    "id",
+                    "__by_col",
                 ],
             )?;
             if options.contains_key("double_penalty") {

--- a/tests/factor_smooths_formula.rs
+++ b/tests/factor_smooths_formula.rs
@@ -1,0 +1,132 @@
+use gam::inference::data::EncodedDataset;
+use gam::inference::formula_dsl::{ParsedTerm, parse_formula};
+use gam::inference::model::{ColumnKindTag, DataSchema, SchemaColumn};
+use gam::resource::ResourcePolicy;
+use gam::smooth::{ByVarKind, FactorSmoothFlavour, SmoothBasisSpec, build_term_collection_design};
+use gam::term_builder::build_termspec;
+use ndarray::Array2;
+
+fn ds() -> EncodedDataset {
+    let n = 24;
+    let mut values = Array2::<f64>::zeros((n, 5));
+    for i in 0..n {
+        values[[i, 0]] = i as f64 / (n as f64 - 1.0); // x
+        values[[i, 1]] = (i % 3) as f64; // fac
+        values[[i, 2]] = if i % 2 == 0 { 0.5 } else { 1.5 }; // z
+        values[[i, 3]] = (i % 3) as f64; // ord_fac
+        values[[i, 4]] = (n - i) as f64 / n as f64; // x2
+    }
+    let headers = vec!["x", "fac", "z", "ord_fac", "x2"]
+        .into_iter()
+        .map(String::from)
+        .collect::<Vec<_>>();
+    let kinds = vec![
+        ColumnKindTag::Continuous,
+        ColumnKindTag::Categorical,
+        ColumnKindTag::Continuous,
+        ColumnKindTag::Categorical,
+        ColumnKindTag::Continuous,
+    ];
+    EncodedDataset {
+        headers: headers.clone(),
+        values,
+        schema: DataSchema {
+            columns: headers
+                .iter()
+                .zip(kinds.iter())
+                .map(|(name, kind)| SchemaColumn {
+                    name: name.clone(),
+                    kind: *kind,
+                    levels: vec![],
+                })
+                .collect(),
+        },
+        column_kinds: kinds,
+    }
+}
+
+#[test]
+fn factor_smooth_aliases_parse_to_options() {
+    for (formula, bs) in [
+        ("y ~ s(x, fac, bs=\"fs\")", "fs"),
+        ("y ~ fs(x, fac)", "fs"),
+        ("y ~ s(x, fac, bs=fs, k=10)", "fs"),
+        ("y ~ s(x, fac, bs=\"sz\")", "sz"),
+        ("y ~ sz(x, fac)", "sz"),
+    ] {
+        let parsed = parse_formula(formula).unwrap_or_else(|e| panic!("{formula}: {e}"));
+        let ParsedTerm::Smooth { options, .. } = &parsed.terms[0] else {
+            panic!("expected smooth")
+        };
+        assert_eq!(options.get("bs").map(String::as_str), Some(bs));
+    }
+    for formula in ["y ~ s(x, by=fac)", "y ~ s(x, by=z, k=8)"] {
+        let parsed = parse_formula(formula).unwrap_or_else(|e| panic!("{formula}: {e}"));
+        let ParsedTerm::Smooth { options, .. } = &parsed.terms[0] else {
+            panic!("expected smooth")
+        };
+        assert!(options.contains_key("by"));
+    }
+}
+
+#[test]
+fn by_fs_sz_and_random_slope_build_termspec() {
+    let data = ds();
+    let col_map = data.column_map();
+    let policy = ResourcePolicy::default_library();
+    for formula in [
+        "y ~ s(x, by=z)",
+        "y ~ s(x, by=fac) + fac",
+        "y ~ s(x) + s(x, by=ord_fac)",
+        "y ~ s(x, fac, bs=\"fs\")",
+        "y ~ s(x, fac, bs=\"fs\", m=1, k=10)",
+        "y ~ fs(x, fac)",
+        "y ~ s(fac, x, bs=\"sz\") + s(x)",
+        "y ~ sz(fac, x)",
+        "y ~ s(fac, x, bs=\"re\") + group(fac)",
+        "y ~ te(x, x2, by=fac)",
+        "y ~ s(x, by=fac, id=1)",
+        "y ~ s(x) + s(x2, fac, bs=\"fs\", k=5) + s(z, k=20)",
+    ] {
+        let parsed = parse_formula(formula).unwrap_or_else(|e| panic!("parse {formula}: {e}"));
+        let mut notes = Vec::new();
+        let spec = build_termspec(&parsed.terms, &data, &col_map, &mut notes, &policy)
+            .unwrap_or_else(|e| panic!("build {formula}: {e}"));
+        let design = build_term_collection_design(data.values.view(), &spec)
+            .unwrap_or_else(|e| panic!("design {formula}: {e}"));
+        assert_eq!(design.design.nrows(), data.values.nrows(), "{formula}");
+    }
+}
+
+#[test]
+fn termspec_routes_new_constructs_to_new_variants() {
+    let data = ds();
+    let col_map = data.column_map();
+    let policy = ResourcePolicy::default_library();
+
+    let parsed = parse_formula("y ~ s(x, by=z)").unwrap();
+    let spec = build_termspec(&parsed.terms, &data, &col_map, &mut vec![], &policy).unwrap();
+    assert!(matches!(
+        spec.smooth_terms[0].basis,
+        SmoothBasisSpec::BySmooth {
+            by_kind: ByVarKind::Numeric { .. },
+            ..
+        }
+    ));
+
+    let parsed = parse_formula("y ~ s(x, by=fac)").unwrap();
+    let spec = build_termspec(&parsed.terms, &data, &col_map, &mut vec![], &policy).unwrap();
+    assert!(matches!(
+        spec.smooth_terms[0].basis,
+        SmoothBasisSpec::BySmooth {
+            by_kind: ByVarKind::Factor { .. },
+            ..
+        }
+    ));
+
+    let parsed = parse_formula("y ~ fs(x, fac)").unwrap();
+    let spec = build_termspec(&parsed.terms, &data, &col_map, &mut vec![], &policy).unwrap();
+    assert!(
+        matches!(spec.smooth_terms[0].basis, SmoothBasisSpec::FactorSmooth { ref spec } if matches!(spec.flavour, FactorSmoothFlavour::Fs { .. }))
+    );
+}


### PR DESCRIPTION
### Motivation
- Provide mgcv-compatible factor-modulated smooths (`s(x, by=...)`), factor-smooth interactions (`bs="fs"` / `bs="sz"`) and the random-slope special case (`bs="re"`) so users can express per-group curves, partial-pooling trajectories, and deviations-from-main-effect smooths from the formula DSL. 
- Preserve prediction-time behaviour by capturing frozen-level metadata and marginal knot transforms so saved models remain robust to unseen levels and prediction replay.

### Description
- Parser and DSL: accept `by=` option and smooth aliases `fs(...)` / `sz(...)` and inject `bs=fs|sz` when those aliases are used; thread `by` through `ParsedTerm::Smooth` options. (files: `src/inference/formula_dsl.rs`, `src/terms/term_builder.rs`).
- New basis/spec types: add `SmoothBasisSpec::BySmooth` and `SmoothBasisSpec::FactorSmooth` plus helpers `ByVarKind`, `FactorSmoothSpec`, `FactorSmoothFlavour`, and `TensorMarginalSpec` to represent categorical margins and factor-smooth flavours. (file: `src/terms/smooth.rs`, small metadata addition in `src/terms/basis.rs`).
- Term-building: detect `by=` and build a nested inner smooth plus `ByVarKind` routing; accept `bs="fs"`/`bs="sz"`/`bs="re"` and synthesize a `FactorSmoothSpec` for later basis construction. Emit an inference-note if a factor `by=` is used without an explicit main-effect term. (file: `src/terms/term_builder.rs`).
- Basis construction: implement `build_by_smooth_basis` (numeric `by` = scale inner design; factor `by` = replicate inner design per level with per-level penalties) and `build_factor_smooth_basis` (construct `fs`/`sz`/`re` variants including Sz contrasts and Fs ridge/null-space scaffolding). Capture `FactorSmooth` metadata for freezing. (file: `src/terms/smooth.rs`).
- Freeze & remap: extend frozen-spec handling and prediction remapping to carry frozen group levels and marginal knots/identifiability for the new variants. (files: `src/terms/smooth.rs`, `src/families/survival_predict.rs`).
- Surface-level integrations: expose primary-column helpers, feature-collection helpers, family/derivative guards, and penalty metadata support for the new variants so they participate in downstream assembly/REML paths. (files: `src/main.rs`, `src/terms/smooth.rs`, `src/terms/basis.rs`).
- Docs and examples: update `docs/formulas.md` and `docs/cookbook.md` with usage for `by=`, `bs="fs"` / `bs="sz"`, and random slopes; add cookbook recipes for per-group trajectories and hierarchical smooths. (files: `docs/formulas.md`, `docs/cookbook.md`).
- Tests: add `tests/factor_smooths_formula.rs` exercising parser aliases, `by=` routing, `fs`/`sz`/`re` routing into term specs and a design-build smoke assertion. (file: `tests/factor_smooths_formula.rs`).

### Testing
- Ran the new parser/build unit tests: `tests/factor_smooths_formula` passed (3 tests). 
- Performed a workspace `cargo check` which completed successfully and flagged no type errors for the changes.
- Ran targeted integration smoke: `build_termspec` → `build_term_collection_design` for the example formulas in `tests/factor_smooths_formula.rs` and verified the materialized design rows match the dataset rows; these assertions passed.
- Notes on full test run: a full `cargo test --workspace` was attempted but initially hit linker failures caused by transient disk-space exhaustion in the environment; after cleaning build artifacts the targeted tests and `cargo check` were re-run successfully; environment resource constraints prevented a single uninterrupted end-to-end full workspace test run in this session.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ab3cfbbc8832499757e2e08cd2e71)