### PR TITLE
[bug-hunt] pyffi 2/5 (penalty + predict helpers): 1 bugs

### DIFF
--- a/tests/analytic_penalty_nested_prefix_dispatch_missing.rs
+++ b/tests/analytic_penalty_nested_prefix_dispatch_missing.rs
@@ -1,0 +1,19 @@
+use std::fs;
+
+#[test]
+fn analytic_penalty_nested_prefix_kind_is_missing_from_pyffi_json_dispatch() {
+    let pyffi = fs::read_to_string("crates/gam-pyffi/src/lib.rs")
+        .expect("BUG: could not read crates/gam-pyffi/src/lib.rs");
+    let registry = fs::read_to_string("src/terms/penalties/mod.rs")
+        .expect("BUG: could not read src/terms/penalties/mod.rs");
+
+    assert!(
+        registry.contains("register!(NestedPrefix, NestedPrefixPenalty);"),
+        "BUG: NestedPrefix is not registered in analytic_penalty_registry macro"
+    );
+
+    assert!(
+        pyffi.contains("\"nested_prefix\"") || pyffi.contains("\"nestedprefix\""),
+        "BUG: pyffi build_analytic_penalty_registry_from_json does not dispatch NestedPrefix even though AnalyticPenaltyKind includes it"
+    );
+}


### PR DESCRIPTION
### Motivation
- Add a focused regression that captures a missing JSON dispatch case in the PyFFI analytic-penalty builder for a penalty registered in the core registry.

### Description
- Add test `tests/analytic_penalty_nested_prefix_dispatch_missing.rs` which asserts the core `analytic_penalty_registry` contains `NestedPrefix` and that `crates/gam-pyffi/src/lib.rs` dispatches the corresponding `"nested_prefix"` kind in `build_analytic_penalty_registry_from_json`.

### Testing
- Ran `cargo test --test analytic_penalty_nested_prefix_dispatch_missing` which executes the new test and it failed as expected, exposing the missing `nested_prefix` dispatch in the PyFFI JSON builder.

---
Codex Cloud task: https://chatgpt.com/codex/tasks/task_e_6a13c364310483248bd8539818e372c3