### PR TITLE
[bug-hunt] survival_location_scale 3/3 (CustomFamily impl + exact Newton workspaces): 1 bugs

### DIFF
--- a/tests/bug_hunt_survival_location_scale_exact_newton_workspace_state_reuse.rs
+++ b/tests/bug_hunt_survival_location_scale_exact_newton_workspace_state_reuse.rs
@@ -1,0 +1,60 @@
+use csv::StringRecord;
+use gam::{FitConfig, FitResult, encode_recordswith_inferred_schema, fit_from_formula};
+
+fn tiny_dataset(rows: &[[f64; 4]]) -> gam::inference::data::EncodedDataset {
+    let headers = ["entry", "exit", "event", "x"]
+        .into_iter()
+        .map(str::to_string)
+        .collect::<Vec<_>>();
+    let records = rows
+        .iter()
+        .map(|row| StringRecord::from(row.map(|v| v.to_string()).to_vec()))
+        .collect::<Vec<_>>();
+    encode_recordswith_inferred_schema(headers, records).expect("encode tiny dataset")
+}
+
+fn fit_theta(data: &gam::inference::data::EncodedDataset) -> Vec<f64> {
+    let cfg = FitConfig {
+        survival_likelihood: "location-scale".to_string(),
+        noise_formula: Some("1".to_string()),
+        ..FitConfig::default()
+    };
+    let FitResult::SurvivalLocationScale(fit) =
+        fit_from_formula("Surv(entry, exit, event) ~ x", data, &cfg).expect("fit should succeed")
+    else {
+        panic!("expected survival location-scale result")
+    };
+    let u=&fit.fit.fit;
+    u.beta_time().iter().chain(u.beta_threshold().iter()).chain(u.beta_log_sigma().iter()).copied().collect()
+}
+
+#[test]
+fn workspace_state_reuse_does_not_change_repeated_fit_output_after_different_call() {
+    let data_a = tiny_dataset(&[
+        [1.0, 2.0, 1.0, -1.0],
+        [1.0, 3.0, 0.0, 0.0],
+        [1.0, 4.0, 1.0, 1.0],
+        [1.0, 5.0, 0.0, 2.0],
+    ]);
+    let data_b = tiny_dataset(&[
+        [1.0, 2.0, 0.0, -0.5],
+        [1.0, 3.0, 0.0, 0.5],
+        [1.0, 6.0, 0.0, 1.5],
+        [1.0, 7.0, 0.0, 2.5],
+    ]);
+
+    let theta_first = fit_theta(&data_a);
+    let _ = fit_theta(&data_b);
+    let theta_second = fit_theta(&data_a);
+
+    let max_abs = theta_first
+        .iter()
+        .zip(theta_second.iter())
+        .map(|(a, b)| (a - b).abs())
+        .fold(0.0_f64, f64::max);
+
+    assert!(
+        max_abs <= 0.0,
+        "Calling the exact Newton survival workspace twice with identical inputs should return identical coefficients"
+    );
+}


### PR DESCRIPTION
### Motivation
- Add an integration test to reproduce a suspected workspace state reuse bug in the survival location-scale exact-Newton workspaces where a second identical fit (after an intervening fit on different inputs) should produce identical coefficients but may observe leaked state.

### Description
- Add `tests/bug_hunt_survival_location_scale_exact_newton_workspace_state_reuse.rs` with helpers `tiny_dataset` and `fit_theta`, and a test `workspace_state_reuse_does_not_change_repeated_fit_output_after_different_call` that fits dataset A, fits dataset B, then refits A and asserts exact coefficient identity with a plain-English assertion message.

### Testing
- Ran `cargo test --test bug_hunt_survival_location_scale_exact_newton_workspace_state_reuse` for the new test; the run failed to complete due to runtime attempts to dynamically load CUDA libraries (`cudarc`), preventing reaching the assertion (test environment lacked the CUDA shared library).

---
Codex Cloud task: https://chatgpt.com/codex/tasks/task_e_6a13c736d5348324b563c62c0c8b8f13