### PR TITLE
[bug-hunt] cross-cutting: CDF inverse links are monotone in [0,1]

### DIFF
--- a/tests/latent_cloglog_inverse_link_cdf_monotone_bounds.rs
+++ b/tests/latent_cloglog_inverse_link_cdf_monotone_bounds.rs
@@ -1,0 +1,27 @@
+use gam::solver::mixture_link::inverse_link_mu_d1_for_inverse_link;
+use gam::types::{InverseLink, LatentCLogLogState};
+use rand::rngs::StdRng;
+use rand::{Rng, SeedableRng};
+
+#[test]
+fn latent_cloglog_inverse_link_is_monotone_and_bounded_as_cdf() {
+    let link = InverseLink::LatentCLogLog(
+        LatentCLogLogState::new(1.0).expect("valid latent cloglog state"),
+    );
+    let mut rng = StdRng::seed_from_u64(0xBEEF_CAFE_D00D_4242);
+    let mut eta: Vec<f64> = (0..1000).map(|_| rng.random_range(-40.0..40.0)).collect();
+    eta.sort_by(|a, b| a.total_cmp(b));
+
+    let mut prev = f64::NEG_INFINITY;
+    for x in eta {
+        let (mu, _) = inverse_link_mu_d1_for_inverse_link(&link, x).expect("latent cloglog inverse link");
+        assert!(mu >= prev, "Latent CLogLog inverse-link is not monotone at eta={x}: prev={prev}, mu={mu}");
+        assert!((0.0..=1.0).contains(&mu), "Latent CLogLog inverse-link left [0,1] at eta={x}: mu={mu}");
+        prev = mu;
+    }
+
+    let (mu_lo, _) = inverse_link_mu_d1_for_inverse_link(&link, -1.0e6).expect("latent cloglog low tail");
+    let (mu_hi, _) = inverse_link_mu_d1_for_inverse_link(&link, 1.0e6).expect("latent cloglog high tail");
+    assert!(mu_lo <= 1.0e-12, "Latent CLogLog low tail is not near 0: mu(-1e6)={mu_lo}");
+    assert!(mu_hi >= 1.0 - 1.0e-12, "Latent CLogLog high tail is not near 1: mu(1e6)={mu_hi}");
+}

--- a/tests/sas_inverse_link_cdf_monotone_bounds.rs
+++ b/tests/sas_inverse_link_cdf_monotone_bounds.rs
@@ -1,0 +1,29 @@
+use gam::solver::mixture_link::inverse_link_mu_d1_for_inverse_link;
+use gam::types::{InverseLink, SasLinkState};
+use rand::rngs::StdRng;
+use rand::{Rng, SeedableRng};
+
+#[test]
+fn sas_inverse_link_is_monotone_and_bounded_as_cdf() {
+    let link = InverseLink::Sas(SasLinkState {
+        epsilon: 0.7,
+        log_delta: 2.0,
+        delta: 0.0,
+    });
+    let mut rng = StdRng::seed_from_u64(0x5A5A_1234_5678_9ABC);
+    let mut eta: Vec<f64> = (0..1000).map(|_| rng.random_range(-40.0..40.0)).collect();
+    eta.sort_by(|a, b| a.total_cmp(b));
+
+    let mut prev = f64::NEG_INFINITY;
+    for x in eta {
+        let (mu, _) = inverse_link_mu_d1_for_inverse_link(&link, x).expect("sas inverse link");
+        assert!(mu >= prev, "SAS inverse-link is not monotone at eta={x}: prev={prev}, mu={mu}");
+        assert!((0.0..=1.0).contains(&mu), "SAS inverse-link left [0,1] at eta={x}: mu={mu}");
+        prev = mu;
+    }
+
+    let (mu_lo, _) = inverse_link_mu_d1_for_inverse_link(&link, -1.0e6).expect("sas low tail");
+    let (mu_hi, _) = inverse_link_mu_d1_for_inverse_link(&link, 1.0e6).expect("sas high tail");
+    assert!(mu_lo <= 1.0e-12, "SAS inverse-link low tail is not near 0: mu(-1e6)={mu_lo}");
+    assert!(mu_hi >= 1.0 - 1.0e-12, "SAS inverse-link high tail is not near 1: mu(1e6)={mu_hi}");
+}


### PR DESCRIPTION
### Motivation
- Add focused regression coverage to validate that inverse-link transforms with a CDF interpretation behave as CDFs (monotone, bounded in [0,1], and correct extreme-tail limits) for suspected problematic branches.

### Description
- Added two focused tests: `tests/sas_inverse_link_cdf_monotone_bounds.rs` and `tests/latent_cloglog_inverse_link_cdf_monotone_bounds.rs`, each sampling 1000 random `eta` values, asserting monotonicity of `mu(eta)`, that `mu(eta) ∈ [0,1]`, and that `mu(±1e6)` approaches `0`/`1`; no production source files were changed.

### Testing
- Attempted an earlier focused `cargo test` scan but the build aborted due to a pre-existing repository build-hook violation (a `debug_assert!` ban reported during the build script), so no new test run completed after adding these tests.

---
Codex Cloud task: https://chatgpt.com/codex/tasks/task_e_6a13cd958ecc8324adbb49794c0bc625