### PR TITLE
[bug-hunt] survival_location_scale 1/3 (residual distributions + row kernel + survival_fit_from_parts): 1 bugs

### DIFF
--- a/tests/survival_fit_from_parts_rejects_mismatched_lambda_lengths.rs
+++ b/tests/survival_fit_from_parts_rejects_mismatched_lambda_lengths.rs
@@ -1,0 +1,33 @@
+use gam::survival_location_scale::{survival_fit_from_parts, SurvivalLocationScaleFitResultParts};
+use ndarray::{array, Array2};
+
+#[test]
+fn survival_fit_from_parts_rejects_mismatched_lambda_lengths() {
+    let parts = SurvivalLocationScaleFitResultParts {
+        beta_time: array![0.1, -0.2],
+        beta_threshold: array![0.3, 0.4],
+        beta_log_sigma: array![0.5],
+        beta_link_wiggle: None,
+        link_wiggle_knots: None,
+        link_wiggle_degree: None,
+        lambdas_time: array![1.0],
+        lambdas_threshold: array![2.0, 3.0, 4.0],
+        lambdas_log_sigma: array![5.0, 6.0],
+        lambdas_linkwiggle: None,
+        log_likelihood: -10.0,
+        reml_score: -9.0,
+        stable_penalty_term: 0.0,
+        penalized_objective: 10.0,
+        outer_iterations: 1,
+        outer_gradient_norm: Some(0.1),
+        outer_converged: true,
+        covariance_conditional: Some(Array2::eye(5)),
+        geometry: None,
+    };
+
+    let result = survival_fit_from_parts(parts);
+    assert!(
+        result.is_err(),
+        "survival_fit_from_parts should reject inconsistent lambda lengths for parameter blocks instead of silently accepting them"
+    );
+}


### PR DESCRIPTION
### Motivation
- Add a failing regression test to surface that `survival_fit_from_parts` does not validate inconsistent lambda vector lengths across parameter blocks.

### Description
- Add test file `tests/survival_fit_from_parts_rejects_mismatched_lambda_lengths.rs` which builds a `SurvivalLocationScaleFitResultParts` with mismatched `lambdas_time`, `lambdas_threshold`, and `lambdas_log_sigma` lengths and asserts `survival_fit_from_parts` returns an error.

### Testing
- Ran `cargo test --test survival_fit_from_parts_rejects_mismatched_lambda_lengths` and the test failed (red), exposing the missing validation bug.

---
Codex Cloud task: https://chatgpt.com/codex/tasks/task_e_6a13c735e9dc8324b2d53fe094259f24