### PR TITLE
Cache projected covariate·factor products and add cached/streaming trace paths; remove legacy SIMD log routine

### DIFF
--- a/src/families/transformation_normal.rs
+++ b/src/families/transformation_normal.rs
@@ -6864,6 +6864,8 @@ impl TransformationNormalFamily {
         cov: ArrayView2<'_, f64>,
         cov_psi: ArrayView2<'_, f64>,
         factor: ArrayView2<'_, f64>,
+        projected_cov_f: Option<ArrayView2<'_, f64>>,
+        projected_psi_f: Option<ArrayView2<'_, f64>>,
     ) -> Result<f64, String> {
         let total_n = self.response_val_basis.nrows();
         let n = cov.nrows();
@@ -6979,6 +6981,72 @@ impl TransformationNormalFamily {
             }
         }
 
+        // Project the low-rank REML factor through each response-slice of the
+        // covariate design with BLAS instead of recomputing
+        // `sum_c F[(k,c), r] * x_ic` inside every row. This is an exact
+        // algebraic refactor of the old row loop: for each response basis `k`,
+        // `projected_cov_f[:, k, :] = cov · factor_k` and
+        // `projected_psi_f[:, k, :] = cov_psi · factor_k`. Callers that sweep
+        // multiple ψ-Hessian directional traces may supply cached projections;
+        // otherwise we build the chunk-local projections here.
+        let projected_len = p_resp * rank;
+        let mut projected_cov_storage;
+        let mut projected_psi_storage;
+        let projected_cov_f = match projected_cov_f {
+            Some(view) => {
+                if view.nrows() != n || view.ncols() != projected_len {
+                    return Err(format!(
+                        "SCOP psi Hessian directional projected cov-factor shape {}x{} != expected {}x{}",
+                        view.nrows(),
+                        view.ncols(),
+                        n,
+                        projected_len
+                    ));
+                }
+                view
+            }
+            None => {
+                projected_cov_storage = Array2::<f64>::zeros((n, projected_len));
+                if rank > 0 && n > 0 {
+                    for k in 0..p_resp {
+                        let factor_block = factor.slice(s![k * p_cov..(k + 1) * p_cov, ..]);
+                        let cov_projection = fast_ab(&cov, &factor_block);
+                        projected_cov_storage
+                            .slice_mut(s![.., k * rank..(k + 1) * rank])
+                            .assign(&cov_projection);
+                    }
+                }
+                projected_cov_storage.view()
+            }
+        };
+        let projected_psi_f = match projected_psi_f {
+            Some(view) => {
+                if view.nrows() != n || view.ncols() != projected_len {
+                    return Err(format!(
+                        "SCOP psi Hessian directional projected psi-factor shape {}x{} != expected {}x{}",
+                        view.nrows(),
+                        view.ncols(),
+                        n,
+                        projected_len
+                    ));
+                }
+                view
+            }
+            None => {
+                projected_psi_storage = Array2::<f64>::zeros((n, projected_len));
+                if rank > 0 && n > 0 {
+                    for k in 0..p_resp {
+                        let factor_block = factor.slice(s![k * p_cov..(k + 1) * p_cov, ..]);
+                        let psi_projection = fast_ab(&cov_psi, &factor_block);
+                        projected_psi_storage
+                            .slice_mut(s![.., k * rank..(k + 1) * rank])
+                            .assign(&psi_projection);
+                    }
+                }
+                projected_psi_storage.view()
+            }
+        };
+
         use rayon::iter::{IntoParallelIterator, ParallelIterator};
         let weights = self.weights.as_ref();
         let h_prime = row_quantities.h_prime.as_ref();
@@ -7007,23 +7075,18 @@ impl TransformationNormalFamily {
                         acc.gamma_psi_dir[k] = dir_mat.row(k).dot(&psi_row);
                     }
 
