### PR TITLE
[bug-hunt] linalg/matrix 1/2 (DesignMatrix / LinearOperator / sparse-dense round-trip): 0 bugs

### DIFF
--- a/tests/sparse_design_to_csr_arc_returns_some_for_well_formed_matrix.rs
+++ b/tests/sparse_design_to_csr_arc_returns_some_for_well_formed_matrix.rs
@@ -1,0 +1,26 @@
+use faer::sparse::{SparseColMat, Triplet};
+use gam::linalg::matrix::SparseDesignMatrix;
+
+#[test]
+fn sparse_design_to_csr_arc_returns_some_for_well_formed_matrix() {
+    let sparse = SparseColMat::try_new_from_triplets(
+        4,
+        3,
+        &[
+            Triplet::new(0, 0, 1.5),
+            Triplet::new(1, 1, -2.0),
+            Triplet::new(2, 2, 0.25),
+            Triplet::new(3, 0, 4.0),
+            Triplet::new(1, 2, 3.5),
+        ],
+    )
+    .expect("Expected sparse constructor to accept a well-formed triplet list");
+
+    let design = SparseDesignMatrix::new(sparse);
+    let csr = design.to_csr_arc();
+
+    assert!(
+        csr.is_some(),
+        "Expected to_csr_arc to return Some for a well-formed sparse matrix"
+    );
+}


### PR DESCRIPTION
### Motivation
- Add a small focused test to exercise the sparse-to-CSR conversion path and caching in `SparseDesignMatrix::to_csr_arc()` for a well-formed sparse CSC matrix.

### Description
- Add `tests/sparse_design_to_csr_arc_returns_some_for_well_formed_matrix.rs` which builds a `SparseColMat` from `Triplet::new(...)`, wraps it with `SparseDesignMatrix::new(...)`, and asserts that `to_csr_arc().is_some()` with a plain-English failure message.

### Testing
- Ran `cargo test --test sparse_design_to_csr_arc_returns_some_for_well_formed_matrix -q` and the single new test passed (1 passed; 0 failed).

---
Codex Cloud task: https://chatgpt.com/codex/tasks/task_e_6a13cbbff0148324956e2fad58bede30