### PR TITLE
[bug-hunt] cross-cutting: B-spline partition of unity (every degree)

### DIFF
--- a/tests/bspline_partition_unity_degree_1.rs
+++ b/tests/bspline_partition_unity_degree_1.rs
@@ -1,0 +1,53 @@
+use gam::terms::basis::{SplineScratch, evaluate_bspline_basis_scalar};
+use ndarray::Array1;
+use rand::rngs::StdRng;
+use rand::{Rng, SeedableRng};
+
+fn clamped_uniform_knots(degree: usize, num_basis: usize) -> Array1<f64> {
+    let interior_count = num_basis.saturating_sub(degree + 1);
+    let mut knots = Vec::with_capacity(num_basis + degree + 1);
+    knots.extend(std::iter::repeat_n(0.0, degree + 1));
+    for j in 1..=interior_count {
+        knots.push(j as f64 / (interior_count as f64 + 1.0));
+    }
+    knots.extend(std::iter::repeat_n(1.0, degree + 1));
+    Array1::from(knots)
+}
+
+fn clamped_random_knots(rng: &mut StdRng, degree: usize, num_basis: usize) -> Array1<f64> {
+    let interior_count = num_basis.saturating_sub(degree + 1);
+    let mut interior: Vec<f64> = (0..interior_count).map(|_| rng.random::<f64>()).collect();
+    interior.sort_by(|a, b| a.partial_cmp(b).unwrap());
+    let mut knots = Vec::with_capacity(num_basis + degree + 1);
+    knots.extend(std::iter::repeat_n(0.0, degree + 1));
+    knots.extend(interior);
+    knots.extend(std::iter::repeat_n(1.0, degree + 1));
+    Array1::from(knots)
+}
+
+#[test]
+fn bspline_partition_of_unity_degree_1_random_clamped_and_uniform_knots() {
+    let degree = 1usize;
+    let num_basis = degree + 8;
+    let mut rng = StdRng::seed_from_u64(0xBAD5_0001);
+
+    for knots in [
+        clamped_uniform_knots(degree, num_basis),
+        clamped_random_knots(&mut rng, degree, num_basis),
+    ] {
+        let low = knots[degree];
+        let high = knots[knots.len() - degree - 1];
+        let mut out = vec![0.0; num_basis];
+        let mut scratch = SplineScratch::new(degree);
+        for _ in 0..1000 {
+            let x = rng.random_range(low..high);
+            evaluate_bspline_basis_scalar(x, knots.view(), degree, &mut out, &mut scratch)
+                .expect("B-spline evaluation should succeed");
+            let sum: f64 = out.iter().sum();
+            assert!(
+                (sum - 1.0).abs() <= 1e-12,
+                "degree={degree}, x={x:.17e}, sum={sum:.17e}, knots={knots:?}"
+            );
+        }
+    }
+}

--- a/tests/bspline_partition_unity_degree_2.rs
+++ b/tests/bspline_partition_unity_degree_2.rs
@@ -1,0 +1,53 @@
+use gam::terms::basis::{SplineScratch, evaluate_bspline_basis_scalar};
+use ndarray::Array1;
+use rand::rngs::StdRng;
+use rand::{Rng, SeedableRng};
+
+fn clamped_uniform_knots(degree: usize, num_basis: usize) -> Array1<f64> {
+    let interior_count = num_basis.saturating_sub(degree + 1);
+    let mut knots = Vec::with_capacity(num_basis + degree + 1);
+    knots.extend(std::iter::repeat_n(0.0, degree + 1));
+    for j in 1..=interior_count {
+        knots.push(j as f64 / (interior_count as f64 + 1.0));
+    }
+    knots.extend(std::iter::repeat_n(1.0, degree + 1));
+    Array1::from(knots)
+}
+
+fn clamped_random_knots(rng: &mut StdRng, degree: usize, num_basis: usize) -> Array1<f64> {
+    let interior_count = num_basis.saturating_sub(degree + 1);
+    let mut interior: Vec<f64> = (0..interior_count).map(|_| rng.random::<f64>()).collect();
+    interior.sort_by(|a, b| a.partial_cmp(b).unwrap());
+    let mut knots = Vec::with_capacity(num_basis + degree + 1);
+    knots.extend(std::iter::repeat_n(0.0, degree + 1));
+    knots.extend(interior);
+    knots.extend(std::iter::repeat_n(1.0, degree + 1));
+    Array1::from(knots)
+}
+
+#[test]
+fn bspline_partition_of_unity_degree_2_random_clamped_and_uniform_knots() {
+    let degree = 2usize;
+    let num_basis = degree + 8;
+    let mut rng = StdRng::seed_from_u64(0xBAD50000 + degree as u64);
+
+    for knots in [
+        clamped_uniform_knots(degree, num_basis),
+        clamped_random_knots(&mut rng, degree, num_basis),
+    ] {
+        let low = knots[degree];
+        let high = knots[knots.len() - degree - 1];
+        let mut out = vec![0.0; num_basis];
+        let mut scratch = SplineScratch::new(degree);
+        for _ in 0..1000 {
+            let x = rng.random_range(low..high);
+            evaluate_bspline_basis_scalar(x, knots.view(), degree, &mut out, &mut scratch)
+                .expect("B-spline evaluation should succeed");
+            let sum: f64 = out.iter().sum();
+            assert!(
+                (sum - 1.0).abs() <= 1e-12,
+                "degree={degree}, x={x:.17e}, sum={sum:.17e}, knots={knots:?}"
+            );
+        }
+    }
+}

