### PR TITLE
Implement CI parity-lock for GPU and CPU formulas

### DIFF
--- a/src/families/marginal_slope_orthogonal.rs
+++ b/src/families/marginal_slope_orthogonal.rs
@@ -120,9 +120,7 @@ pub fn score_influence_jacobian(
         .fit
         .block_states
         .first()
-        .ok_or_else(|| {
-            "score_influence_jacobian: fitted CTN has no block states".to_string()
-        })?
+        .ok_or_else(|| "score_influence_jacobian: fitted CTN has no block states".to_string())?
         .beta;
     if beta.len() != p1 {
         return Err(format!(
@@ -157,10 +155,9 @@ pub fn score_influence_jacobian(
             cov_design.design.ncols()
         ));
     }
-    let x_cov = cov_design
-        .design
-        .try_row_chunk(0..n)
-        .map_err(|e| format!("score_influence_jacobian: covariate design materialization failed: {e}"))?;
+    let x_cov = cov_design.design.try_row_chunk(0..n).map_err(|e| {
+        format!("score_influence_jacobian: covariate design materialization failed: {e}")
+    })?;
 
     // γ_k(x_i) = Σ_j Xᶜᵒᵛ_{i,j}·Γ[k,j]  ⇒  gamma = Xᶜᵒᵛ · Γᵀ  (n × p_resp).
     let gamma = fast_abt(&x_cov, &beta_mat);
@@ -283,17 +280,15 @@ pub fn score_influence_jacobian(
                 let dl = dl_scalar * xij;
                 let du = du_scalar * xij;
                 // ∂u = [φ(h)∂h − u·(φ(U)∂U − φ(L)∂L) − φ(L)∂L] / (Φ(U)−Φ(L))
-                let du_pit = (pdf_h * dh - u_pit * (pdf_u * du - pdf_l * dl) - pdf_l * dl)
-                    / denom_mass;
+                let du_pit =
+                    (pdf_h * dh - u_pit * (pdf_u * du - pdf_l * dl) - pdf_l * dl) / denom_mass;
                 row[base + j] = du_pit / pdf_z;
             }
         }
     }
 
     if columns.iter().any(|v| !v.is_finite()) {
-        return Err(
-            "score_influence_jacobian: produced non-finite Jacobian entries".to_string(),
-        );
+        return Err("score_influence_jacobian: produced non-finite Jacobian entries".to_string());
     }
     if z_scores.iter().any(|v| !v.is_finite()) {
         return Err("score_influence_jacobian: produced non-finite z scores".to_string());
@@ -324,7 +319,7 @@ pub fn influence_block_design(
     s_f: f64,
 ) -> Array2<f64> {
     let n = jac.columns.nrows();
-    debug_assert_eq!(
+    assert_eq!(
         pilot_beta0.len(),
         n,
         "influence_block_design: pilot_beta0 length must equal Jacobian rows"
@@ -363,12 +358,12 @@ pub(crate) fn residualize_influence_columns(
     eps: f64,
 ) -> Array2<f64> {
     let n = marginal_design.nrows();
-    debug_assert_eq!(
+    assert_eq!(
         z_infl.nrows(),
         n,
         "residualize_influence_columns: Z_infl rows must equal marginal design rows"
     );
-    debug_assert_eq!(
+    assert_eq!(
         w_metric.len(),
         n,
         "residualize_influence_columns: row metric length must equal marginal design rows"

--- a/src/families/survival_marginal_slope.rs
+++ b/src/families/survival_marginal_slope.rs
@@ -2136,12 +2136,9 @@ impl BlockHessianAccumulator {
         // existing channels: time uses {q0,q1,qd1}, marginal {q0,q1}, logslope
         // {g}, score_warp/link_dev their own primary ranges.
         if let Some(infl_idx) = primary.infl {
-            let z_tilde = family
-                .influence_absorber
-                .as_ref()
-                .ok_or_else(|| {
-                    "add_pullback: influence primary index present but no Z̃ design".to_string()
-                })?;
+            let z_tilde = family.influence_absorber.as_ref().ok_or_else(|| {
+                "add_pullback: influence primary index present but no Z̃ design".to_string()
+            })?;
             let z_row = z_tilde.row(row);
             let p_i = z_row.len();
 
@@ -5920,8 +5917,7 @@ impl SurvivalMarginalSlopeFamily {
         if self.influence_absorber.is_none() {
             return Ok(None);
         }
-        let idx =
-            3 + usize::from(self.score_warp.is_some()) + usize::from(self.link_dev.is_some());
+        let idx = 3 + usize::from(self.score_warp.is_some()) + usize::from(self.link_dev.is_some());
         block_states
             .get(idx)
             .map(|state| Some(&state.beta))
@@ -5936,9 +5932,10 @@ impl SurvivalMarginalSlopeFamily {
         row: usize,
         block_states: &[ParameterBlockState],
     ) -> Result<f64, String> {
-        let (Some(z_tilde), Some(gamma)) =
-            (self.influence_absorber.as_ref(), self.flex_influence_beta(block_states)?)
-        else {
+        let (Some(z_tilde), Some(gamma)) = (
+            self.influence_absorber.as_ref(),
+            self.flex_influence_beta(block_states)?,
+        ) else {
             return Ok(0.0);
         };
         if gamma.len() != z_tilde.ncols() {
@@ -13763,9 +13760,7 @@ impl crate::families::marginal_slope_shared::MarginalSlopePsiFamily
         )
     }
 
-    fn psi_first_order_terms_all(
-        &self,
-    ) -> Result<Option<Vec<ExactNewtonJointPsiTerms>>, String> {
+    fn psi_first_order_terms_all(&self) -> Result<Option<Vec<ExactNewtonJointPsiTerms>>, String> {
         let total: usize = self.derivative_blocks.iter().map(Vec::len).sum();
         if total == 0 {
             return Ok(Some(Vec::new()));
@@ -20217,11 +20212,11 @@ pub fn fit_survival_marginal_slope_terms(
     let influence_absorber_residualized: Option<Array2<f64>> =
         if let Some(jac) = spec.score_influence_jacobian.as_ref() {
             use crate::families::marginal_slope_orthogonal::{
-                influence_block_design, residualize_influence_columns, ScoreInfluenceJacobian,
+                ScoreInfluenceJacobian, influence_block_design, residualize_influence_columns,
             };
-            let marginal_dense = marginal_design
-                .design
-                .try_to_dense_by_chunks("survival marginal-slope influence-absorber marginal span")?;
+            let marginal_dense = marginal_design.design.try_to_dense_by_chunks(
+                "survival marginal-slope influence-absorber marginal span",
+            )?;
             // Realized leakage directions `Z_infl = diag(s_f·β̂₀)·J` via the core
             // builder; `β̂₀(x_i)` is the rigid-pilot logslope and `s_f =
             // probit_scale`. `influence_block_design` reads only `columns`; the
@@ -20231,8 +20226,7 @@ pub fn fit_survival_marginal_slope_terms(
                 z: z_primary.clone(),
             };
             let rigid_logslope_at_rows = &spec.logslope_offset + baseline_slope;
-            let z_infl =
-                influence_block_design(&jacobian, &rigid_logslope_at_rows, probit_scale);
+            let z_infl = influence_block_design(&jacobian, &rigid_logslope_at_rows, probit_scale);
             // Marginal-Gram ridge scaled to the weighted Gram's own magnitude so
             // the projection solve stays stable when the marginal design is
             // rank-deficient at the pilot, without perturbing a well-conditioned
@@ -20258,9 +20252,11 @@ pub fn fit_survival_marginal_slope_terms(
             );
             if residualized.iter().any(|v| !v.is_finite()) {
                 return Err(SurvivalMarginalSlopeError::NumericalFailure {
-                    reason: "survival influence-absorber residualized columns contain non-finite entries".to_string(),
-                }
-                .into());
+                reason:
+                    "survival influence-absorber residualized columns contain non-finite entries"
+                        .to_string(),
+            }
+            .into());
             }
             Some(residualized)
         } else {
@@ -22624,6 +22620,7 @@ mod tests {
             logslope_surface_ranges: empty_logslope_surface_ranges(),
             score_warp,
             link_dev,
+            influence_absorber: None,
             time_linear_constraints: None,
             time_wiggle_knots: None,
             time_wiggle_degree: None,
@@ -22897,41 +22894,41 @@ mod tests {
 
     #[test]
     fn block_to_dense_matches_hand_scatter_bit_exact() {
-        for (pt, pm, pg, ph, pw) in PARITY_LAYOUTS {
-            let sl = parity_make_slices(pt, pm, pg, ph, pw);
-            let acc = parity_filled_accumulator(pt, pm, pg, ph, pw);
+        for (pt, pm, pg, ph, pw, pi) in PARITY_LAYOUTS {
+            let sl = parity_make_slices(pt, pm, pg, ph, pw, pi);
+            let acc = parity_filled_accumulator(pt, pm, pg, ph, pw, pi);
             let got = acc.to_dense(&sl);
             let want = parity_reference_dense(&acc, &sl);
             assert_eq!(
                 got,
                 want,
                 "to_dense diverged from hand scatter for layout {:?}",
-                (pt, pm, pg, ph, pw)
+                (pt, pm, pg, ph, pw, pi)
             );
         }
     }
 
     #[test]
     fn block_diagonal_matches_dense_diagonal_bit_exact() {
-        for (pt, pm, pg, ph, pw) in PARITY_LAYOUTS {
-            let sl = parity_make_slices(pt, pm, pg, ph, pw);
-            let acc = parity_filled_accumulator(pt, pm, pg, ph, pw);
+        for (pt, pm, pg, ph, pw, pi) in PARITY_LAYOUTS {
+            let sl = parity_make_slices(pt, pm, pg, ph, pw, pi);
+            let acc = parity_filled_accumulator(pt, pm, pg, ph, pw, pi);
             let got = acc.diagonal(&sl);
             let want = parity_reference_dense(&acc, &sl).diag().to_owned();
             assert_eq!(
                 got,
                 want,
                 "diagonal diverged from dense diagonal for layout {:?}",
-                (pt, pm, pg, ph, pw)
+                (pt, pm, pg, ph, pw, pi)
             );
         }
     }
 
     #[test]
     fn block_operator_matvec_matches_dense_gemv() {
-        for (pt, pm, pg, ph, pw) in PARITY_LAYOUTS {
-            let sl = parity_make_slices(pt, pm, pg, ph, pw);
-            let acc = parity_filled_accumulator(pt, pm, pg, ph, pw);
+        for (pt, pm, pg, ph, pw, pi) in PARITY_LAYOUTS {
+            let sl = parity_make_slices(pt, pm, pg, ph, pw, pi);
+            let acc = parity_filled_accumulator(pt, pm, pg, ph, pw, pi);
             let dense = parity_reference_dense(&acc, &sl);
             let v = Array1::from_shape_fn(sl.total, |i| (i as f64 * 0.37).sin());
             let op = acc.into_operator(sl.clone());
@@ -22948,9 +22945,9 @@ mod tests {
 
     #[test]
     fn block_operator_bilinear_matches_dense_quadratic_form() {
-        for (pt, pm, pg, ph, pw) in PARITY_LAYOUTS {
-            let sl = parity_make_slices(pt, pm, pg, ph, pw);
-            let acc = parity_filled_accumulator(pt, pm, pg, ph, pw);
+        for (pt, pm, pg, ph, pw, pi) in PARITY_LAYOUTS {
+            let sl = parity_make_slices(pt, pm, pg, ph, pw, pi);
+            let acc = parity_filled_accumulator(pt, pm, pg, ph, pw, pi);
             let dense = parity_reference_dense(&acc, &sl);
             let v = Array1::from_shape_fn(sl.total, |i| (i as f64 * 0.37).sin());
             let u = Array1::from_shape_fn(sl.total, |i| (i as f64 * 0.53).cos());
@@ -22963,9 +22960,9 @@ mod tests {
 
     #[test]
     fn block_operator_dense_matches_accumulator_dense_bit_exact() {
-        for (pt, pm, pg, ph, pw) in PARITY_LAYOUTS {
-            let sl = parity_make_slices(pt, pm, pg, ph, pw);
-            let acc = parity_filled_accumulator(pt, pm, pg, ph, pw);
+        for (pt, pm, pg, ph, pw, pi) in PARITY_LAYOUTS {
+            let sl = parity_make_slices(pt, pm, pg, ph, pw, pi);
+            let acc = parity_filled_accumulator(pt, pm, pg, ph, pw, pi);
             let direct = acc.to_dense(&sl);
             let op = acc.into_operator(sl.clone());
             let via_op = op.to_dense();
@@ -22973,16 +22970,16 @@ mod tests {
                 direct,
                 via_op,
                 "operator to_dense diverged from accumulator to_dense for layout {:?}",
-                (pt, pm, pg, ph, pw)
+                (pt, pm, pg, ph, pw, pi)
             );
         }
     }
 
     #[test]
     fn block_view_is_transpose_symmetric_across_present_pairs() {
-        for (pt, pm, pg, ph, pw) in PARITY_LAYOUTS {
-            let sl = parity_make_slices(pt, pm, pg, ph, pw);
-            let acc = parity_filled_accumulator(pt, pm, pg, ph, pw);
+        for (pt, pm, pg, ph, pw, pi) in PARITY_LAYOUTS {
+            let sl = parity_make_slices(pt, pm, pg, ph, pw, pi);
+            let acc = parity_filled_accumulator(pt, pm, pg, ph, pw, pi);
             for a in HessBlock::ALL {
                 if sl.range_of(a).is_none() {
                     continue;
@@ -23287,6 +23284,7 @@ mod tests {
             logslope_surface_ranges: empty_logslope_surface_ranges(),
             score_warp: Some(score_runtime.clone()),
             link_dev: Some(link_runtime.clone()),
+            influence_absorber: None,
             time_linear_constraints: None,
             time_wiggle_knots: None,
             time_wiggle_degree: None,
@@ -23373,6 +23371,7 @@ mod tests {
             logslope_surface_ranges: empty_logslope_surface_ranges(),
             score_warp: Some(score_runtime.clone()),
             link_dev: Some(link_runtime.clone()),
+            influence_absorber: None,
             time_linear_constraints: None,
             time_wiggle_knots: None,
             time_wiggle_degree: None,
@@ -23417,6 +23416,7 @@ mod tests {
             logslope_surface_ranges: empty_logslope_surface_ranges(),
             score_warp: Some(score_runtime.clone()),
             link_dev: None,
+            influence_absorber: None,
             time_linear_constraints: None,
             time_wiggle_knots: Some(time_wiggle_knots),
             time_wiggle_degree: Some(time_wiggle_degree),
@@ -23549,6 +23549,7 @@ mod tests {
             logslope_surface_ranges: empty_logslope_surface_ranges(),
             score_warp: None,
             link_dev: Some(link_runtime.clone()),
+            influence_absorber: None,
             time_linear_constraints: None,
             time_wiggle_knots: Some(time_wiggle_knots),
             time_wiggle_degree: Some(time_wiggle_degree),
@@ -23594,6 +23595,7 @@ mod tests {
             logslope_surface_ranges: empty_logslope_surface_ranges(),
             score_warp: Some(score_runtime.clone()),
             link_dev: None,
+            influence_absorber: None,
             time_linear_constraints: None,
             time_wiggle_knots: Some(time_wiggle_knots),
             time_wiggle_degree: Some(time_wiggle_degree),
@@ -23665,6 +23667,7 @@ mod tests {
             logslope_surface_ranges: empty_logslope_surface_ranges(),
             score_warp: Some(score_runtime.clone()),
             link_dev: None,
+            influence_absorber: None,
             time_linear_constraints: None,
             time_wiggle_knots: Some(time_wiggle_knots),
             time_wiggle_degree: Some(time_wiggle_degree),
@@ -23742,6 +23745,7 @@ mod tests {
             logslope_surface_ranges: empty_logslope_surface_ranges(),
             score_warp: Some(score_runtime.clone()),
             link_dev: Some(link_runtime.clone()),
+            influence_absorber: None,
             time_linear_constraints: None,
             time_wiggle_knots: None,
             time_wiggle_degree: None,
@@ -23845,6 +23849,7 @@ mod tests {
             logslope_surface_ranges: empty_logslope_surface_ranges(),
             score_warp: Some(score_runtime.clone()),
             link_dev: Some(link_runtime.clone()),
+            influence_absorber: None,
             time_linear_constraints: None,
             time_wiggle_knots: None,
             time_wiggle_degree: None,
@@ -23907,6 +23912,7 @@ mod tests {
             logslope_surface_ranges: empty_logslope_surface_ranges(),
             score_warp: Some(score_runtime.clone()),
             link_dev: Some(link_runtime.clone()),
+            influence_absorber: None,
             time_linear_constraints: None,
             time_wiggle_knots: None,
             time_wiggle_degree: None,
@@ -23989,6 +23995,7 @@ mod tests {
             logslope_surface_ranges: empty_logslope_surface_ranges(),
             score_warp: Some(score_runtime.clone()),
             link_dev: Some(link_runtime.clone()),
+            influence_absorber: None,
             time_linear_constraints: None,
             time_wiggle_knots: None,
             time_wiggle_degree: None,
@@ -24078,6 +24085,7 @@ mod tests {
             logslope_surface_ranges: empty_logslope_surface_ranges(),
             score_warp: Some(score_runtime.clone()),
             link_dev: Some(link_runtime.clone()),
+            influence_absorber: None,
             time_linear_constraints: None,
             time_wiggle_knots: None,
             time_wiggle_degree: None,
@@ -24168,6 +24176,7 @@ mod tests {
             logslope_surface_ranges: empty_logslope_surface_ranges(),
             score_warp: Some(score_runtime.clone()),
             link_dev: None,
+            influence_absorber: None,
             time_linear_constraints: None,
             time_wiggle_knots: Some(time_wiggle_knots),
             time_wiggle_degree: Some(time_wiggle_degree),
@@ -24256,6 +24265,7 @@ mod tests {
             logslope_surface_ranges: empty_logslope_surface_ranges(),
             score_warp: Some(score_runtime.clone()),
             link_dev: None,
+            influence_absorber: None,
             time_linear_constraints: None,
             time_wiggle_knots: Some(time_wiggle_knots),
             time_wiggle_degree: Some(time_wiggle_degree),
@@ -24315,6 +24325,7 @@ mod tests {
             logslope_surface_ranges: empty_logslope_surface_ranges(),
             score_warp: Some(score_runtime.clone()),
             link_dev: Some(link_runtime.clone()),
+            influence_absorber: None,
             time_linear_constraints: None,
             time_wiggle_knots: Some(time_wiggle_knots),
             time_wiggle_degree: Some(time_wiggle_degree),
@@ -24410,6 +24421,7 @@ mod tests {
             logslope_surface_ranges: empty_logslope_surface_ranges(),
             score_warp: Some(score_runtime.clone()),
             link_dev: Some(link_runtime.clone()),
+            influence_absorber: None,
             time_linear_constraints: None,
             time_wiggle_knots: Some(time_wiggle_knots),
             time_wiggle_degree: Some(time_wiggle_degree),
@@ -24590,6 +24602,7 @@ mod tests {
             logslope_surface_ranges: empty_logslope_surface_ranges(),
             score_warp: Some(score_runtime.clone()),
             link_dev: Some(link_runtime.clone()),
+            influence_absorber: None,
             time_linear_constraints: None,
             time_wiggle_knots: Some(time_wiggle_knots),
             time_wiggle_degree: Some(time_wiggle_degree),
@@ -24665,6 +24678,7 @@ mod tests {
             logslope_surface_ranges: empty_logslope_surface_ranges(),
             score_warp: Some(score_runtime.clone()),
             link_dev: None,
+            influence_absorber: None,
             time_linear_constraints: None,
             time_wiggle_knots: Some(time_wiggle_knots),
             time_wiggle_degree: Some(time_wiggle_degree),
@@ -24751,6 +24765,7 @@ mod tests {
             logslope_surface_ranges: empty_logslope_surface_ranges(),
             score_warp: Some(score_runtime.clone()),
             link_dev: None,
+            influence_absorber: None,
             time_linear_constraints: None,
             time_wiggle_knots: Some(time_wiggle_knots),
             time_wiggle_degree: Some(time_wiggle_degree),
@@ -25258,6 +25273,7 @@ mod tests {
                 Array2::zeros((2, 0)),
             )),
             logslope_surface_ranges: empty_logslope_surface_ranges(),
+            influence_absorber: None,
             time_linear_constraints: time_derivative_guard_constraints(
                 &DesignMatrix::Dense(crate::matrix::DenseDesignMatrix::from(array![
                     [1.0, 1.0],
@@ -25462,6 +25478,7 @@ mod tests {
                 Array2::zeros((1, 0)),
             )),
             logslope_surface_ranges: empty_logslope_surface_ranges(),
+            influence_absorber: None,
             time_linear_constraints: Some(constraints),
             score_warp: None,
             link_dev: None,
@@ -25535,6 +25552,7 @@ mod tests {
                 Array2::zeros((1, 0)),
             )),
             logslope_surface_ranges: empty_logslope_surface_ranges(),
+            influence_absorber: None,
             time_linear_constraints: Some(constraints),
             score_warp: None,
             link_dev: None,
@@ -25585,6 +25603,7 @@ mod tests {
                 Array2::zeros((1, 0)),
             )),
             logslope_surface_ranges: empty_logslope_surface_ranges(),
+            influence_absorber: None,
             time_linear_constraints: append_timewiggle_tail_nonnegative_constraints(
                 time_derivative_guard_constraints(
                     &DesignMatrix::Dense(crate::matrix::DenseDesignMatrix::from(array![[
@@ -25823,6 +25842,7 @@ mod tests {
             logslope_surface_ranges: empty_logslope_surface_ranges(),
             score_warp: None,
             link_dev: None,
+            influence_absorber: None,
             time_linear_constraints: time_derivative_guard_constraints(
                 &DesignMatrix::Dense(crate::matrix::DenseDesignMatrix::from(array![[1.0, 0.0]])),
                 &array![0.2],
@@ -27103,6 +27123,7 @@ mod tests {
             logslope_surface_ranges: empty_logslope_surface_ranges(),
             score_warp: Some(score_runtime),
             link_dev: None,
+            influence_absorber: None,
             time_linear_constraints: None,
             time_wiggle_knots: None,
             time_wiggle_degree: None,
@@ -27291,6 +27312,7 @@ mod tests {
             logslope_surface_ranges: empty_logslope_surface_ranges(),
             score_warp: Some(score_runtime.clone()),
             link_dev: Some(link_runtime.clone()),
+            influence_absorber: None,
             time_linear_constraints: None,
             time_wiggle_knots: Some(time_wiggle_knots),
             time_wiggle_degree: Some(time_wiggle_degree),
@@ -27433,28 +27455,96 @@ mod tests {
     // to within 5e-8 absolute / 5e-7 relative.
     // ────────────────────────────────────────────────────────────────────
 
-    fn b10_flex_family_for_parity() -> (SurvivalMarginalSlopeFamily, Vec<ParameterBlockState>) {
+    #[derive(Clone, Copy)]
+    struct B10ParityFixture {
+        label: &'static str,
+        event: f64,
+        weight: f64,
+        z: f64,
+        q0: f64,
+        q1: f64,
+        qd1: f64,
+        score_eta: f64,
+        h_scale: f64,
+        w_scale: f64,
+    }
+
+    const B10_PARITY_FIXTURES: &[B10ParityFixture] = &[
+        B10ParityFixture {
+            label: "event_nonzero_warps",
+            event: 1.0,
+            weight: 0.75,
+            z: -0.2,
+            q0: -0.4,
+            q1: 0.6,
+            qd1: 0.85,
+            score_eta: 0.32,
+            h_scale: 0.05,
+            w_scale: 0.04,
+        },
+        B10ParityFixture {
+            label: "censored_left_tail",
+            event: 0.0,
+            weight: 1.35,
+            z: -1.15,
+            q0: -1.35,
+            q1: -0.9,
+            qd1: 0.42,
+            score_eta: -0.55,
+            h_scale: -0.035,
+            w_scale: 0.025,
+        },
+        B10ParityFixture {
+            label: "near_boundary_derivative",
+            event: 1.0,
+            weight: 0.2,
+            z: 0.95,
+            q0: 0.15,
+            q1: 1.05,
+            qd1: 0.08,
+            score_eta: 0.72,
+            h_scale: 0.015,
+            w_scale: -0.02,
+        },
+        B10ParityFixture {
+            label: "zero_warp_edge",
+            event: 0.0,
+            weight: 0.9,
+            z: 0.0,
+            q0: -0.05,
+            q1: 0.25,
+            qd1: 1.2,
+            score_eta: 0.0,
+            h_scale: 0.0,
+            w_scale: 0.0,
+        },
+    ];
+
+    fn b10_flex_family_for_parity(
+        fixture: B10ParityFixture,
+    ) -> (SurvivalMarginalSlopeFamily, Vec<ParameterBlockState>) {
         let score_runtime = test_deviation_runtime();
         let link_runtime = test_deviation_runtime();
         let family = SurvivalMarginalSlopeFamily {
             n: 1,
-            event: Arc::new(array![1.0]),
-            weights: Arc::new(array![0.75]),
-            z: Arc::new(array![-0.2].insert_axis(Axis(1))),
+            event: Arc::new(array![fixture.event]),
+            weights: Arc::new(array![fixture.weight]),
+            z: Arc::new(array![fixture.z].insert_axis(Axis(1))),
             score_covariance: unit_score_covariance(),
             gaussian_frailty_sd: None,
             derivative_guard: 1e-6,
             design_entry: DesignMatrix::from(Array2::zeros((1, 1))),
             design_exit: DesignMatrix::from(Array2::zeros((1, 1))),
             design_derivative_exit: DesignMatrix::from(Array2::zeros((1, 1))),
-            offset_entry: Arc::new(array![-0.4]),
-            offset_exit: Arc::new(array![0.6]),
-            derivative_offset_exit: Arc::new(array![0.85]),
+            offset_entry: Arc::new(array![fixture.q0]),
+            offset_exit: Arc::new(array![fixture.q1]),
+            derivative_offset_exit: Arc::new(array![fixture.qd1]),
             marginal_design: DesignMatrix::from(Array2::zeros((1, 0))),
             logslope_design: DesignMatrix::from(Array2::zeros((1, 0))),
             logslope_surface_ranges: empty_logslope_surface_ranges(),
             score_warp: Some(score_runtime.clone()),
             link_dev: Some(link_runtime.clone()),
+            influence_absorber: None,
             time_linear_constraints: None,
             time_wiggle_knots: None,
             time_wiggle_degree: None,
@@ -27465,14 +27555,12 @@ mod tests {
         };
         let h_dim = score_runtime.basis_dim();
         let w_dim = link_runtime.basis_dim();
-        // Mild non-zero coefficients to drive the chi/D quotient terms
-        // away from the zero-warp / zero-deviation degenerate case.
         let h_beta: Array1<f64> = (0..h_dim)
-            .map(|k| 0.05 * ((k as f64 + 1.0).sin()))
+            .map(|k| fixture.h_scale * ((k as f64 + 1.0).sin()))
             .collect::<Vec<_>>()
             .into();
         let w_beta: Array1<f64> = (0..w_dim)
-            .map(|k| 0.04 * ((k as f64 + 1.0).cos()))
+            .map(|k| fixture.w_scale * ((k as f64 + 1.0).cos()))
             .collect::<Vec<_>>()
             .into();
         let block_states = vec![
@@ -27486,7 +27574,7 @@ mod tests {
             },
             ParameterBlockState {
                 beta: Array1::zeros(0),
-                eta: array![0.32],
+                eta: array![fixture.score_eta],
             },
             ParameterBlockState {
                 beta: h_beta,
@@ -27498,6 +27586,28 @@ mod tests {
             },
         ];
         (family, block_states)
+    }
+
+    fn b10_direction_set(p: usize) -> Vec<(&'static str, Array1<f64>)> {
+        let mixed: Array1<f64> = (0..p)
+            .map(|k| 0.1 + 0.07 * ((k as f64 + 1.7).sin()))
+            .collect::<Vec<_>>()
+            .into();
+        let alternating: Array1<f64> = (0..p)
+            .map(|k| if k % 2 == 0 { 0.16 } else { -0.11 })
+            .collect::<Vec<_>>()
+            .into();
+        let mut qd_axis = Array1::zeros(p);
+        if p > 2 {
+            qd_axis[2] = 1.0;
+        }
+        let zero = Array1::zeros(p);
+        vec![
+            ("mixed", mixed),
+            ("alternating", alternating),
+            ("qd_axis", qd_axis),
+            ("zero", zero),
+        ]
     }
 
     fn b10_pack_base(
@@ -27667,35 +27777,14 @@ mod tests {
         }
     }
 
-    #[test]
-    fn block10_cpu_oracle_third_contraction_matches_family() {
-        let (family, block_states) = b10_flex_family_for_parity();
-        let primary = flex_primary_slices(&family);
-        let p = primary.total;
-        // Deterministic non-axis-aligned direction.
-        let dir: Array1<f64> = (0..p)
-            .map(|k| 0.1 + 0.07 * ((k as f64 + 1.7).sin()))
-            .collect::<Vec<_>>()
-            .into();
-
-        let expected = family
-            .row_flex_primary_third_contracted_exact(0, &block_states, &dir)
-            .expect("cpu third contraction");
-
-        let (
-            entry_base,
-            exit_base,
-            entry_ext,
-            exit_ext,
-            _e2,
-            _x2,
-            _eb,
-            _xb,
-            _qd1,
-            qd1_idx,
-            p_total,
-        ) = flex_primary_timepoint_jets_for_test(&family, 0, &block_states, &dir, None)
-            .expect("jets");
+    fn b10_third_oracle_from_family(
+        family: &SurvivalMarginalSlopeFamily,
+        block_states: &[ParameterBlockState],
+        dir: &Array1<f64>,
+    ) -> Vec<f64> {
+        let (entry_base, exit_base, entry_ext, exit_ext, _e2, _x2, _eb, _xb, qd1, qd1_idx, p_total) =
+            flex_primary_timepoint_jets_for_test(family, 0, block_states, dir, None)
+                .expect("third-contraction jets");
 
         let entry_b = b10_pack_base(&entry_base);
         let exit_b = b10_pack_base(&exit_base);
@@ -27705,10 +27794,7 @@ mod tests {
         let inputs = crate::gpu::survival_flex::SurvivalFlexBlock10ThirdInputs {
             p: p_total,
             qd1_index: qd1_idx,
-            qd1: family
-                .row_dynamic_q_geometry(0, &block_states)
-                .expect("q geom")
-                .qd1,
+            qd1,
             w: family.weights[0],
             d: family.event[0],
             dir: &dir_vec,
@@ -27717,30 +27803,15 @@ mod tests {
             entry_ext: &entry_d,
             exit_ext: &exit_d,
         };
-        let actual =
-            crate::gpu::survival_flex::cpu_oracle_third_contraction(&inputs).expect("oracle third");
-        assert_eq!(actual.len(), expected.nrows() * expected.ncols());
-        b10_assert_parity(&actual, &expected, "block10_third");
+        crate::gpu::survival_flex::cpu_oracle_third_contraction(&inputs).expect("oracle third")
     }
 
-    #[test]
-    fn block10_cpu_oracle_fourth_contraction_matches_family() {
-        let (family, block_states) = b10_flex_family_for_parity();
-        let primary = flex_primary_slices(&family);
-        let p = primary.total;
-        let dir_u: Array1<f64> = (0..p)
-            .map(|k| 0.08 + 0.06 * ((k as f64 + 0.4).cos()))
-            .collect::<Vec<_>>()
-            .into();
-        let dir_v: Array1<f64> = (0..p)
-            .map(|k| -0.05 + 0.09 * ((k as f64 + 1.1).sin()))
-            .collect::<Vec<_>>()
-            .into();
-
-        let expected = family
-            .row_flex_primary_fourth_contracted_exact(0, &block_states, &dir_u, &dir_v)
-            .expect("cpu fourth contraction");
-
+    fn b10_fourth_oracle_from_family(
+        family: &SurvivalMarginalSlopeFamily,
+        block_states: &[ParameterBlockState],
+        dir_u: &Array1<f64>,
+        dir_v: &Array1<f64>,
+    ) -> Vec<f64> {
         let (
             entry_base,
             exit_base,
@@ -27750,11 +27821,11 @@ mod tests {
             exit_ext2,
             entry_bi,
             exit_bi,
-            _qd1,
+            qd1,
             qd1_idx,
             p_total,
-        ) = flex_primary_timepoint_jets_for_test(&family, 0, &block_states, &dir_u, Some(&dir_v))
-            .expect("bi-jets");
+        ) = flex_primary_timepoint_jets_for_test(family, 0, block_states, dir_u, Some(dir_v))
+            .expect("fourth-contraction bi-jets");
         let entry_ext2 = entry_ext2.expect("entry ext2");
         let exit_ext2 = exit_ext2.expect("exit ext2");
         let entry_bi = entry_bi.expect("entry bi");
@@ -27773,10 +27844,7 @@ mod tests {
         let inputs = crate::gpu::survival_flex::SurvivalFlexBlock10FourthInputs {
             p: p_total,
             qd1_index: qd1_idx,
-            qd1: family
-                .row_dynamic_q_geometry(0, &block_states)
-                .expect("q geom")
-                .qd1,
+            qd1,
             w: family.weights[0],
             d: family.event[0],
             dir_u: &dir_u_v,
@@ -27790,10 +27858,53 @@ mod tests {
             entry_bi: &entry_bi_p,
             exit_bi: &exit_bi_p,
         };
-        let actual = crate::gpu::survival_flex::cpu_oracle_fourth_contraction(&inputs)
-            .expect("oracle fourth");
-        assert_eq!(actual.len(), expected.nrows() * expected.ncols());
-        b10_assert_parity(&actual, &expected, "block10_fourth");
+        crate::gpu::survival_flex::cpu_oracle_fourth_contraction(&inputs).expect("oracle fourth")
+    }
+
+    #[test]
+    fn block10_cpu_oracle_third_contraction_matches_family_shared_fixtures() {
+        for &fixture in B10_PARITY_FIXTURES {
+            let (family, block_states) = b10_flex_family_for_parity(fixture);
+            let primary = flex_primary_slices(&family);
+            for (dir_label, dir) in b10_direction_set(primary.total) {
+                let expected = family
+                    .row_flex_primary_third_contracted_exact(0, &block_states, &dir)
+                    .unwrap_or_else(|err| {
+                        panic!(
+                            "{} / {dir_label}: cpu third contraction failed: {err}",
+                            fixture.label
+                        )
+                    });
+                let actual = b10_third_oracle_from_family(&family, &block_states, &dir);
+                assert_eq!(actual.len(), expected.nrows() * expected.ncols());
+                b10_assert_parity(&actual, &expected, fixture.label);
+            }
+        }
+    }
+
+    #[test]
+    fn block10_cpu_oracle_fourth_contraction_matches_family_shared_fixtures() {
+        for &fixture in B10_PARITY_FIXTURES {
+            let (family, block_states) = b10_flex_family_for_parity(fixture);
+            let primary = flex_primary_slices(&family);
+            let dirs = b10_direction_set(primary.total);
+            let pairs = [(0usize, 0usize), (0, 1), (1, 0), (1, 2), (2, 3), (3, 0)];
+            for &(u_idx, v_idx) in &pairs {
+                let (u_label, dir_u) = &dirs[u_idx];
+                let (v_label, dir_v) = &dirs[v_idx];
+                let expected = family
+                    .row_flex_primary_fourth_contracted_exact(0, &block_states, dir_u, dir_v)
+                    .unwrap_or_else(|err| {
+                        panic!(
+                            "{} / {u_label}->{v_label}: cpu fourth contraction failed: {err}",
+                            fixture.label
+                        )
+                    });
+                let actual = b10_fourth_oracle_from_family(&family, &block_states, dir_u, dir_v);
+                assert_eq!(actual.len(), expected.nrows() * expected.ncols());
+                b10_assert_parity(&actual, &expected, fixture.label);
+            }
+        }
     }
 
     // ── flex-chain Jacobian FD tests ─────────────────────────────────────────
@@ -28205,7 +28316,7 @@ mod tests {
         p_h: usize,
         p_w: usize,
     ) -> BlockHessianAccumulator {
-        let mut acc = BlockHessianAccumulator::new(p_t, p_m, p_g, p_h, p_w, p_i);
+        let mut acc = BlockHessianAccumulator::new(p_t, p_m, p_g, p_h, p_w, 0);
         // Per-pair base offsets keep the diagonal blocks symmetric (required
         // for a valid Hessian) while making the off-diagonal blocks distinct
         // and asymmetric, so `to_dense` must place each transpose correctly.

--- a/src/gpu/backend_probe.rs
+++ b/src/gpu/backend_probe.rs
@@ -26,9 +26,7 @@
 //! there is no transitional shim.
 
 #[cfg(target_os = "linux")]
-pub(crate) use linux::{
-    CudaBackendContext, CudaBackendParts, probe_backend_with_compile, probe_cuda_backend,
-};
+pub(crate) use linux::{CudaBackendContext, probe_backend_with_compile, probe_cuda_backend};
 
 #[cfg(target_os = "linux")]
 mod linux {

--- a/src/gpu/bms_flex_row.rs
+++ b/src/gpu/bms_flex_row.rs
@@ -824,11 +824,13 @@ impl RowKernelBackend {
                             reason: format!("bms_flex_row NVRTC compile failed: {err}"),
                         }
                     })?;
-                    let module = parts.ctx.load_module(ptx).map_err(|err| {
-                        GpuError::DriverCallFailed {
-                            reason: format!("bms_flex_row module load failed: {err}"),
-                        }
-                    })?;
+                    let module =
+                        parts
+                            .ctx
+                            .load_module(ptx)
+                            .map_err(|err| GpuError::DriverCallFailed {
+                                reason: format!("bms_flex_row module load failed: {err}"),
+                            })?;
                     Ok(RowKernelBackend {
                         stream: parts.stream.clone(),
                         module,
@@ -1755,11 +1757,13 @@ impl HvpKernelBackend {
                             reason: format!("bms_flex_row hvp NVRTC compile failed: {err}"),
                         }
                     })?;
-                    let module = parts.ctx.load_module(ptx).map_err(|err| {
-                        GpuError::DriverCallFailed {
-                            reason: format!("bms_flex_row hvp module load failed: {err}"),
-                        }
-                    })?;
+                    let module =
+                        parts
+                            .ctx
+                            .load_module(ptx)
+                            .map_err(|err| GpuError::DriverCallFailed {
+                                reason: format!("bms_flex_row hvp module load failed: {err}"),
+                            })?;
                     Ok(HvpKernelBackend {
                         stream: parts.stream.clone(),
                         module,
@@ -3410,14 +3414,10 @@ mod tests {
             let inputs_gpu = parity_inputs(&buffers);
             let gpu_out = match launch_bms_flex_row_kernel(inputs_gpu) {
                 Ok(out) => out,
-                Err(err) => {
-                    eprintln!(
-                        "[bms_flex_row parity] launch failed on CUDA host: \
-                         {err}; skipping parity (treat as CI infra outage, \
-                         not a parity regression)"
-                    );
-                    return;
-                }
+                Err(err) => panic!(
+                    "[bms_flex_row parity] launch failed on CUDA-selected host; \
+                     device/oracle parity must fail loudly on GPU CI: {err}"
+                ),
             };
 
             let n = inputs_cpu.n_rows;

--- a/src/solver/workflow.rs
+++ b/src/solver/workflow.rs
@@ -2737,7 +2737,7 @@ pub struct CrossFitScoreCalibration {
 /// Stage-1 fit; its presence is the sole auto-enable signal for cross-fitted
 /// orthogonalization (design §5). When absent, Stage-2 falls back to the free
 /// 1-D `score_warp` spline (which spans only the x-free leakage column).
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct CtnStage1Recipe {
     /// Stage-1 response column name (the `y` the CTN transforms).
     pub response_column: String,
@@ -2910,8 +2910,8 @@ fn crossfit_score_calibration(
     }
 
     // Stage-1 response / weights / offset, resolved against the full dataset.
-    let y_col =
-        resolve_role_col(col_map, &recipe.response_column, "response").map_err(|e| e.to_string())?;
+    let y_col = resolve_role_col(col_map, &recipe.response_column, "response")
+        .map_err(|e| e.to_string())?;
     let response_full = data.values.column(y_col).to_owned();
     let weights_full = resolve_weight_column(data, col_map, recipe.weight_column.as_deref())
         .map_err(|e| e.to_string())?;
@@ -5606,9 +5606,7 @@ fn materialize_survival<'a>(
     // z_column is supplied. With a CTN Stage-1 recipe there is no dose column
     // (z is produced out-of-fold by cross-fitting) and the marginal formula
     // references only the x covariates, so no alias is needed.
-    let marginal_slope_aliased_col_map = if survival_mode
-        == SurvivalLikelihoodMode::MarginalSlope
-    {
+    let marginal_slope_aliased_col_map = if survival_mode == SurvivalLikelihoodMode::MarginalSlope {
         match config.z_column.as_deref() {
             Some(z_column) => Some(column_map_with_alias(col_map, "z", z_column)),
             None if config.ctn_stage1.is_some() => None,
@@ -5806,8 +5804,7 @@ fn materialize_survival<'a>(
                 Some(base_link),
             )
         } else if let Some(ls_formula) = config.logslope_formula.as_deref() {
-            let default_z_column =
-                marginal_z_column_name.expect("z column present when no recipe");
+            let default_z_column = marginal_z_column_name.expect("z column present when no recipe");
             let (_, ls_parsed) =
                 parse_matching_auxiliary_formula(ls_formula, &parsed.response, "logslope_formula")?;
             if ls_parsed.linkspec.is_some() {
@@ -5866,8 +5863,7 @@ fn materialize_survival<'a>(
                 Some(base_link),
             )
         } else {
-            let default_z_column =
-                marginal_z_column_name.expect("z column present when no recipe");
+            let default_z_column = marginal_z_column_name.expect("z column present when no recipe");
             validate_marginal_slope_z_column_exclusion(
                 parsed,
                 parsed,


### PR DESCRIPTION
### Summary
* Expanded the survival-flex Block 10 parity lock into a shared fixture matrix covering event/censoring, left-tail, near-boundary derivative, and zero-warp/degenerate rows, so the sensitive third/fourth-order contraction formulas are no longer checked only on a single nominal row. 

* Added shared contraction direction fixtures for mixed, alternating, qd-axis, and zero directions, then reused those fixtures across both third-order and ordered fourth-order parity checks. 

* Centralized the survival-flex host-oracle construction helpers so every shared fixture compares the CPU family formula against `gpu::survival_flex`’s host oracle for both third and fourth contracted matrices. 

* Tightened the BMS flex-row device parity arm: on CUDA-selected hosts, kernel-launch failure now panics instead of being reported as an infra skip, so CUDA CI cannot silently pass without executing the oracle-vs-device assertion path. 

* Fixed verification-blocking compile hygiene surfaced during targeted builds: removed an unused CUDA re-export, made the CTN recipe satisfy existing `Debug` derivation, and converted banned debug-only shape assertions into always-on assertions. 


Root cause confirmed: the previous survival-flex Block 10 CPU-family ↔ GPU-host-oracle tests covered only one smooth non-edge fixture and one direction per contraction order, leaving formula drift in edge inputs and ordered fourth-contraction variants undetected. The BMS device parity test also had a CUDA launch-failure skip that could mask a real GPU-runner regression.

Committed on the current branch: `acf8369` (`Parity-lock marginal slope GPU row formulas`). PR metadata has been created.

**Testing**
* ✅ `cargo build`
* ✅ `cargo test block10_cpu_oracle --lib -- --nocapture`
* ⚠️ `cargo test bms_flex_row_kernel_matches_cpu_oracle_when_cuda_available --lib -- --nocapture` — passed on this CPU-only builder with the expected “no CUDA runtime” skip; on CUDA-selected CI, the same test now fails loudly on launch failure or output drift.

Closes #415