### PR TITLE
[bug-hunt] basis 4/4 (scalar evaluators + B-spline derivatives + periodic 1D): 0 bugs

### DIFF
--- a/tests/bspline_derivative_identity_bug.rs
+++ b/tests/bspline_derivative_identity_bug.rs
@@ -1,0 +1,37 @@
+use gam::terms::basis::{evaluate_bspline_basis_scalar, evaluate_bspline_derivative_scalar, SplineScratch};
+use ndarray::array;
+
+#[test]
+fn bug_first_derivative_matches_analytic_difference_identity_including_multiplicity_points() {
+    let knots = array![0.0, 0.0, 0.0, 0.5, 0.5, 1.0, 1.5, 2.0, 2.0, 2.0];
+    let degree = 2usize;
+    let n = knots.len() - degree - 1;
+    let xs = [0.25, 0.5, 0.75, 1.25];
+
+    for &x in &xs {
+        let mut b_km1 = vec![0.0; knots.len() - (degree - 1) - 1];
+        let mut db = vec![0.0; n];
+        evaluate_bspline_basis_scalar(x, knots.view(), degree - 1, &mut b_km1, &mut SplineScratch::new(degree - 1))
+            .expect("B_{k-1}");
+        evaluate_bspline_derivative_scalar(x, knots.view(), degree, &mut db).expect("dB");
+
+        for i in 0..n {
+            let term1 = if knots[i + degree] > knots[i] {
+                degree as f64 / (knots[i + degree] - knots[i]) * b_km1[i]
+            } else {
+                0.0
+            };
+            let term2 = if i + 1 < b_km1.len() && knots[i + degree + 1] > knots[i + 1] {
+                degree as f64 / (knots[i + degree + 1] - knots[i + 1]) * b_km1[i + 1]
+            } else {
+                0.0
+            };
+            let rhs = term1 - term2;
+            assert!(
+                (db[i] - rhs).abs() < 2e-11,
+                "identity mismatch at x={x}, i={i}: dB={} rhs={rhs}",
+                db[i]
+            );
+        }
+    }
+}

--- a/tests/mspline_ispline_scalar_identity_bug.rs
+++ b/tests/mspline_ispline_scalar_identity_bug.rs
@@ -1,0 +1,30 @@
+use gam::terms::basis::{evaluate_bspline_basis_scalar, evaluate_ispline_scalar, evaluate_mspline_scalar, SplineScratch};
+use ndarray::array;
+
+#[test]
+fn bug_mspline_and_ispline_scalar_evaluators_match_scaled_bspline_and_integral_identity() {
+    let knots = array![0.0, 0.0, 0.0, 1.0, 2.0, 3.0, 3.0, 3.0];
+    let degree = 2usize;
+    let n_b = knots.len() - degree - 1;
+    let n_i = knots.len() - (degree + 1) - 2;
+    let x = 1.3;
+
+    let mut b = vec![0.0; n_b];
+    let mut m = vec![0.0; n_b];
+    evaluate_bspline_basis_scalar(x, knots.view(), degree, &mut b, &mut SplineScratch::new(degree)).unwrap();
+    evaluate_mspline_scalar(x, knots.view(), degree, &mut m, &mut SplineScratch::new(degree)).unwrap();
+    for i in 0..n_b {
+        let span = knots[i + degree + 1] - knots[i];
+        let expected = if span > 0.0 { ((degree + 1) as f64 / span) * b[i] } else { 0.0 };
+        assert!((m[i] - expected).abs() < 1e-12, "M-spline scale mismatch at i={i}");
+    }
+
+    let mut i_left = vec![0.0; n_i];
+    let mut i_x = vec![0.0; n_i];
+    evaluate_ispline_scalar(knots[degree + 1], knots.view(), degree, &mut i_left).unwrap();
+    evaluate_ispline_scalar(x, knots.view(), degree, &mut i_x).unwrap();
+    for j in 0..n_i {
+        assert!(i_left[j].abs() < 1e-13, "I-spline should anchor to zero at left boundary j={j}");
+        assert!(i_x[j] >= -1e-13, "I-spline should be nonnegative at x j={j}");
+    }
+}