--- a/tests/bspline_partition_unity_degree_3.rs
+++ b/tests/bspline_partition_unity_degree_3.rs
@@ -1,0 +1,53 @@
+use gam::terms::basis::{SplineScratch, evaluate_bspline_basis_scalar};
+use ndarray::Array1;
+use rand::rngs::StdRng;
+use rand::{Rng, SeedableRng};
+
+fn clamped_uniform_knots(degree: usize, num_basis: usize) -> Array1<f64> {
+    let interior_count = num_basis.saturating_sub(degree + 1);
+    let mut knots = Vec::with_capacity(num_basis + degree + 1);
+    knots.extend(std::iter::repeat_n(0.0, degree + 1));
+    for j in 1..=interior_count {
+        knots.push(j as f64 / (interior_count as f64 + 1.0));
+    }
+    knots.extend(std::iter::repeat_n(1.0, degree + 1));
+    Array1::from(knots)
+}
+
+fn clamped_random_knots(rng: &mut StdRng, degree: usize, num_basis: usize) -> Array1<f64> {
+    let interior_count = num_basis.saturating_sub(degree + 1);
+    let mut interior: Vec<f64> = (0..interior_count).map(|_| rng.random::<f64>()).collect();
+    interior.sort_by(|a, b| a.partial_cmp(b).unwrap());
+    let mut knots = Vec::with_capacity(num_basis + degree + 1);
+    knots.extend(std::iter::repeat_n(0.0, degree + 1));
+    knots.extend(interior);
+    knots.extend(std::iter::repeat_n(1.0, degree + 1));
+    Array1::from(knots)
+}
+
+#[test]
+fn bspline_partition_of_unity_degree_3_random_clamped_and_uniform_knots() {
+    let degree = 3usize;
+    let num_basis = degree + 8;
+    let mut rng = StdRng::seed_from_u64(0xBAD50000 + degree as u64);
+
+    for knots in [
+        clamped_uniform_knots(degree, num_basis),
+        clamped_random_knots(&mut rng, degree, num_basis),
+    ] {
+        let low = knots[degree];
+        let high = knots[knots.len() - degree - 1];
+        let mut out = vec![0.0; num_basis];
+        let mut scratch = SplineScratch::new(degree);
+        for _ in 0..1000 {
+            let x = rng.random_range(low..high);
+            evaluate_bspline_basis_scalar(x, knots.view(), degree, &mut out, &mut scratch)
+                .expect("B-spline evaluation should succeed");
+            let sum: f64 = out.iter().sum();
+            assert!(
+                (sum - 1.0).abs() <= 1e-12,
+                "degree={degree}, x={x:.17e}, sum={sum:.17e}, knots={knots:?}"
+            );
+        }
+    }
+}

--- a/tests/bspline_partition_unity_degree_4.rs
+++ b/tests/bspline_partition_unity_degree_4.rs
@@ -1,0 +1,53 @@
+use gam::terms::basis::{SplineScratch, evaluate_bspline_basis_scalar};
+use ndarray::Array1;
+use rand::rngs::StdRng;
+use rand::{Rng, SeedableRng};
+
+fn clamped_uniform_knots(degree: usize, num_basis: usize) -> Array1<f64> {
+    let interior_count = num_basis.saturating_sub(degree + 1);
+    let mut knots = Vec::with_capacity(num_basis + degree + 1);
+    knots.extend(std::iter::repeat_n(0.0, degree + 1));
+    for j in 1..=interior_count {
+        knots.push(j as f64 / (interior_count as f64 + 1.0));
+    }
+    knots.extend(std::iter::repeat_n(1.0, degree + 1));
+    Array1::from(knots)
+}
+
+fn clamped_random_knots(rng: &mut StdRng, degree: usize, num_basis: usize) -> Array1<f64> {
+    let interior_count = num_basis.saturating_sub(degree + 1);
+    let mut interior: Vec<f64> = (0..interior_count).map(|_| rng.random::<f64>()).collect();
+    interior.sort_by(|a, b| a.partial_cmp(b).unwrap());
+    let mut knots = Vec::with_capacity(num_basis + degree + 1);
+    knots.extend(std::iter::repeat_n(0.0, degree + 1));
+    knots.extend(interior);
+    knots.extend(std::iter::repeat_n(1.0, degree + 1));
+    Array1::from(knots)
+}
+
+#[test]
+fn bspline_partition_of_unity_degree_4_random_clamped_and_uniform_knots() {
+    let degree = 4usize;
+    let num_basis = degree + 8;
+    let mut rng = StdRng::seed_from_u64(0xBAD50000 + degree as u64);
+
+    for knots in [
+        clamped_uniform_knots(degree, num_basis),
+        clamped_random_knots(&mut rng, degree, num_basis),
+    ] {
+        let low = knots[degree];
+        let high = knots[knots.len() - degree - 1];
+        let mut out = vec![0.0; num_basis];
+        let mut scratch = SplineScratch::new(degree);
+        for _ in 0..1000 {
+            let x = rng.random_range(low..high);
+            evaluate_bspline_basis_scalar(x, knots.view(), degree, &mut out, &mut scratch)
+                .expect("B-spline evaluation should succeed");
+            let sum: f64 = out.iter().sum();
+            assert!(
+                (sum - 1.0).abs() <= 1e-12,
+                "degree={degree}, x={x:.17e}, sum={sum:.17e}, knots={knots:?}"
+            );
+        }
+    }
+}

