### PR TITLE
[bug-hunt] smooth 1/3 (specs + design materialization): 1 bugs

### DIFF
--- a/tests/weighted_blockwise_penalty_sum_rejects_negative_weights.rs
+++ b/tests/weighted_blockwise_penalty_sum_rejects_negative_weights.rs
@@ -1,0 +1,9 @@
+use gam::terms::smooth::{weighted_blockwise_penalty_sum, BlockwisePenalty};
+use ndarray::array;
+
+#[test]
+#[should_panic(expected = "negative")]
+fn bug_weighted_blockwise_penalty_sum_accepts_negative_weight_instead_of_erroring() {
+    let penalties = vec![BlockwisePenalty::new(0..2, array![[2.0, 0.0], [0.0, 3.0]])];
+    let _result = weighted_blockwise_penalty_sum(&penalties, &[-1.0], 2);
+}


### PR DESCRIPTION
### Motivation
- Add a regression test to exercise and reveal a bug where `weighted_blockwise_penalty_sum` accepts negative block weights instead of rejecting them.

### Description
- Add test `tests/weighted_blockwise_penalty_sum_rejects_negative_weights.rs` containing a single `#[test] #[should_panic(expected = "negative")]` that calls `weighted_blockwise_penalty_sum` with a negative lambda for a 2×2 `BlockwisePenalty`.

### Testing
- Ran `cargo test --test weighted_blockwise_penalty_sum_rejects_negative_weights` and the test failed (did not panic) demonstrating the bug.

---
Codex Cloud task: https://chatgpt.com/codex/tasks/task_e_6a13c56860a88324bae53d3eb375b91f