### PR TITLE
[bug-hunt] gamfit topology + select_topology + sae_manifold (topology spec + selection + assignment modes): 4 bugs

### DIFF
--- a/tests/test_sae_assignment_and_schedule_bridge.py
+++ b/tests/test_sae_assignment_and_schedule_bridge.py
@@ -1,0 +1,26 @@
+import numpy as np
+
+import gamfit._sae_manifold as sae
+
+
+def test_sae_assignment_mode_and_schedule_survive_python_to_rust_bridge(monkeypatch):
+    captured = {}
+
+    class _FakeRust:
+        def sae_manifold_fit_minimal(self, z, k_atoms, atom_basis, atom_dim, assignment_kind, alpha, tau, learnable_alpha, sparsity_strength, smoothness, max_iter, learning_rate, random_state, top_k, *, gumbel_schedule=None):
+            captured["assignment_kind"] = assignment_kind
+            captured["tau"] = tau
+            captured["gumbel_schedule"] = dict(gumbel_schedule or {})
+            atoms = [{"decoder_B": np.ones((2, z.shape[1])), "basis_kind": atom_basis[0], "on_atom_coords_t": np.zeros((z.shape[0], atom_dim[0])), "assignments_z": np.ones(z.shape[0]), "active_dim": atom_dim[0]}]
+            return {"atoms": atoms, "assignments_z": np.ones((z.shape[0], 1)), "fitted": np.zeros_like(z), "reml_score": -1.0}
+
+        def sae_manifold_reconstruction_r2(self, observed, fitted):
+            return 0.0
+
+    monkeypatch.setattr(sae, "rust_module", lambda: _FakeRust())
+
+    schedule = sae.gumbel_linear_schedule(tau_start=0.9, tau_min=0.2, steps=7, iter_count=3)
+    sae.sae_manifold_fit(np.random.default_rng(0).normal(size=(4, 2)), K=1, assignment="gated", tau=0.7, schedule=schedule, n_iter=1)
+
+    assert captured["assignment_kind"] == "jumprelu", "Python AssignmentMode 'gated' should map to Rust AssignmentMode::JumpReLU, not any other mode."
+    assert captured["tau"] == 0.7 and captured["gumbel_schedule"] == schedule.to_rust_descriptor(), "Temperature scalar and schedule descriptor should survive the Python-to-Rust FFI bridge unchanged."

--- a/tests/test_sae_dictionary_k_preserved.py
+++ b/tests/test_sae_dictionary_k_preserved.py
@@ -1,0 +1,21 @@
+import numpy as np
+
+import gamfit._sae_manifold as sae
+
+
+def test_sae_dictionary_atom_count_matches_python_and_rust_payload(monkeypatch):
+    class _FakeRust:
+        def sae_manifold_fit_minimal(self, z, k_atoms, atom_basis, atom_dim, assignment_kind, alpha, tau, learnable_alpha, sparsity_strength, smoothness, max_iter, learning_rate, random_state, top_k, *, gumbel_schedule=None):
+            atoms = []
+            for i in range(k_atoms):
+                atoms.append({"decoder_B": np.ones((2, z.shape[1])) * (i + 1), "basis_kind": atom_basis[i], "on_atom_coords_t": np.zeros((z.shape[0], atom_dim[i])), "assignments_z": np.ones(z.shape[0]), "active_dim": atom_dim[i]})
+            return {"atoms": atoms, "assignments_z": np.ones((z.shape[0], k_atoms)), "fitted": np.zeros_like(z), "reml_score": -1.0, "chosen_k": 1}
+
+        def sae_manifold_reconstruction_r2(self, observed, fitted):
+            return 0.0
+
+    monkeypatch.setattr(sae, "rust_module", lambda: _FakeRust())
+
+    fit = sae.sae_manifold_fit(np.random.default_rng(1).normal(size=(5, 3)), K=3, n_iter=1)
+
+    assert fit.low_level.chosen_k == 1, "The chosen K reported by Rust should be preserved; Python should not silently overwrite it with len(atoms)."

