### PR TITLE
[bug-hunt] predict 1/2 (StandardPredictor + apply_family_inverse_link + posterior mean): 2 bugs

### DIFF
--- a/tests/apply_family_inverse_link_variants_match_documented_mu.rs
+++ b/tests/apply_family_inverse_link_variants_match_documented_mu.rs
@@ -1,0 +1,54 @@
+use gam::inference::predict::predict_gam;
+use gam::types::{InverseLink, LatentCLogLogState, LikelihoodSpec, LinkComponent,  MixtureLinkState, ResponseFamily, SasLinkState};
+use ndarray::{arr1, arr2};
+
+fn std_norm_cdf(x: f64) -> f64 {
+    0.5 * (1.0 + statrs::function::erf::erf(x / std::f64::consts::SQRT_2))
+}
+
+#[test]
+fn apply_family_inverse_link_variants_match_documented_mu() {
+    let eta = 0.37;
+    let x = arr2(&[[1.0]]);
+    let off = arr1(&[0.0]);
+
+    let logit_mu = predict_gam(x.clone(), arr1(&[eta]).view(), off.view(), LikelihoodSpec::binomial_logit())
+        .expect("logit prediction should succeed")
+        .mean[0];
+    let expected_logit = 1.0 / (1.0 + (-eta).exp());
+    assert!((logit_mu - expected_logit).abs() < 1e-12, "Logit inverse link should equal sigmoid(eta).");
+
+    let probit_mu = predict_gam(x.clone(), arr1(&[eta]).view(), off.view(), LikelihoodSpec::binomial_probit())
+        .expect("probit prediction should succeed")
+        .mean[0];
+    let expected_probit = std_norm_cdf(eta);
+    assert!((probit_mu - expected_probit).abs() < 1e-12, "Probit inverse link should equal Φ(eta).");
+
+    let cloglog_mu = predict_gam(x.clone(), arr1(&[eta]).view(), off.view(), LikelihoodSpec::binomial_cloglog())
+        .expect("cloglog prediction should succeed")
+        .mean[0];
+    let expected_cloglog = 1.0 - (-(eta.exp())).exp();
+    assert!((cloglog_mu - expected_cloglog).abs() < 1e-12, "CLogLog inverse link should equal 1 - exp(-exp(eta)).");
+
+    let latent = LikelihoodSpec::binomial_latent_cloglog(LatentCLogLogState::new(0.25).expect("valid latent sd"));
+    let latent_mu = predict_gam(x.clone(), arr1(&[eta]).view(), off.view(), latent)
+        .expect("latent cloglog prediction should succeed")
+        .mean[0];
+    assert!(latent_mu.is_finite() && latent_mu > 0.0 && latent_mu < 1.0, "Latent CLogLog inverse link should produce a finite probability inside (0,1).");
+
+    let sas = LikelihoodSpec::new(ResponseFamily::Binomial, InverseLink::Sas(SasLinkState { epsilon: 0.1, log_delta: -0.3, delta: 0.8 }));
+    let sas_mu = predict_gam(x.clone(), arr1(&[eta]).view(), off.view(), sas)
+        .expect("sas prediction should succeed")
+        .mean[0];
+    assert!(sas_mu.is_finite() && sas_mu > 0.0 && sas_mu < 1.0, "SAS inverse link should produce a finite probability inside (0,1).");
+
+    let comps = vec![LinkComponent::Logit, LinkComponent::Probit, LinkComponent::CLogLog];
+    let pi = arr1(&[0.2, 0.3, 0.5]);
+    let rho = arr1(&[-0.916290731874155, -0.510825623765991]);
+    let mix_spec = LikelihoodSpec::binomial_mixture(MixtureLinkState { components: comps, rho, pi: pi.clone() });
+    let mix_mu = predict_gam(x, arr1(&[eta]).view(), off.view(), mix_spec)
+        .expect("mixture prediction should succeed")
+        .mean[0];
+    let expected_mix = pi[0] * expected_logit + pi[1] * expected_probit + pi[2] * expected_cloglog;
+    assert!((mix_mu - expected_mix).abs() < 1e-10, "Mixture inverse link should equal weighted component mean sum pi_k * mu_k(eta).");
+}

--- a/tests/predict_new_row_eta_uses_training_column_order.rs
+++ b/tests/predict_new_row_eta_uses_training_column_order.rs
@@ -1,0 +1,16 @@
+use gam::inference::predict::predict_gam;
+use gam::types::LikelihoodSpec;
+use ndarray::{arr1, arr2};
+
+#[test]
+fn predict_new_row_eta_uses_training_column_order() {
+    let x_new = arr2(&[[10.0, -3.0, 0.25]]);
+    let beta = arr1(&[0.1, 2.0, -4.0]);
+    let offset = arr1(&[0.7]);
+
+    let out = predict_gam(x_new.view(), beta.view(), offset.view(), LikelihoodSpec::gaussian_identity())
+        .expect("standard prediction should succeed");
+
+    let expected_eta = 10.0 * 0.1 + (-3.0) * 2.0 + 0.25 * (-4.0) + 0.7;
+    assert!((out.eta[0] - expected_eta).abs() < 1e-12, "New-row eta should be computed as X_new * beta + offset using fit-time column order.");
+}


### PR DESCRIPTION
### Motivation
- Add lightweight regression tests that exercise the standard prediction path and parameterized inverse-link behaviour to catch regressions in `apply_family_inverse_link`, fresh-row `η` assembly, mixture-link composition, and bounded-family clamping.

### Description
- Added two tests under `tests/`: `apply_family_inverse_link_variants_match_documented_mu.rs` which checks logit/probit/cloglog closed forms, finite-range behaviour for latent-cloglog and SAS, and mixture mean = `∑ π_k μ_k(η)`, and `predict_new_row_eta_uses_training_column_order.rs` which validates `η = X_new · β + offset` uses fit-time column ordering; no production source files were modified.

### Testing
- Ran the targeted test invocation `cargo test --test apply_family_inverse_link_variants_match_documented_mu --test predict_new_row_eta_uses_training_column_order` which compiled the tests but the run aborted because `cudarc` attempted to dynamically load the CUDA driver (`libcuda.so`) and panicked, so the tests could not be completed in this environment.
- Attempted `GAM_GPU=off` to disable GPU dispatch but observed the same runtime dynamic-load panic, so the new tests could not be fully verified here.

---
Codex Cloud task: https://chatgpt.com/codex/tasks/task_e_6a13ca9dd4908324990ba968f86caf1f