### PR TITLE
[bug-hunt] cross-cutting: concurrency invariants (cell-moment cache + OnceLock/rayon + faer init + warm-start cache)

### DIFF
--- a/tests/once_lock_get_or_init_not_inside_parallel_regions.rs
+++ b/tests/once_lock_get_or_init_not_inside_parallel_regions.rs
@@ -1,0 +1,43 @@
+use std::fs;
+use std::path::Path;
+
+#[test]
+fn once_lock_get_or_init_not_inside_parallel_regions() {
+    let src_root = Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
+    let mut offenders: Vec<String> = Vec::new();
+
+    let mut stack = vec![src_root];
+    while let Some(dir) = stack.pop() {
+        let entries = fs::read_dir(&dir).expect("read_dir failed");
+        for entry in entries {
+            let entry = entry.expect("dir entry failed");
+            let path = entry.path();
+            if path.is_dir() {
+                stack.push(path);
+                continue;
+            }
+            if path.extension().and_then(|s| s.to_str()) != Some("rs") {
+                continue;
+            }
+            let content = fs::read_to_string(&path).expect("read file failed");
+            let lines: Vec<&str> = content.lines().collect();
+            for i in 0..lines.len() {
+                let line = lines[i];
+                if line.contains("get_or_init(") {
+                    let start = i.saturating_sub(80);
+                    let end = (i + 80).min(lines.len().saturating_sub(1));
+                    let window = &lines[start..=end];
+                    if window.iter().any(|l| l.contains(".par_iter(") || l.contains(".into_par_iter(")) {
+                        offenders.push(format!("{}:{}", path.display(), i + 1));
+                    }
+                }
+            }
+        }
+    }
+
+    assert!(
+        offenders.is_empty(),
+        "found get_or_init in proximity of par_iter/into_par_iter:\n{}",
+        offenders.join("\n")
+    );
+}


### PR DESCRIPTION
### Motivation
- Add a lightweight regression guard to encode cross-cutting concurrency invariants (avoid `OnceLock::get_or_init` being first hit from inside Rayon parallel regions to prevent nested-rayon deadlocks, and to help surface related race/consistency concerns such as the `tail_cell_moment_cache`, idempotent `init_parallelism`, and persistent warm-start budget invariants).

### Description
- Added a single integration test `tests/once_lock_get_or_init_not_inside_parallel_regions.rs` which recursively scans Rust sources under `src/` and fails if it finds `get_or_init(` within an ±80-line window of `.par_iter(` or `.into_par_iter(`; no `src/` production files were modified.

### Testing
- Invoked `cargo test --test once_lock_get_or_init_not_inside_parallel_regions` to run the new test; compilation proceeded but the full run did not complete in the current environment within the interactive session; a direct code search (`rg`) shows multiple `get_or_init` occurrences proximate to parallel-iterator usage so the test is expected to report offenders (i.e. fail) until the offending initializers are warmed at top-level.

---
Codex Cloud task: https://chatgpt.com/codex/tasks/task_e_6a13cdb9c2288324ab7e7551141988de