### PR TITLE
[bug-hunt] main.rs (CLI parsing + run_fit + run_predict + CSV writers): 1 bugs

### DIFF
--- a/tests/cli_parse_link_choice_unknown_returns_err.rs
+++ b/tests/cli_parse_link_choice_unknown_returns_err.rs
@@ -1,0 +1,10 @@
+use gam::inference::formula_dsl::parse_link_choice;
+
+#[test]
+fn cli_parse_link_choice_unknown_returns_err() {
+    let result = parse_link_choice(Some("not-a-real-link"), false);
+    assert!(
+        result.is_err(),
+        "Expected unknown link string to return an error instead of parsing successfully"
+    );
+}


### PR DESCRIPTION
### Motivation
- Add a regression test to ensure `parse_link_choice` rejects unknown link tokens provided via the CLI.

### Description
- Add `tests/cli_parse_link_choice_unknown_returns_err.rs` containing one `#[test]` that calls `parse_link_choice(Some("not-a-real-link"), false)` and asserts `is_err()` with a plain-English failure message.

### Testing
- Executed `cargo test -q --test cli_parse_link_choice_unknown_returns_err` in the environment but the test process did not complete within the session window so the automated test result is unknown.

---
Codex Cloud task: https://chatgpt.com/codex/tasks/task_e_6a13ccf45bec8324b18172bc25a8dc90