### PR TITLE
Add by=, bs="fs"/"sz" and factor-smooth scaffolding

### DIFF
--- a/docs/cookbook.md
+++ b/docs/cookbook.md
@@ -376,3 +376,15 @@ print(gs.best_params_, gs.best_score_)
 model.report("report.html")     # writes to disk
 html = model.report()           # returns string for Jupyter / inline display
 ```
+
+## Per-group trajectories (factor by smooth)
+
+`y ~ fac + s(time, by=fac)` fits separate time trajectories by level; include the main `fac` effect for level offsets.
+
+## Hierarchical / partial-pooling smooths (`bs="fs"`)
+
+`y ~ s(time) + s(time, subject, bs="fs")` models a population curve plus shrinkage-stabilized subject-specific departures.
+
+## Treatment vs control difference smooth (`bs="sz"`)
+
+`y ~ s(time) + s(time, treatment, bs="sz")` estimates a population time effect and sum-to-zero treatment deviations.

--- a/docs/formulas.md
+++ b/docs/formulas.md
@@ -78,7 +78,7 @@ y ~ x + re(site)            # alias
 ```
 
 Adds a random intercept per level of the grouping column. The column may be
-string- or integer-valued. Random slopes are not supported.
+string- or integer-valued. Random slopes are supported with `s(x, group, bs="re")`, usually paired with `group(group)` for random intercepts.
 
 ## Univariate smooths
 
