### PR TITLE
[bug-hunt] cross-cutting: gamfit Python ↔ Rust FFI parity

### DIFF
--- a/tests/python_rust_ffi_parity_gaussian_linear.rs
+++ b/tests/python_rust_ffi_parity_gaussian_linear.rs
@@ -1,0 +1,63 @@
+use csv::StringRecord;
+use gam::{encode_recordswith_inferred_schema, fit_model, materialize, FitConfig, FitResult};
+use serde_json::Value;
+use std::process::Command;
+
+#[test]
+fn python_rust_ffi_parity_gaussian_linear_case() {
+    let n = 80usize;
+    let mut rows: Vec<StringRecord> = Vec::with_capacity(n);
+    for i in 0..n {
+        let x = -1.0 + 2.0 * (i as f64) / ((n - 1) as f64);
+        let y = 0.5 + 1.25 * x;
+        rows.push(StringRecord::from(vec![x.to_string(), y.to_string()]));
+    }
+    let headers = vec!["x".to_string(), "y".to_string()];
+    let data = encode_recordswith_inferred_schema(headers, rows).expect("encode");
+
+    let cfg = FitConfig { family: Some("gaussian".to_string()), ..FitConfig::default() };
+    let mat = materialize("y ~ x", &data, &cfg).expect("materialize");
+    let fit = fit_model(mat.request).expect("fit");
+    let FitResult::Standard(sf) = fit else { panic!("expected standard fit") };
+
+    let beta_rust: Vec<f64> = sf.fit.beta.to_vec();
+    let ll_rust = sf.fit.log_likelihood;
+    let reml_rust = sf.fit.reml_score;
+
+    let py = r#"
+import json, math
+import gamfit
+rows=[]
+n=80
+for i in range(n):
+    x=-1.0+2.0*i/(n-1)
+    y=0.5+1.25*x
+    rows.append({'x':x,'y':y})
+m=gamfit.fit('y ~ x', rows, family='gaussian')
+s=m.summary()
+p=m.predict(rows, with_uncertainty=True)
+out={
+ 'beta': [c['estimate'] for c in s['coefficients']],
+ 'll': float(s['deviance']) if 'deviance' in s else float('nan'),
+ 'reml': float(s['reml_score']),
+ 'mean0': float(p[0]['.mean'] if isinstance(p, list) else p['.mean'][0]),
+}
+print(json.dumps(out))
+"#;
+    let out = Command::new("python3")
+        .arg("-c")
+        .arg(py)
+        .output()
+        .expect("run python");
+    assert!(out.status.success(), "python failed: {}", String::from_utf8_lossy(&out.stderr));
+    let v: Value = serde_json::from_slice(&out.stdout).expect("json");
+    let beta_py: Vec<f64> = v["beta"].as_array().unwrap().iter().map(|x| x.as_f64().unwrap()).collect();
+    let reml_py = v["reml"].as_f64().unwrap();
+
+    assert_eq!(beta_rust.len(), beta_py.len());
+    for (i,(a,b)) in beta_rust.iter().zip(beta_py.iter()).enumerate() {
+        assert!((a-b).abs() <= 1e-9, "beta[{i}] rust={a} py={b}");
+    }
+    assert!((reml_rust - reml_py).abs() <= 1e-9, "reml rust={reml_rust} py={reml_py}");
+    let _ = ll_rust;
+}


### PR DESCRIPTION
### Motivation
- Provide a minimal, descriptive parity harness that exercises the Python `gamfit` API and the Rust core in the same process to detect cross-language numerical divergences for a simple Gaussian linear case.

### Description
- Added a single Rust integration test `tests/python_rust_ffi_parity_gaussian_linear.rs` that builds a deterministic Gaussian linear dataset and fits it both via direct Rust (`materialize` + `fit_model`) and via a Python subprocess calling `gamfit.fit`.
- The test compares fitted coefficient estimates (`beta`) and the REML score between Rust and Python at a `1e-9` tolerance and exposes results in one `#[test]` file without modifying production sources.
- The Python side invoked from the test uses `gamfit.fit`, `summary()`, and `predict(..., with_uncertainty=True)` and marshals JSON back to the Rust test harness for numeric comparison.

### Testing
- Attempted to run the new test with `cargo test -q --test python_rust_ffi_parity_gaussian_linear -- --nocapture`, but the build/test run was blocked during the build step by an unrelated repository-wide ban-rule failure (a `debug_assert!` hit in `tests/survival_marginal_slope_stall.rs`), so the new parity test did not execute.
- No automated parity assertions have yet been observed passing or failing because the CI/local `cargo test` run failed prior to test execution due to the unrelated build-time error.

---
Codex Cloud task: https://chatgpt.com/codex/tasks/task_e_6a13cdbba5708324ac4dd70cbd6b77cd