-                    acc.gamma_f.fill(0.0);
-                    acc.gamma_psi_f.fill(0.0);
-                    for k in 0..p_resp {
-                        let factor_row_base = k * p_cov;
-                        let projected_base = k * rank;
-                        for cidx in 0..p_cov {
-                            let factor_row = factor_row_base + cidx;
-                            let cov_v = cov_row[cidx];
-                            let psi_v = psi_row[cidx];
-                            for col in 0..rank {
-                                let coeff = factor[[factor_row, col]];
-                                let idx = projected_base + col;
-                                acc.gamma_f[idx] += coeff * cov_v;
-                                acc.gamma_psi_f[idx] += coeff * psi_v;
-                            }
-                        }
-                    }
+                    let projected_cov_row = projected_cov_f.row(local_i);
+                    let projected_psi_row = projected_psi_f.row(local_i);
+                    acc.gamma_f.copy_from_slice(
+                        projected_cov_row
+                            .as_slice()
+                            .expect("projected CTN covariate-factor row should be contiguous"),
+                    );
+                    acc.gamma_psi_f.copy_from_slice(
+                        projected_psi_row
+                            .as_slice()
+                            .expect("projected CTN psi-factor row should be contiguous"),
+                    );
 
                     let mut hp_psi = rd[0] * acc.gamma_psi[0];
                     let mut h_dir = rv[0] * acc.gamma_dir[0];
@@ -8753,31 +8816,157 @@ impl TransformationNormalPsiDhMatrixFreeOperator {
                 .expect("validated CTN psi dH dense materialization inputs should not fail")
         })
     }
-}
 
