### PR TITLE
[bug-hunt] cross-cutting: boundary / pathological inputs to fit_gam family

### DIFF
--- a/tests/pathological_all_zero_weights_rejected.rs
+++ b/tests/pathological_all_zero_weights_rejected.rs
@@ -1,0 +1,19 @@
+use gam::estimate::{fit_gam, fit_gam_with_penalty_specs, fit_gamwith_heuristic_lambdas, FitOptions, PenaltySpec};
+use gam::terms::smooth::BlockwisePenalty;
+use gam::types::{InverseLink, LikelihoodSpec, LinkFunction, ResponseFamily};
+use ndarray::array;
+
+#[test]
+fn fit_family_rejects_all_zero_weights() {
+    let x = array![[1.0], [2.0], [3.0]];
+    let y = array![0.1, 0.2, 0.3];
+    let w = array![0.0, 0.0, 0.0];
+    let offset = array![0.0, 0.0, 0.0];
+    let s_list: Vec<BlockwisePenalty> = vec![];
+    let fam = LikelihoodSpec::new(ResponseFamily::Gaussian, InverseLink::Standard(LinkFunction::Identity));
+    let opts = FitOptions::default();
+
+    assert!(fit_gam(x.view(), y.view(), w.view(), offset.view(), &s_list, fam.clone(), &opts).is_err());
+    assert!(fit_gamwith_heuristic_lambdas(x.view(), y.view(), w.view(), offset.view(), &s_list, None, fam.clone(), &opts).is_err());
+    assert!(fit_gam_with_penalty_specs(x.view(), y.view(), w.view(), offset.view(), Vec::<PenaltySpec>::new(), vec![], fam, &opts).is_err());
+}

--- a/tests/pathological_empty_smooth_collection_behavior.rs
+++ b/tests/pathological_empty_smooth_collection_behavior.rs
@@ -1,0 +1,22 @@
+use gam::estimate::{fit_gam, fit_gam_with_penalty_specs, fit_gamwith_heuristic_lambdas, FitOptions, PenaltySpec};
+use gam::types::LikelihoodSpec;
+use ndarray::array;
+
+#[test]
+fn empty_smooth_collection_is_handled_or_rejected_cleanly() {
+    let x = array![[1.0], [2.0], [3.0], [4.0]];
+    let y = array![1.0, 2.0, 3.0, 4.0];
+    let w = array![1.0, 1.0, 1.0, 1.0];
+    let offset = array![0.0, 0.0, 0.0, 0.0];
+    let fam = LikelihoodSpec::gaussian_identity();
+    let opts = FitOptions::default();
+
+    let r1 = fit_gam(x.view(), y.view(), w.view(), offset.view(), &[], fam.clone(), &opts);
+    let r2 = fit_gamwith_heuristic_lambdas(x.view(), y.view(), w.view(), offset.view(), &[], None, fam.clone(), &opts);
+    let r3 = fit_gam_with_penalty_specs(x.view(), y.view(), w.view(), offset.view(), Vec::<PenaltySpec>::new(), vec![], fam, &opts);
+    for r in [r1, r2, r3] {
+        if let Ok(fit) = r {
+            assert_eq!(fit.lambdas.len(), 0, "pure parametric fit should carry zero smooth lambdas");
+        }
+    }
+}

--- a/tests/pathological_extreme_rho_reml_finite.rs
+++ b/tests/pathological_extreme_rho_reml_finite.rs
@@ -1,0 +1,23 @@
+use gam::estimate::{fit_gamwith_heuristic_lambdas, FitOptions};
+use gam::terms::smooth::BlockwisePenalty;
+use gam::types::LikelihoodSpec;
+use ndarray::array;
+
+#[test]
+fn extreme_rho_bounds_keep_reml_finite() {
+    let x = array![[1.0], [2.0], [3.0], [4.0], [5.0]];
+    let y = array![1.1, 1.9, 3.1, 4.2, 5.1];
+    let w = array![1.0, 1.0, 1.0, 1.0, 1.0];
+    let offset = array![0.0, 0.0, 0.0, 0.0, 0.0];
+    let s_list: Vec<BlockwisePenalty> = vec![];
+    let fam = LikelihoodSpec::gaussian_identity();
+    let opts = FitOptions::default();
+
+    for rho in [-20.0_f64, 20.0_f64] {
+        let lambdas = [rho.exp()];
+        let fit = fit_gamwith_heuristic_lambdas(
+            x.view(), y.view(), w.view(), offset.view(), &s_list, Some(&lambdas), fam.clone(), &opts,
+        ).expect("fit should complete at extreme rho");
+        assert!(fit.reml_score.is_finite(), "REML score must be finite at rho={rho}");
+    }
+}

