### PR TITLE
[bug-hunt] pirls 3/3 (outer loop + observed Hessian curvature + dispersion + integrated link): 1 bugs

### DIFF
--- a/tests/pirls_beta_dispersion_bug.rs
+++ b/tests/pirls_beta_dispersion_bug.rs
@@ -1,0 +1,51 @@
+use gam::pirls::update_glmvectors_by_family;
+use gam::types::{GlmLikelihoodSpec, LikelihoodSpec};
+use ndarray::Array1;
+
+#[test]
+fn beta_working_weights_should_change_when_beta_phi_changes() {
+    let y = Array1::from_vec(vec![0.2, 0.6, 0.8]);
+    let eta = Array1::from_vec(vec![-0.4, 0.1, 0.9]);
+    let priorweights = Array1::from_vec(vec![1.0, 1.0, 1.0]);
+
+    let low_phi = GlmLikelihoodSpec::canonical(LikelihoodSpec::beta_logit(2.0));
+    let high_phi = GlmLikelihoodSpec::canonical(LikelihoodSpec::beta_logit(200.0));
+
+    let mut mu_low = Array1::zeros(y.len());
+    let mut w_low = Array1::zeros(y.len());
+    let mut z_low = Array1::zeros(y.len());
+
+    update_glmvectors_by_family(
+        y.view(),
+        &eta,
+        &low_phi,
+        priorweights.view(),
+        &mut mu_low,
+        &mut w_low,
+        &mut z_low,
+    )
+    .expect("Beta(phi=2) working-vector update should succeed");
+
+    let mut mu_high = Array1::zeros(y.len());
+    let mut w_high = Array1::zeros(y.len());
+    let mut z_high = Array1::zeros(y.len());
+
+    update_glmvectors_by_family(
+        y.view(),
+        &eta,
+        &high_phi,
+        priorweights.view(),
+        &mut mu_high,
+        &mut w_high,
+        &mut z_high,
+    )
+    .expect("Beta(phi=200) working-vector update should succeed");
+
+    assert!(
+        w_low
+            .iter()
+            .zip(w_high.iter())
+            .any(|(a, b)| (a - b).abs() > 1e-10),
+        "Beta working weights should change when response-family phi changes; phi=2 and phi=200 produced indistinguishable weights"
+    );
+}


### PR DESCRIPTION
### Motivation
- Add a focused regression to catch a bug where the Beta-family dispersion (`phi`) is not threaded into the GLM working-vector update, causing `update_glmvectors_by_family` to produce identical weights for different `phi` values.

### Description
- Add failing integration test `tests/pirls_beta_dispersion_bug.rs` that calls `update_glmvectors_by_family` with two `GlmLikelihoodSpec::canonical(LikelihoodSpec::beta_logit(...))` instances differing only in `phi` (2.0 vs 200.0) and asserts the returned `weights` vectors are different.

### Testing
- Executed `cargo test -q --test pirls_beta_dispersion_bug` and `cargo test --test pirls_beta_dispersion_bug -- --nocapture` in this environment but the runs did not complete, so no pass/fail outcome was captured.

---
Codex Cloud task: https://chatgpt.com/codex/tasks/task_e_6a13c97bdf788324a5a663754613328e