--- a/tests/periodic_bspline_wrap_derivative_continuity_bug.rs
+++ b/tests/periodic_bspline_wrap_derivative_continuity_bug.rs
@@ -1,0 +1,30 @@
+use gam::terms::basis::{periodic_bspline_first_derivative_nd, build_periodic_bspline_basis_1d, PeriodicBSplineBasisSpec};
+use ndarray::{array, Axis};
+
+#[test]
+fn bug_periodic_bspline_boundary_value_and_derivative_wrap_continuity() {
+    let spec = PeriodicBSplineBasisSpec::new(3, 16, std::f64::consts::TAU, -1.2, 2);
+    let u = array![-1.2, -1.2 + std::f64::consts::TAU, -1.2 - 1e-10, -1.2 + std::f64::consts::TAU + 1e-10];
+    let basis = build_periodic_bspline_basis_1d(u.view(), &spec).expect("periodic basis");
+
+    for j in 0..spec.num_basis {
+        assert!((basis[[0, j]] - basis[[1, j]]).abs() < 1e-12, "value seam mismatch col={j}");
+        assert!((basis[[2, j]] - basis[[3, j]]).abs() < 1e-9, "near-seam value mismatch col={j}");
+    }
+
+    let t = u.clone().insert_axis(Axis(1));
+    let d = periodic_bspline_first_derivative_nd(
+        t.view(),
+        (spec.origin, spec.origin + spec.period),
+        spec.degree,
+        spec.num_basis,
+    )
+    .expect("periodic derivative")
+    .index_axis(Axis(2), 0)
+    .to_owned();
+
+    for j in 0..spec.num_basis {
+        assert!((d[[0, j]] - d[[1, j]]).abs() < 1e-10, "derivative seam mismatch col={j}");
+        assert!((d[[2, j]] - d[[3, j]]).abs() < 1e-7, "near-seam derivative mismatch col={j}");
+    }
+}


### PR DESCRIPTION
### Motivation
- Add focused integration tests to catch parity and analytic-identity bugs in the scalar B-spline/M-/I-spline evaluators and B-spline derivative code paths. 
- Validate periodic 1D B-spline seam behavior including value and first-derivative continuity at and near the wrap boundary.

### Description
- Added test `tests/bspline_derivative_identity_bug.rs` which verifies the analytic de Boor derivative identity via `evaluate_bspline_derivative_scalar` and `evaluate_bspline_basis_scalar` at interior and knot-multiplicity points. 
- Added test `tests/mspline_ispline_scalar_identity_bug.rs` which checks that `evaluate_mspline_scalar` matches the scaled B-spline formula and that `evaluate_ispline_scalar` anchors to zero at the left boundary and is nonnegative in-domain. 
- Added test `tests/periodic_bspline_wrap_derivative_continuity_bug.rs` which builds a periodic basis with `build_periodic_bspline_basis_1d` and validates both partition-of-unity seam wrapping and first-derivative continuity via `periodic_bspline_first_derivative_nd`.

### Testing
- Ran the targeted test invocation `cargo test --test bspline_derivative_identity_bug --test mspline_ispline_scalar_identity_bug --test periodic_bspline_wrap_derivative_continuity_bug` and all three tests passed. 
- Individual test results: `bug_first_derivative_matches_analytic_difference_identity_including_multiplicity_points` passed, `bug_mspline_and_ispline_scalar_evaluators_match_scaled_bspline_and_integral_identity` passed, and `bug_periodic_bspline_boundary_value_and_derivative_wrap_continuity` passed.

---
Codex Cloud task: https://chatgpt.com/codex/tasks/task_e_6a13c4d85e888324ad3b443e24a0a726