### PR TITLE
Wire BMS flex row-kernel GPU policy

### DIFF
--- a/src/families/bernoulli_marginal_slope.rs
+++ b/src/families/bernoulli_marginal_slope.rs
@@ -8336,10 +8336,11 @@ impl BernoulliMarginalSlopeFamily {
             cache_bytes, plan.bytes,
             "row-primary Hessian cache byte plan must match the dense row-cache shape"
         );
+        let gpu_decision = crate::gpu::bms_flex::require_row_primary_hessian_supported(n, r)?;
         if !plan.materialize {
             if log_exact_work(n) {
                 log::info!(
-                    "[BMS row-primary-hessian-cache] stream rows n={} r={} bytes={} workspace_existing_bytes={} budget_bytes={} policy_operator_budget_bytes={} runtime_available_bytes={} expected_reuse_passes={} materialized_row_hessian_evals={} streamed_row_hessian_evals={} reason={}",
+                    "[BMS row-primary-hessian-cache] stream rows n={} r={} bytes={} workspace_existing_bytes={} budget_bytes={} policy_operator_budget_bytes={} runtime_available_bytes={} expected_reuse_passes={} materialized_row_hessian_evals={} streamed_row_hessian_evals={} reason={} gpu_policy={} gpu_selected={} gpu_reason={}",
                     n,
                     r,
                     plan.bytes,
@@ -8351,6 +8352,9 @@ impl BernoulliMarginalSlopeFamily {
                     plan.materialized_row_hessian_evals,
                     plan.streamed_row_hessian_evals,
                     plan.reason.as_str(),
+                    gpu_decision.policy.as_str(),
+                    gpu_decision.use_gpu,
+                    gpu_decision.reason,
                 );
             }
             return Ok(None);
@@ -8362,7 +8366,7 @@ impl BernoulliMarginalSlopeFamily {
         ));
         if log_exact_work(n) {
             log::info!(
-                "[BMS row-primary-hessian-cache] materialize start n={} r={} bytes={} workspace_existing_bytes={} budget_bytes={} policy_operator_budget_bytes={} runtime_available_bytes={} expected_reuse_passes={} materialized_row_hessian_evals={} streamed_row_hessian_evals={} reason={}",
+                "[BMS row-primary-hessian-cache] materialize start n={} r={} bytes={} workspace_existing_bytes={} budget_bytes={} policy_operator_budget_bytes={} runtime_available_bytes={} expected_reuse_passes={} materialized_row_hessian_evals={} streamed_row_hessian_evals={} reason={} gpu_policy={} gpu_selected={} gpu_reason={}",
                 n,
                 r,
                 plan.bytes,
@@ -8374,6 +8378,9 @@ impl BernoulliMarginalSlopeFamily {
                 plan.materialized_row_hessian_evals,
                 plan.streamed_row_hessian_evals,
                 plan.reason.as_str(),
+                gpu_decision.policy.as_str(),
+                gpu_decision.use_gpu,
+                gpu_decision.reason,
             );
         }
         let completed_rows = AtomicUsize::new(0);

--- a/src/gpu/bms_flex.rs
+++ b/src/gpu/bms_flex.rs
@@ -1,0 +1,35 @@
+//! GPU dispatch policy for Bernoulli marginal-slope FLEX row kernels.
+//!
+//! The BMS FLEX row-primary Hessian is not a BLAS-shaped operation: it depends
+//! on denested cubic-cell geometry, row intercepts, and deviation-anchor
+//! semantics. Until that exact row calculus is lowered to CUDA, this module is
+//! the single policy gate for the route. `Auto` keeps the numerically exact CPU
+//! implementation; `Force` fails at the call site instead of silently running
+//! an unsupported CPU path.
+
+use super::{GpuDecision, GpuKernel, decide};
+
+#[must_use]
+pub fn row_primary_hessian_decision(n: usize, r: usize) -> GpuDecision {
+    let large_enough = super::runtime::GpuRuntime::global()
+        .map(|runtime| n >= runtime.policy().row_kernel_min_n && r > 0)
+        .unwrap_or(false);
+    decide(GpuKernel::MarginalSlopeRows, false, large_enough)
+}
+
+pub fn require_row_primary_hessian_supported(n: usize, r: usize) -> Result<GpuDecision, String> {
+    let decision = row_primary_hessian_decision(n, r);
+    decision.clone().log();
+    decision.require_supported()?;
+    Ok(decision)
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn bms_flex_row_kernel_policy_is_explicitly_unsupported() {
+        let decision = super::row_primary_hessian_decision(50_000, 4);
+        assert!(!decision.use_gpu);
+        assert_eq!(decision.kernel, crate::gpu::GpuKernel::MarginalSlopeRows);
+    }
+}

--- a/src/gpu/mod.rs
+++ b/src/gpu/mod.rs
@@ -7,6 +7,7 @@
 //! never loaded by default CPU-only builds.
 
 pub mod blas;
+pub mod bms_flex;
 pub mod cpu_traits;
 pub mod device;
 pub mod driver;


### PR DESCRIPTION
Repairs #210 without keeping the dead NVRTC skeleton.\n\nChanges:\n- adds a used src/gpu/bms_flex.rs policy gate for BMS FLEX row-primary Hessian caching\n- wires the BMS row-primary Hessian cache through GpuKernel::MarginalSlopeRows\n- makes gpu=force fail loudly while the exact CUDA row calculus is unsupported, instead of silently using CPU\n- logs GPU policy/selection/reason alongside row-primary Hessian cache decisions\n\nThis deliberately avoids a fake CUDA kernel: the existing PR's TODO kernel would produce incorrect Hessians because the real source of truth is the denested cubic-cell row calculus in bernoulli_marginal_slope.rs.\n\nVerification:\n- rustfmt --check on src/gpu/bms_flex.rs, src/gpu/mod.rs, and src/families/bernoulli_marginal_slope.rs passed\n- cargo test bms_flex_row_kernel_policy_is_explicitly_unsupported --lib is blocked by the repo build-script lint on unrelated dirty SAE work: src/terms/sae_manifold.rs:2140 underscore-prefixed parameter