### PR TITLE
[bug-hunt] evidence + gaussian_reml (laplace_evidence + log-det + closed-form Gaussian REML + topology selection): 0 bugs

### DIFF
--- a/tests/bug_hunt_evidence_gaussian_reml_topology.rs
+++ b/tests/bug_hunt_evidence_gaussian_reml_topology.rs
@@ -1,0 +1,52 @@
+use gam::solver::evidence::{
+    select_topology, TopologyCandidate, TopologyKind, TopologyScoreScale, TopologySelectOptions,
+};
+
+#[test]
+fn select_topology_keeps_input_order_for_identical_scores_and_same_complexity() {
+    let candidates = vec![
+        TopologyCandidate {
+            kind: TopologyKind::Flat,
+            negative_log_evidence: 100.0,
+            effective_dim: 10.0,
+            n_obs: 50,
+            converged: true,
+            exclusion_reason: None,
+        },
+        TopologyCandidate {
+            kind: TopologyKind::Flat,
+            negative_log_evidence: 100.0,
+            effective_dim: 10.0,
+            n_obs: 50,
+            converged: true,
+            exclusion_reason: None,
+        },
+        TopologyCandidate {
+            kind: TopologyKind::Periodic,
+            negative_log_evidence: 100.0,
+            effective_dim: 10.0,
+            n_obs: 50,
+            converged: true,
+            exclusion_reason: None,
+        },
+    ];
+
+    let selected = select_topology(
+        &candidates,
+        TopologySelectOptions {
+            tie_tolerance: 0.0,
+            score_scale: TopologyScoreScale::PerObservation,
+        },
+    );
+
+    assert_eq!(selected.ranking.len(), candidates.len(), "Topology selection should preserve the input candidate count when nothing is rejected.");
+    for (idx, candidate) in candidates.iter().enumerate() {
+        assert!(
+            selected.ranking[idx].kind == candidate.kind
+                && (selected.ranking[idx].negative_log_evidence - candidate.negative_log_evidence).abs() < 1e-12
+                && (selected.ranking[idx].effective_dim - candidate.effective_dim).abs() < 1e-12
+                && selected.ranking[idx].n_obs == candidate.n_obs,
+            "Topology selection should keep a deterministic stable ordering when normalized scores are identical."
+        );
+    }
+}


### PR DESCRIPTION
### Motivation
- Add a small regression to ensure `select_topology` produces a deterministic stable ordering when normalized scores are identical and no candidate is rejected.

### Description
- Added `tests/bug_hunt_evidence_gaussian_reml_topology.rs` containing the test `select_topology_keeps_input_order_for_identical_scores_and_same_complexity` which asserts that `select_topology` preserves the input candidate count and ordering when normalized scores are identical and candidates share the same complexity.

### Testing
- Ran `cargo test --test bug_hunt_evidence_gaussian_reml_topology` and the new test passed (1 passed; 0 failed).

---
Codex Cloud task: https://chatgpt.com/codex/tasks/task_e_6a13ca0fe3d88324aeb22d91f047471b