### PR TITLE
[bug-hunt] gamfit/smooth + _equivariant + _response_geometry (Smooth specs + by-var + tensor + factor + equivariant): 1 bugs

### DIFF
--- a/tests/response_geometry_alr_reference_roundtrip.py
+++ b/tests/response_geometry_alr_reference_roundtrip.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import importlib
+from typing import Any
+
+pytest: Any = importlib.import_module("pytest")
+np = pytest.importorskip("numpy")
+pytest.importorskip("gamfit._rust")
+
+from gamfit._response_geometry import geometry_exp_map, geometry_log_map
+
+
+def test_response_geometry_alr_reference_roundtrip_preserves_rows() -> None:
+    values = np.array(
+        [
+            [0.15, 0.35, 0.50],
+            [0.60, 0.20, 0.20],
+            [0.30, 0.30, 0.40],
+        ],
+        dtype=float,
+    )
+    tangent, base_point, coordinates = geometry_log_map(
+        values,
+        geometry="alr",
+        reference=0,
+    )
+    reconstructed = geometry_exp_map(
+        tangent,
+        geometry="alr",
+        base=base_point,
+        reference=0,
+    )
+
+    assert coordinates == "alr", "ALR geometry should retain ALR tangent coordinates"
+    assert np.allclose(
+        reconstructed,
+        values,
+        atol=1.0e-8,
+        rtol=1.0e-8,
+    ), "ALR log/exp round-trip should reconstruct each composition row"


### PR DESCRIPTION
### Motivation
- Add a regression to ensure Python ↔ Rust response-geometry wiring correctly preserves ALR reference propagation and coordinate mode for ALR log/exp maps.

### Description
- Add `tests/response_geometry_alr_reference_roundtrip.py` which calls `geometry_log_map(..., geometry="alr", reference=0)` and `geometry_exp_map(..., geometry="alr", base=...)` and asserts the round-trip reconstructs each composition row and that the returned `coordinates` equals `"alr"`.

### Testing
- Ran `pytest -q tests/response_geometry_alr_reference_roundtrip.py`, which could not execute in this environment because `numpy` is not installed and `tests/conftest.py` imports it, so the test run failed with a `ModuleNotFoundError` for `numpy`.

---
Codex Cloud task: https://chatgpt.com/codex/tasks/task_e_6a13cd2fdc5c8324bc6582ee66c83a78