### PR TITLE
[bug-hunt] custom_family 1/3 (trait + coefficient groups + blockwise fit + outer HvP): 1 bugs

### DIFF
--- a/tests/coefficient_label_by_block_name_rejects_duplicate_block_names.rs
+++ b/tests/coefficient_label_by_block_name_rejects_duplicate_block_names.rs
@@ -1,0 +1,32 @@
+use gam::families::custom_family::{
+    CoefficientGroupSpec, ParameterBlockSpec, coefficient_label,
+    realize_coefficient_groups_for_custom_family,
+};
+use gam::matrix::{DenseDesignMatrix, DesignMatrix};
+use gam::types::RhoPrior;
+use ndarray::{Array1, Array2};
+
+fn make_spec(name: &str) -> ParameterBlockSpec {
+    ParameterBlockSpec {
+        name: name.to_string(),
+        design: DesignMatrix::Dense(DenseDesignMatrix::from(Array2::zeros((3, 2)))),
+        offset: Array1::zeros(3),
+        penalties: vec![],
+        nullspace_dims: vec![],
+        initial_log_lambdas: Array1::zeros(0),
+        initial_beta: None,
+    }
+}
+
+#[test]
+fn coefficient_label_by_block_name_rejects_duplicate_block_names() {
+    let specs = vec![make_spec("dup"), make_spec("dup")];
+    let groups = vec![CoefficientGroupSpec::new("g", vec![coefficient_label("dup", 1)])];
+
+    let result = realize_coefficient_groups_for_custom_family(&specs, &groups, RhoPrior::Flat);
+
+    assert!(
+        result.is_err(),
+        "coefficient labels by block name must be unambiguous: duplicate block names should be rejected"
+    );
+}


### PR DESCRIPTION
### Motivation
- Add a regression that captures ambiguous block-name resolution when selecting coefficients by name via `CoefficientLabel::by_block_name`, because `realize_coefficient_groups_for_custom_family` should reject duplicate `ParameterBlockSpec.name` values rather than silently resolving the first match.

### Description
- Add integration test `tests/coefficient_label_by_block_name_rejects_duplicate_block_names.rs` which builds two `ParameterBlockSpec` entries with the same `name` and asserts that `realize_coefficient_groups_for_custom_family` returns an error when passed a `CoefficientGroupSpec` using `coefficient_label("dup", 1)`; no production source changes were made.

### Testing
- Ran `cargo test --test coefficient_label_by_block_name_rejects_duplicate_block_names`, and the test failed as expected, proving the ambiguous-name resolution is a real defect.

---
Codex Cloud task: https://chatgpt.com/codex/tasks/task_e_6a13c86169e4832493616ed0142de904