### PR TITLE
[bug-hunt] cross-cutting: jet kernels finite-difference (sigma_link / lognormal / cubic_cell)

### DIFF
--- a/tests/cubic_cell_kernel_transformed_link_jet_fd_mismatch.rs
+++ b/tests/cubic_cell_kernel_transformed_link_jet_fd_mismatch.rs
@@ -1,0 +1,38 @@
+use gam::families::cubic_cell_kernel::{LocalSpanCubic, transformed_link_cubic};
+
+fn eval(span: LocalSpanCubic, x: f64) -> f64 {
+    span.evaluate(x)
+}
+
+#[test]
+fn cubic_cell_kernel_transformed_link_second_and_third_derivatives_match_fd() {
+    let span = LocalSpanCubic {
+        left: -0.7,
+        right: 2.0,
+        c0: 0.21,
+        c1: -0.43,
+        c2: 0.37,
+        c3: -0.19,
+    };
+    let a = 0.38;
+    let b = -1.17;
+
+    let (_d0, d1, d2, d3) = transformed_link_cubic(span, a, b);
+
+    for &h in &[1e-3, 1e-5, 1e-7] {
+        let f = |z: f64| eval(span, a + b * z);
+        let fm2 = f(-2.0 * h);
+        let fm1 = f(-h);
+        let f0 = f(0.0);
+        let fp1 = f(h);
+        let fp2 = f(2.0 * h);
+
+        let fd1 = (fp1 - fm1) / (2.0 * h);
+        let fd2 = (fp1 - 2.0 * f0 + fm1) / (h * h);
+        let fd3 = (fm2 - 2.0 * fm1 + 2.0 * fp1 - fp2) / (2.0 * h * h * h);
+
+        assert!((d1 - fd1).abs() < 1e-6, "h={h}, d1={d1}, fd1={fd1}");
+        assert!((d2 - fd2).abs() < 1e-5, "h={h}, d2={d2}, fd2={fd2}");
+        assert!((d3 - fd3).abs() < 1e-4, "h={h}, d3={d3}, fd3={fd3}");
+    }
+}


### PR DESCRIPTION
### Motivation
- Add a focused regression test to surface mismatches between analytic jet derivatives and finite-difference checks as part of a cross-cutting verification of jet kernels (sigma_link / lognormal / cubic_cell).

### Description
- Add `tests/cubic_cell_kernel_transformed_link_jet_fd_mismatch.rs` containing a single `#[test]` that evaluates `transformed_link_cubic(span, a, b)` and compares the analytic `d1`, `d2`, `d3` against central finite-differences for `h ∈ {1e-3, 1e-5, 1e-7}` with tolerances `1e-6`, `1e-5`, and `1e-4` respectively.

### Testing
- Ran `cargo test --test cubic_cell_kernel_transformed_link_jet_fd_mismatch -- --nocapture`, which failed to build due to an unrelated repository build rule violation (`debug_assert!` ban hit in `tests/survival_marginal_slope_stall.rs`), so the new test was not executed.

---
Codex Cloud task: https://chatgpt.com/codex/tasks/task_e_6a13cd9277ec8324afcc212d8f375958