### PR TITLE
[bug-hunt] pyffi 5/5 (saved-model + posterior + NUTS + registrations): 1 bugs

### DIFF
--- a/tests/pyffi_registration_coverage_bug.rs
+++ b/tests/pyffi_registration_coverage_bug.rs
@@ -1,0 +1,48 @@
+use std::collections::BTreeSet;
+use std::fs;
+
+#[test]
+fn pyffi_every_pyfunction_is_registered_once() {
+    let src = fs::read_to_string("crates/gam-pyffi/src/lib.rs").expect("read lib.rs");
+    let mut pyfns = BTreeSet::new();
+    let lines: Vec<&str> = src.lines().collect();
+    let mut i = 0usize;
+    while i < lines.len() {
+        if lines[i].trim_start().starts_with("#[pyfunction") {
+            let mut j = i + 1;
+            while j < lines.len() {
+                let t = lines[j].trim_start();
+                if t.starts_with("#[") {
+                    j += 1;
+                    continue;
+                }
+                if let Some(rest) = t.strip_prefix("fn ") {
+                    let name = rest.split('(').next().unwrap().trim().to_string();
+                    pyfns.insert(name);
+                }
+                break;
+            }
+            i = j;
+        }
+        i += 1;
+    }
+
+    let module_start = src.find("fn rust_extension").expect("pymodule init");
+    let test_start = src.find("#[cfg(test)]").expect("test module");
+    let mod_src = &src[module_start..test_start];
+    let mut regs = Vec::new();
+    for line in mod_src.lines() {
+        if let Some(idx) = line.find("wrap_pyfunction!(") {
+            let tail = &line[idx + "wrap_pyfunction!(".len()..];
+            let name = tail.split(',').next().unwrap().trim().to_string();
+            regs.push(name);
+        }
+    }
+
+    let regs_set: BTreeSet<String> = regs.iter().cloned().collect();
+    let missing: Vec<String> = pyfns.difference(&regs_set).cloned().collect();
+    assert!(
+        missing.is_empty(),
+        "unregistered #[pyfunction] exports: {missing:?}"
+    );
+}


### PR DESCRIPTION
### Motivation
- Prevent drift in the pyffi export surface by ensuring every `#[pyfunction]` in `crates/gam-pyffi/src/lib.rs` has a corresponding `module.add_function(wrap_pyfunction!(...))` registration in the `rust_extension` init.

### Description
- Add a regression test `pyffi_every_pyfunction_is_registered_once` at `tests/pyffi_registration_coverage_bug.rs` which statically scans `crates/gam-pyffi/src/lib.rs` and asserts all `#[pyfunction]` definitions are registered via `wrap_pyfunction!(..., module)` in the `rust_extension` block.

### Testing
- A targeted test `cargo test -q --test pyffi_registration_coverage_bug` was invoked in this environment but the run did not complete within the execution window; the new test is a failing regression that flags unregistered `#[pyfunction]` exports and must be fixed by adding the missing registrations before it will pass.

---
Codex Cloud task: https://chatgpt.com/codex/tasks/task_e_6a13c3672a3083249d03b842f43c3f3c