### PR TITLE
[bug-hunt] basis 1/4 (B-spline / M-spline / I-spline / cyclic): 2 bugs

### DIFF
--- a/gamfit/_sae_manifold.py
+++ b/gamfit/_sae_manifold.py
@@ -502,7 +502,7 @@ def _oos_reconstruct(model: ManifoldSAE, x_new: np.ndarray) -> np.ndarray:
     if k_atoms == 1 and model.assignment in {"ibp", "ibp_map"}:
         initial_logits[:, 0] = 4.0  # strong "atom on" prior; trained ibp behaves the same
 
-    max_iter_total = max(1, int(np.asarray(model.coords[0]).shape[0] >= 0) * 50)
+    max_iter_total = 50
     assignment_kind = str(
         {"ibp": "ibp_map"}.get(model.assignment, model.assignment)
     )

--- a/tests/cyclic_bspline_first_derivative_periodicity_breaks.rs
+++ b/tests/cyclic_bspline_first_derivative_periodicity_breaks.rs
@@ -1,0 +1,33 @@
+use gam::terms::basis::{BasisOptions, Dense, KnotSource, create_basis};
+use ndarray::array;
+
+#[test]
+fn cyclic_bspline_first_derivative_periodicity_breaks() {
+    let degree = 3usize;
+    let start = 0.0;
+    let end = 1.0;
+    let num_basis = 8usize;
+    let period = end - start;
+    let h = period / num_basis as f64;
+    let total_knots = num_basis + 2 * degree + 1;
+    let knots = ndarray::Array1::from_iter((0..total_knots).map(|i| start + (i as f64 - degree as f64) * h));
+
+    let x = array![0.123456789, 0.876543211];
+    let x_shifted = x.mapv(|v| v + period);
+
+    let (b0, _) = create_basis::<Dense>(x.view(), KnotSource::Provided(knots.view()), degree, BasisOptions::first_derivative())
+        .expect("basis should build at x");
+    let (b1, _) = create_basis::<Dense>(x_shifted.view(), KnotSource::Provided(knots.view()), degree, BasisOptions::first_derivative())
+        .expect("basis should build at x+period");
+
+    for i in 0..b0.nrows() {
+        for j in 0..num_basis {
+            let folded0 = b0[[i, j]] + b0[[i, j + num_basis]];
+            let folded1 = b1[[i, j]] + b1[[i, j + num_basis]];
+            assert!(
+                (folded0 - folded1).abs() < 1e-12,
+                "bug: cyclic B-spline first derivative is not periodic after fold-back"
+            );
+        }
+    }
+}

--- a/tests/cyclic_bspline_second_derivative_periodicity_breaks.rs
+++ b/tests/cyclic_bspline_second_derivative_periodicity_breaks.rs
@@ -1,0 +1,31 @@
+use gam::terms::basis::{BasisOptions, Dense, KnotSource, create_basis};
+use ndarray::array;
+
+#[test]
+fn cyclic_bspline_second_derivative_periodicity_breaks() {
+    let degree = 3usize;
+    let start = 0.0;
+    let end = 1.0;
+    let num_basis = 8usize;
+    let period = end - start;
+    let h = period / num_basis as f64;
+    let total_knots = num_basis + 2 * degree + 1;
+    let knots = ndarray::Array1::from_iter((0..total_knots).map(|i| start + (i as f64 - degree as f64) * h));
+
+    let x = array![0.22222];
+    let x_shifted = x.mapv(|v| v + period);
+
+    let (b0, _) = create_basis::<Dense>(x.view(), KnotSource::Provided(knots.view()), degree, BasisOptions::second_derivative())
+        .expect("basis should build at x");
+    let (b1, _) = create_basis::<Dense>(x_shifted.view(), KnotSource::Provided(knots.view()), degree, BasisOptions::second_derivative())
+        .expect("basis should build at x+period");
+
+    for j in 0..num_basis {
+        let folded0 = b0[[0, j]] + b0[[0, j + num_basis]];
+        let folded1 = b1[[0, j]] + b1[[0, j + num_basis]];
+        assert!(
+            (folded0 - folded1).abs() < 1e-10,
+            "bug: cyclic B-spline second derivative is not periodic after fold-back"
+        );
+    }
+}


### PR DESCRIPTION
### Motivation
- Add focused regression tests to expose violations of cyclic B-spline invariants: the derivatives should be periodic after folding extended (wrapped) B-spline columns back into the primary `num_basis` columns.

### Description
- Added two failing tests that compare folded-column sums at `x` and `x + period`: `tests/cyclic_bspline_first_derivative_periodicity_breaks.rs` and `tests/cyclic_bspline_second_derivative_periodicity_breaks.rs` which assert periodicity of the first and second derivatives respectively.

### Testing
- Executed `cargo test --test cyclic_bspline_first_derivative_periodicity_breaks` and `cargo test --test cyclic_bspline_second_derivative_periodicity_breaks`, and both tests failed as expected, demonstrating reproducible regressions in cyclic derivative periodicity.

---
Codex Cloud task: https://chatgpt.com/codex/tasks/task_e_6a13c4d595e48324a977b3a03de7f5d5