--- a/tests/pathological_n0_p0_rejected.rs
+++ b/tests/pathological_n0_p0_rejected.rs
@@ -1,0 +1,20 @@
+use gam::estimate::{fit_gam, fit_gam_with_penalty_specs, fit_gamwith_heuristic_lambdas, FitOptions, PenaltySpec};
+use gam::terms::smooth::BlockwisePenalty;
+use gam::types::{InverseLink, LikelihoodSpec, LinkFunction, ResponseFamily};
+use ndarray::{Array2, array};
+
+fn opts() -> FitOptions { FitOptions::default() }
+fn fam() -> LikelihoodSpec { LikelihoodSpec::new(ResponseFamily::Gaussian, InverseLink::Standard(LinkFunction::Identity)) }
+
+#[test]
+fn fit_family_rejects_empty_rows_and_columns_without_panic() {
+    let x = Array2::<f64>::zeros((0, 0));
+    let y = array![];
+    let w = array![];
+    let offset = array![];
+    let s_list: Vec<BlockwisePenalty> = vec![];
+
+    assert!(fit_gam(x.view(), y.view(), w.view(), offset.view(), &s_list, fam(), &opts()).is_err());
+    assert!(fit_gamwith_heuristic_lambdas(x.view(), y.view(), w.view(), offset.view(), &s_list, None, fam(), &opts()).is_err());
+    assert!(fit_gam_with_penalty_specs(x.view(), y.view(), w.view(), offset.view(), Vec::<PenaltySpec>::new(), vec![], fam(), &opts()).is_err());
+}

--- a/tests/pathological_nan_inputs_rejected.rs
+++ b/tests/pathological_nan_inputs_rejected.rs
@@ -1,0 +1,19 @@
+use gam::estimate::{fit_gam, fit_gam_with_penalty_specs, fit_gamwith_heuristic_lambdas, FitOptions, PenaltySpec};
+use gam::terms::smooth::BlockwisePenalty;
+use gam::types::{InverseLink, LikelihoodSpec, LinkFunction, ResponseFamily};
+use ndarray::array;
+
+#[test]
+fn fit_family_rejects_nan_in_weights_and_design() {
+    let x = array![[1.0], [f64::NAN], [3.0]];
+    let y = array![0.1, 0.2, 0.3];
+    let w = array![1.0, f64::NAN, 1.0];
+    let offset = array![0.0, 0.0, 0.0];
+    let s_list: Vec<BlockwisePenalty> = vec![];
+    let fam = LikelihoodSpec::new(ResponseFamily::Gaussian, InverseLink::Standard(LinkFunction::Identity));
+    let opts = FitOptions::default();
+
+    assert!(fit_gam(x.view(), y.view(), w.view(), offset.view(), &s_list, fam.clone(), &opts).is_err());
+    assert!(fit_gamwith_heuristic_lambdas(x.view(), y.view(), w.view(), offset.view(), &s_list, None, fam.clone(), &opts).is_err());
+    assert!(fit_gam_with_penalty_specs(x.view(), y.view(), w.view(), offset.view(), Vec::<PenaltySpec>::new(), vec![], fam, &opts).is_err());
+}

--- a/tests/pathological_rank_deficient_design_diagnostic.rs
+++ b/tests/pathological_rank_deficient_design_diagnostic.rs
@@ -1,0 +1,26 @@
+use gam::estimate::{fit_gam, fit_gam_with_penalty_specs, fit_gamwith_heuristic_lambdas, FitOptions, PenaltySpec};
+use gam::terms::smooth::BlockwisePenalty;
+use gam::types::LikelihoodSpec;
+use ndarray::array;
+
+#[test]
+fn rank_deficient_design_reports_diagnostic_or_fits() {
+    let x = array![[1.0, 1.0], [2.0, 2.0], [3.0, 3.0], [4.0, 4.0]];
+    let y = array![1.0, 2.0, 3.0, 4.0];
+    let w = array![1.0, 1.0, 1.0, 1.0];
+    let offset = array![0.0, 0.0, 0.0, 0.0];
+    let s_list: Vec<BlockwisePenalty> = vec![];
+    let fam = LikelihoodSpec::gaussian_identity();
+    let opts = FitOptions::default();
+
+    for out in [
+        fit_gam(x.view(), y.view(), w.view(), offset.view(), &s_list, fam.clone(), &opts),
+        fit_gamwith_heuristic_lambdas(x.view(), y.view(), w.view(), offset.view(), &s_list, None, fam.clone(), &opts),
+        fit_gam_with_penalty_specs(x.view(), y.view(), w.view(), offset.view(), Vec::<PenaltySpec>::new(), vec![], fam.clone(), &opts),
+    ] {
+        if let Err(e) = out {
+            let m = e.to_string().to_lowercase();
+            assert!(m.contains("rank") || m.contains("singular") || m.contains("collinear") || m.contains("deficien"), "unexpected error message: {m}");
+        }
+    }
+}

