### PR TITLE
[bug-hunt] identifiability (null-space projector + idempotence + constraint orthogonality): 1 bugs

### DIFF
--- a/tests/identifiability_nullspace_projector_idempotence_bug.rs
+++ b/tests/identifiability_nullspace_projector_idempotence_bug.rs
@@ -1,0 +1,49 @@
+use faer::sparse::{SparseColMat, Triplet};
+use gam::basis::apply_sum_to_zero_constraint_sparse;
+use ndarray::Array2;
+
+fn dense_from_sparse(s: &SparseColMat<usize, f64>) -> Array2<f64> {
+    let mut out = Array2::<f64>::zeros((s.nrows(), s.ncols()));
+    let (sym, vals) = s.parts();
+    let col_ptr = sym.col_ptr();
+    let row_idx = sym.row_idx();
+    for j in 0..s.ncols() {
+        for idx in col_ptr[j]..col_ptr[j + 1] {
+            out[[row_idx[idx], j]] = vals[idx];
+        }
+    }
+    out
+}
+
+#[test]
+fn sparse_sum_to_zero_transform_acts_like_true_projector_under_zz_t() {
+    let triplets = vec![
+        Triplet::new(0usize, 0usize, 1.0),
+        Triplet::new(1, 1, 1.0),
+        Triplet::new(2, 2, 1.0),
+        Triplet::new(3, 0, 1.0),
+        Triplet::new(3, 1, 1.0),
+        Triplet::new(3, 2, 1.0),
+    ];
+    let basis = SparseColMat::<usize, f64>::try_new_from_triplets(4, 3, &triplets)
+        .expect("sparse basis from triplets");
+    let (_constrained, z) = apply_sum_to_zero_constraint_sparse(&basis, None)
+        .expect("sum-to-zero transform should build");
+
+    let p = z.dot(&z.t());
+    let p2 = p.dot(&p);
+    let err = (&p2 - &p).mapv(|x| x * x).sum().sqrt();
+    assert!(
+        err <= 1e-12,
+        "Expected ZZ^T to be idempotent to machine precision for a null-space projector, but ||P^2 - P||_F = {err:.3e}"
+    );
+
+    let b_dense = dense_from_sparse(&basis);
+    let projected = b_dense.dot(&p);
+    let ctp = projected.t().dot(&ndarray::Array1::ones(projected.nrows()));
+    let max_abs = ctp.iter().fold(0.0_f64, |acc, v| acc.max(v.abs()));
+    assert!(
+        max_abs <= 1e-12,
+        "Projected basis should satisfy the sum-to-zero constraint column-wise, but max |1^T B P| = {max_abs:.3e}"
+    );
+}


### PR DESCRIPTION
### Motivation
- Add a small, focused regression that captures numeric defects in the sum-to-zero identifiability transform for sparse bases so projector idempotence and constraint-orthogonality are enforced to machine precision.

### Description
- Add `tests/identifiability_nullspace_projector_idempotence_bug.rs` with the test `sparse_sum_to_zero_transform_acts_like_true_projector_under_zz_t` that builds a tiny `SparseColMat`, calls `apply_sum_to_zero_constraint_sparse` to get `Z`, forms `P = Z Z^T`, asserts `P^2 ≈ P` and that the projected basis columns satisfy the sum-to-zero constraint, and uses plain-English assertion messages.

### Testing
- The new test `sparse_sum_to_zero_transform_acts_like_true_projector_under_zz_t` was added as an automated regression and currently fails (demonstrates the bug); running `cargo test` for the test in-session did not complete to success.

---
Codex Cloud task: https://chatgpt.com/codex/tasks/task_e_6a13ccf42a008324ac583bcc0fc8c52f