### PR TITLE
[bug-hunt] torch_dispatch + penalties submodule (entry-kind mapping + spec round-trip): 2 bugs

### DIFF
--- a/tests/bug_hunt_torch_dispatch_penalties.rs
+++ b/tests/bug_hunt_torch_dispatch_penalties.rs
@@ -1,0 +1,69 @@
+use gam::terms::torch_dispatch::dispatch_key;
+use serde::{Deserialize, Serialize};
+
+#[test]
+fn torch_dispatch_maps_every_torch_exported_smooth_class() {
+    let exported_torch_smooth_classes = [
+        "Duchon",
+        "BSpline",
+        "TensorBSpline",
+        "Matern",
+        "Pca",
+        "PeriodicSplineCurve",
+        "Sphere",
+        "Categorical",
+    ];
+
+    for class_name in exported_torch_smooth_classes {
+        let result = dispatch_key(class_name);
+        assert!(
+            result.is_ok(),
+            "Expected torch dispatch to map exported smooth class '{class_name}' to a backend entry kind, but got error: {result:?}"
+        );
+    }
+}
+
+#[test]
+fn unknown_entry_kind_returns_clear_error_without_panicking() {
+    let unknown_kind = "TotallyUnknownSmooth";
+    let result = dispatch_key(unknown_kind);
+    assert!(
+        result.is_err(),
+        "Expected unknown smooth class '{unknown_kind}' to return an error instead of success"
+    );
+    let err = result.unwrap_err();
+    assert!(
+        err.contains("unknown Smooth subclass") && err.contains(unknown_kind),
+        "Expected unknown smooth error to clearly include both the unknown-kind marker and class name; got: {err}"
+    );
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct TorchDispatchSpec {
+    smooth_class_name: String,
+}
+
+#[test]
+fn torch_dispatch_spec_round_trip_preserves_dispatch_result() {
+    let original = TorchDispatchSpec {
+        smooth_class_name: "TensorBSpline".to_string(),
+    };
+
+    let encoded = serde_json::to_string(&original)
+        .expect("Expected TorchDispatchSpec to serialize to JSON");
+    let decoded: TorchDispatchSpec = serde_json::from_str(&encoded)
+        .expect("Expected TorchDispatchSpec JSON to deserialize back to struct");
+
+    let before = dispatch_key(&original.smooth_class_name);
+    let after = dispatch_key(&decoded.smooth_class_name);
+
+    assert!(
+        before.is_ok(),
+        "Expected original torch-dispatch spec class '{}' to be dispatchable before serialization, but got: {before:?}",
+        original.smooth_class_name
+    );
+    assert_eq!(
+        before, after,
+        "Expected torch-dispatch result to remain identical after spec serialize/deserialize round-trip"
+    );
+}


### PR DESCRIPTION
### Motivation
- Provide explicit, automated coverage that the Rust torch dispatch maps every Smooth subclass exported to the `gamfit.torch` Python bridge, that unknown kinds return an `Err` (not a panic) with a clear class-name-containing message, and that serializing/deserializing a torch-dispatch spec preserves the dispatch result.

### Description
- Add a new test file `tests/bug_hunt_torch_dispatch_penalties.rs` containing three tests: `torch_dispatch_maps_every_torch_exported_smooth_class`, `unknown_entry_kind_returns_clear_error_without_panicking`, and `torch_dispatch_spec_round_trip_preserves_dispatch_result` which exercises `gam::terms::torch_dispatch::dispatch_key` and JSON round-trip via `serde`.
- The tests assert mapping coverage for the Smooth classes exported by `gamfit.torch` and require dispatch identity before/after a `serde_json` serialize/deserialize round-trip.

### Testing
- Ran `cargo test --test bug_hunt_torch_dispatch_penalties` and observed 3 tests run with 1 passing and 2 failing.
- `unknown_entry_kind_returns_clear_error_without_panicking` passed, confirming unknown kinds return an `Err` containing the expected marker and class name.
- `torch_dispatch_maps_every_torch_exported_smooth_class` failed because `dispatch_key("TensorBSpline")` currently returns an `Err` (missing entry-kind mapping for this documented exported smooth class).
- `torch_dispatch_spec_round_trip_preserves_dispatch_result` failed because the pre-round-trip dispatch for `TensorBSpline` is already an `Err`, causing the round-trip identity assertion to fail.

---
Codex Cloud task: https://chatgpt.com/codex/tasks/task_e_6a13cc35c0348324b30b015a8069b9c7