--- a/tests/bspline_partition_unity_degree_5.rs
+++ b/tests/bspline_partition_unity_degree_5.rs
@@ -1,0 +1,53 @@
+use gam::terms::basis::{SplineScratch, evaluate_bspline_basis_scalar};
+use ndarray::Array1;
+use rand::rngs::StdRng;
+use rand::{Rng, SeedableRng};
+
+fn clamped_uniform_knots(degree: usize, num_basis: usize) -> Array1<f64> {
+    let interior_count = num_basis.saturating_sub(degree + 1);
+    let mut knots = Vec::with_capacity(num_basis + degree + 1);
+    knots.extend(std::iter::repeat_n(0.0, degree + 1));
+    for j in 1..=interior_count {
+        knots.push(j as f64 / (interior_count as f64 + 1.0));
+    }
+    knots.extend(std::iter::repeat_n(1.0, degree + 1));
+    Array1::from(knots)
+}
+
+fn clamped_random_knots(rng: &mut StdRng, degree: usize, num_basis: usize) -> Array1<f64> {
+    let interior_count = num_basis.saturating_sub(degree + 1);
+    let mut interior: Vec<f64> = (0..interior_count).map(|_| rng.random::<f64>()).collect();
+    interior.sort_by(|a, b| a.partial_cmp(b).unwrap());
+    let mut knots = Vec::with_capacity(num_basis + degree + 1);
+    knots.extend(std::iter::repeat_n(0.0, degree + 1));
+    knots.extend(interior);
+    knots.extend(std::iter::repeat_n(1.0, degree + 1));
+    Array1::from(knots)
+}
+
+#[test]
+fn bspline_partition_of_unity_degree_5_random_clamped_and_uniform_knots() {
+    let degree = 5usize;
+    let num_basis = degree + 8;
+    let mut rng = StdRng::seed_from_u64(0xBAD50000 + degree as u64);
+
+    for knots in [
+        clamped_uniform_knots(degree, num_basis),
+        clamped_random_knots(&mut rng, degree, num_basis),
+    ] {
+        let low = knots[degree];
+        let high = knots[knots.len() - degree - 1];
+        let mut out = vec![0.0; num_basis];
+        let mut scratch = SplineScratch::new(degree);
+        for _ in 0..1000 {
+            let x = rng.random_range(low..high);
+            evaluate_bspline_basis_scalar(x, knots.view(), degree, &mut out, &mut scratch)
+                .expect("B-spline evaluation should succeed");
+            let sum: f64 = out.iter().sum();
+            assert!(
+                (sum - 1.0).abs() <= 1e-12,
+                "degree={degree}, x={x:.17e}, sum={sum:.17e}, knots={knots:?}"
+            );
+        }
+    }
+}


### PR DESCRIPTION
### Motivation
- Surface and regress on potential partition-of-unity violations in the scalar B-spline evaluator across all supported degrees (1..5) using randomized clamped knots and uniform clamped knots. 
- Tight numeric tolerance (`1e-12`) and many random interior samples help reveal degree-specific numerical/regression faults in `evaluate_bspline_basis_scalar` and its scratch handling.

### Description
- Add one test file per degree: `tests/bspline_partition_unity_degree_1.rs` through `tests/bspline_partition_unity_degree_5.rs`, each containing a single `#[test]` that exercises the degree. 
- Each test builds clamped uniform and clamped random knot vectors, samples 1000 random interior `x` values, evaluates `evaluate_bspline_basis_scalar` with a `SplineScratch`, and asserts that `∑_i B_{i,k}(x) == 1` within `1e-12`. 
- Tests use deterministic seeds via `StdRng::seed_from_u64(...)` and avoid allocations in the hot path by reusing `SplineScratch` and an output buffer. 

### Testing
- Attempted a focused run with `cargo test --test tmp_bspline_partition_scan -- --nocapture` to exercise a quick scan, but the build failed during the repository build step due to a pre-existing `debug_assert!` violation in `tests/survival_marginal_slope_stall.rs`, which is unrelated to these new tests, so the targeted verification could not complete. 
- No automated test pass/fail result for the newly added degree-specific test files is available from CI in this rollout due to the unrelated build blockage.

---
Codex Cloud task: https://chatgpt.com/codex/tasks/task_e_6a13cd94eb04832490cc260120f9a101