--- a/tests/test_select_topology_rank_ordering.py
+++ b/tests/test_select_topology_rank_ordering.py
@@ -1,0 +1,28 @@
+import gamfit._select_topology as st
+
+
+def test_select_topology_uses_ranked_order_from_comparison_layer(monkeypatch):
+    class _Fit:
+        def __init__(self, reml, edf):
+            self._summary = {"reml_score": reml, "effective_dim": edf, "coefficients": [0.0, 0.0]}
+
+        def summary(self):
+            return self._summary
+
+    monkeypatch.setattr(st, "_formula_from_response", lambda data, response: ("y ~ s(x, type=AUTO)", 1, 5))
+    monkeypatch.setattr(st, "_normalize_candidates", lambda candidates, feature_dim: [
+        st._Candidate("a", object.__new__(st.PeriodicSplineCurve)),
+        st._Candidate("b", object.__new__(st.PeriodicSplineCurve)),
+    ])
+    monkeypatch.setattr(st, "_formula_for_candidate", lambda formula, auto, candidate, strict_dimension: formula)
+    monkeypatch.setattr(st, "fit", lambda data, formula, **kwargs: _Fit(-1.0 if "a" in formula else -2.0, 1.0))
+    monkeypatch.setattr(st, "_extract_reml_score_raw", lambda m: float(m.summary()["reml_score"]))
+    monkeypatch.setattr(st, "_basis_size", lambda m: 2)
+    monkeypatch.setattr(st, "_effective_dim", lambda m: 1.0)
+    monkeypatch.setattr(st, "_fitted_or_candidate_null_dim", lambda fit, candidate, basis_size: 0.0)
+    monkeypatch.setattr(st, "_score_disagreement_warnings", lambda *args, **kwargs: [])
+    monkeypatch.setattr(st, "compare_models", lambda payload, names: {"winner": "b", "ranking": [("b", 0.0), ("a", 0.0)]})
+
+    result = st.select_topology({"y": [1, 2, 3], "x": [0, 1, 2]}, "y")
+
+    assert result.rankings == [("b", result.scores["b"]), ("a", result.scores["a"])], "select_topology should return rankings in the exact score order produced by the ranking/comparison layer."

--- a/tests/test_topology_candidate_payloads_roundtrip.py
+++ b/tests/test_topology_candidate_payloads_roundtrip.py
@@ -1,0 +1,22 @@
+import json
+
+import gamfit.topology as topology
+from gamfit._select_topology import _Candidate, _candidate_to_rust_payload
+
+
+def test_topology_candidate_payloads_are_json_serializable_and_have_required_kind_fields():
+    candidates = [
+        _Candidate("circle", topology.Circle(name="theta")),
+        _Candidate("cylinder", topology.Cylinder(name="cyl")),
+        _Candidate("torus", topology.Torus(name="tor")),
+        _Candidate("sphere", topology.Sphere(name="omega")),
+        _Candidate("euclidean", topology.EuclideanPatch(d=2, name="x", centers=[[0.0, 0.0], [1.0, 1.0]])),
+    ]
+
+    payloads = [_candidate_to_rust_payload(candidate) for candidate in candidates]
+    kinds = {payload["kind"] for payload in payloads}
+
+    for payload in payloads:
+        json.dumps(payload)
+
+    assert kinds == {"periodic_spline_curve", "tensor", "sphere", "duchon"}, "Each topology spec must produce a valid Rust TopologyCandidate JSON payload with an expected kind tag."


### PR DESCRIPTION
### Motivation
- Add regression tests to lock down corner cases in topology candidate serialization, topology selection ordering, SAE assignment-mode mapping, temperature schedule FFI passthrough, and SAE chosen-K preservation.

### Description
- Add `tests/test_topology_candidate_payloads_roundtrip.py` which constructs `Circle`, `Cylinder`, `Torus`, `Sphere`, and `EuclideanPatch` candidates and asserts `_candidate_to_rust_payload` yields JSON-serializable payloads with expected `kind` tags.
- Add `tests/test_select_topology_rank_ordering.py` which monkeypatches `select_topology` internals and asserts the returned `rankings` list matches the ordering produced by the comparison layer.
- Add `tests/test_sae_assignment_and_schedule_bridge.py` which monkeypatches the Rust bridge to verify Python assignment aliases (`gated` → `jumprelu`), `tau` scalar passthrough, and `GumbelTemperatureSchedule.to_rust_descriptor()` survive the Python→Rust call.
- Add `tests/test_sae_dictionary_k_preserved.py` which monkeypatches the Rust bridge to ensure the `chosen_k` reported by Rust is preserved on the Python wrapper rather than being overwritten by `len(atoms)`.

### Testing
- Created and committed four new tests covering the described behaviors (`tests/test_topology_candidate_payloads_roundtrip.py`, `tests/test_select_topology_rank_ordering.py`, `tests/test_sae_assignment_and_schedule_bridge.py`, `tests/test_sae_dictionary_k_preserved.py`).
- Attempted to run `pytest -q` for the new tests but execution failed due to missing test environment dependency: `ModuleNotFoundError: No module named 'numpy'` (from `tests/conftest.py`).

---
Codex Cloud task: https://chatgpt.com/codex/tasks/task_e_6a13cd31e8948324b666ef95861a4c8f