### PR TITLE
[bug-hunt] gamlss 1/3 (wiggle config + location-scale specs + builders + Gaussian LS family): 1 bugs

### DIFF
--- a/tests/wiggle_penalty_orders_do_not_drop_requested_orders.rs
+++ b/tests/wiggle_penalty_orders_do_not_drop_requested_orders.rs
@@ -1,0 +1,34 @@
+use gam::families::gamlss::{
+    WiggleBlockConfig, buildwiggle_block_input_from_seed, split_wiggle_penalty_orders,
+};
+use ndarray::array;
+
+#[test]
+fn wiggle_penalty_orders_requested_by_spec_are_not_silently_dropped() {
+    let seed = array![-2.0, -1.0, 0.0, 1.0, 2.0];
+    let cfg = WiggleBlockConfig {
+        degree: 3,
+        num_internal_knots: 3,
+        penalty_order: 2,
+        double_penalty: false,
+    };
+    let requested_orders = vec![1, 3, 7];
+    let (primary, extras) = split_wiggle_penalty_orders(cfg.penalty_order, &requested_orders);
+
+    let mut effective_cfg = cfg.clone();
+    effective_cfg.penalty_order = primary;
+
+    let (mut block, _knots) = buildwiggle_block_input_from_seed(seed.view(), &effective_cfg)
+        .expect("setup must build wiggle block");
+
+    let baseline_penalty_count = block.penalties.len();
+    gam::families::gamlss::append_selected_wiggle_penalty_orders(&mut block, &extras)
+        .expect("appending selected wiggle penalties must succeed");
+
+    let appended_count = block.penalties.len() - baseline_penalty_count;
+    assert_eq!(
+        appended_count,
+        extras.len(),
+        "BUG: append_selected_wiggle_penalty_orders silently drops user-requested wiggle penalty orders when order >= basis dimension"
+    );
+}


### PR DESCRIPTION
### Motivation
- The wiggle-block penalty plumbing should preserve and append all user-requested penalty orders (partitioning primary vs extra orders without dropping or duplicating any), so add a regression that exercises `split_wiggle_penalty_orders` + `append_selected_wiggle_penalty_orders` to catch silent-loss cases.

### Description
- Add a failing regression test `tests/wiggle_penalty_orders_do_not_drop_requested_orders.rs` that builds a wiggle block from a seed using `buildwiggle_block_input_from_seed`, computes `primary` and `extras` with `split_wiggle_penalty_orders`, calls `append_selected_wiggle_penalty_orders`, and asserts the number of appended penalties equals `extras.len()`.

### Testing
- Ran `cargo test --test wiggle_penalty_orders_do_not_drop_requested_orders -- --nocapture` which compiled and executed the test and failed RED with an assertion showing that `append_selected_wiggle_penalty_orders` dropped a requested penalty order (appended 1 vs expected 2).

---
Codex Cloud task: https://chatgpt.com/codex/tasks/task_e_6a13c6c72d408324afdf2185a1271d28