--- a/tests/pathological_single_row_graceful_error.rs
+++ b/tests/pathological_single_row_graceful_error.rs
@@ -1,0 +1,19 @@
+use gam::estimate::{fit_gam, fit_gam_with_penalty_specs, fit_gamwith_heuristic_lambdas, FitOptions, PenaltySpec};
+use gam::terms::smooth::BlockwisePenalty;
+use gam::types::LikelihoodSpec;
+use ndarray::array;
+
+#[test]
+fn single_row_input_errors_gracefully() {
+    let x = array![[1.0, 2.0]];
+    let y = array![1.0];
+    let w = array![1.0];
+    let offset = array![0.0];
+    let s_list: Vec<BlockwisePenalty> = vec![];
+    let fam = LikelihoodSpec::gaussian_identity();
+    let opts = FitOptions::default();
+
+    assert!(fit_gam(x.view(), y.view(), w.view(), offset.view(), &s_list, fam.clone(), &opts).is_err());
+    assert!(fit_gamwith_heuristic_lambdas(x.view(), y.view(), w.view(), offset.view(), &s_list, None, fam.clone(), &opts).is_err());
+    assert!(fit_gam_with_penalty_specs(x.view(), y.view(), w.view(), offset.view(), Vec::<PenaltySpec>::new(), vec![], fam, &opts).is_err());
+}

--- a/tests/pathological_tied_survival_times_no_divzero.rs
+++ b/tests/pathological_tied_survival_times_no_divzero.rs
@@ -1,0 +1,26 @@
+use gam::estimate::{fit_gam, fit_gam_with_penalty_specs, fit_gamwith_heuristic_lambdas, FitOptions, PenaltySpec};
+use gam::terms::smooth::BlockwisePenalty;
+use gam::types::{InverseLink, LikelihoodSpec, LinkFunction, ResponseFamily};
+use ndarray::array;
+
+#[test]
+fn tied_survival_times_do_not_trigger_division_by_zero() {
+    let x = array![[1.0], [1.0], [1.0], [1.0]];
+    let y = array![5.0, 5.0, 5.0, 5.0];
+    let w = array![1.0, 1.0, 1.0, 1.0];
+    let offset = array![0.0, 0.0, 0.0, 0.0];
+    let s_list: Vec<BlockwisePenalty> = vec![];
+    let fam = LikelihoodSpec::new(ResponseFamily::RoystonParmar, InverseLink::Standard(LinkFunction::Identity));
+    let opts = FitOptions::default();
+
+    for r in [
+        fit_gam(x.view(), y.view(), w.view(), offset.view(), &s_list, fam.clone(), &opts),
+        fit_gamwith_heuristic_lambdas(x.view(), y.view(), w.view(), offset.view(), &s_list, None, fam.clone(), &opts),
+        fit_gam_with_penalty_specs(x.view(), y.view(), w.view(), offset.view(), Vec::<PenaltySpec>::new(), vec![], fam.clone(), &opts),
+    ] {
+        if let Err(e) = r {
+            let msg = e.to_string().to_lowercase();
+            assert!(!msg.contains("division by zero") && !msg.contains("divide by zero"));
+        }
+    }
+}


### PR DESCRIPTION
### Motivation
- Add focused, minimal tests to exercise boundary and pathological inputs across the `fit_gam` entry points to ensure they return errors (not panics) or sensible diagnostics for degenerate inputs.
- Cover cross-cutting cases that historically cause numerical or control-flow surprises: empty design (n=0/p=0), all-zero or NaN weights, rank-deficient design, tied survival times, extreme rho bounds, empty smooth-term collection, and single-row degeneracy.

### Description
- Add eight new test files under `tests/` (one `#[test]` per file) that exercise `fit_gam`, `fit_gam_with_penalty_specs`, and `fit_gamwith_heuristic_lambdas` as appropriate: `pathological_n0_p0_rejected.rs`, `pathological_all_zero_weights_rejected.rs`, `pathological_nan_inputs_rejected.rs`, `pathological_rank_deficient_design_diagnostic.rs`, `pathological_tied_survival_times_no_divzero.rs`, `pathological_extreme_rho_reml_finite.rs`, `pathological_empty_smooth_collection_behavior.rs`, and `pathological_single_row_graceful_error.rs`.
- Each test makes a single focused assertion about expected behavior such as returning `Err`, emitting a rank/collinearity diagnostic, avoiding division-by-zero messages, producing a finite REML score at extreme `rho`, or producing a pure-parametric fit with zero smooth lambdas.
- Tests are test-only additions with no changes to library/source code and use concise, descriptive snake_case filenames.

### Testing
- Attempted to run `cargo test --tests pathological_ -- --nocapture` to execute the new pathological tests as a group, but the build aborted before those tests ran due to a repository-wide build-time ban check failing on an existing test (`debug_assert!` violation in `tests/survival_marginal_slope_stall.rs`).
- The new tests were compiled into the working tree and committed, but automated execution of them in this environment was blocked by the unrelated build-time failure so they did not execute here.

---
Codex Cloud task: https://chatgpt.com/codex/tasks/task_e_6a13cdb9e6ac8324a26f63570df09574