-impl HyperOperator for TransformationNormalPsiDhMatrixFreeOperator {
-    fn dim(&self) -> usize {
-        self.p_total()
+    fn trace_projected_factor_dense(&self, factor: &Array2<f64>) -> f64 {
+        let dense_factor = crate::faer_ndarray::fast_ab(self.dense_matrix(), factor);
+        factor
+            .iter()
+            .zip(dense_factor.iter())
+            .map(|(&f, &bf)| f * bf)
+            .sum()
     }
 
-    fn mul_vec(&self, v: &Array1<f64>) -> Array1<f64> {
-        debug_assert_eq!(v.len(), self.p_total());
-        self.dense_matrix().dot(v)
+    fn projected_factor_cache_id(&self) -> usize {
+        let family_ptr = Arc::as_ptr(&self.family) as usize;
+        family_ptr
+            ^ self.axis.wrapping_add(0x9e37_79b9).rotate_left(17)
+            ^ self.family.response_val_basis.nrows().rotate_left(7)
+            ^ self.family.covariate_design.ncols().rotate_left(29)
     }
 
-    fn mul_mat(&self, factor: &Array2<f64>) -> Array2<f64> {
-        debug_assert_eq!(factor.nrows(), self.p_total());
-        self.dense_matrix().dot(factor)
+    fn projected_factor_table_bytes(&self, factor: &Array2<f64>) -> usize {
+        let n = self.family.response_val_basis.nrows();
+        let p_resp = self.family.response_val_basis.ncols();
+        let rank = factor.ncols();
+        n.saturating_mul(p_resp)
+            .saturating_mul(rank)
+            .saturating_mul(2)
+            .saturating_mul(std::mem::size_of::<f64>())
     }
 
-    fn trace_projected_factor(&self, factor: &Array2<f64>) -> f64 {
+    fn projected_factor_table_fits_budget(&self, factor: &Array2<f64>) -> bool {
+        let bytes = self.projected_factor_table_bytes(factor);
+        let policy = ResourcePolicy::default_library();
+        bytes <= policy.max_single_materialization_bytes && bytes <= policy.max_operator_cache_bytes
+    }
+
+    fn projected_factor_table(&self, factor: &Array2<f64>) -> Array2<f64> {
         debug_assert_eq!(factor.nrows(), self.p_total());
         let n = self.family.response_val_basis.nrows();
         let p_cov = self.family.covariate_design.ncols();
-        let rows_per_chunk = self
-            .family
-            .scop_psi_pair_rows_per_chunk(p_cov)
-            .min(n.max(1));
+        let p_resp = self.family.response_val_basis.ncols();
+        let rank = factor.ncols();
+        let projected_len = p_resp * rank;
+        let mut table = Array2::<f64>::zeros((n, 2 * projected_len));
+        if n == 0 || rank == 0 {
+            return table;
+        }
+        let op = self.tensor_op();
+        let policy = ResourcePolicy::default_library();
+        let live_cols = p_cov
+            .saturating_mul(2)
+            .saturating_add(p_resp.saturating_mul(rank).saturating_mul(2))
+            .max(1);
+        let rows_per_chunk =
+            crate::resource::rows_for_target_bytes(policy.row_chunk_target_bytes, live_cols)
+                .max(1)
+                .min(n.max(1));
+        for start in (0..n).step_by(rows_per_chunk) {
+            let end = (start + rows_per_chunk).min(n);
+            let rows = start..end;
+            let cov = self
+                .family
+                .covariate_design
+                .try_row_chunk(rows.clone())
+                .expect("validated CTN psi dH projected-table covariate chunk should not fail");
+            let cov_psi = op
+                .cov_first_axis_row_chunk_streaming(self.axis, rows.clone())
+                .expect("validated CTN psi dH projected-table covariate derivative chunk should not fail");
+            for k in 0..p_resp {
+                let factor_block = factor.slice(s![k * p_cov..(k + 1) * p_cov, ..]);
+                let cov_projection = fast_ab(&cov, &factor_block);
+                let psi_projection = fast_ab(&cov_psi, &factor_block);
+                table
+                    .slice_mut(s![start..end, k * rank..(k + 1) * rank])
+                    .assign(&cov_projection);
+                table
+                    .slice_mut(s![
+                        start..end,
+                        projected_len + k * rank..projected_len + (k + 1) * rank
+                    ])
+                    .assign(&psi_projection);
+            }
+        }
+        table
+    }
+
+    fn trace_projected_factor_with_projected_table(
+        &self,
+        factor: &Array2<f64>,
+        table: ArrayView2<'_, f64>,
+    ) -> f64 {
+        debug_assert_eq!(factor.nrows(), self.p_total());
+        let n = self.family.response_val_basis.nrows();
+        let p_cov = self.family.covariate_design.ncols();
+        let p_resp = self.family.response_val_basis.ncols();
+        let rank = factor.ncols();
+        let projected_len = p_resp * rank;
+        debug_assert_eq!(table.dim(), (n, 2 * projected_len));
+        let op = self.tensor_op();
+        let policy = ResourcePolicy::default_library();
+        let live_cols = p_cov.saturating_mul(2).max(1);
+        let rows_per_chunk =
+            crate::resource::rows_for_target_bytes(policy.row_chunk_target_bytes, live_cols)
+                .max(1)
+                .min(n.max(1));
+        let mut total = 0.0;
+        for start in (0..n).step_by(rows_per_chunk) {
+            let end = (start + rows_per_chunk).min(n);
+            let rows = start..end;
+            let cov = self
+                .family
+                .covariate_design
+                .try_row_chunk(rows.clone())
+                .expect(
+                    "validated CTN psi dH cached projected trace covariate chunk should not fail",
+                );
+            let cov_psi = op
+                .cov_first_axis_row_chunk_streaming(self.axis, rows.clone())
+                .expect("validated CTN psi dH cached projected trace covariate derivative chunk should not fail");
+            let projected_cov = table.slice(s![start..end, ..projected_len]);
+            let projected_psi = table.slice(s![start..end, projected_len..]);
+            total += self
+                .family
+                .scop_psi_hessian_directional_trace_factor_chunk_from_cov(
+                    &self.beta,
+                    &self.direction,
+                    &self.row_quantities,
+                    start,
+                    cov.view(),
+                    cov_psi.view(),
+                    factor.view(),
+                    Some(projected_cov),
+                    Some(projected_psi),
+                )
+                .expect("validated CTN psi dH cached projected trace inputs should not fail");
+        }
+        total
+    }
+
+    fn trace_projected_factor_streaming(&self, factor: &Array2<f64>) -> f64 {
+        let n = self.family.response_val_basis.nrows();
+        let p_cov = self.family.covariate_design.ncols();
+        let rank = factor.ncols();
+        let p_resp = self.family.response_val_basis.ncols();
+        let policy = ResourcePolicy::default_library();
+        let live_cols = p_cov
+            .saturating_mul(2)
+            .saturating_add(p_resp.saturating_mul(rank).saturating_mul(2))
+            .max(1);
+        let rows_per_chunk =
+            crate::resource::rows_for_target_bytes(policy.row_chunk_target_bytes, live_cols)
+                .max(1)
+                .min(n.max(1));
         let op = self.tensor_op();
         let mut total = 0.0;
         for start in (0..n).step_by(rows_per_chunk) {
@@ -8801,10 +8990,62 @@ impl HyperOperator for TransformationNormalPsiDhMatrixFreeOperator {
                     cov.view(),
                     cov_psi.view(),
                     factor.view(),
+                    None,
+                    None,
                 )
                 .expect("validated CTN psi dH projected trace inputs should not fail");
         }
         total
+    }
+}
+
+impl HyperOperator for TransformationNormalPsiDhMatrixFreeOperator {
+    fn dim(&self) -> usize {
+        self.p_total()
+    }
+
+    fn mul_vec(&self, v: &Array1<f64>) -> Array1<f64> {
+        debug_assert_eq!(v.len(), self.p_total());
+        self.dense_matrix().dot(v)
+    }
+
+    fn mul_mat(&self, factor: &Array2<f64>) -> Array2<f64> {
+        debug_assert_eq!(factor.nrows(), self.p_total());
+        self.dense_matrix().dot(factor)
+    }
+
+    fn trace_projected_factor(&self, factor: &Array2<f64>) -> f64 {
+        debug_assert_eq!(factor.nrows(), self.p_total());
+
+        // At the CTN biobank benchmark shape (`p≈264`, `n≈20k`), the
+        // coefficient-space directional Hessian is tiny (< 1 MiB) while the
+        // streaming projected trace repeats a full row-kernel pass for every
+        // outer-gradient coordinate and every BFGS line-search evaluation.
+        // Materializing the exact p×p directional derivative once and doing a
+        // dense BLAS3 projection is mathematically identical to the streaming
+        // contraction and is several times faster at these moderate p values.
+        // Keep the old streaming path for larger coefficient systems where a
+        // dense p×p cache can dominate memory or construction cost.
+        if self.p_total() <= 512 {
+            return self.trace_projected_factor_dense(factor);
+        }
+
+        self.trace_projected_factor_streaming(factor)
+    }
+
+    fn trace_projected_factor_cached(
+        &self,
+        factor: &Array2<f64>,
+        cache: &crate::solver::estimate::reml::unified::ProjectedFactorCache,
+    ) -> f64 {
+        debug_assert_eq!(factor.nrows(), self.p_total());
+        if self.p_total() <= 512 || !self.projected_factor_table_fits_budget(factor) {
+            return self.trace_projected_factor(factor);
+        }
+        let key =
+            ProjectedFactorKey::from_factor_view(self.projected_factor_cache_id(), factor.view());
+        let table = cache.get_or_insert_with(key, || self.projected_factor_table(factor));
+        self.trace_projected_factor_with_projected_table(factor, table.view())
     }
 
     fn to_dense(&self) -> Array2<f64> {
@@ -14445,6 +14686,7 @@ pub fn fit_transformation_normal(
     // rather than the generic `coefficient_*_cost × K` default.
     let outer_derivative_policy =
         probe_family.outer_derivative_policy(&probe_blocks, joint_setup.log_kappa_dim(), &options);
+
     let solved = optimize_spatial_length_scale_exact_joint(
         covariate_data,
         &block_specs_slice,

--- a/src/terms/basis.rs
+++ b/src/terms/basis.rs
@@ -13515,87 +13515,6 @@ fn validate_lat_lon_matrix(
     Ok(())
 }
 
-/// High-accuracy SIMD natural logarithm for `f64x4`.
-///
-/// Implemented as `ln(x) = e·ln(2) + 2·atanh((m-1)/(m+1))` with the mantissa
-/// rebalanced into `m ∈ [√2/2, √2]` so `|f| = |(m-1)/(m+1)| ≤ 0.1716`. The
-/// `2·atanh` series uses exact rational coefficients `1/(2k+1)` through
-/// `f^{17}/17`; the truncation tail is bounded by `0.172^{19}/19 ≈ 1.4e-16`,
-/// safely below one ulp at the magnitudes that appear in
-/// `wahba_sphere_kernel_from_cos`. `ln(2)` is carried as a double-double
-/// (`hi + lo`) so the exponent reconstruction does not introduce its own
-/// rounding error.
-///
-/// Inputs are assumed strictly positive and finite — the call site clamps
-/// the kernel argument to `(0, ∞)` before invocation, so we skip the
-/// inf/NaN/subnormal blends that `wide::f64x4::ln` carries (those branches
-/// are also coarse at f64 precision; see `wide-0.7.33/src/f64x4_.rs:1297`).
-#[inline]
-fn wahba_simd_ln(x: wide::f64x4) -> wide::f64x4 {
-    use wide::{CmpGt, f64x4};
-    // Bit-twiddle each lane to split into mantissa m ∈ [1, 2) and integer
-    // exponent e. `wide` keeps `fraction_2`/`exponent` private, so we route
-    // through `to_array` / `from`. The 8 scalar bit ops below are cheap
-    // relative to the vectorised polynomial that follows.
-    let arr = x.to_array();
-    let mut m_arr = [0.0_f64; 4];
-    let mut e_arr = [0.0_f64; 4];
-    for k in 0..4 {
-        let bits = arr[k].to_bits();
-        let raw_exp = ((bits >> 52) & 0x7FF) as i64;
-        let exp = raw_exp - 1023;
-        let m_bits = (bits & 0x000F_FFFF_FFFF_FFFF) | 0x3FF0_0000_0000_0000;
-        m_arr[k] = f64::from_bits(m_bits);
-        e_arr[k] = exp as f64;
-    }
-    let m = f64x4::from(m_arr);
-    let mut e = f64x4::from(e_arr);
-    // Rebalance into [√2/2, √2]: if m > √2, halve m and bump e by 1.
-    // We use `m > √2` rather than `> √2/2 · 2` so the centred range is symmetric.
-    let sqrt2 = f64x4::from(std::f64::consts::SQRT_2);
-    let mask = m.cmp_gt(sqrt2);
-    let m = mask.blend(m * f64x4::from(0.5), m);
-    e = mask.blend(e + f64x4::ONE, e);
-
-    // f = (m - 1) / (m + 1), then ln(m) = 2·atanh(f) = 2·Σ f^{2k+1}/(2k+1).
-    let one = f64x4::ONE;
-    let f = (m - one) / (m + one);
-    let f2 = f * f;
-    // Horner on the inner polynomial P(f²) so that 2·atanh(f) = 2·f·P(f²),
-    // with P(u) = 1 + u/3 + u²/5 + u³/7 + ... up to u^8 (degree 17 in f).
-    // Coefficients are exact 1/(2k+1) for k = 0..8.
-    let c0 = one;
-    let c1 = f64x4::from(1.0 / 3.0);
-    let c2 = f64x4::from(1.0 / 5.0);
-    let c3 = f64x4::from(1.0 / 7.0);
-    let c4 = f64x4::from(1.0 / 9.0);
-    let c5 = f64x4::from(1.0 / 11.0);
-    let c6 = f64x4::from(1.0 / 13.0);
-    let c7 = f64x4::from(1.0 / 15.0);
-    let c8 = f64x4::from(1.0 / 17.0);
-    // Horner: ((((((((c8·u + c7)·u + c6)·u + c5)·u + c4)·u + c3)·u + c2)·u + c1)·u + c0
-    let mut p = c8;
-    p = p * f2 + c7;
-    p = p * f2 + c6;
-    p = p * f2 + c5;
-    p = p * f2 + c4;
-    p = p * f2 + c3;
-    p = p * f2 + c2;
-    p = p * f2 + c1;
-    p = p * f2 + c0;
-    let ln_m = (f + f) * p;
-
-    // ln(2) double-double split: hi is the f64 closest to ln(2)
-    // (`0x3FE62E42FEFA39EF` = 0.69314718055994528623...), lo is the
-    // residual `ln(2) - hi ≈ 2.319e-17`. `e` is integer-valued and small
-    // (|e| ≤ ~1024), so `e * ln2_hi` introduces only a single rounding,
-    // and the `lo` term restores the lost precision.
-    let ln2_hi = f64x4::from(std::f64::consts::LN_2);
-    let ln2_lo = f64x4::from(2.319_046_813_846_299_6e-17_f64);
-    // ln(x) = e·ln2_hi + (e·ln2_lo + ln_m). Order matters for accuracy.
-    e * ln2_hi + (e * ln2_lo + ln_m)
-}
-
 /// True Wahba / Sobolev spectral reproducing kernel on S² for general m.
 ///
 ///   K_m(γ) = (1/4π) Σ_{l ≥ 1} (2l + 1) · [l(l + 1)]^{-m} · P_l(cos γ)
@@ -13640,17 +13559,6 @@ fn wahba_sphere_kernel_spectral(cos_gamma: f64, m: usize) -> f64 {
         p_l = p_l_plus_1;
     }
     sum
-}
-
-/// Legacy alias retained so existing call sites continue to compile.
-#[inline]
-fn wahba_sphere_kernel_m4_spectral(cos_gamma: f64) -> f64 {
-    wahba_sphere_kernel_spectral(cos_gamma, 4)
-}
-
-#[inline]
-fn wahba_sphere_kernel_m4_spectral_simd(cos_gamma: wide::f64x4) -> wide::f64x4 {
-    wide::f64x4::from(cos_gamma.to_array().map(wahba_sphere_kernel_m4_spectral))
 }
 
 /// SIMD-vectorised companion to `wahba_sphere_kernel_from_cos`. Each lane of


### PR DESCRIPTION
### Motivation

- Reduce redundant work in the CTN ψ-Hessian directional trace by projecting low-rank REML factors through covariate slices once and reusing those projections across rows and repeated traces. 
- Provide memory-policy-aware caching/materialization of projected factor tables to accelerate workloads with moderate `p` while retaining a streaming fallback for large problems. 
- Remove an unused/legacy SIMD natural-log helper to trim dead code.

### Description

- Extended `scop_psi_hessian_directional_trace_factor_chunk_from_cov` to accept optional `projected_cov_f` and `projected_psi_f` views, and added logic to compute per-chunk projections with BLAS (`fast_ab`) when the views are not provided. 
- Replaced the inner per-row triple loop that accumulated `gamma_f`/`gamma_psi_f` with direct copies from the projected rows to avoid recomputing `sum_c F[(k,c), r] * x_ic` for each row. 
- Added multiple helper methods on `TransformationNormalPsiDhMatrixFreeOperator`: `trace_projected_factor_dense`, `projected_factor_cache_id`, `projected_factor_table_bytes`, `projected_factor_table_fits_budget`, `projected_factor_table`, `trace_projected_factor_with_projected_table`, `trace_projected_factor_streaming`, and `trace_projected_factor_cached`, plus logic to select a dense BLAS path for small systems (`p_total() <= 512`) and a streaming path otherwise. 
- Implemented a materialization routine that builds a `(n × 2·(p_resp·rank))` projected-table in row chunks subject to `ResourcePolicy` limits and added cache lookup via `ProjectedFactorCache` keyed by the factor and operator instance. 
- Kept the original streaming path as a fallback and preserved the `HyperOperator` behavior; reworked chunk sizing to use `rows_for_target_bytes`. 
- Removed the `wahba_simd_ln` implementation and related legacy aliases/simd helpers from `terms/basis.rs` to simplify the basis code.

### Testing

- Ran the Rust unit test suite with `cargo test` for the workspace and the tests touching `transformation_normal` and `terms::basis`, and the test run completed successfully. 
- Exercised the new projected-table materialization and cached trace paths with existing CTN unit tests and observed no regressions. 
- Verified the dense vs streaming selection on representative problem sizes (small `p` uses dense BLAS path; large `p` falls back to streaming) during the test runs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a12c348cc8324b5e274238b94b50a)