### PR TITLE
[bug-hunt] cross-cutting: NUTS leapfrog identity + posterior recovery

### DIFF
--- a/tests/nuts_leapfrog_identity_posterior_recovery.rs
+++ b/tests/nuts_leapfrog_identity_posterior_recovery.rs
@@ -1,0 +1,120 @@
+use gam::inference::hmc::{NUTSMassMatrixConfig, NutsConfig};
+use general_mcmc::generic_hmc::HamiltonianTarget;
+use general_mcmc::generic_nuts::GenericNUTS;
+use ndarray::{arr1, arr2, Array1, Array2, Axis};
+
+#[derive(Clone)]
+struct GaussianTarget {
+    mean: Array1<f64>,
+    precision: Array2<f64>,
+}
+
+impl HamiltonianTarget<Array1<f64>> for GaussianTarget {
+    fn logp_and_grad(&self, position: &Array1<f64>, grad: &mut Array1<f64>) -> f64 {
+        let delta = position - &self.mean;
+        let q = self.precision.dot(&delta);
+        grad.assign(&(-&q));
+        -0.5 * delta.dot(&q)
+    }
+}
+
+fn leapfrog_step(
+    target: &GaussianTarget,
+    q: &Array1<f64>,
+    p: &Array1<f64>,
+    eps: f64,
+) -> (Array1<f64>, Array1<f64>) {
+    let mut g0 = Array1::<f64>::zeros(q.len());
+    target.logp_and_grad(q, &mut g0);
+    let p_half = p + &(g0 * (0.5 * eps));
+    let q_new = q + &(p_half.clone() * eps);
+    let mut g1 = Array1::<f64>::zeros(q.len());
+    target.logp_and_grad(&q_new, &mut g1);
+    let p_new = p_half + &(g1 * (0.5 * eps));
+    (q_new, p_new)
+}
+
+#[test]
+fn nuts_leapfrog_identity_and_gaussian_posterior_recovery() {
+    let mean = arr1(&[1.5, -0.5]);
+    let cov = arr2(&[[1.2, 0.3], [0.3, 0.8]]);
+    let det = cov[[0, 0]] * cov[[1, 1]] - cov[[0, 1]] * cov[[1, 0]];
+    let precision = arr2(&[
+        [cov[[1, 1]] / det, -cov[[0, 1]] / det],
+        [-cov[[1, 0]] / det, cov[[0, 0]] / det],
+    ]);
+    let target = GaussianTarget {
+        mean: mean.clone(),
+        precision,
+    };
+
+    let eps = 0.1;
+    let k = 50;
+    let q0 = arr1(&[0.2, -1.0]);
+    let p0 = arr1(&[0.3, 0.7]);
+    let mut qf = q0.clone();
+    let mut pf = p0.clone();
+    for _ in 0..k {
+        (qf, pf) = leapfrog_step(&target, &qf, &pf, eps);
+    }
+    for _ in 0..k {
+        (qf, pf) = leapfrog_step(&target, &qf, &pf, -eps);
+    }
+    let rev_err = (&qf - &q0).mapv(f64::abs).sum() + (&pf - &p0).mapv(f64::abs).sum();
+    assert!(rev_err < 1e-10, "leapfrog reversibility violated: {}", rev_err);
+
+    let mut qd = q0.clone();
+    let mut pd = p0.clone();
+    let mut h_vals = Vec::new();
+    for _ in 0..50 {
+        let dq = &qd - &mean;
+        let u = 0.5 * dq.dot(&target.precision.dot(&dq));
+        let k_e = 0.5 * pd.dot(&pd);
+        h_vals.push(u + k_e);
+        (qd, pd) = leapfrog_step(&target, &qd, &pd, eps);
+    }
+    let h0 = h_vals[0];
+    let max_drift = h_vals
+        .into_iter()
+        .map(|h| (h - h0).abs())
+        .fold(0.0_f64, f64::max);
+    assert!(max_drift < 0.05 * eps * eps, "energy drift too large: {}", max_drift);
+
+    let theta_minus = arr1(&[-2.0, -2.0]);
+    let theta_plus = arr1(&[2.0, 2.0]);
+    let r_minus = arr1(&[1.0, 1.0]);
+    let r_plus = arr1(&[1.0, 1.0]);
+    let delta = &theta_plus - &theta_minus;
+    let should_uturn = delta.dot(&r_minus) <= 0.0 || delta.dot(&r_plus) <= 0.0;
+    assert!(!should_uturn, "constructed non-U-turn state misclassified");
+    let r_minus_uturn = arr1(&[-1.0, -1.0]);
+    let should_uturn_now = delta.dot(&r_minus_uturn) <= 0.0 || delta.dot(&r_plus) <= 0.0;
+    assert!(should_uturn_now, "U-turn condition did not fire when expected");
+
+    let n = 5000usize;
+    let initial = vec![arr1(&[0.0, 0.0])];
+    let mut sampler = GenericNUTS::new_with_mass_matrix(
+        target,
+        initial,
+        NutsConfig::default().target_accept,
+        NUTSMassMatrixConfig::disabled(),
+    )
+    .set_seed(123);
+    let draws = sampler.run(n, 1000);
+    let chain = draws.index_axis(Axis(0), 0).to_owned();
+    let sample_mean = chain.mean_axis(Axis(0)).unwrap();
+    let centered = &chain - &sample_mean;
+    let sample_cov = centered.t().dot(&centered) / ((n - 1) as f64);
+
+    for d in 0..2 {
+        let sigma = (cov[[d, d]] / n as f64).sqrt();
+        let z = (sample_mean[d] - mean[d]).abs() / sigma;
+        assert!(z < 3.0, "mean recovery failed on dim {d}: z={z}");
+    }
+
+    let fro = (&sample_cov - &cov).mapv(|v| v * v).sum().sqrt();
+    assert!(
+        fro < 0.01,
+        "covariance recovery failed: frobenius distance={fro}"
+    );
+}


### PR DESCRIPTION
### Motivation
- Provide a lightweight, reproducible integration test that exercises the NUTS / HMC machinery end-to-end to surface numerical/logic regressions in leapfrog integration, U-turn detection, energy conservation scaling, and posterior recovery for a simple Gaussian posterior.

### Description
- Add a single integration test at `tests/nuts_leapfrog_identity_posterior_recovery.rs` that implements a 2D `GaussianTarget` with analytic `logp_and_grad` and a local `leapfrog_step` helper.
- Verify leapfrog reversibility by composing `k` forward steps then `k` backward steps and asserting near-identity with tolerance `1e-10`, and check 50-step energy drift scales like `O(epsilon^2)`.
- Validate the documented U-turn condition on explicitly constructed plus/minus states, and run `GenericNUTS` for `N=5000` draws to assert sample mean recovery within `3σ` and sample covariance Frobenius distance to the documented tolerance.

### Testing
- Attempted to run the new test via `cargo test --test nuts_leapfrog_identity_posterior_recovery -- --nocapture`, but the build failed before test execution due to a repository build-script / test invariant: a `debug_assert!` violation surfaced in `tests/survival_marginal_slope_stall.rs` causing `cargo` to exit with an error (build exit status 101), so the new integration test was not executed.
- No other automated test runs were completed for this change in this rollout due to the repository-level build failure.

---
Codex Cloud task: https://chatgpt.com/codex/tasks/task_e_6a13cd940e848324838aa1c62d6aab61