### PR TITLE
Verify slop cleanup of estimator modules

### DIFF
--- a/src/families/bms/block_specs.rs
+++ b/src/families/bms/block_specs.rs
@@ -317,7 +317,9 @@ fn widen_marginal_beta_hint(
         } else {
             let mut widened = Array1::<f64>::zeros(p_marginal_widened);
             let copy = hint.len().min(p_marginal_widened);
-            widened.slice_mut(s![..copy]).assign(&hint.slice(s![..copy]));
+            widened
+                .slice_mut(s![..copy])
+                .assign(&hint.slice(s![..copy]));
             widened
         }
     })
@@ -341,7 +343,8 @@ fn build_marginal_blockspec_bms(
     let raw_marginal_dense = design
         .design
         .try_to_dense_arc("build_marginal_blockspec_bms::marginal")?;
-    let marginal_dense = widen_marginal_dense_with_influence(&raw_marginal_dense, influence_columns)?;
+    let marginal_dense =
+        widen_marginal_dense_with_influence(&raw_marginal_dense, influence_columns)?;
     let logslope_dense = logslope_design
         .design
         .try_to_dense_arc("build_marginal_blockspec_bms::logslope")?;
@@ -710,12 +713,13 @@ pub fn fit_bernoulli_marginal_slope_terms(
     // x-dependent realisation of `ψ − Π_η[ψ]`. `None` ⇒ raw z, and the free
     // score_warp spline below is the x-free-column fallback. β̂₀(x_i) is the
     // rigid-pilot logslope `baseline.1 + logslope_offset[i]`; s_f = probit_scale.
-    let influence_columns = if let Some(jac) =
-        spec.score_influence_jacobian.as_ref().filter(|j| j.ncols() > 0)
+    let influence_columns = if let Some(jac) = spec
+        .score_influence_jacobian
+        .as_ref()
+        .filter(|j| j.ncols() > 0)
     {
-        use crate::faer_ndarray::fast_xt_diag_x;
         use crate::families::marginal_slope_orthogonal::{
-            influence_block_design, residualize_influence_columns, ScoreInfluenceJacobian,
+            ScoreInfluenceJacobian, residualized_influence_block,
         };
         let marginal_dense_for_proj = marginal_design
             .design
@@ -737,33 +741,14 @@ pub fn fit_bernoulli_marginal_slope_terms(
             columns: (*jac).clone(),
             z: z_train.clone(),
         };
-        let z_infl = influence_block_design(&score_jac, &rigid_logslope_at_rows, probit_scale);
-        // Magnitude-scaled ridge for the weighted-Gram projection solve so a
-        // rank-deficient marginal design at the pilot stays solvable without
-        // perturbing a well-conditioned projection. Core's residualiser is
-        // infallible (the ridge guarantees invertibility); guard the final
-        // columns for finiteness here.
-        let p_m = marginal_dense.ncols();
-        let residualized = if p_m == 0 {
-            z_infl
-        } else {
-            let gram_diag = fast_xt_diag_x(marginal_dense, &cross_block_pilot_w_score_warp);
-            let gram_scale = (0..p_m).map(|i| gram_diag[[i, i]]).fold(0.0_f64, f64::max);
-            let eps = (gram_scale * 1e-10).max(1e-12);
-            let out = residualize_influence_columns(
-                &z_infl,
-                marginal_dense.view(),
-                &cross_block_pilot_w_score_warp,
-                eps,
-            );
-            if out.iter().any(|v| !v.is_finite()) {
-                return Err(
-                    "influence block: residualised influence columns contain non-finite entries"
-                        .to_string(),
-                );
-            }
-            out
-        };
+        let residualized = residualized_influence_block(
+            &score_jac,
+            &rigid_logslope_at_rows,
+            probit_scale,
+            marginal_dense.view(),
+            &cross_block_pilot_w_score_warp,
+        )
+        .map_err(|err| format!("influence block: {err}"))?;
         Some(residualized)
     } else {
         None

--- a/src/families/marginal_slope_orthogonal.rs
+++ b/src/families/marginal_slope_orthogonal.rs
@@ -120,9 +120,7 @@ pub fn score_influence_jacobian(
         .fit
         .block_states
         .first()
-        .ok_or_else(|| {
-            "score_influence_jacobian: fitted CTN has no block states".to_string()
-        })?
+        .ok_or_else(|| "score_influence_jacobian: fitted CTN has no block states".to_string())?
         .beta;
     if beta.len() != p1 {
         return Err(format!(
@@ -157,10 +155,9 @@ pub fn score_influence_jacobian(
             cov_design.design.ncols()
         ));
     }
-    let x_cov = cov_design
-        .design
-        .try_row_chunk(0..n)
-        .map_err(|e| format!("score_influence_jacobian: covariate design materialization failed: {e}"))?;
+    let x_cov = cov_design.design.try_row_chunk(0..n).map_err(|e| {
+        format!("score_influence_jacobian: covariate design materialization failed: {e}")
+    })?;
 
     // γ_k(x_i) = Σ_j Xᶜᵒᵛ_{i,j}·Γ[k,j]  ⇒  gamma = Xᶜᵒᵛ · Γᵀ  (n × p_resp).
     let gamma = fast_abt(&x_cov, &beta_mat);
@@ -283,17 +280,15 @@ pub fn score_influence_jacobian(
                 let dl = dl_scalar * xij;
                 let du = du_scalar * xij;
                 // ∂u = [φ(h)∂h − u·(φ(U)∂U − φ(L)∂L) − φ(L)∂L] / (Φ(U)−Φ(L))
-                let du_pit = (pdf_h * dh - u_pit * (pdf_u * du - pdf_l * dl) - pdf_l * dl)
-                    / denom_mass;
+                let du_pit =
+                    (pdf_h * dh - u_pit * (pdf_u * du - pdf_l * dl) - pdf_l * dl) / denom_mass;
                 row[base + j] = du_pit / pdf_z;
             }
         }
     }
 
     if columns.iter().any(|v| !v.is_finite()) {
-        return Err(
-            "score_influence_jacobian: produced non-finite Jacobian entries".to_string(),
-        );
+        return Err("score_influence_jacobian: produced non-finite Jacobian entries".to_string());
     }
     if z_scores.iter().any(|v| !v.is_finite()) {
         return Err("score_influence_jacobian: produced non-finite z scores".to_string());
@@ -324,7 +319,7 @@ pub fn influence_block_design(
     s_f: f64,
 ) -> Array2<f64> {
     let n = jac.columns.nrows();
-    debug_assert_eq!(
+    assert_eq!(
         pilot_beta0.len(),
         n,
         "influence_block_design: pilot_beta0 length must equal Jacobian rows"
@@ -363,12 +358,12 @@ pub(crate) fn residualize_influence_columns(
     eps: f64,
 ) -> Array2<f64> {
     let n = marginal_design.nrows();
-    debug_assert_eq!(
+    assert_eq!(
         z_infl.nrows(),
         n,
         "residualize_influence_columns: Z_infl rows must equal marginal design rows"
     );
-    debug_assert_eq!(
+    assert_eq!(
         w_metric.len(),
         n,
         "residualize_influence_columns: row metric length must equal marginal design rows"
@@ -443,7 +438,8 @@ pub(crate) fn residualized_influence_block(
     let p_m = marginal_design.ncols();
     let gram = fast_xt_diag_x(&marginal_design, w_metric);
     let gram_scale = (0..p_m).map(|i| gram[[i, i]]).fold(0.0_f64, f64::max);
-    let eps = (gram_scale * INFLUENCE_PROJECTION_RELATIVE_RIDGE).max(INFLUENCE_PROJECTION_RIDGE_FLOOR);
+    let eps =
+        (gram_scale * INFLUENCE_PROJECTION_RELATIVE_RIDGE).max(INFLUENCE_PROJECTION_RIDGE_FLOOR);
 
     let residualized = residualize_influence_columns(&z_infl, marginal_design, w_metric, eps);
     if residualized.iter().any(|v| !v.is_finite()) {

--- a/src/families/survival_marginal_slope.rs
+++ b/src/families/survival_marginal_slope.rs
@@ -5787,8 +5787,7 @@ impl SurvivalMarginalSlopeFamily {
         if self.influence_absorber.is_none() {
             return Ok(None);
         }
-        let idx =
-            3 + usize::from(self.score_warp.is_some()) + usize::from(self.link_dev.is_some());
+        let idx = 3 + usize::from(self.score_warp.is_some()) + usize::from(self.link_dev.is_some());
         block_states
             .get(idx)
             .map(|state| Some(&state.beta))
@@ -5803,9 +5802,10 @@ impl SurvivalMarginalSlopeFamily {
         row: usize,
         block_states: &[ParameterBlockState],
     ) -> Result<f64, String> {
-        let (Some(z_tilde), Some(gamma)) =
-            (self.influence_absorber.as_ref(), self.flex_influence_beta(block_states)?)
-        else {
+        let (Some(z_tilde), Some(gamma)) = (
+            self.influence_absorber.as_ref(),
+            self.flex_influence_beta(block_states)?,
+        ) else {
             return Ok(0.0);
         };
         if gamma.len() != z_tilde.ncols() {
@@ -13623,9 +13623,7 @@ impl crate::families::marginal_slope_shared::MarginalSlopePsiFamily
         )
     }
 
-    fn psi_first_order_terms_all(
-        &self,
-    ) -> Result<Option<Vec<ExactNewtonJointPsiTerms>>, String> {
+    fn psi_first_order_terms_all(&self) -> Result<Option<Vec<ExactNewtonJointPsiTerms>>, String> {
         let total: usize = self.derivative_blocks.iter().map(Vec::len).sum();
         if total == 0 {
             return Ok(Some(Vec::new()));
@@ -20077,11 +20075,11 @@ pub fn fit_survival_marginal_slope_terms(
     let influence_absorber_residualized: Option<Array2<f64>> =
         if let Some(jac) = spec.score_influence_jacobian.as_ref() {
             use crate::families::marginal_slope_orthogonal::{
-                influence_block_design, residualize_influence_columns, ScoreInfluenceJacobian,
+                ScoreInfluenceJacobian, residualized_influence_block,
             };
-            let marginal_dense = marginal_design
-                .design
-                .try_to_dense_by_chunks("survival marginal-slope influence-absorber marginal span")?;
+            let marginal_dense = marginal_design.design.try_to_dense_by_chunks(
+                "survival marginal-slope influence-absorber marginal span",
+            )?;
             // Realized leakage directions `Z_infl = diag(s_f·β̂₀)·J` via the core
             // builder; `β̂₀(x_i)` is the rigid-pilot logslope and `s_f =
             // probit_scale`. `influence_block_design` reads only `columns`; the
@@ -20091,37 +20089,16 @@ pub fn fit_survival_marginal_slope_terms(
                 z: z_primary.clone(),
             };
             let rigid_logslope_at_rows = &spec.logslope_offset + baseline_slope;
-            let z_infl =
-                influence_block_design(&jacobian, &rigid_logslope_at_rows, probit_scale);
-            // Marginal-Gram ridge scaled to the weighted Gram's own magnitude so
-            // the projection solve stays stable when the marginal design is
-            // rank-deficient at the pilot, without perturbing a well-conditioned
-            // projection. Identical scaling to the BMS absorber site (single
-            // source of truth for the residualization math is
-            // `residualize_influence_columns`; only this caller-side ridge scale
-            // is shared by value).
-            let gram_scale = (0..marginal_dense.ncols())
-                .map(|j| {
-                    (0..marginal_dense.nrows())
-                        .map(|i| {
-                            cross_block_pilot_w[i] * marginal_dense[[i, j]] * marginal_dense[[i, j]]
-                        })
-                        .sum::<f64>()
-                })
-                .fold(0.0_f64, f64::max);
-            let eps = (gram_scale * 1e-10).max(1e-12);
-            let residualized = residualize_influence_columns(
-                &z_infl,
+            let residualized = residualized_influence_block(
+                &jacobian,
+                &rigid_logslope_at_rows,
+                probit_scale,
                 marginal_dense.view(),
                 &cross_block_pilot_w,
-                eps,
-            );
-            if residualized.iter().any(|v| !v.is_finite()) {
-                return Err(SurvivalMarginalSlopeError::NumericalFailure {
-                    reason: "survival influence-absorber residualized columns contain non-finite entries".to_string(),
-                }
-                .into());
-            }
+            )
+            .map_err(|err| SurvivalMarginalSlopeError::NumericalFailure {
+                reason: format!("survival influence-absorber {err}"),
+            })?;
             Some(residualized)
         } else {
             None

--- a/src/inference/conformal.rs
+++ b/src/inference/conformal.rs
@@ -31,10 +31,11 @@
 //! With `s_i ≡ 1` this is classic absolute-residual split conformal; with
 //! heteroscedastic `s_i` it is conformalized scale regression.
 //!
-//! CRITICAL: this uses the EXACT k-th order statistic (sort, take index
-//! `rank − 1`). It deliberately does NOT use the interpolating quantile in
-//! `crate::util::quantile` — linear interpolation between order statistics
-//! would void the finite-sample coverage proof.
+//! CRITICAL: this uses the EXACT k-th order statistic from
+//! [`crate::util::quantile::order_statistic`]. It deliberately does NOT use
+//! the interpolating [`crate::util::quantile::quantile_from_sorted`] — linear
+//! interpolation between order statistics would void the finite-sample coverage
+//! proof.
 //!
 //! # Where the calibration lives, and how it is wired
 //!
@@ -71,12 +72,13 @@
 //! coverage proof does not need.
 
 use crate::estimate::{EstimationError, UnifiedFitResult};
-use crate::families::strategy::strategy_for_spec;
 use crate::families::strategy::FamilyStrategy;
+use crate::families::strategy::strategy_for_spec;
 use crate::inference::alo::compute_alo_diagnostics_from_unified;
-use crate::inference::predict::interval_policy::ResponseBounds;
 use crate::inference::predict::PredictUncertaintyResult;
+use crate::inference::predict::interval_policy::ResponseBounds;
 use crate::types::{LikelihoodSpec, LinkFunction};
+use crate::util::quantile::order_statistic;
 use ndarray::{Array1, Array2, ArrayView1};
 
 /// The conformal nonconformity scores `e_i = |r_i| / s_i` for held-out
@@ -155,10 +157,8 @@ pub fn conformal_multiplier(
         // Too few calibration points to certify coverage at this level.
         return Ok(f64::INFINITY);
     }
-    let mut sorted: Vec<f64> = scores.iter().copied().collect();
-    sorted.sort_by(|a, b| a.partial_cmp(b).expect("scores are finite, checked above"));
-    // rank is 1-based; the k-th smallest is at index k − 1.
-    Ok(sorted[rank - 1])
+    let values: Vec<f64> = scores.iter().copied().collect();
+    Ok(order_statistic(&values, rank))
 }
 
 /// A fitted conformal calibrator: the single scalar `q̂` and the miscoverage
@@ -391,9 +391,12 @@ mod tests {
 
     #[test]
     fn calibrated_interval_is_symmetric_and_clamped() {
-        let calib =
-            ConformalCalibrator::from_residuals_and_scales(array![1.0].view(), array![1.0].view(), 0.5)
-                .expect("valid");
+        let calib = ConformalCalibrator::from_residuals_and_scales(
+            array![1.0].view(),
+            array![1.0].view(),
+            0.5,
+        )
+        .expect("valid");
         // n = 1, alpha = 0.5 → rank = ceil(2 * 0.5) = 1 → q̂ = score = 1.0.
         assert_eq!(calib.q_hat(), 1.0);
         let mean = array![0.5, 2.0];

--- a/src/util/quantile.rs
+++ b/src/util/quantile.rs
@@ -13,3 +13,26 @@ pub fn quantile_from_sorted(sorted: &[f64], q: f64) -> f64 {
     let frac = pos - lo as f64;
     sorted[lo] * (1.0 - frac) + sorted[hi] * frac
 }
+
+/// Exact 1-based order statistic from an already sorted slice.
+///
+/// Returns `NaN` when the slice is empty, `rank` is zero, or `rank` exceeds
+/// the number of observations. This is intentionally not an interpolating
+/// quantile: split-conformal calibration needs the observed `k`-th value to
+/// preserve the finite-sample coverage proof.
+pub fn order_statistic_from_sorted(sorted: &[f64], rank: usize) -> f64 {
+    if sorted.is_empty() || rank == 0 || rank > sorted.len() {
+        return f64::NAN;
+    }
+    sorted[rank - 1]
+}
+
+/// Exact 1-based order statistic from an unsorted slice.
+///
+/// This centralizes the sort+select path for code that needs an observed
+/// sample value rather than `quantile_from_sorted`'s linear interpolation.
+pub fn order_statistic(values: &[f64], rank: usize) -> f64 {
+    let mut sorted = values.to_vec();
+    sorted.sort_by(f64::total_cmp);
+    order_statistic_from_sorted(&sorted, rank)
+}


### PR DESCRIPTION
**Summary**
* Centralized the conformal exact order-statistic path in `src/util/quantile.rs` with `order_statistic_from_sorted` and `order_statistic`, keeping it explicitly non-interpolating so it remains distinct from `quantile_from_sorted`. 

* Routed `conformal_multiplier` through the shared quantile utility instead of maintaining its own bespoke score sort, while preserving the exact conformal rank calculation and `+∞` behavior for too-small calibration sets. 

* Updated the conformal module documentation to state the intentional split: conformal uses exact observed order statistics, not the interpolating quantile. 

* Removed duplicated influence-residualization caller logic by routing both BMS and survival marginal-slope influence absorbers through the shared `residualized_influence_block` core. 

* Hardened the shared influence-block core by replacing debug-only shape checks with real assertions and keeping the scaled-ridge residualization/finiteness validation as the single source of truth. 

* Confirmed the #464 audit disposition on the current tree: stochastic trace is integrated in REML unified machinery, not a standalone module. 

* Confirmed the rho-marginalized core lives directly in evidence code via `ift_dbeta_drho`, with a surviving direct-cache test. 

* Confirmed posterior-SNR weighting is folded into smooth Charbonnier state and wired through the adaptive-weight path, with objective quality assertions for noise suppression and edge preservation. 

* Confirmed topology selection remains winner-take-all ranking by `tk_normalized_score`, with no stacking path reintroduced. 


Committed changes:
* `54b224c Clean estimator audit remnants`

PR created:
* **Clean estimator audit remnants**

**Testing**
* ✅ `git diff --check`
* ✅ `find src -path '*stochastic_trace.rs' -o -path '*rho_marginalized.rs' -o -path '*stacking.rs' -o -path '*posterior_snr_weights.rs'`
* ✅ `rg -n "pub mod (stochastic_trace|rho_marginalized|stacking|posterior_snr_weights)|mod (stochastic_trace|rho_marginalized|stacking|posterior_snr_weights)|Stacking|posterior_snr_weights|rho_marginalized" src tests -S`
* ✅ `rg -n "sorted\\.sort_by\\(|sort_by\\(\\|a, b\\| a\\.partial_cmp\\(b\\).*scores" src/inference/conformal.rs -S`
* ✅ `rg -n "StochasticTraceState|pub struct StochasticTraceEstimator|ift_dbeta_drho|surrogateweights_posterior_snr|tk_normalized_score|order_statistic\\(" src/solver/reml/unified.rs src/solver/evidence.rs src/terms/smooth.rs src/solver/topology_selector.rs src/inference/conformal.rs src/util/quantile.rs -S`
* ⚠️ `cargo build` — blocked by unrelated current-main compilation failures, including unused `CudaBackendParts`, incomplete survival influence Hessian constructor call sites, missing `Debug` for `CtnStage1Recipe`, and non-exhaustive `HessBlock::Influence` matching.
* ⚠️ `cargo test conformal_multiplier --lib` — blocked by the same unrelated current-main compilation failures before the conformal tests could run.
* ⚠️ `cargo test multiplier_is_exact_order_statistic --lib` — blocked by the same unrelated current-main compilation failures before the targeted conformal test could run.

Closes #464