### PR TITLE
Improve projected-factor cache concurrency and trace batching; various small fixes

### DIFF
--- a/src/families/gamlss.rs
+++ b/src/families/gamlss.rs
@@ -23765,7 +23765,11 @@ mod tests {
 
     fn spatial_fit_smoke_options() -> BlockwiseFitOptions {
         BlockwiseFitOptions {
-            inner_max_cycles: 24,
+            // The location-scale-wiggle spatial smoke test can need more than
+            // 24 blockwise cycles after the final outer REML refit; keep the
+            // tolerance unchanged and allow enough iterations for the same
+            // convergence criterion to be reached deterministically.
+            inner_max_cycles: 48,
             inner_tol: 1e-4,
             outer_max_iter: 3,
             outer_tol: 1e-4,

--- a/src/solver/gaussian_reml.rs
+++ b/src/solver/gaussian_reml.rs
@@ -1063,6 +1063,10 @@ fn dense_xt_diag_y(
     fast_xt_diag_y(&x, &w, &y)
 }
 
+fn dense_xt_diag_x(x: ArrayView2<'_, f64>, w: ArrayView1<'_, f64>) -> Array2<f64> {
+    fast_xt_diag_y(&x, &w, &x)
+}
+
 fn matrix_fingerprint(matrix: ArrayView2<'_, f64>) -> u64 {
     let mut hash = 0xcbf29ce484222325_u64;
     hash = fnv1a_mix(hash, matrix.nrows() as u64);

--- a/src/solver/reml/unified.rs
+++ b/src/solver/reml/unified.rs
@@ -103,9 +103,10 @@
 use ndarray::{Array1, Array2, ArrayView1, ArrayView2, ArrayViewMut1, ArrayViewMut2, Zip};
 use rayon::prelude::*;
 use std::collections::HashMap;
-use std::sync::{Arc, Mutex};
+use std::panic::{AssertUnwindSafe, catch_unwind, resume_unwind};
+use std::sync::{Arc, Condvar, Mutex};
 
-use crate::faer_ndarray::FaerEigh;
+use crate::faer_ndarray::{FaerCholesky, FaerEigh};
 use crate::linalg::matrix::DesignMatrix;
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -1724,6 +1725,20 @@ pub trait HyperOperator: Send + Sync {
         None
     }
 
+    /// Downcast to `CompositeHyperOperator` when this operator is a linear
+    /// bundle. Exact dense-spectral trace batching uses this to flatten
+    /// coordinate drifts across coordinates, so one shared design projection
+    /// can feed many implicit ψ/correction operators.
+    fn as_composite(&self) -> Option<&CompositeHyperOperator> {
+        None
+    }
+
+    /// Downcast to `WeightedHyperOperator` when this operator is a weighted
+    /// linear bundle.
+    fn as_weighted(&self) -> Option<&WeightedHyperOperator> {
+        None
+    }
+
     /// If this operator is block-local (nonzero only in [start..end, start..end]),
     /// returns the block range and local matrix. Enables O(p_block²) trace
     /// computations instead of O(p²).
@@ -1807,9 +1822,20 @@ pub struct ProjectedFactorCache {
 
 struct ProjectedFactorCacheInner {
     entries: HashMap<ProjectedFactorKey, ProjectedFactorEntry>,
+    in_progress: HashMap<ProjectedFactorKey, Arc<ProjectedFactorInProgress>>,
     next_seq: u64,
     total_bytes: usize,
     budget_bytes: usize,
+}
+
+struct ProjectedFactorInProgress {
+    state: Mutex<Option<ProjectedFactorInProgressState>>,
+    ready: Condvar,
+}
+
+enum ProjectedFactorInProgressState {
+    Ready(Arc<Array2<f64>>),
+    Failed,
 }
 
 struct ProjectedFactorEntry {
@@ -1840,6 +1866,7 @@ impl ProjectedFactorCache {
         Self {
             inner: Mutex::new(ProjectedFactorCacheInner {
                 entries: HashMap::new(),
+                in_progress: HashMap::new(),
                 next_seq: 0,
                 total_bytes: 0,
                 budget_bytes,
@@ -1852,9 +1879,13 @@ impl ProjectedFactorCache {
         key: ProjectedFactorKey,
         compute: impl FnOnce() -> Array2<f64>,
     ) -> Arc<Array2<f64>> {
-        // Fast path: probe the cache under a short critical section. If the
-        // entry is already materialized, bump its LRU timestamp and return.
-        {
+        enum CacheLookup {
+            Hit(Arc<Array2<f64>>),
+            Wait(Arc<ProjectedFactorInProgress>),
+            Compute(Arc<ProjectedFactorInProgress>),
+        }
+
+        let lookup = {
             let mut inner = self
                 .inner
                 .lock()
@@ -1863,64 +1894,119 @@ impl ProjectedFactorCache {
             let now = inner.next_seq;
             if let Some(entry) = inner.entries.get_mut(&key) {
                 entry.last_used = now;
-                return entry.value.clone();
+                CacheLookup::Hit(entry.value.clone())
+            } else if let Some(waiter) = inner.in_progress.get(&key) {
+                CacheLookup::Wait(waiter.clone())
+            } else {
+                let marker = Arc::new(ProjectedFactorInProgress {
+                    state: Mutex::new(None),
+                    ready: Condvar::new(),
+                });
+                inner.in_progress.insert(key, marker.clone());
+                CacheLookup::Compute(marker)
             }
-        }
-        // Compute *outside* the lock. The projection `J·F` runs a rayon
-        // `par_chunks_mut` inside; holding a mutex across rayon work
-        // dispatches to workers that may steal sibling jobs which also call
-        // `get_or_insert_with` on this cache, and those workers block on the
-        // mutex this thread still holds — classic nested-rayon mutex
-        // deadlock. Releasing here costs at most a duplicate compute on
-        // simultaneous misses against the same key, which we resolve on
-        // re-acquire by preferring the racer's cached value.
-        let computed = Arc::new(compute());
-        let bytes = computed.len().saturating_mul(std::mem::size_of::<f64>());
-        let mut inner = self
-            .inner
-            .lock()
-            .expect("projected factor cache lock poisoned");
-        inner.next_seq += 1;
-        let now = inner.next_seq;
-        if let Some(entry) = inner.entries.get_mut(&key) {
-            // Another caller computed and inserted the same key while we
-            // were busy. Keep theirs (already counted in `total_bytes`) and
-            // drop ours; mark the survivor as most-recently used.
-            entry.last_used = now;
-            return entry.value.clone();
-        }
-        // LRU eviction. Skip when the budget is disabled or when the
-        // new entry alone exceeds the budget (in which case eviction
-        // can never make it fit; we accept the over-budget insertion
-        // because the alternative — refusing to cache — guarantees a
-        // recompute on every query).
-        if inner.budget_bytes > 0 && bytes <= inner.budget_bytes {
-            while inner.total_bytes.saturating_add(bytes) > inner.budget_bytes
-                && !inner.entries.is_empty()
-            {
-                let Some(oldest_key) = inner
-                    .entries
-                    .iter()
-                    .min_by_key(|(_, e)| e.last_used)
-                    .map(|(k, _)| *k)
-                else {
-                    break;
-                };
-                if let Some(removed) = inner.entries.remove(&oldest_key) {
-                    inner.total_bytes = inner.total_bytes.saturating_sub(removed.bytes);
+        };
+
+        match lookup {
+            CacheLookup::Hit(value) => value,
+            CacheLookup::Wait(marker) => {
+                let mut guard = marker
+                    .state
+                    .lock()
+                    .expect("projected factor in-progress lock poisoned");
+                loop {
+                    match guard.as_ref() {
+                        Some(ProjectedFactorInProgressState::Ready(value)) => return value.clone(),
+                        Some(ProjectedFactorInProgressState::Failed) => {
+                            panic!("projected factor cache producer panicked")
+                        }
+                        None => {
+                            guard = marker
+                                .ready
+                                .wait(guard)
+                                .expect("projected factor in-progress wait poisoned");
+                        }
+                    }
                 }
             }
+            CacheLookup::Compute(marker) => {
+                // Compute outside the cache mutex so expensive design GEMMs do
+                // not serialize unrelated cache keys. Sibling callers for the
+                // same key wait on `marker` instead of redundantly launching the
+                // same projection, which is crucial when exact outer-gradient
+                // coordinates are evaluated in parallel.
+                let computed = match catch_unwind(AssertUnwindSafe(|| Arc::new(compute()))) {
+                    Ok(value) => value,
+                    Err(payload) => {
+                        let mut inner = self
+                            .inner
+                            .lock()
+                            .expect("projected factor cache lock poisoned");
+                        inner.in_progress.remove(&key);
+                        drop(inner);
+
+                        let mut guard = marker
+                            .state
+                            .lock()
+                            .expect("projected factor in-progress lock poisoned");
+                        *guard = Some(ProjectedFactorInProgressState::Failed);
+                        marker.ready.notify_all();
+                        resume_unwind(payload);
+                    }
+                };
+                let bytes = computed.len().saturating_mul(std::mem::size_of::<f64>());
+                let mut inner = self
+                    .inner
+                    .lock()
+                    .expect("projected factor cache lock poisoned");
+                inner.next_seq += 1;
+                let now = inner.next_seq;
+
+                if inner.budget_bytes > 0 && bytes <= inner.budget_bytes {
+                    while inner.total_bytes.saturating_add(bytes) > inner.budget_bytes
+                        && !inner.entries.is_empty()
+                    {
+                        let Some(oldest_key) = inner
+                            .entries
+                            .iter()
+                            .min_by_key(|(_, e)| e.last_used)
+                            .map(|(k, _)| *k)
+                        else {
+                            break;
+                        };
+                        if let Some(removed) = inner.entries.remove(&oldest_key) {
+                            inner.total_bytes = inner.total_bytes.saturating_sub(removed.bytes);
+                        }
+                    }
+                }
+
+                let value = if let Some(entry) = inner.entries.get_mut(&key) {
+                    entry.last_used = now;
+                    entry.value.clone()
+                } else {
+                    inner.entries.insert(
+                        key,
+                        ProjectedFactorEntry {
+                            value: computed.clone(),
+                            bytes,
+                            last_used: now,
+                        },
+                    );
+                    inner.total_bytes = inner.total_bytes.saturating_add(bytes);
+                    computed
+                };
+                inner.in_progress.remove(&key);
+                drop(inner);
+
+                let mut guard = marker
+                    .state
+                    .lock()
+                    .expect("projected factor in-progress lock poisoned");
+                *guard = Some(ProjectedFactorInProgressState::Ready(value.clone()));
+                marker.ready.notify_all();
+                value
+            }
         }
-        inner.entries.insert(
-            key,
-            ProjectedFactorEntry {
-                value: computed.clone(),
-                bytes,
-                last_used: now,
-            },
-        );
-        inner.total_bytes = inner.total_bytes.saturating_add(bytes);
-        computed
     }
 
     /// Number of entries currently cached. Intended for diagnostics
@@ -2085,7 +2171,184 @@ fn composite_trace_implicit_batched(
     trace
 }
 
+fn dense_trace_projected_factor(matrix: &Array2<f64>, factor: &Array2<f64>) -> f64 {
+    let matrix_factor = matrix.dot(factor);
+    factor
+        .iter()
+        .zip(matrix_factor.iter())
+        .map(|(&f, &mf)| f * mf)
+        .sum()
+}
+
+fn collect_projected_trace_terms<'a>(
+    out_idx: usize,
+    weight: f64,
+    op: &'a dyn HyperOperator,
+    factor: &Array2<f64>,
+    dense_acc: &mut [f64],
+    terms: &mut Vec<(usize, f64, &'a dyn HyperOperator)>,
+) {
+    if weight == 0.0 {
+        return;
+    }
+    if let Some(composite) = op.as_composite() {
+        if let Some(dense) = composite.dense.as_ref() {
+            dense_acc[out_idx] += weight * dense_trace_projected_factor(dense, factor);
+        }
+        for inner in &composite.operators {
+            collect_projected_trace_terms(
+                out_idx,
+                weight,
+                inner.as_ref(),
+                factor,
+                dense_acc,
+                terms,
+            );
+        }
+    } else if let Some(weighted) = op.as_weighted() {
+        for (term_weight, inner) in &weighted.terms {
+            collect_projected_trace_terms(
+                out_idx,
+                weight * *term_weight,
+                inner.as_ref(),
+                factor,
+                dense_acc,
+                terms,
+            );
+        }
+    } else {
+        terms.push((out_idx, weight, op));
+    }
+}
+
+fn trace_projected_operator_terms_batched(
+    n_out: usize,
+    terms: &[(usize, f64, &dyn HyperOperator)],
+    factor: &Array2<f64>,
+    cache: &ProjectedFactorCache,
+) -> Vec<f64> {
+    let mut out = vec![0.0_f64; n_out];
+    let mut handled = vec![false; terms.len()];
+
+    for i in 0..terms.len() {
+        if handled[i] {
+            continue;
+        }
+        let Some(impl_i) = terms[i].2.as_implicit() else {
+            continue;
+        };
+        let mut group = vec![i];
+        handled[i] = true;
+        for j in (i + 1)..terms.len() {
+            if handled[j] {
+                continue;
+            }
+            if let Some(impl_j) = terms[j].2.as_implicit() {
+                if Arc::ptr_eq(&impl_i.implicit_deriv, &impl_j.implicit_deriv)
+                    && Arc::ptr_eq(&impl_i.x_design, &impl_j.x_design)
+                    && Arc::ptr_eq(&impl_i.w_diag, &impl_j.w_diag)
+                    && impl_i.p == impl_j.p
+                {
+                    group.push(j);
+                    handled[j] = true;
+                }
+            }
+        }
+
+        let lead = terms[group[0]].2.as_implicit().unwrap();
+        let xf = lead.cached_xf(factor, cache);
+        let axes: Vec<(usize, &Array2<f64>, Option<&Array1<f64>>)> = group
+            .iter()
+            .map(|&term_idx| {
+                let op = terms[term_idx].2.as_implicit().unwrap();
+                (op.axis, &op.s_psi, op.c_x_psi_beta.as_deref())
+            })
+            .collect();
+        let values = lead.trace_projected_factor_all_axes_with_xf(factor, xf.view(), &axes);
+        for (&term_idx, value) in group.iter().zip(values.iter()) {
+            let (out_idx, weight, _) = terms[term_idx];
+            out[out_idx] += weight * *value;
+        }
+    }
+
+    for (i, (out_idx, weight, op)) in terms.iter().enumerate() {
+        if handled[i] {
+            continue;
+        }
+        out[*out_idx] += *weight * op.trace_projected_factor_cached(factor, cache);
+    }
+
+    out
+}
+
+fn trace_logdet_drifts_projected_factor_batched(
+    drifts: &[DriftDerivResult],
+    factor: &Array2<f64>,
+    cache: &ProjectedFactorCache,
+) -> Vec<f64> {
+    let mut out = vec![0.0_f64; drifts.len()];
+    let mut terms: Vec<(usize, f64, &dyn HyperOperator)> = Vec::new();
+    for (idx, drift) in drifts.iter().enumerate() {
+        match drift {
+            DriftDerivResult::Dense(matrix) => {
+                out[idx] += dense_trace_projected_factor(matrix, factor);
+            }
+            DriftDerivResult::Operator(op) => {
+                collect_projected_trace_terms(idx, 1.0, op.as_ref(), factor, &mut out, &mut terms);
+            }
+        }
+    }
+    let batched = trace_projected_operator_terms_batched(drifts.len(), &terms, factor, cache);
+    for (dst, value) in out.iter_mut().zip(batched) {
+        *dst += value;
+    }
+    out
+}
+
+fn dense_spectral_trace_logdet_drifts_batched(
+    ds: &DenseSpectralOperator,
+    drifts: &[DriftDerivResult],
+) -> Vec<f64> {
+    trace_logdet_drifts_projected_factor_batched(drifts, &ds.g_factor, &ds.projected_factor_cache)
+}
+
+fn penalty_subspace_trace_factor(kernel: &PenaltySubspaceTrace) -> Array2<f64> {
+    if let Ok(chol) = kernel.h_proj_inverse.cholesky(faer::Side::Lower) {
+        let lower = chol.lower_triangular();
+        return crate::faer_ndarray::fast_ab(&kernel.u_s, &lower);
+    }
+
+    let (evals, evecs) = kernel
+        .h_proj_inverse
+        .eigh(faer::Side::Lower)
+        .expect("PenaltySubspaceTrace kernel factor eigendecomposition failed");
+    let r = evals.len();
+    let max_eval = evals.iter().fold(0.0_f64, |acc, &v| acc.max(v.abs()));
+    let floor = f64::EPSILON.sqrt() * (r as f64).max(1.0) * max_eval.max(1.0);
+    let mut root = evecs.clone();
+    for col in 0..r {
+        let scale = evals[col].max(floor).sqrt();
+        for row in 0..r {
+            root[[row, col]] *= scale;
+        }
+    }
+    crate::faer_ndarray::fast_ab(&kernel.u_s, &root)
+}
+
+fn penalty_subspace_trace_drifts_batched(
+    kernel: &PenaltySubspaceTrace,
+    drifts: &[DriftDerivResult],
+) -> Vec<f64> {
+    let factor = penalty_subspace_trace_factor(kernel);
+    let cache = ProjectedFactorCache::default();
+    trace_logdet_drifts_projected_factor_batched(drifts, &factor, &cache)
+}
+
 impl HyperOperator for CompositeHyperOperator {
+    fn as_composite(&self) -> Option<&CompositeHyperOperator> {
+        Some(self)
+    }
+
     fn dim(&self) -> usize {
         self.dim_hint
     }
@@ -5540,6 +5803,43 @@ pub fn reml_laml_evaluate(
         None
     };
 
+    let build_trace_drifts = || {
+        let mut drifts = Vec::with_capacity(k + ext_dim);
+        for idx in 0..k {
+            drifts.push(penalty_total_drift_result(
+                &solution.penalty_coords[idx],
+                curvature_lambdas[idx],
+                rho_corrections[idx].as_ref(),
+            ));
+        }
+        for (ext_idx, coord) in solution.ext_coords.iter().enumerate() {
+            drifts.push(hyper_coord_total_drift_result(
+                &coord.drift,
+                ext_corrections[ext_idx].as_ref(),
+                hop.dim(),
+            ));
+        }
+        drifts
+    };
+
+    let projected_trace_values: Option<Vec<f64>> =
+        if incl_logdet_h && stochastic_trace_values.is_none() {
+            solution
+                .penalty_subspace_trace
+                .as_ref()
+                .map(|kernel| penalty_subspace_trace_drifts_batched(kernel, &build_trace_drifts()))
+        } else {
+            None
+        };
+
+    let exact_dense_trace_values: Option<Vec<f64>> =
+        if incl_logdet_h && stochastic_trace_values.is_none() && projected_trace_values.is_none() {
+            hop.as_exact_dense_spectral()
+                .map(|ds| dense_spectral_trace_logdet_drifts_batched(ds, &build_trace_drifts()))
+        } else {
+            None
+        };
+
     // ── Gradient: one shared formula for ALL coordinate types ──
     //
     // Both ρ and ext coordinates are processed through outer_gradient_entry()
@@ -5568,6 +5868,10 @@ pub fn reml_laml_evaluate(
                 0.0
             } else if let Some(ref stoch_traces) = stochastic_trace_values {
                 stoch_traces[idx]
+            } else if let Some(ref projected_traces) = projected_trace_values {
+                projected_traces[idx]
+            } else if let Some(ref exact_traces) = exact_dense_trace_values {
+                exact_traces[idx]
             } else if let Some(kernel) = solution.penalty_subspace_trace.as_ref() {
                 let drift = penalty_total_drift_result(
                     coord,
@@ -5659,6 +5963,10 @@ pub fn reml_laml_evaluate(
                 0.0
             } else if let Some(ref stoch_traces) = stochastic_trace_values {
                 stoch_traces[k + ext_idx]
+            } else if let Some(ref projected_traces) = projected_trace_values {
+                projected_traces[k + ext_idx]
+            } else if let Some(ref exact_traces) = exact_dense_trace_values {
+                exact_traces[k + ext_idx]
             } else {
                 let correction = ext_corrections[ext_idx].as_ref();
                 let drift = hyper_coord_total_drift_result(&coord.drift, correction, hop.dim());
@@ -7404,12 +7712,16 @@ impl HyperOperator for BorrowedStoredDriftOperator<'_> {
 /// per-term linear combination) into a single matrix-free operator that
 /// implements the same `HyperOperator` trait, so callers downstream do not
 /// need to handle a vector of (weight, op) pairs themselves.
-pub(crate) struct WeightedHyperOperator {
+pub struct WeightedHyperOperator {
     pub(crate) terms: Vec<(f64, Arc<dyn HyperOperator>)>,
     pub(crate) dim_hint: usize,
 }
 
 impl HyperOperator for WeightedHyperOperator {
+    fn as_weighted(&self) -> Option<&WeightedHyperOperator> {
+        Some(self)
+    }
+
     fn dim(&self) -> usize {
         self.dim_hint
     }
@@ -13327,6 +13639,42 @@ mod tests {
         let huge = cache.get_or_insert_with(make_factor_key(1), || Array2::from_elem((4, 4), 1.0));
         assert_eq!(huge[[0, 0]], 1.0);
         assert_eq!(cache.len(), 1);
+    }
+    #[test]
+    fn projected_factor_cache_waiters_wake_when_producer_panics() {
+        let cache = Arc::new(ProjectedFactorCache::with_budget(0));
+        let key = make_factor_key(42);
+        let (started_tx, started_rx) = std::sync::mpsc::channel();
+
+        let producer_cache = Arc::clone(&cache);
+        let producer = std::thread::spawn(move || {
+            std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                producer_cache.get_or_insert_with(key, || {
+                    started_tx.send(()).expect("send producer-start signal");
+                    std::thread::sleep(std::time::Duration::from_millis(50));
+                    panic!("simulated projected-factor panic");
+                });
+            }))
+            .is_err()
+        });
+
+        started_rx
+            .recv_timeout(std::time::Duration::from_secs(2))
+            .expect("producer started computing");
+
+        let waiter_cache = Arc::clone(&cache);
+        let waiter = std::thread::spawn(move || {
+            std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                waiter_cache.get_or_insert_with(key, || Array2::from_elem((1, 1), 7.0));
+            }))
+            .is_err()
+        });
+
+        assert!(producer.join().expect("producer thread joined"));
+        assert!(waiter.join().expect("waiter thread joined"));
+
+        let recovered = cache.get_or_insert_with(key, || Array2::from_elem((1, 1), 9.0));
+        assert_eq!(recovered[[0, 0]], 9.0);
     }
 
     struct SentinelOuterHessianOperator {

--- a/src/terms/basis.rs
+++ b/src/terms/basis.rs
@@ -13515,87 +13515,6 @@ fn validate_lat_lon_matrix(
     Ok(())
 }
 
-/// High-accuracy SIMD natural logarithm for `f64x4`.
-///
-/// Implemented as `ln(x) = e·ln(2) + 2·atanh((m-1)/(m+1))` with the mantissa
-/// rebalanced into `m ∈ [√2/2, √2]` so `|f| = |(m-1)/(m+1)| ≤ 0.1716`. The
-/// `2·atanh` series uses exact rational coefficients `1/(2k+1)` through
-/// `f^{17}/17`; the truncation tail is bounded by `0.172^{19}/19 ≈ 1.4e-16`,
-/// safely below one ulp at the magnitudes that appear in
-/// `wahba_sphere_kernel_from_cos`. `ln(2)` is carried as a double-double
-/// (`hi + lo`) so the exponent reconstruction does not introduce its own
-/// rounding error.
-///
-/// Inputs are assumed strictly positive and finite — the call site clamps
-/// the kernel argument to `(0, ∞)` before invocation, so we skip the
-/// inf/NaN/subnormal blends that `wide::f64x4::ln` carries (those branches
-/// are also coarse at f64 precision; see `wide-0.7.33/src/f64x4_.rs:1297`).
-#[inline]
-fn wahba_simd_ln(x: wide::f64x4) -> wide::f64x4 {
-    use wide::{CmpGt, f64x4};
-    // Bit-twiddle each lane to split into mantissa m ∈ [1, 2) and integer
-    // exponent e. `wide` keeps `fraction_2`/`exponent` private, so we route
-    // through `to_array` / `from`. The 8 scalar bit ops below are cheap
-    // relative to the vectorised polynomial that follows.
-    let arr = x.to_array();
-    let mut m_arr = [0.0_f64; 4];
-    let mut e_arr = [0.0_f64; 4];
-    for k in 0..4 {
-        let bits = arr[k].to_bits();
-        let raw_exp = ((bits >> 52) & 0x7FF) as i64;
-        let exp = raw_exp - 1023;
-        let m_bits = (bits & 0x000F_FFFF_FFFF_FFFF) | 0x3FF0_0000_0000_0000;
-        m_arr[k] = f64::from_bits(m_bits);
-        e_arr[k] = exp as f64;
-    }
-    let m = f64x4::from(m_arr);
-    let mut e = f64x4::from(e_arr);
-    // Rebalance into [√2/2, √2]: if m > √2, halve m and bump e by 1.
-    // We use `m > √2` rather than `> √2/2 · 2` so the centred range is symmetric.
-    let sqrt2 = f64x4::from(std::f64::consts::SQRT_2);
-    let mask = m.cmp_gt(sqrt2);
-    let m = mask.blend(m * f64x4::from(0.5), m);
-    e = mask.blend(e + f64x4::ONE, e);
-
-    // f = (m - 1) / (m + 1), then ln(m) = 2·atanh(f) = 2·Σ f^{2k+1}/(2k+1).
-    let one = f64x4::ONE;
-    let f = (m - one) / (m + one);
-    let f2 = f * f;
-    // Horner on the inner polynomial P(f²) so that 2·atanh(f) = 2·f·P(f²),
-    // with P(u) = 1 + u/3 + u²/5 + u³/7 + ... up to u^8 (degree 17 in f).
-    // Coefficients are exact 1/(2k+1) for k = 0..8.
-    let c0 = one;
-    let c1 = f64x4::from(1.0 / 3.0);
-    let c2 = f64x4::from(1.0 / 5.0);
-    let c3 = f64x4::from(1.0 / 7.0);
-    let c4 = f64x4::from(1.0 / 9.0);
-    let c5 = f64x4::from(1.0 / 11.0);
-    let c6 = f64x4::from(1.0 / 13.0);
-    let c7 = f64x4::from(1.0 / 15.0);
-    let c8 = f64x4::from(1.0 / 17.0);
-    // Horner: ((((((((c8·u + c7)·u + c6)·u + c5)·u + c4)·u + c3)·u + c2)·u + c1)·u + c0
-    let mut p = c8;
-    p = p * f2 + c7;
-    p = p * f2 + c6;
-    p = p * f2 + c5;
-    p = p * f2 + c4;
-    p = p * f2 + c3;
-    p = p * f2 + c2;
-    p = p * f2 + c1;
-    p = p * f2 + c0;
-    let ln_m = (f + f) * p;
-
-    // ln(2) double-double split: hi is the f64 closest to ln(2)
-    // (`0x3FE62E42FEFA39EF` = 0.69314718055994528623...), lo is the
-    // residual `ln(2) - hi ≈ 2.319e-17`. `e` is integer-valued and small
-    // (|e| ≤ ~1024), so `e * ln2_hi` introduces only a single rounding,
-    // and the `lo` term restores the lost precision.
-    let ln2_hi = f64x4::from(std::f64::consts::LN_2);
-    let ln2_lo = f64x4::from(2.319_046_813_846_299_6e-17_f64);
-    // ln(x) = e·ln2_hi + (e·ln2_lo + ln_m). Order matters for accuracy.
-    e * ln2_hi + (e * ln2_lo + ln_m)
-}
-
 /// True Wahba / Sobolev spectral reproducing kernel on S² for general m.
 ///
 ///   K_m(γ) = (1/4π) Σ_{l ≥ 1} (2l + 1) · [l(l + 1)]^{-m} · P_l(cos γ)
@@ -13640,17 +13559,6 @@ fn wahba_sphere_kernel_spectral(cos_gamma: f64, m: usize) -> f64 {
         p_l = p_l_plus_1;
     }
     sum
-}
-
-/// Legacy alias retained so existing call sites continue to compile.
-#[inline]
-fn wahba_sphere_kernel_m4_spectral(cos_gamma: f64) -> f64 {
-    wahba_sphere_kernel_spectral(cos_gamma, 4)
-}
-
-#[inline]
-fn wahba_sphere_kernel_m4_spectral_simd(cos_gamma: wide::f64x4) -> wide::f64x4 {
-    wide::f64x4::from(cos_gamma.to_array().map(wahba_sphere_kernel_m4_spectral))
 }
 
 /// SIMD-vectorised companion to `wahba_sphere_kernel_from_cos`. Each lane of


### PR DESCRIPTION
### Motivation
- Prevent nested-rayon deadlocks and races when materializing cached projected factors while enabling parallel producers/waiters. 
- Provide batched exact trace computation paths for projected / composite / weighted hyper-operators to avoid redundant GEMMs and enable reuse of a single projection across many coordinates. 
- Make a few small utility fixes and robustness tweaks used by REML/LAML assembly and tests (longer blockwise cycles for a spatial smoke test, a small dense helper, and removal of an unused SIMD ln helper). 

### Description
- Reworked `ProjectedFactorCache` to support an `in_progress` marker map with `Condvar` waiters, so concurrent callers wait for a single producer instead of duplicating work or deadlocking; producers notify waiters on success or panic. 
- Added panic-safe compute path that removes in-progress markers and wakes waiters using `catch_unwind`/`resume_unwind`. 
- Introduced `ProjectedFactorInProgress` and state enum and updated cache eviction / insertion logic to account for in-progress entries. 
- Added batched trace helpers: `dense_trace_projected_factor`, `collect_projected_trace_terms`, `trace_projected_operator_terms_batched`, `trace_logdet_drifts_projected_factor_batched`, `dense_spectral_trace_logdet_drifts_batched`, and subspace helpers `penalty_subspace_trace_factor` / `penalty_subspace_trace_drifts_batched` and hooked them into the REML/LAML evaluator to use projected or exact dense trace values when available. 
- Extended the `HyperOperator` trait with `as_composite` / `as_weighted` downcasts and implemented them on `CompositeHyperOperator` and `WeightedHyperOperator` (made `WeightedHyperOperator` public where needed). 
- Increased `inner_max_cycles` from `24` to `48` in `spatial_fit_smoke_options` to make the spatial location-scale smoke test deterministic. 
- Added a small dense helper `dense_xt_diag_x` in `gaussian_reml.rs`. 
- Removed an unused SIMD `wahba_simd_ln` implementation from `terms::basis`. 
- Added a new unit test `projected_factor_cache_waiters_wake_when_producer_panics` covering waiter wakeup on producer panic, and adjusted/retained several `ProjectedFactorCache` tests. 

### Testing
- Ran the crate unit test suite via `cargo test` including new cache tests `projected_factor_cache_waiters_wake_when_producer_panics`, `projected_factor_cache_zero_budget_disables_eviction`, and `projected_factor_cache_oversize_entry_is_cached_unconditionally`, all of which passed. 
- Exercised REML/LAML evaluator paths impacted by the new batched trace helpers via existing unit tests, which succeeded. 
- Verified the spatial smoke-test configuration change by running the related test, which passed with the increased `inner_max_cycles`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a1437bf608324bba11eefa2e7a886)