### PR TITLE
[bug-hunt] cross-cutting: MixtureLinkSpec rejects (or supports end-to-end) Cauchit / LogLog components

### DIFF
--- a/tests/mixture_link_cauchit_loglog_state_rejection.rs
+++ b/tests/mixture_link_cauchit_loglog_state_rejection.rs
@@ -1,0 +1,22 @@
+use gam::mixture_link::state_fromspec;
+use gam::types::{LinkComponent, MixtureLinkSpec};
+use ndarray::arr1;
+
+#[test]
+fn state_fromspec_rejects_cauchit_and_loglog_components() {
+    let spec = MixtureLinkSpec {
+        components: vec![LinkComponent::Cauchit, LinkComponent::LogLog],
+        initial_rho: arr1(&[0.0]),
+    };
+
+    let err = state_fromspec(&spec).expect_err(
+        "MixtureLinkSpec with Cauchit/LogLog must be rejected until LinkFunction supports them",
+    );
+
+    assert!(
+        err.to_ascii_lowercase().contains("cauchit")
+            || err.to_ascii_lowercase().contains("loglog")
+            || err.to_ascii_lowercase().contains("unsupported"),
+        "error should clearly mention unsupported component(s), got: {err}"
+    );
+}


### PR DESCRIPTION
### Motivation
- Capture a cross-cutting mismatch where `MixtureLinkSpec` can be constructed with `LinkComponent::Cauchit` or `LinkComponent::LogLog` but the `LinkFunction`/downstream pipeline does not uniformly support those components, so either `state_fromspec` should reject them or the pipeline must be extended to handle them end-to-end.

### Description
- Add a focused regression test `tests/mixture_link_cauchit_loglog_state_rejection.rs` that constructs a `MixtureLinkSpec` with `LinkComponent::Cauchit` and `LinkComponent::LogLog` and asserts that `state_fromspec` returns an `Err` whose message mentions the unsupported component(s).

### Testing
- Attempted to run the new test with `cargo test --test mixture_link_cauchit_loglog_state_rejection -- --nocapture`, but the build aborted early due to an existing build-time ban violation (`debug_assert!` elsewhere) so the test was not executed to completion; the test is intended to fail until the mismatch is resolved.

---
Codex Cloud task: https://chatgpt.com/codex/tasks/task_e_6a13cd994144832484c38a12df5160ba