### PR TITLE
[bug-hunt] pyffi 3/5 (standard fit + GAMLSS + survival entry): 1 bugs

### DIFF
--- a/tests/pyffi_fitted_family_roundtrip_bug.rs
+++ b/tests/pyffi_fitted_family_roundtrip_bug.rs
@@ -1,0 +1,8 @@
+use gam::inference::model::FittedFamily;
+
+#[test]
+fn fitted_family_marginal_slope_deserializes_without_base_link_for_backward_compat() {
+    let raw = r#"{\"family_kind\":\"marginal-slope\",\"likelihood\":{\"response\":\"Binomial\",\"inverse\":{\"Standard\":\"Logit\"},\"scale\":\"Fixed\"},\"frailty\":{\"kind\":\"none\"}}"#;
+    let parsed: Result<FittedFamily, _> = serde_json::from_str(raw);
+    assert_eq!(parsed.is_ok(), true);
+}


### PR DESCRIPTION
### Motivation
- Add a minimal regression test to capture a backward-compatibility deserialization failure where `FittedFamily::MarginalSlope` payloads that omit the optional `base_link` field should still deserialize but currently do not.

### Description
- Add `tests/pyffi_fitted_family_roundtrip_bug.rs` which attempts to `serde_json::from_str` a `"family_kind":"marginal-slope"` payload missing `base_link` and asserts that deserialization succeeds.

### Testing
- Ran `cargo test -q --test pyffi_fitted_family_roundtrip_bug` and the test failed as expected, demonstrating the regression (parsed.is_ok() was `false`).

---
Codex Cloud task: https://chatgpt.com/codex/tasks/task_e_6a13c364eeb88324aef42f88cfca4006