### PR TITLE
Implement ALO-stabilized REML smoothing selection

### DIFF
--- a/src/families/bms/block_specs.rs
+++ b/src/families/bms/block_specs.rs
@@ -317,7 +317,9 @@ fn widen_marginal_beta_hint(
         } else {
             let mut widened = Array1::<f64>::zeros(p_marginal_widened);
             let copy = hint.len().min(p_marginal_widened);
-            widened.slice_mut(s![..copy]).assign(&hint.slice(s![..copy]));
+            widened
+                .slice_mut(s![..copy])
+                .assign(&hint.slice(s![..copy]));
             widened
         }
     })
@@ -341,7 +343,8 @@ fn build_marginal_blockspec_bms(
     let raw_marginal_dense = design
         .design
         .try_to_dense_arc("build_marginal_blockspec_bms::marginal")?;
-    let marginal_dense = widen_marginal_dense_with_influence(&raw_marginal_dense, influence_columns)?;
+    let marginal_dense =
+        widen_marginal_dense_with_influence(&raw_marginal_dense, influence_columns)?;
     let logslope_dense = logslope_design
         .design
         .try_to_dense_arc("build_marginal_blockspec_bms::logslope")?;
@@ -710,12 +713,13 @@ pub fn fit_bernoulli_marginal_slope_terms(
     // x-dependent realisation of `ψ − Π_η[ψ]`. `None` ⇒ raw z, and the free
     // score_warp spline below is the x-free-column fallback. β̂₀(x_i) is the
     // rigid-pilot logslope `baseline.1 + logslope_offset[i]`; s_f = probit_scale.
-    let influence_columns = if let Some(jac) =
-        spec.score_influence_jacobian.as_ref().filter(|j| j.ncols() > 0)
+    let influence_columns = if let Some(jac) = spec
+        .score_influence_jacobian
+        .as_ref()
+        .filter(|j| j.ncols() > 0)
     {
-        use crate::faer_ndarray::fast_xt_diag_x;
         use crate::families::marginal_slope_orthogonal::{
-            influence_block_design, residualize_influence_columns, ScoreInfluenceJacobian,
+            ScoreInfluenceJacobian, residualized_influence_block,
         };
         let marginal_dense_for_proj = marginal_design
             .design
@@ -737,33 +741,14 @@ pub fn fit_bernoulli_marginal_slope_terms(
             columns: (*jac).clone(),
             z: z_train.clone(),
         };
-        let z_infl = influence_block_design(&score_jac, &rigid_logslope_at_rows, probit_scale);
-        // Magnitude-scaled ridge for the weighted-Gram projection solve so a
-        // rank-deficient marginal design at the pilot stays solvable without
-        // perturbing a well-conditioned projection. Core's residualiser is
-        // infallible (the ridge guarantees invertibility); guard the final
-        // columns for finiteness here.
-        let p_m = marginal_dense.ncols();
-        let residualized = if p_m == 0 {
-            z_infl
-        } else {
-            let gram_diag = fast_xt_diag_x(marginal_dense, &cross_block_pilot_w_score_warp);
-            let gram_scale = (0..p_m).map(|i| gram_diag[[i, i]]).fold(0.0_f64, f64::max);
-            let eps = (gram_scale * 1e-10).max(1e-12);
-            let out = residualize_influence_columns(
-                &z_infl,
-                marginal_dense.view(),
-                &cross_block_pilot_w_score_warp,
-                eps,
-            );
-            if out.iter().any(|v| !v.is_finite()) {
-                return Err(
-                    "influence block: residualised influence columns contain non-finite entries"
-                        .to_string(),
-                );
-            }
-            out
-        };
+        let residualized = residualized_influence_block(
+            &score_jac,
+            &rigid_logslope_at_rows,
+            probit_scale,
+            marginal_dense.view(),
+            &cross_block_pilot_w_score_warp,
+        )
+        .map_err(|reason| format!("influence block: {reason}"))?;
         Some(residualized)
     } else {
         None

--- a/src/families/marginal_slope_orthogonal.rs
+++ b/src/families/marginal_slope_orthogonal.rs
@@ -120,9 +120,7 @@ pub fn score_influence_jacobian(
         .fit
         .block_states
         .first()
-        .ok_or_else(|| {
-            "score_influence_jacobian: fitted CTN has no block states".to_string()
-        })?
+        .ok_or_else(|| "score_influence_jacobian: fitted CTN has no block states".to_string())?
         .beta;
     if beta.len() != p1 {
         return Err(format!(
@@ -157,10 +155,9 @@ pub fn score_influence_jacobian(
             cov_design.design.ncols()
         ));
     }
-    let x_cov = cov_design
-        .design
-        .try_row_chunk(0..n)
-        .map_err(|e| format!("score_influence_jacobian: covariate design materialization failed: {e}"))?;
+    let x_cov = cov_design.design.try_row_chunk(0..n).map_err(|e| {
+        format!("score_influence_jacobian: covariate design materialization failed: {e}")
+    })?;
 
     // γ_k(x_i) = Σ_j Xᶜᵒᵛ_{i,j}·Γ[k,j]  ⇒  gamma = Xᶜᵒᵛ · Γᵀ  (n × p_resp).
     let gamma = fast_abt(&x_cov, &beta_mat);
@@ -283,17 +280,15 @@ pub fn score_influence_jacobian(
                 let dl = dl_scalar * xij;
                 let du = du_scalar * xij;
                 // ∂u = [φ(h)∂h − u·(φ(U)∂U − φ(L)∂L) − φ(L)∂L] / (Φ(U)−Φ(L))
-                let du_pit = (pdf_h * dh - u_pit * (pdf_u * du - pdf_l * dl) - pdf_l * dl)
-                    / denom_mass;
+                let du_pit =
+                    (pdf_h * dh - u_pit * (pdf_u * du - pdf_l * dl) - pdf_l * dl) / denom_mass;
                 row[base + j] = du_pit / pdf_z;
             }
         }
     }
 
     if columns.iter().any(|v| !v.is_finite()) {
-        return Err(
-            "score_influence_jacobian: produced non-finite Jacobian entries".to_string(),
-        );
+        return Err("score_influence_jacobian: produced non-finite Jacobian entries".to_string());
     }
     if z_scores.iter().any(|v| !v.is_finite()) {
         return Err("score_influence_jacobian: produced non-finite z scores".to_string());
@@ -324,7 +319,7 @@ pub fn influence_block_design(
     s_f: f64,
 ) -> Array2<f64> {
     let n = jac.columns.nrows();
-    debug_assert_eq!(
+    assert_eq!(
         pilot_beta0.len(),
         n,
         "influence_block_design: pilot_beta0 length must equal Jacobian rows"
@@ -363,12 +358,12 @@ pub(crate) fn residualize_influence_columns(
     eps: f64,
 ) -> Array2<f64> {
     let n = marginal_design.nrows();
-    debug_assert_eq!(
+    assert_eq!(
         z_infl.nrows(),
         n,
         "residualize_influence_columns: Z_infl rows must equal marginal design rows"
     );
-    debug_assert_eq!(
+    assert_eq!(
         w_metric.len(),
         n,
         "residualize_influence_columns: row metric length must equal marginal design rows"
@@ -443,7 +438,8 @@ pub(crate) fn residualized_influence_block(
     let p_m = marginal_design.ncols();
     let gram = fast_xt_diag_x(&marginal_design, w_metric);
     let gram_scale = (0..p_m).map(|i| gram[[i, i]]).fold(0.0_f64, f64::max);
-    let eps = (gram_scale * INFLUENCE_PROJECTION_RELATIVE_RIDGE).max(INFLUENCE_PROJECTION_RIDGE_FLOOR);
+    let eps =
+        (gram_scale * INFLUENCE_PROJECTION_RELATIVE_RIDGE).max(INFLUENCE_PROJECTION_RIDGE_FLOOR);
 
     let residualized = residualize_influence_columns(&z_infl, marginal_design, w_metric, eps);
     if residualized.iter().any(|v| !v.is_finite()) {

--- a/src/families/survival_marginal_slope.rs
+++ b/src/families/survival_marginal_slope.rs
@@ -5787,8 +5787,7 @@ impl SurvivalMarginalSlopeFamily {
         if self.influence_absorber.is_none() {
             return Ok(None);
         }
-        let idx =
-            3 + usize::from(self.score_warp.is_some()) + usize::from(self.link_dev.is_some());
+        let idx = 3 + usize::from(self.score_warp.is_some()) + usize::from(self.link_dev.is_some());
         block_states
             .get(idx)
             .map(|state| Some(&state.beta))
@@ -5803,9 +5802,10 @@ impl SurvivalMarginalSlopeFamily {
         row: usize,
         block_states: &[ParameterBlockState],
     ) -> Result<f64, String> {
-        let (Some(z_tilde), Some(gamma)) =
-            (self.influence_absorber.as_ref(), self.flex_influence_beta(block_states)?)
-        else {
+        let (Some(z_tilde), Some(gamma)) = (
+            self.influence_absorber.as_ref(),
+            self.flex_influence_beta(block_states)?,
+        ) else {
             return Ok(0.0);
         };
         if gamma.len() != z_tilde.ncols() {
@@ -13623,9 +13623,7 @@ impl crate::families::marginal_slope_shared::MarginalSlopePsiFamily
         )
     }
 
-    fn psi_first_order_terms_all(
-        &self,
-    ) -> Result<Option<Vec<ExactNewtonJointPsiTerms>>, String> {
+    fn psi_first_order_terms_all(&self) -> Result<Option<Vec<ExactNewtonJointPsiTerms>>, String> {
         let total: usize = self.derivative_blocks.iter().map(Vec::len).sum();
         if total == 0 {
             return Ok(Some(Vec::new()));
@@ -20077,11 +20075,11 @@ pub fn fit_survival_marginal_slope_terms(
     let influence_absorber_residualized: Option<Array2<f64>> =
         if let Some(jac) = spec.score_influence_jacobian.as_ref() {
             use crate::families::marginal_slope_orthogonal::{
-                influence_block_design, residualize_influence_columns, ScoreInfluenceJacobian,
+                ScoreInfluenceJacobian, residualized_influence_block,
             };
-            let marginal_dense = marginal_design
-                .design
-                .try_to_dense_by_chunks("survival marginal-slope influence-absorber marginal span")?;
+            let marginal_dense = marginal_design.design.try_to_dense_by_chunks(
+                "survival marginal-slope influence-absorber marginal span",
+            )?;
             // Realized leakage directions `Z_infl = diag(s_f·β̂₀)·J` via the core
             // builder; `β̂₀(x_i)` is the rigid-pilot logslope and `s_f =
             // probit_scale`. `influence_block_design` reads only `columns`; the
@@ -20091,37 +20089,16 @@ pub fn fit_survival_marginal_slope_terms(
                 z: z_primary.clone(),
             };
             let rigid_logslope_at_rows = &spec.logslope_offset + baseline_slope;
-            let z_infl =
-                influence_block_design(&jacobian, &rigid_logslope_at_rows, probit_scale);
-            // Marginal-Gram ridge scaled to the weighted Gram's own magnitude so
-            // the projection solve stays stable when the marginal design is
-            // rank-deficient at the pilot, without perturbing a well-conditioned
-            // projection. Identical scaling to the BMS absorber site (single
-            // source of truth for the residualization math is
-            // `residualize_influence_columns`; only this caller-side ridge scale
-            // is shared by value).
-            let gram_scale = (0..marginal_dense.ncols())
-                .map(|j| {
-                    (0..marginal_dense.nrows())
-                        .map(|i| {
-                            cross_block_pilot_w[i] * marginal_dense[[i, j]] * marginal_dense[[i, j]]
-                        })
-                        .sum::<f64>()
-                })
-                .fold(0.0_f64, f64::max);
-            let eps = (gram_scale * 1e-10).max(1e-12);
-            let residualized = residualize_influence_columns(
-                &z_infl,
+            let residualized = residualized_influence_block(
+                &jacobian,
+                &rigid_logslope_at_rows,
+                probit_scale,
                 marginal_dense.view(),
                 &cross_block_pilot_w,
-                eps,
-            );
-            if residualized.iter().any(|v| !v.is_finite()) {
-                return Err(SurvivalMarginalSlopeError::NumericalFailure {
-                    reason: "survival influence-absorber residualized columns contain non-finite entries".to_string(),
-                }
-                .into());
-            }
+            )
+            .map_err(|reason| SurvivalMarginalSlopeError::NumericalFailure {
+                reason: format!("survival influence-absorber {reason}"),
+            })?;
             Some(residualized)
         } else {
             None

--- a/src/gpu/backend_probe.rs
+++ b/src/gpu/backend_probe.rs
@@ -26,9 +26,7 @@
 //! there is no transitional shim.
 
 #[cfg(target_os = "linux")]
-pub(crate) use linux::{
-    CudaBackendContext, CudaBackendParts, probe_backend_with_compile, probe_cuda_backend,
-};
+pub(crate) use linux::{CudaBackendContext, probe_backend_with_compile, probe_cuda_backend};
 
 #[cfg(target_os = "linux")]
 mod linux {

--- a/src/inference/mod.rs
+++ b/src/inference/mod.rs
@@ -15,6 +15,7 @@ pub mod posterior;
 pub mod posterior_bands;
 pub mod predict;
 pub mod probability;
+pub mod psis;
 pub mod quadrature;
 pub mod sample;
 pub mod smooth_test;

--- a/src/inference/psis.rs
+++ b/src/inference/psis.rs
@@ -1,0 +1,148 @@
+//! Pareto-smoothed importance-sampling utilities.
+//!
+//! The implementation is intentionally self-contained: it estimates the
+//! generalized-Pareto tail shape `k` from the largest positive weights and
+//! replaces only that empirical tail by monotone GPD expected quantiles.  The
+//! returned `k_hat` is the same stability diagnostic used by PSIS-LOO: values
+//! near zero indicate light tails; values above roughly `0.5` indicate that a
+//! few observations dominate the estimate.
+
+#[derive(Debug, Clone)]
+pub struct PsisResult {
+    pub smoothed: Vec<f64>,
+    pub k_hat: f64,
+    pub tail_start: usize,
+    pub tail_count: usize,
+}
+
+const MIN_TAIL_COUNT: usize = 5;
+const MAX_TAIL_FRACTION: f64 = 0.2;
+
+/// Pareto-smooth a non-negative weight vector and report the fitted GPD tail
+/// shape.  Non-tail observations are left bit-identical; only the largest tail
+/// observations are replaced by sorted GPD expected quantiles and then clipped
+/// to be non-decreasing in the original sorted order.
+pub fn pareto_smooth_weights(weights: &[f64]) -> Option<PsisResult> {
+    if weights.len() < MIN_TAIL_COUNT * 2 || weights.iter().any(|w| !w.is_finite() || *w < 0.0) {
+        return None;
+    }
+    let mut indexed: Vec<(usize, f64)> = weights.iter().copied().enumerate().collect();
+    indexed.sort_by(|a, b| a.1.total_cmp(&b.1));
+    let n = indexed.len();
+    let tail_count = ((n as f64).sqrt().ceil() as usize)
+        .max(MIN_TAIL_COUNT)
+        .min(((MAX_TAIL_FRACTION * n as f64).ceil() as usize).max(MIN_TAIL_COUNT))
+        .min(n - 1);
+    let tail_start = n - tail_count;
+    let threshold = indexed[tail_start - 1].1;
+    let excesses: Vec<f64> = indexed[tail_start..]
+        .iter()
+        .map(|(_, w)| (w - threshold).max(0.0))
+        .collect();
+    let (k_hat, sigma_hat) = fit_gpd_moments(&excesses)?;
+    let mut smoothed = weights.to_vec();
+    let mut previous = threshold;
+    for (rank, (original_idx, _)) in indexed[tail_start..].iter().enumerate() {
+        let p = (rank as f64 + 0.5) / tail_count as f64;
+        let q = threshold + gpd_quantile(p, k_hat, sigma_hat).max(0.0);
+        let monotone = q.max(previous);
+        smoothed[*original_idx] = monotone;
+        previous = monotone;
+    }
+    Some(PsisResult {
+        smoothed,
+        k_hat,
+        tail_start,
+        tail_count,
+    })
+}
+
+/// Fit a generalized-Pareto distribution to positive excesses by the analytic
+/// method-of-moments identities `E[X]=σ/(1-k)` and
+/// `Var[X]=σ²/((1-k)²(1-2k))`.
+pub fn fit_gpd_moments(excesses: &[f64]) -> Option<(f64, f64)> {
+    let positives: Vec<f64> = excesses
+        .iter()
+        .copied()
+        .filter(|x| x.is_finite() && *x > 0.0)
+        .collect();
+    if positives.len() < MIN_TAIL_COUNT {
+        return None;
+    }
+    let n = positives.len() as f64;
+    let mean = positives.iter().sum::<f64>() / n;
+    if !(mean.is_finite() && mean > 0.0) {
+        return None;
+    }
+    let var = positives
+        .iter()
+        .map(|x| {
+            let centered = *x - mean;
+            centered * centered
+        })
+        .sum::<f64>()
+        / n.max(1.0);
+    if !(var.is_finite() && var > 0.0) {
+        return None;
+    }
+    let k = (0.5 * (1.0 - mean * mean / var)).clamp(-0.5, 0.95);
+    let sigma = (mean * (1.0 - k)).max(f64::MIN_POSITIVE);
+    Some((k, sigma))
+}
+
+#[inline]
+fn gpd_quantile(p: f64, k: f64, sigma: f64) -> f64 {
+    let survival = (1.0 - p).clamp(1e-12, 1.0);
+    if k.abs() < 1e-8 {
+        -sigma * survival.ln()
+    } else {
+        sigma * (survival.powf(-k) - 1.0) / k
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn gpd_sample(u: f64, k: f64, sigma: f64) -> f64 {
+        if k.abs() < 1e-12 {
+            -sigma * (1.0 - u).ln()
+        } else {
+            sigma * ((1.0 - u).powf(-k) - 1.0) / k
+        }
+    }
+
+    #[test]
+    fn psis_k_hat_recovers_known_generalized_pareto_tail() {
+        let k_true = 0.35_f64;
+        let sigma = 1.7_f64;
+        let mut xs = Vec::new();
+        for i in 1..=10_000 {
+            let u = (i as f64 - 0.5) / 10_000.0;
+            xs.push(gpd_sample(u, k_true, sigma));
+        }
+        let (k_hat, sigma_hat) = fit_gpd_moments(&xs).expect("GPD fit should succeed");
+        assert!(
+            (k_hat - k_true).abs() < 0.03,
+            "k_hat={k_hat}, k_true={k_true}"
+        );
+        assert!(
+            (sigma_hat - sigma).abs() < 0.08,
+            "sigma_hat={sigma_hat}, sigma={sigma}"
+        );
+    }
+
+    #[test]
+    fn pareto_smoothing_preserves_nontail_and_reports_heavy_tail() {
+        let mut w = vec![1.0; 80];
+        for j in 0..20 {
+            w.push(1.0 + (j as f64 + 1.0).powf(2.0));
+        }
+        let out = pareto_smooth_weights(&w).expect("PSIS should fit a positive tail");
+        assert_eq!(out.smoothed[0], 1.0);
+        assert!(
+            out.k_hat > 0.2,
+            "heavy synthetic tail should have positive k"
+        );
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,8 +92,8 @@ pub use geometry::{
 };
 pub use gpu::GpuPolicy;
 pub use inference::{
-    alo, conformal, data, generative, hmc, polya_gamma, predict, probability, quadrature, sample,
-    smooth_test,
+    alo, conformal, data, generative, hmc, polya_gamma, predict, probability, psis, quadrature,
+    sample, smooth_test,
 };
 pub use linalg::{faer_ndarray, matrix, utils};
 pub use resource::{
@@ -123,9 +123,10 @@ pub use solver::workflow::{
     CtnStage1Recipe, FitConfig, FitRequest, FitResult, GaussianLocationScaleFitRequest,
     LatentBinaryFitRequest, LatentSurvivalFitRequest, LinkWiggleConfig, MaterializedModel,
     PreparedSurvivalTimeStack, StandardBinomialWiggleConfig, StandardFitRequest, StandardFitResult,
-    SurvivalLocationScaleFitRequest, SurvivalLocationScaleFitResult, SurvivalMarginalSlopeFitRequest,
-    SurvivalTransformationFitRequest, SurvivalTransformationFitResult,
-    SurvivalTransformationTermSpec, TransformationNormalFitRequest, WorkflowError, fit_from_formula,
-    fit_model, is_binary_response, materialize, prepare_survival_time_stack, resolve_family,
-    resolve_offset_column, resolve_weight_column,
+    SurvivalLocationScaleFitRequest, SurvivalLocationScaleFitResult,
+    SurvivalMarginalSlopeFitRequest, SurvivalTransformationFitRequest,
+    SurvivalTransformationFitResult, SurvivalTransformationTermSpec,
+    TransformationNormalFitRequest, WorkflowError, fit_from_formula, fit_model, is_binary_response,
+    materialize, prepare_survival_time_stack, resolve_family, resolve_offset_column,
+    resolve_weight_column,
 };

--- a/src/solver/reml/runtime.rs
+++ b/src/solver/reml/runtime.rs
@@ -72,6 +72,53 @@ const ACTIVE_CONSTRAINT_SLACK_TOL: f64 = 1e-8;
 // because we are comparing squared-norm residuals after subtraction.
 const ORTHONORM_DROP_TOL: f64 = 1e-10;
 
+#[derive(Debug, Clone)]
+struct AloStabilizationEval {
+    cost: f64,
+    gradient: Option<Array1<f64>>,
+    k_hat: Option<f64>,
+    max_leverage: f64,
+    min_denominator: f64,
+}
+
+const ALO_STABILIZATION_MIN_N: usize = 20;
+const ALO_DENOM_INSTABILITY_THRESHOLD: f64 = 0.20;
+const ALO_MAX_LEVERAGE_THRESHOLD: f64 = 0.80;
+const ALO_TAU: f64 = 0.5;
+const ALO_GAMMA: f64 = 0.5;
+const ALO_GRADIENT_MAX_WORK: usize = 4_000_000;
+
+fn alo_leverage_barrier(h: f64) -> f64 {
+    let excess = (h - ALO_MAX_LEVERAGE_THRESHOLD).max(0.0);
+    excess * excess
+}
+
+fn alo_leverage_barrier_derivative(h: f64) -> f64 {
+    if h > ALO_MAX_LEVERAGE_THRESHOLD {
+        2.0 * (h - ALO_MAX_LEVERAGE_THRESHOLD)
+    } else {
+        0.0
+    }
+}
+
+fn gaussian_alo_deviance(y: f64, eta_loo: f64, prior_weight: f64, phi: f64) -> f64 {
+    let residual = y - eta_loo;
+    prior_weight * residual * residual / phi.max(f64::MIN_POSITIVE)
+}
+
+fn transformed_penalty_matvec(
+    penalty: &crate::construction::CanonicalPenalty,
+    beta: &Array1<f64>,
+) -> Array1<f64> {
+    let mut out = Array1::<f64>::zeros(beta.len());
+    let beta_block = beta.slice(ndarray::s![penalty.col_range.clone()]);
+    let centered = &beta_block - &penalty.prior_mean;
+    let local = penalty.local.dot(&centered);
+    out.slice_mut(ndarray::s![penalty.col_range.clone()])
+        .assign(&local);
+    out
+}
+
 static OUTER_IFT_RESIDUAL_ENERGY: OnceLock<Mutex<HashMap<Vec<u64>, (f64, u64)>>> = OnceLock::new();
 static OUTER_IFT_RESIDUAL_ENERGY_ITER: AtomicU64 = AtomicU64::new(0);
 
@@ -8694,6 +8741,214 @@ impl<'a> RemlState<'a> {
         }
     }
 
+    fn apply_alo_stabilization_to_result(
+        &self,
+        rho: &Array1<f64>,
+        bundle: &EvalShared,
+        mode: super::unified::EvalMode,
+        mut result: super::unified::RemlLamlResult,
+    ) -> Result<super::unified::RemlLamlResult, EstimationError> {
+        let want_gradient = mode != super::unified::EvalMode::ValueOnly;
+        let Some(alo_eval) = self.alo_stabilization_eval(rho, bundle, want_gradient)? else {
+            return Ok(result);
+        };
+        result.cost += alo_eval.cost;
+        if want_gradient {
+            match (result.gradient.as_mut(), alo_eval.gradient.as_ref()) {
+                (Some(gradient), Some(alo_gradient)) if gradient.len() >= alo_gradient.len() => {
+                    for idx in 0..alo_gradient.len() {
+                        gradient[idx] += alo_gradient[idx];
+                    }
+                    result.hessian = HessianResult::Unavailable;
+                }
+                _ => {
+                    log::warn!(
+                        "[ALO-STABILIZED-REML] unstable ALO detected but analytic gradient augmentation                          was unavailable; retaining REML gradient and adding value term only                          (n={} max_h={:.3} min_denom={:.3})",
+                        self.y.len(),
+                        alo_eval.max_leverage,
+                        alo_eval.min_denominator,
+                    );
+                }
+            }
+        }
+        log::info!(
+            "[ALO-STABILIZED-REML] active cost_add={:.6e} max_h={:.3} min_denom={:.3} k_hat={:?}",
+            alo_eval.cost,
+            alo_eval.max_leverage,
+            alo_eval.min_denominator,
+            alo_eval.k_hat,
+        );
+        Ok(result)
+    }
+
+    fn alo_stabilization_eval(
+        &self,
+        rho: &Array1<f64>,
+        bundle: &EvalShared,
+        want_gradient: bool,
+    ) -> Result<Option<AloStabilizationEval>, EstimationError> {
+        if self.config.firth_bias_reduction
+            || !matches!(
+                self.config.likelihood.spec.response,
+                ResponseFamily::Gaussian
+            )
+            || !matches!(self.config.link_function(), LinkFunction::Identity)
+            || !matches!(
+                bundle.pirls_result.coordinate_frame,
+                pirls::PirlsCoordinateFrame::TransformedQs
+            )
+            || bundle.backend_kind() == GeometryBackendKind::SparseExactSpd
+        {
+            return Ok(None);
+        }
+        let n = self.y.len();
+        if n < ALO_STABILIZATION_MIN_N {
+            return Ok(None);
+        }
+        let alo = crate::inference::alo::compute_alo_diagnostics_from_pirls(
+            bundle.pirls_result.as_ref(),
+            self.y,
+            self.config.link_function(),
+        )?;
+        let max_leverage = alo
+            .leverage
+            .iter()
+            .copied()
+            .fold(0.0_f64, |acc, h| acc.max(h));
+        let min_denominator = alo
+            .leverage
+            .iter()
+            .copied()
+            .map(|h| 1.0 - h)
+            .fold(f64::INFINITY, |acc, d| acc.min(d));
+        if max_leverage < ALO_MAX_LEVERAGE_THRESHOLD
+            && min_denominator > ALO_DENOM_INSTABILITY_THRESHOLD
+        {
+            return Ok(None);
+        }
+
+        let raw_influence: Vec<f64> = alo
+            .leverage
+            .iter()
+            .copied()
+            .map(|h| h.max(0.0) / (1.0 - h).max(1e-12))
+            .collect();
+        let psis = crate::inference::psis::pareto_smooth_weights(&raw_influence);
+        let smoothed_influence = psis
+            .as_ref()
+            .map(|p| p.smoothed.as_slice())
+            .unwrap_or(raw_influence.as_slice());
+        let mean_influence =
+            smoothed_influence.iter().sum::<f64>() / smoothed_influence.len() as f64;
+        let influence_scale: Vec<f64> = smoothed_influence
+            .iter()
+            .map(|w| (*w / mean_influence.max(f64::MIN_POSITIVE)).clamp(0.25, 4.0))
+            .collect();
+        let phi = match self.config.likelihood.scale.fixed_phi() {
+            Some(phi) if phi.is_finite() && phi > 0.0 => phi,
+            Some(_) => 1.0,
+            None => {
+                let dp = bundle.pirls_result.deviance + bundle.pirls_result.stable_penalty_term;
+                let denom = (n as f64 - bundle.pirls_result.edf).max(1.0);
+                (dp / denom).max(f64::MIN_POSITIVE)
+            }
+        };
+        let mut cost = 0.0_f64;
+        for i in 0..n {
+            cost += ALO_TAU * alo_leverage_barrier(alo.leverage[i]);
+            cost += ALO_GAMMA
+                * influence_scale[i]
+                * gaussian_alo_deviance(self.y[i], alo.eta_tilde[i], self.weights[i], phi);
+        }
+        if !(cost.is_finite() && cost >= 0.0) {
+            return Ok(None);
+        }
+        let gradient = if want_gradient
+            && rho.len()
+                == bundle
+                    .pirls_result
+                    .reparam_result
+                    .canonical_transformed
+                    .len()
+            && n.saturating_mul(bundle.pirls_result.beta_transformed.as_ref().len())
+                <= ALO_GRADIENT_MAX_WORK
+        {
+            self.alo_stabilization_gradient(rho, bundle, &alo, &influence_scale, phi)?
+        } else {
+            None
+        };
+        Ok(Some(AloStabilizationEval {
+            cost,
+            gradient,
+            k_hat: psis.as_ref().map(|p| p.k_hat),
+            max_leverage,
+            min_denominator,
+        }))
+    }
+
+    fn alo_stabilization_gradient(
+        &self,
+        rho: &Array1<f64>,
+        bundle: &EvalShared,
+        alo: &crate::inference::alo::AloDiagnostics,
+        influence_scale: &[f64],
+        phi: f64,
+    ) -> Result<Option<Array1<f64>>, EstimationError> {
+        let x = bundle.pirls_result.x_transformed.to_dense();
+        let h = bundle
+            .pirls_result
+            .dense_stabilizedhessian_transformed("ALO-stabilized REML gradient")?;
+        let chol = match h.cholesky(Side::Lower) {
+            Ok(chol) => chol,
+            Err(_) => return Ok(None),
+        };
+        let mut h_inv_xt = x.t().to_owned();
+        chol.solve_mat_in_place(&mut h_inv_xt);
+        let beta = bundle.pirls_result.beta_transformed.as_ref();
+        let k = rho.len();
+        let mut grad = Array1::<f64>::zeros(k);
+        for penalty_idx in 0..k {
+            let lambda = rho[penalty_idx].exp();
+            let sbeta = transformed_penalty_matvec(
+                &bundle.pirls_result.reparam_result.canonical_transformed[penalty_idx],
+                beta,
+            )
+            .mapv(|v| lambda * v);
+            let mut mode_deriv = chol.solvevec(&sbeta);
+            mode_deriv.mapv_inplace(|v| -v);
+            let eta_deriv = x.dot(&mode_deriv);
+
+            let mut leverage_deriv = Array1::<f64>::zeros(x.nrows());
+            for i in 0..x.nrows() {
+                let m_i = h_inv_xt.column(i);
+                let penalty_m = transformed_penalty_matvec(
+                    &bundle.pirls_result.reparam_result.canonical_transformed[penalty_idx],
+                    &m_i.to_owned(),
+                );
+                leverage_deriv[i] = -self.weights[i] * lambda * m_i.dot(&penalty_m);
+            }
+
+            let mut gk = 0.0_f64;
+            for i in 0..x.nrows() {
+                let h_i = alo.leverage[i];
+                let denom = (1.0 - h_i).max(1e-12);
+                let residual = self.y[i] - bundle.pirls_result.final_eta[i];
+                let deta_loo =
+                    eta_deriv[i] / denom - residual * leverage_deriv[i] / (denom * denom);
+                let dev_eta_grad = -2.0 * self.weights[i] * (self.y[i] - alo.eta_tilde[i])
+                    / phi.max(f64::MIN_POSITIVE);
+                gk += ALO_TAU * alo_leverage_barrier_derivative(h_i) * leverage_deriv[i];
+                gk += ALO_GAMMA * influence_scale[i] * dev_eta_grad * deta_loo;
+            }
+            grad[penalty_idx] = gk;
+        }
+        if grad.iter().all(|g| g.is_finite()) {
+            Ok(Some(grad))
+        } else {
+            Ok(None)
+        }
+    }
+
     /// Build the soft prior tuple for the given mode.
     fn build_prior(
         &self,
@@ -8748,6 +9003,7 @@ impl<'a> RemlState<'a> {
         )
         .map_err(EstimationError::InvalidInput)?;
         let result = self.apply_tk_to_result(result, tk_terms)?;
+        let result = self.apply_alo_stabilization_to_result(rho, bundle, mode, result)?;
         self.store_ift_mode_response_cache_from_result(rho, bundle, &result);
         if let Some(polish_step) = result.inner_polish_step.as_ref() {
             self.apply_inner_polish_step_to_warm_start(bundle, &solution_beta, polish_step);


### PR DESCRIPTION
**Summary**
* Added a self-contained PSIS utility that fits a generalized-Pareto tail via analytic moments, Pareto-smooths only the empirical tail, exposes `k_hat`, and includes targeted tests for known-tail recovery and heavy-tail smoothing behavior. 

* Exported the new PSIS module through the Rust inference API so the REML runtime can use it without duplicating tail logic. 

* Wired ALO stabilization into the single unified REML/LAML assembly path, after the existing REML/TK evaluation and before downstream mode-response/cache handling, so all standard dense REML callers flow through the same objective augmentation. 

* Added automatic activation gates for Gaussian identity REML only, using existing ALO diagnostics and derived leverage/denominator instability thresholds; low-leverage clean fits return without changing the objective. 

* Reused existing ALO leverage and ALO-corrected predictors, then added the influence objective term with PSIS-smoothed influence weights and the Gaussian ALO deviance contribution. 

* Added an analytic first-order gradient contribution for the dense Gaussian path, including the implicit mode derivative, leverage derivative, and ALO-corrected predictor derivative; the Hessian is marked unavailable when this first-order term is added. 

* Routed BMS and survival marginal-slope influence-block residualization through the existing shared helper to satisfy the repo’s single-source-of-truth/build-ban checks instead of leaving duplicated caller-side projection code. 

* Removed an unused Linux GPU backend re-export that the build-ban/`-D warnings` path surfaced during verification. 


**Testing**
* ❌ `set -o pipefail; cargo test psis_k_hat_recovers_known_generalized_pareto_tail --lib 2>&1 | tee /tmp/gam-test-psis-pipefail.log` — failed before running the PSIS test because the current branch has unrelated compile blockers, including missing `BlockHessianAccumulator::new(..., p_i)` arguments in `src/families/survival_marginal_slope.rs`, missing `Debug` on `CtnStage1Recipe` in `src/solver/workflow.rs`, Duchon collocation call-signature mismatches in `src/terms/basis.rs`, and a non-exhaustive `HessBlock::Influence` match.
* ❌ `set -o pipefail; cargo build 2>&1 | tee /tmp/gam-build.log` — failed on the same unrelated compile blockers before completing a build.

Committed changes on the current branch and created the PR record.

Closes #462