### PR TITLE
[bug-hunt] pirls 1/3 (working weights + deviance + log-likelihood per family): 1 bugs

### DIFF
--- a/tests/gaussian_fixed_dispersion_is_ignored_in_pirls_geometry_and_deviance.rs
+++ b/tests/gaussian_fixed_dispersion_is_ignored_in_pirls_geometry_and_deviance.rs
@@ -1,0 +1,41 @@
+use gam::solver::pirls::{calculate_deviance, update_glmvectors_by_family};
+use gam::types::{GlmLikelihoodSpec, InverseLink, LikelihoodScaleMetadata, LikelihoodSpec, ResponseFamily};
+use ndarray::array;
+
+#[test]
+fn gaussian_fixed_dispersion_should_scale_working_weight_and_deviance() {
+    let likelihood = GlmLikelihoodSpec {
+        spec: LikelihoodSpec {
+            response: ResponseFamily::Gaussian,
+            link: InverseLink::Standard(gam::types::LinkFunction::Identity),
+        },
+        scale: LikelihoodScaleMetadata::FixedDispersion { phi: 4.0 },
+    };
+
+    let y = array![3.0];
+    let eta = array![1.0];
+    let prior = array![2.0];
+    let mut mu = array![0.0];
+    let mut w = array![0.0];
+    let mut z = array![0.0];
+
+    update_glmvectors_by_family(y.view(), &eta, &likelihood, prior.view(), &mut mu, &mut w, &mut z)
+        .expect("Gaussian IRLS update should succeed");
+
+    let expected_weight = prior[0] / 4.0;
+    assert!(
+        (w[0] - expected_weight).abs() < 1e-12,
+        "Gaussian working weight must include fixed dispersion phi (expected {}, got {})",
+        expected_weight,
+        w[0]
+    );
+
+    let dev = calculate_deviance(y.view(), &mu, &likelihood, prior.view());
+    let expected_dev = prior[0] * (y[0] - mu[0]).powi(2) / 4.0;
+    assert!(
+        (dev - expected_dev).abs() < 1e-12,
+        "Gaussian deviance must divide weighted RSS by fixed dispersion phi (expected {}, got {})",
+        expected_dev,
+        dev
+    );
+}


### PR DESCRIPTION
### Motivation
- Add a minimal regression that captures a definitive PIRLS bug where Gaussian fixed dispersion (`phi`) is not applied to the IRLS working weight or the deviance calculation.

### Description
- Add test `tests/gaussian_fixed_dispersion_is_ignored_in_pirls_geometry_and_deviance.rs` which constructs a `GlmLikelihoodSpec` with `LikelihoodScaleMetadata::FixedDispersion { phi: 4.0 }` and asserts that `update_glmvectors_by_family` produces a working weight scaled by `1/phi` and `calculate_deviance` divides the weighted RSS by `phi`.

### Testing
- Ran `cargo test --test gaussian_fixed_dispersion_is_ignored_in_pirls_geometry_and_deviance` and the single test failed as expected, showing the observed working weight `2.0` vs expected `0.5`, confirming the bug is present.

---
Codex Cloud task: https://chatgpt.com/codex/tasks/task_e_6a13c97a7a708324bb05cb9388c3d6b9