### PR TITLE
[bug-hunt] survival_location_scale 2/3 (constraints projection + dynamic geometry + middle family impls): 1 bugs

### DIFF
--- a/tests/survival_location_scale_constraint_projection_regression.rs
+++ b/tests/survival_location_scale_constraint_projection_regression.rs
@@ -1,0 +1,20 @@
+use gam::solver::active_set::LinearInequalityConstraints;
+use gam::survival_location_scale::project_onto_linear_constraints;
+use ndarray::{array, Array1};
+
+#[test]
+fn project_onto_linear_constraints_should_project_onto_equalities_not_only_inequalities() {
+    let constraints = LinearInequalityConstraints {
+        a: array![[1.0, 0.0], [0.0, 1.0]],
+        b: array![0.0, 0.0],
+    };
+    let v = Array1::from_vec(vec![2.5, 3.5]);
+
+    let projected = project_onto_linear_constraints(2, &constraints, Some(&v));
+
+    assert!(
+        projected.dot(&constraints.a.row(0)).abs() <= 1e-12
+            && projected.dot(&constraints.a.row(1)).abs() <= 1e-12,
+        "Expected projector to enforce C v* = 0 for all supplied linear constraints, but got projected={projected:?}"
+    );
+}


### PR DESCRIPTION
### Motivation
- Add a focused regression test that exposes incorrect behavior in `project_onto_linear_constraints` where the projector is expected to return `v*` with `C v* = 0` (within machine tolerance) but currently leaves feasible positive coordinates unchanged.

### Description
- Added `tests/survival_location_scale_constraint_projection_regression.rs` containing `project_onto_linear_constraints_should_project_onto_equalities_not_only_inequalities`, which builds `LinearInequalityConstraints` with `A = [[1,0],[0,1]]`, `b = [0,0]`, projects `v = [2.5,3.5]`, and asserts the projection satisfies `A v* == 0` within `1e-12`.

### Testing
- Executed `cargo test -q --test survival_location_scale_constraint_projection_regression -- --nocapture` in this environment but the test run did not complete within the execution window; the new test is expected to fail against the current implementation and therefore serves as a regression witness.

---
Codex Cloud task: https://chatgpt.com/codex/tasks/task_e_6a13c736254083249950fcfdfa75edc0