@@ -408,3 +408,16 @@ See [survival.md](survival.md).
 # Random intercept per site
 "y ~ smooth(x) + group(site)"
 ```
+
+
+## Factor smooths and by-smooths
+
+GAM formulas support mgcv-style factor-conditioned smooths:
+
+- `s(x, by=z)` scales one smooth of `x` by numeric covariate `z`.
+- `s(x, by=fac)` creates one smooth block per observed factor level. Unseen prediction levels contribute zero for that by-smooth.
+- `s(x, fac, bs="fs")` (or `fs(x, fac)`) creates ridge-penalized factor smooth interactions for partial-pooling style per-group curves; unseen groups contribute zero from the factor-smooth term.
+- `s(x, fac, bs="sz")` (or `sz(x, fac)`) uses sum-to-zero contrasts across factor levels for deviation smooths that can be paired with a population `s(x)`.
+- `s(x, group, bs="re")` builds a random-slope block; use `group(group)` as a companion term when random intercepts are needed.
+
+These terms preserve frozen factor levels in saved model specifications so prediction does not drift when new data omits a training level or contains an unseen level.

--- a/src/families/survival_predict.rs
+++ b/src/families/survival_predict.rs
@@ -1215,6 +1215,35 @@ fn remap_term_collectionspec_columns(
                     *feature_col = resolve_training_index(*feature_col)?;
                 }
             }
+            SmoothBasisSpec::BySmooth { smooth, by_kind } => {
+                match smooth.as_mut() {
+                    SmoothBasisSpec::BSpline1D { feature_col, .. } => {
+                        *feature_col = resolve_training_index(*feature_col)?
+                    }
+                    SmoothBasisSpec::ThinPlate { feature_cols, .. }
+                    | SmoothBasisSpec::Sphere { feature_cols, .. }
+                    | SmoothBasisSpec::Matern { feature_cols, .. }
+                    | SmoothBasisSpec::Duchon { feature_cols, .. }
+                    | SmoothBasisSpec::TensorBSpline { feature_cols, .. } => {
+                        for feature_col in feature_cols.iter_mut() {
+                            *feature_col = resolve_training_index(*feature_col)?;
+                        }
+                    }
+                    SmoothBasisSpec::BySmooth { .. } | SmoothBasisSpec::FactorSmooth { .. } => {}
+                }
+                match by_kind {
+                    crate::smooth::ByVarKind::Numeric { feature_col }
+                    | crate::smooth::ByVarKind::Factor { feature_col, .. } => {
+                        *feature_col = resolve_training_index(*feature_col)?
+                    }
+                }
+            }
+            SmoothBasisSpec::FactorSmooth { spec } => {
+                for feature_col in spec.continuous_cols.iter_mut() {
+                    *feature_col = resolve_training_index(*feature_col)?;
+                }
+                spec.group_col = resolve_training_index(spec.group_col)?;
+            }
         }
     }
     Ok(remapped)

--- a/src/inference/formula_dsl.rs
+++ b/src/inference/formula_dsl.rs
@@ -1420,7 +1420,7 @@ pub fn parse_term(raw: &str) -> Result<ParsedTerm, String> {
                     options,
                 });
             }
-            "smooth" | "s" | "cyclic" | "periodic" | "cc" | "cp" => {
+            "smooth" | "s" | "cyclic" | "periodic" | "cc" | "cp" | "fs" | "sz" => {
                 if vars.is_empty() {
                     return Err(format!(
                         "smooth()/s() requires at least one variable: {raw}"
@@ -1428,6 +1428,9 @@ pub fn parse_term(raw: &str) -> Result<ParsedTerm, String> {
                 }
                 if matches!(name.as_str(), "cyclic" | "periodic" | "cc" | "cp") {
                     options.insert("type".to_string(), "cyclic".to_string());
+                }
+                if matches!(name.as_str(), "fs" | "sz") {
+                    options.insert("bs".to_string(), name.clone());
                 }
                 return Ok(ParsedTerm::Smooth {
                     label: raw.to_string(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -6360,6 +6360,12 @@ fn smooth_term_primary_column(term: &SmoothTermSpec) -> Option<usize> {
                 None
             }
         }
+        SmoothBasisSpec::BySmooth { smooth, .. } => smooth_term_primary_column(&SmoothTermSpec {
+            name: String::new(),
+            basis: *smooth.clone(),
+            shape: gam::smooth::ShapeConstraint::None,
+        }),
+        SmoothBasisSpec::FactorSmooth { spec } => spec.continuous_cols.first().copied(),
     }
 }
 
@@ -7119,7 +7125,10 @@ fn spatial_basiswarning_family_and_cols(term: &SmoothTermSpec) -> Option<(&'stat
         SmoothBasisSpec::Sphere { feature_cols, .. } => Some(("sphere/sos", feature_cols)),
         SmoothBasisSpec::Matern { feature_cols, .. } => Some(("matern", feature_cols)),
         SmoothBasisSpec::Duchon { feature_cols, .. } => Some(("duchon", feature_cols)),
-        SmoothBasisSpec::BSpline1D { .. } | SmoothBasisSpec::TensorBSpline { .. } => None,
+        SmoothBasisSpec::BSpline1D { .. }
+        | SmoothBasisSpec::TensorBSpline { .. }
+        | SmoothBasisSpec::BySmooth { .. }
+        | SmoothBasisSpec::FactorSmooth { .. } => None,
     }
 }
 
@@ -7191,6 +7200,23 @@ fn smooth_term_feature_cols(term: &SmoothTermSpec) -> Vec<usize> {
         | SmoothBasisSpec::Matern { feature_cols, .. }
         | SmoothBasisSpec::Duchon { feature_cols, .. }
         | SmoothBasisSpec::TensorBSpline { feature_cols, .. } => feature_cols.clone(),
+        SmoothBasisSpec::BySmooth { smooth, by_kind } => {
+            let mut cols = smooth_term_feature_cols(&SmoothTermSpec {
+                name: String::new(),
+                basis: *smooth.clone(),
+                shape: gam::smooth::ShapeConstraint::None,
+            });
+            match by_kind {
+                gam::smooth::ByVarKind::Numeric { feature_col }
+                | gam::smooth::ByVarKind::Factor { feature_col, .. } => cols.push(*feature_col),
+            }
+            cols
+        }
+        SmoothBasisSpec::FactorSmooth { spec } => {
+            let mut cols = spec.continuous_cols.clone();
+            cols.push(spec.group_col);
+            cols
+        }
     }
 }
 
@@ -7247,6 +7273,8 @@ fn smooth_basiswarning_family_rank(term: &SmoothTermSpec) -> u8 {
         SmoothBasisSpec::Sphere { .. } => 3,
         SmoothBasisSpec::Matern { .. } => 4,
         SmoothBasisSpec::Duchon { .. } => 5,
+        SmoothBasisSpec::BySmooth { .. } => 6,
+        SmoothBasisSpec::FactorSmooth { .. } => 7,
     }
 }
 

--- a/src/terms/basis.rs
+++ b/src/terms/basis.rs
@@ -3016,6 +3016,20 @@ pub enum BasisMetadata {
         periodic: Vec<Option<(f64, f64, usize)>>,
         identifiability_transform: Option<Array2<f64>>,
     },
+    BySmooth {
+        inner: Box<BasisMetadata>,
+        by_col: usize,
+        levels: Option<Vec<u64>>,
+        ordered: bool,
+    },
+    FactorSmooth {
+        continuous_cols: Vec<usize>,
+        group_col: usize,
+        knots: Array1<f64>,
+        degree: usize,
+        levels: Vec<u64>,
+        flavour: String,
+    },
 }
 
 /// Standardized basis build result for engine-level composition.

--- a/src/terms/smooth.rs
+++ b/src/terms/smooth.rs
@@ -151,6 +151,13 @@ pub enum SmoothBasisSpec {
         feature_cols: Vec<usize>,
         spec: TensorBSplineSpec,
     },
+    BySmooth {
+        smooth: Box<SmoothBasisSpec>,
+        by_kind: ByVarKind,
+    },
+    FactorSmooth {
+        spec: FactorSmoothSpec,
+    },
 }
 
 /// Tensor-product B-spline smooth specification.
@@ -158,6 +165,46 @@ pub enum SmoothBasisSpec {
 /// `marginalspecs[i]` is the 1D B-spline setup for `feature_cols[i]`.
 /// The final penalty set is one Kronecker penalty per margin:
 /// `S_i = I ⊗ ... ⊗ S_marginal_i ⊗ ... ⊗ I`, plus optional global ridge.
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum TensorMarginalSpec {
+    BSpline(BSplineBasisSpec),
+    Categorical {
+        feature_col_offset: usize,
+        drop_first_level: bool,
+        center_for_identifiability: bool,
+        frozen_levels: Option<Vec<u64>>,
+    },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum ByVarKind {
+    Numeric {
+        feature_col: usize,
+    },
+    Factor {
+        feature_col: usize,
+        ordered: bool,
+        frozen_levels: Option<Vec<u64>>,
+    },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FactorSmoothSpec {
+    pub continuous_cols: Vec<usize>,
+    pub group_col: usize,
+    pub marginal: BSplineBasisSpec,
+    pub flavour: FactorSmoothFlavour,
+    pub group_frozen_levels: Option<Vec<u64>>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum FactorSmoothFlavour {
+    Fs { m_null_penalty_orders: Vec<usize> },
+    Sz,
+    Re,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TensorBSplineSpec {
     pub marginalspecs: Vec<BSplineBasisSpec>,
@@ -466,6 +513,37 @@ impl TermCollectionSpec {
                     ) {
                         return Err(format!(
                             "{label} term '{}' is not frozen: Duchon identifiability must be FrozenTransform or None",
+                            st.name
+                        ));
+                    }
+                }
+                SmoothBasisSpec::BySmooth { smooth, by_kind } => {
+                    if let SmoothBasisSpec::BySmooth { .. } = smooth.as_ref() {
+                        return Err(format!("{label} term '{}' has nested by-smooths", st.name));
+                    }
+                    match by_kind {
+                        ByVarKind::Factor { frozen_levels, .. } if frozen_levels.is_none() => {
+                            return Err(format!(
+                                "{label} term '{}' is not frozen: by-factor levels missing",
+                                st.name
+                            ));
+                        }
+                        _ => {}
+                    }
+                }
+                SmoothBasisSpec::FactorSmooth { spec } => {
+                    if spec.group_frozen_levels.is_none() {
+                        return Err(format!(
+                            "{label} term '{}' is not frozen: factor-smooth levels missing",
+                            st.name
+                        ));
+                    }
+                    if !matches!(
+                        spec.marginal.knotspec,
+                        BSplineKnotSpec::Provided(_) | BSplineKnotSpec::PeriodicUniform { .. }
+                    ) {
+                        return Err(format!(
+                            "{label} term '{}' is not frozen: factor-smooth marginal knots missing",
                             st.name
                         ));
                     }
@@ -3550,6 +3628,268 @@ fn tensor_product_design_from_marginals(
     Ok(design)
 }
 
+fn sorted_levels_from_column(
+    col: ArrayView1<'_, f64>,
+    frozen: Option<&Vec<u64>>,
+) -> Result<Vec<u64>, BasisError> {
+    let mut levels: Vec<u64> = if let Some(v) = frozen {
+        v.clone()
+    } else {
+        let mut set = BTreeSet::new();
+        for &x in col {
+            if !x.is_finite() {
+                return Err(BasisError::InvalidInput(
+                    "factor smooth group column contains non-finite values".to_string(),
+                ));
+            }
+            set.insert(x.to_bits());
+        }
+        set.into_iter().collect()
+    };
+    levels.sort_unstable();
+    levels.dedup();
+    if levels.is_empty() {
+        return Err(BasisError::InvalidInput(
+            "factor smooth has no observed levels".to_string(),
+        ));
+    }
+    Ok(levels)
+}
+
+fn block_diag_repeat(base: &Array2<f64>, repeat: usize) -> Array2<f64> {
+    let p = base.nrows();
+    let mut out = Array2::<f64>::zeros((p * repeat, p * repeat));
+    for r in 0..repeat {
+        let start = r * p;
+        out.slice_mut(s![start..start + p, start..start + p])
+            .assign(base);
+    }
+    out
+}
+
+fn build_by_smooth_basis(
+    data: ArrayView2<'_, f64>,
+    smooth: &SmoothBasisSpec,
+    by_kind: &ByVarKind,
+) -> Result<BasisBuildResult, BasisError> {
+    let dummy = SmoothTermSpec {
+        name: "by-inner".to_string(),
+        basis: smooth.clone(),
+        shape: ShapeConstraint::None,
+    };
+    let mut workspace = crate::basis::BasisWorkspace::default();
+    let inner = build_single_local_smooth_term(data, &dummy, &mut workspace)?;
+    let x = inner.design.to_dense();
+    let n = x.nrows();
+    let p = x.ncols();
+    match by_kind {
+        ByVarKind::Numeric { feature_col } => {
+            let z = data.column(*feature_col);
+            let mut design = x.clone();
+            for i in 0..n {
+                for j in 0..p {
+                    design[[i, j]] *= z[i];
+                }
+            }
+            Ok(BasisBuildResult {
+                design: DesignMatrix::Dense(crate::matrix::DenseDesignMatrix::from(design)),
+                penalties: inner.penalties,
+                nullspace_dims: inner.nullspaces,
+                penaltyinfo: inner.penaltyinfo,
+                ops: inner.ops,
+                metadata: BasisMetadata::BySmooth {
+                    inner: Box::new(inner.metadata),
+                    by_col: *feature_col,
+                    levels: None,
+                    ordered: false,
+                },
+                kronecker_factored: None,
+            })
+        }
+        ByVarKind::Factor {
+            feature_col,
+            ordered,
+            frozen_levels,
+        } => {
+            let mut levels =
+                sorted_levels_from_column(data.column(*feature_col), frozen_levels.as_ref())?;
+            if *ordered && levels.len() > 1 {
+                levels.remove(0);
+            }
+            let l = levels.len();
+            let mut design = Array2::<f64>::zeros((n, p * l));
+            for i in 0..n {
+                let bits = data[[i, *feature_col]].to_bits();
+                if let Ok(g) = levels.binary_search(&bits) {
+                    let start = g * p;
+                    for j in 0..p {
+                        design[[i, start + j]] = x[[i, j]];
+                    }
+                }
+            }
+            let mut candidates = Vec::new();
+            for (pi, pen) in inner.penalties.iter().enumerate() {
+                for g in 0..l {
+                    let mut m = Array2::<f64>::zeros((p * l, p * l));
+                    let start = g * p;
+                    m.slice_mut(s![start..start + p, start..start + p])
+                        .assign(pen);
+                    candidates.push(PenaltyCandidate {
+                        matrix: m,
+                        nullspace_dim_hint: 0,
+                        source: PenaltySource::Other(format!("by-factor-level-{g}-penalty-{pi}")),
+                        normalization_scale: 1.0,
+                        kronecker_factors: None,
+                        op: None,
+                    });
+                }
+            }
+            let (penalties, nullspace_dims, penaltyinfo, ops) =
+                filter_active_penalty_candidates_with_ops(candidates)?;
+            Ok(BasisBuildResult {
+                design: DesignMatrix::Dense(crate::matrix::DenseDesignMatrix::from(design)),
+                penalties,
+                nullspace_dims,
+                penaltyinfo,
+                ops,
+                metadata: BasisMetadata::BySmooth {
+                    inner: Box::new(inner.metadata),
+                    by_col: *feature_col,
+                    levels: Some(levels),
+                    ordered: *ordered,
+                },
+                kronecker_factored: None,
+            })
+        }
+    }
+}
+
+fn build_factor_smooth_basis(
+    data: ArrayView2<'_, f64>,
+    spec: &FactorSmoothSpec,
+) -> Result<BasisBuildResult, BasisError> {
+    if spec.continuous_cols.len() != 1 {
+        return Err(BasisError::InvalidInput(
+            "factor smooth currently requires exactly one continuous column".to_string(),
+        ));
+    }
+    let group_col = spec.group_col;
+    let levels =
+        sorted_levels_from_column(data.column(group_col), spec.group_frozen_levels.as_ref())?;
+    let n = data.nrows();
+    let l = levels.len();
+    let (base_x, base_penalties, knots, degree): (
+        Array2<f64>,
+        Vec<Array2<f64>>,
+        Array1<f64>,
+        usize,
+    ) = match spec.flavour {
+        FactorSmoothFlavour::Re => {
+            let xcol = data.column(spec.continuous_cols[0]);
+            let mut x = Array2::<f64>::zeros((n, 1));
+            for i in 0..n {
+                x[[i, 0]] = xcol[i];
+            }
+            (x, vec![Array2::<f64>::eye(1)], Array1::zeros(0), 1)
+        }
+        _ => {
+            let mut marginal = spec.marginal.clone();
+            marginal.identifiability = BSplineIdentifiability::None;
+            let built = build_bspline_basis_1d(data.column(spec.continuous_cols[0]), &marginal)?;
+            let knots = match &built.metadata {
+                BasisMetadata::BSpline1D { knots, .. } => knots.clone(),
+                _ => Array1::zeros(0),
+            };
+            (
+                built.design.to_dense(),
+                built.penalties,
+                knots,
+                marginal.degree,
+            )
+        }
+    };
+    let p = base_x.ncols();
+    let is_sz = matches!(spec.flavour, FactorSmoothFlavour::Sz);
+    let out_levels = if is_sz { l.saturating_sub(1) } else { l };
+    if out_levels == 0 {
+        return Err(BasisError::InvalidInput(
+            "factor smooth needs at least two levels for sz contrasts".to_string(),
+        ));
+    }
+    let mut design = Array2::<f64>::zeros((n, p * out_levels));
+    for i in 0..n {
+        let bits = data[[i, group_col]].to_bits();
+        if let Ok(g) = levels.binary_search(&bits) {
+            if is_sz {
+                for h in 0..out_levels {
+                    let c = if g == h {
+                        1.0
+                    } else if g == l - 1 {
+                        -1.0
+                    } else {
+                        0.0
+                    };
+                    if c != 0.0 {
+                        for j in 0..p {
+                            design[[i, h * p + j]] = c * base_x[[i, j]];
+                        }
+                    }
+                }
+            } else {
+                let start = g * p;
+                for j in 0..p {
+                    design[[i, start + j]] = base_x[[i, j]];
+                }
+            }
+        }
+    }
+    let penalties = match spec.flavour {
+        FactorSmoothFlavour::Fs { .. } | FactorSmoothFlavour::Re => {
+            vec![Array2::<f64>::eye(p * out_levels)]
+        }
+        FactorSmoothFlavour::Sz => base_penalties
+            .iter()
+            .map(|pen| block_diag_repeat(pen, out_levels))
+            .collect(),
+    };
+    let candidates = penalties
+        .into_iter()
+        .enumerate()
+        .map(|(i, matrix)| PenaltyCandidate {
+            matrix,
+            nullspace_dim_hint: 0,
+            source: PenaltySource::Other(format!("factor-smooth-penalty-{i}")),
+            normalization_scale: 1.0,
+            kronecker_factors: None,
+            op: None,
+        })
+        .collect();
+    let (penalties, nullspace_dims, penaltyinfo, ops) =
+        filter_active_penalty_candidates_with_ops(candidates)?;
+    let flavour = match spec.flavour {
+        FactorSmoothFlavour::Fs { .. } => "fs",
+        FactorSmoothFlavour::Sz => "sz",
+        FactorSmoothFlavour::Re => "re",
+    }
+    .to_string();
+    Ok(BasisBuildResult {
+        design: DesignMatrix::Dense(crate::matrix::DenseDesignMatrix::from(design)),
+        penalties,
+        nullspace_dims,
+        penaltyinfo,
+        ops,
+        metadata: BasisMetadata::FactorSmooth {
+            continuous_cols: spec.continuous_cols.clone(),
+            group_col,
+            knots,
+            degree,
+            levels,
+            flavour,
+        },
+        kronecker_factored: None,
+    })
+}
+
 fn build_random_effect_block(
     data: ArrayView2<'_, f64>,
     spec: &RandomEffectTermSpec,
@@ -3905,6 +4245,10 @@ fn build_single_local_smooth_term(
         SmoothBasisSpec::TensorBSpline { feature_cols, spec } => {
             build_tensor_bspline_basis(data, feature_cols, spec)?
         }
+        SmoothBasisSpec::BySmooth { smooth, by_kind } => {
+            build_by_smooth_basis(data, smooth, by_kind)?
+        }
+        SmoothBasisSpec::FactorSmooth { spec } => build_factor_smooth_basis(data, spec)?,
     };
 
     match &term.basis {
@@ -4658,6 +5002,24 @@ fn smooth_term_feature_cols(term: &SmoothTermSpec) -> Vec<usize> {
         | SmoothBasisSpec::Matern { feature_cols, .. }
         | SmoothBasisSpec::Duchon { feature_cols, .. }
         | SmoothBasisSpec::TensorBSpline { feature_cols, .. } => feature_cols.clone(),
+        SmoothBasisSpec::BySmooth { smooth, by_kind } => {
+            let mut cols = smooth_term_feature_cols(&SmoothTermSpec {
+                name: String::new(),
+                basis: *smooth.clone(),
+                shape: ShapeConstraint::None,
+            });
+            match by_kind {
+                ByVarKind::Numeric { feature_col } | ByVarKind::Factor { feature_col, .. } => {
+                    cols.push(*feature_col)
+                }
+            }
+            cols
+        }
+        SmoothBasisSpec::FactorSmooth { spec } => {
+            let mut cols = spec.continuous_cols.clone();
+            cols.push(spec.group_col);
+            cols
+        }
     }
 }
 
@@ -4669,6 +5031,8 @@ fn smooth_basis_family_rank(term: &SmoothTermSpec) -> u8 {
         SmoothBasisSpec::Sphere { .. } => 3,
         SmoothBasisSpec::Matern { .. } => 4,
         SmoothBasisSpec::Duchon { .. } => 5,
+        SmoothBasisSpec::BySmooth { .. } => 6,
+        SmoothBasisSpec::FactorSmooth { .. } => 7,
     }
 }
 
@@ -4691,6 +5055,11 @@ fn smooth_has_frozen_identifiability(term: &SmoothTermSpec) -> bool {
             spec.identifiability,
             MaternIdentifiability::FrozenTransform { .. }
         ),
+        SmoothBasisSpec::BySmooth { by_kind, .. } => match by_kind {
+            ByVarKind::Factor { frozen_levels, .. } => frozen_levels.is_some(),
+            ByVarKind::Numeric { .. } => true,
+        },
+        SmoothBasisSpec::FactorSmooth { spec } => spec.group_frozen_levels.is_some(),
         SmoothBasisSpec::Duchon { spec, .. } => matches!(
             spec.identifiability,
             SpatialIdentifiability::FrozenTransform { .. }
@@ -5460,6 +5829,32 @@ fn with_identifiability_transform(
                 identifiability_transform.as_ref(),
                 transform,
             )?,
+        }),
+        BasisMetadata::BySmooth {
+            inner,
+            by_col,
+            levels,
+            ordered,
+        } => Ok(BasisMetadata::BySmooth {
+            inner: Box::new(with_identifiability_transform(inner, transform)?),
+            by_col: *by_col,
+            levels: levels.clone(),
+            ordered: *ordered,
+        }),
+        BasisMetadata::FactorSmooth {
+            continuous_cols,
+            group_col,
+            knots,
+            degree,
+            levels,
+            flavour,
+        } => Ok(BasisMetadata::FactorSmooth {
+            continuous_cols: continuous_cols.clone(),
+            group_col: *group_col,
+            knots: knots.clone(),
+            degree: *degree,
+            levels: levels.clone(),
+            flavour: flavour.clone(),
         }),
     }
 }
@@ -10839,7 +11234,10 @@ fn try_build_spatial_term_log_kappa_derivative(
             build_duchon_basis_log_kappa_derivatives(x.view(), spec)
                 .map_err(EstimationError::from)?
         }
-        SmoothBasisSpec::BSpline1D { .. } | SmoothBasisSpec::TensorBSpline { .. } => {
+        SmoothBasisSpec::BSpline1D { .. }
+        | SmoothBasisSpec::TensorBSpline { .. }
+        | SmoothBasisSpec::BySmooth { .. }
+        | SmoothBasisSpec::FactorSmooth { .. } => {
             return Ok(None);
         }
     };
@@ -12388,6 +12786,69 @@ pub fn freeze_term_collection_from_design(
                 };
                 s.aniso_log_scales = meta_aniso.clone();
                 *input_scales = meta_scales.clone();
+            }
+            (
+                SmoothBasisSpec::BySmooth { smooth, by_kind },
+                BasisMetadata::BySmooth {
+                    inner,
+                    by_col,
+                    levels,
+                    ordered,
+                },
+            ) => {
+                match by_kind {
+                    ByVarKind::Factor {
+                        feature_col,
+                        ordered: ord,
+                        frozen_levels,
+                    } => {
+                        *feature_col = *by_col;
+                        *ord = *ordered;
+                        *frozen_levels = levels.clone();
+                    }
+                    ByVarKind::Numeric { feature_col } => *feature_col = *by_col,
+                }
+                if let (
+                    SmoothBasisSpec::BSpline1D { spec: s, .. },
+                    BasisMetadata::BSpline1D {
+                        knots,
+                        identifiability_transform,
+                        periodic,
+                    },
+                ) = (smooth.as_mut(), inner.as_ref())
+                {
+                    s.knotspec = periodic
+                        .map(
+                            |(domain_start, period, num_basis)| BSplineKnotSpec::PeriodicUniform {
+                                data_range: (domain_start, domain_start + period),
+                                num_basis,
+                            },
+                        )
+                        .unwrap_or_else(|| BSplineKnotSpec::Provided(knots.clone()));
+                    s.identifiability = identifiability_transform
+                        .as_ref()
+                        .map(|z| BSplineIdentifiability::FrozenTransform {
+                            transform: z.clone(),
+                        })
+                        .unwrap_or(BSplineIdentifiability::None);
+                    s.boundary_conditions = Default::default();
+                }
+            }
+            (
+                SmoothBasisSpec::FactorSmooth { spec: s },
+                BasisMetadata::FactorSmooth {
+                    knots,
+                    degree,
+                    levels,
+                    ..
+                },
+            ) => {
+                s.marginal.degree = *degree;
+                if !knots.is_empty() {
+                    s.marginal.knotspec = BSplineKnotSpec::Provided(knots.clone());
+                }
+                s.marginal.identifiability = BSplineIdentifiability::None;
+                s.group_frozen_levels = Some(levels.clone());
             }
             (
                 SmoothBasisSpec::TensorBSpline {

--- a/src/terms/term_builder.rs
+++ b/src/terms/term_builder.rs
@@ -24,9 +24,9 @@ use crate::inference::formula_dsl::{
 use crate::inference::model::ColumnKindTag;
 use crate::resource::ResourcePolicy;
 use crate::smooth::{
-    LinearCoefficientGeometry, LinearTermSpec, RandomEffectTermSpec, ShapeConstraint,
-    SmoothBasisSpec, SmoothTermSpec, TensorBSplineIdentifiability, TensorBSplineSpec,
-    TermCollectionSpec,
+    ByVarKind, FactorSmoothFlavour, FactorSmoothSpec, LinearCoefficientGeometry, LinearTermSpec,
+    RandomEffectTermSpec, ShapeConstraint, SmoothBasisSpec, SmoothTermSpec,
+    TensorBSplineIdentifiability, TensorBSplineSpec, TermCollectionSpec,
 };
 
 // ---------------------------------------------------------------------------
@@ -183,16 +183,52 @@ pub fn build_termspec(
                     .iter()
                     .map(|v| resolve_col(col_map, v))
                     .collect::<Result<Vec<_>, _>>()?;
-                let basis = build_smooth_basis(
+                let mut inner_options = options.clone();
+                let by_name = inner_options.remove("by");
+                let basis_inner = build_smooth_basis(
                     *kind,
                     vars,
                     &cols,
-                    options,
+                    &inner_options,
                     ds,
                     inference_notes,
                     policy,
                     smooth_coordinate_count,
                 )?;
+                let basis = if let Some(by_name) = by_name {
+                    let by_col = resolve_col(col_map, &by_name)?;
+                    let by_kind = match ds
+                        .column_kinds
+                        .get(by_col)
+                        .copied()
+                        .unwrap_or(ColumnKindTag::Continuous)
+                    {
+                        ColumnKindTag::Categorical => {
+                            let has_main = terms.iter().any(|term| matches!(term,
+                                ParsedTerm::Linear { name, .. } | ParsedTerm::RandomEffect { name } if name == &by_name));
+                            if !has_main {
+                                inference_notes.push(format!(
+                                    "factor by-smooth '{}' uses by={} without an explicit main-effect term; add '{}' for mgcv-style level identifiability",
+                                    label, by_name, by_name
+                                ));
+                            }
+                            ByVarKind::Factor {
+                                feature_col: by_col,
+                                ordered: false,
+                                frozen_levels: None,
+                            }
+                        }
+                        _ => ByVarKind::Numeric {
+                            feature_col: by_col,
+                        },
+                    };
+                    SmoothBasisSpec::BySmooth {
+                        smooth: Box::new(basis_inner),
+                        by_kind,
+                    }
+                } else {
+                    basis_inner
+                };
                 smooth_terms.push(SmoothTermSpec {
                     name: label.clone(),
                     basis,
@@ -398,6 +434,85 @@ pub fn build_smooth_basis(
         });
 
     match type_opt.as_str() {
+        "fs" | "sz" | "re" => {
+            validate_known_options(
+                type_opt.as_str(),
+                options,
+                &[
+                    "type",
+                    "bs",
+                    "k",
+                    "basis_dim",
+                    "basis-dim",
+                    "basisdim",
+                    "knots",
+                    "degree",
+                    "penalty_order",
+                    "m",
+                    "id",
+                ],
+            )?;
+            let mut group_idx = None;
+            let mut cont = Vec::new();
+            for (i, &c) in cols.iter().enumerate() {
+                match ds
+                    .column_kinds
+                    .get(c)
+                    .copied()
+                    .unwrap_or(ColumnKindTag::Continuous)
+                {
+                    ColumnKindTag::Categorical if group_idx.is_none() => group_idx = Some(i),
+                    _ => cont.push((i, c)),
+                }
+            }
+            let group_i = group_idx.ok_or_else(|| {
+                format!(
+                    "bs=\"{}\" smooth requires one categorical grouping variable",
+                    type_opt
+                )
+            })?;
+            if cont.len() != 1 {
+                return Err(format!(
+                    "bs=\"{}\" currently supports exactly one continuous variable plus one factor",
+                    type_opt
+                ));
+            }
+            let c = cont[0].1;
+            let (minv, maxv) = col_minmax(ds.values.column(c))?;
+            let degree = if type_opt == "re" {
+                1
+            } else {
+                option_usize(options, "degree").unwrap_or(3)
+            };
+            let default_internal = heuristic_knots_for_column(ds.values.column(c));
+            let (n_knots, _) = parse_ps_internal_knots(options, degree, default_internal)?;
+            let flavour = match type_opt.as_str() {
+                "fs" => FactorSmoothFlavour::Fs {
+                    m_null_penalty_orders: (0..option_usize(options, "m").unwrap_or(2)).collect(),
+                },
+                "sz" => FactorSmoothFlavour::Sz,
+                _ => FactorSmoothFlavour::Re,
+            };
+            Ok(SmoothBasisSpec::FactorSmooth {
+                spec: FactorSmoothSpec {
+                    continuous_cols: vec![c],
+                    group_col: cols[group_i],
+                    marginal: BSplineBasisSpec {
+                        degree,
+                        penalty_order: option_usize(options, "penalty_order").unwrap_or(2),
+                        knotspec: BSplineKnotSpec::Generate {
+                            data_range: (minv, maxv),
+                            num_internal_knots: n_knots,
+                        },
+                        double_penalty: false,
+                        identifiability: BSplineIdentifiability::None,
+                        boundary_conditions: Default::default(),
+                    },
+                    flavour,
+                    group_frozen_levels: None,
+                },
+            })
+        }
         "tensor" | "te" | "tensor-bspline" => {
             validate_known_options(
                 "te",

--- a/tests/formula_dsl_factor_smooth_aliases.rs
+++ b/tests/formula_dsl_factor_smooth_aliases.rs
@@ -1,0 +1,41 @@
+use gam::inference::formula_dsl::{ParsedTerm, parse_formula};
+
+fn smooth_options(formula: &str) -> (Vec<String>, std::collections::BTreeMap<String, String>) {
+    let parsed = parse_formula(formula).expect(formula);
+    parsed
+        .terms
+        .into_iter()
+        .find_map(|term| match term {
+            ParsedTerm::Smooth { vars, options, .. } => Some((vars, options)),
+            _ => None,
+        })
+        .expect("smooth term")
+}
+
+#[test]
+fn parses_factor_smooth_bs_forms_and_aliases() {
+    for (formula, expected_bs, expected_vars) in [
+        ("y ~ s(x, fac, bs=\"fs\")", "fs", vec!["x", "fac"]),
+        ("y ~ fs(x, fac)", "fs", vec!["x", "fac"]),
+        ("y ~ s(x, fac, bs=fs, k=10)", "fs", vec!["x", "fac"]),
+        ("y ~ s(x, fac, bs=\"sz\")", "sz", vec!["x", "fac"]),
+        ("y ~ sz(x, fac)", "sz", vec!["x", "fac"]),
+    ] {
+        let (vars, options) = smooth_options(formula);
+        assert_eq!(vars, expected_vars);
+        assert_eq!(options.get("bs").map(String::as_str), Some(expected_bs));
+    }
+}
+
+#[test]
+fn parses_by_smooth_options() {
+    for (formula, expected_by, expected_k) in [
+        ("y ~ s(x, by=fac)", "fac", None),
+        ("y ~ s(x, by=group, k=8)", "group", Some("8")),
+    ] {
+        let (vars, options) = smooth_options(formula);
+        assert_eq!(vars, vec!["x"]);
+        assert_eq!(options.get("by").map(String::as_str), Some(expected_by));
+        assert_eq!(options.get("k").map(String::as_str), expected_k);
+    }
+}


### PR DESCRIPTION
### Motivation

- Provide the building blocks to support mgcv-style `s(x, by=...)`, factor-conditioned smooths (`bs="fs"` / `bs="sz"`) and random-slope shorthand (`bs="re"`) so per-group and partial-pooling smooths can be expressed and carried through fit/predict lifecycles. 
- Ensure frozen-level metadata and identifiability bookkeeping round-trip into saved specs so predictions on unseen or held-out factor levels behave robustly.

### Description

- Introduce new spec types and enums: `SmoothBasisSpec::BySmooth` and `SmoothBasisSpec::FactorSmooth`, `ByVarKind`, `FactorSmoothSpec`, and `FactorSmoothFlavour` to represent numeric/factor `by=` and `fs`/`sz`/`re` flavours. (`src/terms/smooth.rs`, `src/terms/basis.rs`).
- Thread `by=` through parsing and term construction: parse `by=<name>`, add `fs(...)` / `sz(...)` aliases (map to `bs=...`), remove `by` from inner smooth options and resolve the by-column into `ByVarKind` (numeric vs factor). (`src/inference/formula_dsl.rs`, `src/terms/term_builder.rs`).
- Implement dense builders: `build_by_smooth_basis` (numeric scales or factor → one block per level with per-level penalties) and `build_factor_smooth_basis` (implements `fs`/`sz`/`re` flavors including `sz` sum-to-zero contrasts and `fs`/`re` ridge-style penalties), and wire them into `build_single_local_smooth_term`. Maintain frozen-level handling and unseen-level-zero behaviour. (`src/terms/smooth.rs`).
- Extend `BasisMetadata` and freeze/remap logic so marginal knots and frozen level lists are captured and restored for prediction-time replay. Update `freeze_term_collection_from_design`, saved-model remapping, and related shape/feature-column utilities. (`src/terms/basis.rs`, `src/terms/smooth.rs`, `src/families/survival_predict.rs`, `src/main.rs`).
- Documentation and examples updated to describe `s(x, by=...)`, `s(x, fac, bs="fs")`, `s(x, fac, bs="sz")`, and random slopes; cookbook entries added. (`docs/formulas.md`, `docs/cookbook.md`).
- Add parser unit tests covering `fs`/`sz` aliases and `by=` options. (`tests/formula_dsl_factor_smooth_aliases.rs`).

### Testing

- Ran `cargo check`; it completed successfully (no type/compile errors against the modified code). 
- Added and ran focused parser unit tests with `cargo test --test formula_dsl_factor_smooth_aliases`, and the tests passed (`parses_factor_smooth_bs_forms_and_aliases` and `parses_by_smooth_options`).
- Attempted a full `cargo test --workspace` but the initial workspace test run failed due to an environment `No space left on device` during linking; after `cargo clean` the focused tests and `cargo check` were re-run and passed. The full workspace test-suite could not be completed in this environment due to those resource limits.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ab3cfbbc8832499757e2e08cd2e71)