### PR TITLE
Fix Duchon smoother sharpness gap

### DIFF
--- a/src/families/bms/block_specs.rs
+++ b/src/families/bms/block_specs.rs
@@ -317,7 +317,9 @@ fn widen_marginal_beta_hint(
         } else {
             let mut widened = Array1::<f64>::zeros(p_marginal_widened);
             let copy = hint.len().min(p_marginal_widened);
-            widened.slice_mut(s![..copy]).assign(&hint.slice(s![..copy]));
+            widened
+                .slice_mut(s![..copy])
+                .assign(&hint.slice(s![..copy]));
             widened
         }
     })
@@ -341,7 +343,8 @@ fn build_marginal_blockspec_bms(
     let raw_marginal_dense = design
         .design
         .try_to_dense_arc("build_marginal_blockspec_bms::marginal")?;
-    let marginal_dense = widen_marginal_dense_with_influence(&raw_marginal_dense, influence_columns)?;
+    let marginal_dense =
+        widen_marginal_dense_with_influence(&raw_marginal_dense, influence_columns)?;
     let logslope_dense = logslope_design
         .design
         .try_to_dense_arc("build_marginal_blockspec_bms::logslope")?;
@@ -710,12 +713,13 @@ pub fn fit_bernoulli_marginal_slope_terms(
     // x-dependent realisation of `ψ − Π_η[ψ]`. `None` ⇒ raw z, and the free
     // score_warp spline below is the x-free-column fallback. β̂₀(x_i) is the
     // rigid-pilot logslope `baseline.1 + logslope_offset[i]`; s_f = probit_scale.
-    let influence_columns = if let Some(jac) =
-        spec.score_influence_jacobian.as_ref().filter(|j| j.ncols() > 0)
+    let influence_columns = if let Some(jac) = spec
+        .score_influence_jacobian
+        .as_ref()
+        .filter(|j| j.ncols() > 0)
     {
-        use crate::faer_ndarray::fast_xt_diag_x;
         use crate::families::marginal_slope_orthogonal::{
-            influence_block_design, residualize_influence_columns, ScoreInfluenceJacobian,
+            ScoreInfluenceJacobian, residualized_influence_block,
         };
         let marginal_dense_for_proj = marginal_design
             .design
@@ -737,33 +741,14 @@ pub fn fit_bernoulli_marginal_slope_terms(
             columns: (*jac).clone(),
             z: z_train.clone(),
         };
-        let z_infl = influence_block_design(&score_jac, &rigid_logslope_at_rows, probit_scale);
-        // Magnitude-scaled ridge for the weighted-Gram projection solve so a
-        // rank-deficient marginal design at the pilot stays solvable without
-        // perturbing a well-conditioned projection. Core's residualiser is
-        // infallible (the ridge guarantees invertibility); guard the final
-        // columns for finiteness here.
-        let p_m = marginal_dense.ncols();
-        let residualized = if p_m == 0 {
-            z_infl
-        } else {
-            let gram_diag = fast_xt_diag_x(marginal_dense, &cross_block_pilot_w_score_warp);
-            let gram_scale = (0..p_m).map(|i| gram_diag[[i, i]]).fold(0.0_f64, f64::max);
-            let eps = (gram_scale * 1e-10).max(1e-12);
-            let out = residualize_influence_columns(
-                &z_infl,
-                marginal_dense.view(),
-                &cross_block_pilot_w_score_warp,
-                eps,
-            );
-            if out.iter().any(|v| !v.is_finite()) {
-                return Err(
-                    "influence block: residualised influence columns contain non-finite entries"
-                        .to_string(),
-                );
-            }
-            out
-        };
+        let residualized = residualized_influence_block(
+            &score_jac,
+            &rigid_logslope_at_rows,
+            probit_scale,
+            marginal_dense.view(),
+            &cross_block_pilot_w_score_warp,
+        )
+        .map_err(|err| format!("influence block: {err}"))?;
         Some(residualized)
     } else {
         None

--- a/src/families/marginal_slope_orthogonal.rs
+++ b/src/families/marginal_slope_orthogonal.rs
@@ -120,9 +120,7 @@ pub fn score_influence_jacobian(
         .fit
         .block_states
         .first()
-        .ok_or_else(|| {
-            "score_influence_jacobian: fitted CTN has no block states".to_string()
-        })?
+        .ok_or_else(|| "score_influence_jacobian: fitted CTN has no block states".to_string())?
         .beta;
     if beta.len() != p1 {
         return Err(format!(
@@ -157,10 +155,9 @@ pub fn score_influence_jacobian(
             cov_design.design.ncols()
         ));
     }
-    let x_cov = cov_design
-        .design
-        .try_row_chunk(0..n)
-        .map_err(|e| format!("score_influence_jacobian: covariate design materialization failed: {e}"))?;
+    let x_cov = cov_design.design.try_row_chunk(0..n).map_err(|e| {
+        format!("score_influence_jacobian: covariate design materialization failed: {e}")
+    })?;
 
     // γ_k(x_i) = Σ_j Xᶜᵒᵛ_{i,j}·Γ[k,j]  ⇒  gamma = Xᶜᵒᵛ · Γᵀ  (n × p_resp).
     let gamma = fast_abt(&x_cov, &beta_mat);
@@ -283,17 +280,15 @@ pub fn score_influence_jacobian(
                 let dl = dl_scalar * xij;
                 let du = du_scalar * xij;
                 // ∂u = [φ(h)∂h − u·(φ(U)∂U − φ(L)∂L) − φ(L)∂L] / (Φ(U)−Φ(L))
-                let du_pit = (pdf_h * dh - u_pit * (pdf_u * du - pdf_l * dl) - pdf_l * dl)
-                    / denom_mass;
+                let du_pit =
+                    (pdf_h * dh - u_pit * (pdf_u * du - pdf_l * dl) - pdf_l * dl) / denom_mass;
                 row[base + j] = du_pit / pdf_z;
             }
         }
     }
 
     if columns.iter().any(|v| !v.is_finite()) {
-        return Err(
-            "score_influence_jacobian: produced non-finite Jacobian entries".to_string(),
-        );
+        return Err("score_influence_jacobian: produced non-finite Jacobian entries".to_string());
     }
     if z_scores.iter().any(|v| !v.is_finite()) {
         return Err("score_influence_jacobian: produced non-finite z scores".to_string());
@@ -324,7 +319,7 @@ pub fn influence_block_design(
     s_f: f64,
 ) -> Array2<f64> {
     let n = jac.columns.nrows();
-    debug_assert_eq!(
+    assert_eq!(
         pilot_beta0.len(),
         n,
         "influence_block_design: pilot_beta0 length must equal Jacobian rows"
@@ -363,12 +358,12 @@ pub(crate) fn residualize_influence_columns(
     eps: f64,
 ) -> Array2<f64> {
     let n = marginal_design.nrows();
-    debug_assert_eq!(
+    assert_eq!(
         z_infl.nrows(),
         n,
         "residualize_influence_columns: Z_infl rows must equal marginal design rows"
     );
-    debug_assert_eq!(
+    assert_eq!(
         w_metric.len(),
         n,
         "residualize_influence_columns: row metric length must equal marginal design rows"
@@ -443,7 +438,8 @@ pub(crate) fn residualized_influence_block(
     let p_m = marginal_design.ncols();
     let gram = fast_xt_diag_x(&marginal_design, w_metric);
     let gram_scale = (0..p_m).map(|i| gram[[i, i]]).fold(0.0_f64, f64::max);
-    let eps = (gram_scale * INFLUENCE_PROJECTION_RELATIVE_RIDGE).max(INFLUENCE_PROJECTION_RIDGE_FLOOR);
+    let eps =
+        (gram_scale * INFLUENCE_PROJECTION_RELATIVE_RIDGE).max(INFLUENCE_PROJECTION_RIDGE_FLOOR);
 
     let residualized = residualize_influence_columns(&z_infl, marginal_design, w_metric, eps);
     if residualized.iter().any(|v| !v.is_finite()) {

--- a/src/families/survival_marginal_slope.rs
+++ b/src/families/survival_marginal_slope.rs
@@ -705,10 +705,6 @@ struct BlockSlices {
     logslope: std::ops::Range<usize>,
     score_warp: Option<std::ops::Range<usize>>,
     link_dev: Option<std::ops::Range<usize>>,
-    /// Absorbed Stage-1 influence block (#461), trailing the flex blocks. Its
-    /// width is `p₁` (the Stage-1 coefficient count), `None` when no CTN Stage-1
-    /// chain produced an influence Jacobian.
-    influence: Option<std::ops::Range<usize>>,
     total: usize,
 }
 
@@ -731,24 +727,18 @@ enum HessBlock {
     Logslope,
     ScoreWarp,
     LinkDev,
-    /// Absorbed Stage-1 influence block (#461). Placed LAST in the canonical
-    /// layout so the existing `score_warp` (index 3) / `link_dev` (index 4)
-    /// block-state positions are undisturbed; the absorber's coordinate range
-    /// trails them and its β is dropped at predict.
-    Influence,
 }
 
 impl HessBlock {
     /// Blocks in canonical coordinate-layout order. Iterating this array is how
     /// every assembler visits blocks; the order fixes floating-point
     /// accumulation order in the matvec / bilinear paths.
-    const ALL: [HessBlock; 6] = [
+    const ALL: [HessBlock; 5] = [
         HessBlock::Time,
         HessBlock::Marginal,
         HessBlock::Logslope,
         HessBlock::ScoreWarp,
         HessBlock::LinkDev,
-        HessBlock::Influence,
     ];
 }
 
@@ -763,7 +753,6 @@ impl BlockSlices {
             HessBlock::Logslope => Some(self.logslope.clone()),
             HessBlock::ScoreWarp => self.score_warp.clone(),
             HessBlock::LinkDev => self.link_dev.clone(),
-            HessBlock::Influence => self.influence.clone(),
         }
     }
 }
@@ -799,12 +788,12 @@ fn block_slices(
         range
     });
     // Absorbed influence block trails the flex blocks: its width is the
-    // Stage-1 coefficient count `p₁` (= `Z̃_infl.ncols()`).
-    let influence = family.influence_absorber.as_ref().map(|z_tilde| {
-        let range = cursor..cursor + z_tilde.ncols();
-        cursor = range.end;
-        range
-    });
+    // Stage-1 coefficient count `p₁` (= `Z̃_infl.ncols()`). It is installed as
+    // plain row-design columns outside BlockHessianAccumulator, so only the
+    // total coordinate cursor needs to include it here.
+    if let Some(z_tilde) = family.influence_absorber.as_ref() {
+        cursor += z_tilde.ncols();
+    }
     let total = cursor;
     BlockSlices {
         time,
@@ -812,7 +801,6 @@ fn block_slices(
         logslope,
         score_warp,
         link_dev,
-        influence,
         total,
     }
 }
@@ -5768,8 +5756,7 @@ impl SurvivalMarginalSlopeFamily {
         if self.influence_absorber.is_none() {
             return Ok(None);
         }
-        let idx =
-            3 + usize::from(self.score_warp.is_some()) + usize::from(self.link_dev.is_some());
+        let idx = 3 + usize::from(self.score_warp.is_some()) + usize::from(self.link_dev.is_some());
         block_states
             .get(idx)
             .map(|state| Some(&state.beta))
@@ -5784,9 +5771,10 @@ impl SurvivalMarginalSlopeFamily {
         row: usize,
         block_states: &[ParameterBlockState],
     ) -> Result<f64, String> {
-        let (Some(z_tilde), Some(gamma)) =
-            (self.influence_absorber.as_ref(), self.flex_influence_beta(block_states)?)
-        else {
+        let (Some(z_tilde), Some(gamma)) = (
+            self.influence_absorber.as_ref(),
+            self.flex_influence_beta(block_states)?,
+        ) else {
             return Ok(0.0);
         };
         if gamma.len() != z_tilde.ncols() {
@@ -13604,9 +13592,7 @@ impl crate::families::marginal_slope_shared::MarginalSlopePsiFamily
         )
     }
 
-    fn psi_first_order_terms_all(
-        &self,
-    ) -> Result<Option<Vec<ExactNewtonJointPsiTerms>>, String> {
+    fn psi_first_order_terms_all(&self) -> Result<Option<Vec<ExactNewtonJointPsiTerms>>, String> {
         let total: usize = self.derivative_blocks.iter().map(Vec::len).sum();
         if total == 0 {
             return Ok(Some(Vec::new()));
@@ -20058,11 +20044,11 @@ pub fn fit_survival_marginal_slope_terms(
     let influence_absorber_residualized: Option<Array2<f64>> =
         if let Some(jac) = spec.score_influence_jacobian.as_ref() {
             use crate::families::marginal_slope_orthogonal::{
-                influence_block_design, residualize_influence_columns, ScoreInfluenceJacobian,
+                ScoreInfluenceJacobian, residualized_influence_block,
             };
-            let marginal_dense = marginal_design
-                .design
-                .try_to_dense_by_chunks("survival marginal-slope influence-absorber marginal span")?;
+            let marginal_dense = marginal_design.design.try_to_dense_by_chunks(
+                "survival marginal-slope influence-absorber marginal span",
+            )?;
             // Realized leakage directions `Z_infl = diag(s_f·β̂₀)·J` via the core
             // builder; `β̂₀(x_i)` is the rigid-pilot logslope and `s_f =
             // probit_scale`. `influence_block_design` reads only `columns`; the
@@ -20072,37 +20058,16 @@ pub fn fit_survival_marginal_slope_terms(
                 z: z_primary.clone(),
             };
             let rigid_logslope_at_rows = &spec.logslope_offset + baseline_slope;
-            let z_infl =
-                influence_block_design(&jacobian, &rigid_logslope_at_rows, probit_scale);
-            // Marginal-Gram ridge scaled to the weighted Gram's own magnitude so
-            // the projection solve stays stable when the marginal design is
-            // rank-deficient at the pilot, without perturbing a well-conditioned
-            // projection. Identical scaling to the BMS absorber site (single
-            // source of truth for the residualization math is
-            // `residualize_influence_columns`; only this caller-side ridge scale
-            // is shared by value).
-            let gram_scale = (0..marginal_dense.ncols())
-                .map(|j| {
-                    (0..marginal_dense.nrows())
-                        .map(|i| {
-                            cross_block_pilot_w[i] * marginal_dense[[i, j]] * marginal_dense[[i, j]]
-                        })
-                        .sum::<f64>()
-                })
-                .fold(0.0_f64, f64::max);
-            let eps = (gram_scale * 1e-10).max(1e-12);
-            let residualized = residualize_influence_columns(
-                &z_infl,
+            let residualized = residualized_influence_block(
+                &jacobian,
+                &rigid_logslope_at_rows,
+                probit_scale,
                 marginal_dense.view(),
                 &cross_block_pilot_w,
-                eps,
-            );
-            if residualized.iter().any(|v| !v.is_finite()) {
-                return Err(SurvivalMarginalSlopeError::NumericalFailure {
-                    reason: "survival influence-absorber residualized columns contain non-finite entries".to_string(),
-                }
-                .into());
-            }
+            )
+            .map_err(|err| SurvivalMarginalSlopeError::NumericalFailure {
+                reason: format!("survival influence-absorber {err}"),
+            })?;
             Some(residualized)
         } else {
             None
@@ -22607,7 +22572,6 @@ mod tests {
             logslope,
             score_warp,
             link_dev,
-            influence: None,
             total,
         }
     }
@@ -28071,7 +28035,6 @@ mod tests {
             logslope,
             score_warp: Some(score_warp),
             link_dev: Some(link_dev),
-            influence: None,
             total,
         }
     }

--- a/src/gpu/backend_probe.rs
+++ b/src/gpu/backend_probe.rs
@@ -26,9 +26,7 @@
 //! there is no transitional shim.
 
 #[cfg(target_os = "linux")]
-pub(crate) use linux::{
-    CudaBackendContext, CudaBackendParts, probe_backend_with_compile, probe_cuda_backend,
-};
+pub(crate) use linux::{CudaBackendContext, probe_backend_with_compile, probe_cuda_backend};
 
 #[cfg(target_os = "linux")]
 mod linux {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -119,15 +119,14 @@ pub use solver::protocol::{
     LatentScoreSemantics, MarginalSlopeCalibrationProtocol, SurvivalMarginalSlopeProtocol,
 };
 pub use solver::workflow::{
-    CALIBRATED_SLOPE_Z_COLUMN, BernoulliMarginalSlopeFitRequest, BinomialLocationScaleFitRequest,
-    CrossFitScoreCalibration, CtnStage1Recipe, FitConfig, FitRequest, FitResult,
-    GaussianLocationScaleFitRequest,
+    BernoulliMarginalSlopeFitRequest, BinomialLocationScaleFitRequest, CrossFitScoreCalibration,
+    CtnStage1Recipe, FitConfig, FitRequest, FitResult, GaussianLocationScaleFitRequest,
     LatentBinaryFitRequest, LatentSurvivalFitRequest, LinkWiggleConfig, MaterializedModel,
     PreparedSurvivalTimeStack, StandardBinomialWiggleConfig, StandardFitRequest, StandardFitResult,
-    SurvivalLocationScaleFitRequest, SurvivalLocationScaleFitResult, SurvivalMarginalSlopeFitRequest,
-    SurvivalTransformationFitRequest, SurvivalTransformationFitResult,
-    SurvivalTransformationTermSpec, TransformationNormalFitRequest, WorkflowError,
-    fit_from_formula, fit_marginal_slope_from_ctn, fit_model, is_binary_response, materialize,
-    prepare_calibrated_marginal_slope_stage2, prepare_survival_time_stack, resolve_family,
-    resolve_offset_column, resolve_weight_column,
+    SurvivalLocationScaleFitRequest, SurvivalLocationScaleFitResult,
+    SurvivalMarginalSlopeFitRequest, SurvivalTransformationFitRequest,
+    SurvivalTransformationFitResult, SurvivalTransformationTermSpec,
+    TransformationNormalFitRequest, WorkflowError, fit_from_formula, fit_model, is_binary_response,
+    materialize, prepare_survival_time_stack, resolve_family, resolve_offset_column,
+    resolve_weight_column,
 };

--- a/src/solver/workflow.rs
+++ b/src/solver/workflow.rs
@@ -2737,7 +2737,7 @@ pub struct CrossFitScoreCalibration {
 /// Stage-1 fit; its presence is the sole auto-enable signal for cross-fitted
 /// orthogonalization (design §5). When absent, Stage-2 falls back to the free
 /// 1-D `score_warp` spline (which spans only the x-free leakage column).
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct CtnStage1Recipe {
     /// Stage-1 response column name (the `y` the CTN transforms).
     pub response_column: String,
@@ -2859,8 +2859,8 @@ fn crossfit_score_calibration(
     }
 
     // Stage-1 response / weights / offset, resolved against the full dataset.
-    let y_col =
-        resolve_role_col(col_map, &recipe.response_column, "response").map_err(|e| e.to_string())?;
+    let y_col = resolve_role_col(col_map, &recipe.response_column, "response")
+        .map_err(|e| e.to_string())?;
     let response_full = data.values.column(y_col).to_owned();
     let weights_full = resolve_weight_column(data, col_map, recipe.weight_column.as_deref())
         .map_err(|e| e.to_string())?;

--- a/src/terms/basis.rs
+++ b/src/terms/basis.rs
@@ -1949,7 +1949,19 @@ pub const fn default_spatial_center_strategy(num_centers: usize, d: usize) -> Ce
 }
 
 pub fn auto_spatial_center_strategy(num_centers: usize, d: usize) -> CenterStrategy {
-    CenterStrategy::Auto(Box::new(default_spatial_center_strategy(num_centers, d)))
+    let strategy = if d == 1 {
+        // In one dimension, farthest-point selection is the deterministic
+        // maximin grid over the observed domain. Equal-mass midpoints leave the
+        // low-frequency Duchon radial block slightly under-resolved at the
+        // boundaries, and REML then compensates with an over-smooth λ on
+        // low-noise signals (#504). The maximin grid matches the native
+        // reproducing-kernel interpolation geometry while keeping the existing
+        // equal-mass defaults for genuinely multivariate smooths.
+        CenterStrategy::FarthestPoint { num_centers }
+    } else {
+        default_spatial_center_strategy(num_centers, d)
+    };
+    CenterStrategy::Auto(Box::new(strategy))
 }
 
 pub const fn center_strategy_is_auto(strategy: &CenterStrategy) -> bool {

--- a/src/terms/term_builder.rs
+++ b/src/terms/term_builder.rs
@@ -2103,7 +2103,16 @@ pub fn enable_scale_dimensions(spec: &mut TermCollectionSpec) {
 // ---------------------------------------------------------------------------
 
 pub fn spatial_center_strategy_for_dimension(num_centers: usize, d: usize) -> CenterStrategy {
-    default_spatial_center_strategy(num_centers, d)
+    if d == 1 {
+        // In one dimension, an explicit `k` is a resolution request rather than
+        // a request for quantile-midpoint centers. Use the same maximin geometry
+        // as the automatic 1D path so Duchon REML sees a well-resolved native
+        // kernel block instead of compensating for endpoint under-resolution by
+        // over-smoothing easy low-noise signals (#504).
+        CenterStrategy::FarthestPoint { num_centers }
+    } else {
+        default_spatial_center_strategy(num_centers, d)
+    }
 }
 
 pub fn col_minmax(col: ArrayView1<'_, f64>) -> Result<(f64, f64), String> {

--- a/tests/duchon_kernel_accuracy_bench.rs
+++ b/tests/duchon_kernel_accuracy_bench.rs
@@ -8,9 +8,10 @@
 //!   * mgcv `bs="ds", m=c(2,0)` — the mature Duchon (`r²·log r`) baseline
 //!
 //! This is a COMPARISON bench: it prints a table (run with `--nocapture`) and
-//! asserts only that every gam fit genuinely recovers the signal (beats the
-//! trivial mean predictor). Which kernel wins on a given truth is reported, not
-//! asserted — that's the data we want to read off.
+//! asserts that every gam fit genuinely recovers the signal (beats the trivial
+//! mean predictor). The low-noise 1D easy case is also an explicit regression
+//! gate for issue #504: gam must match mgcv's truth-recovery sharpness instead
+//! of selecting an over-smooth REML solution.
 
 use gam::matrix::LinearOperator;
 use gam::smooth::build_term_collection_design;
@@ -48,7 +49,14 @@ fn rms(v: &[f64]) -> f64 {
 /// "recovering, not blown up / collapsed" floor. The per-variant asserts here
 /// are the substance of each bench `#[test]`: the tests delegate their checks
 /// to this helper rather than duplicating the floor logic at every call site.
-fn report_and_check(label: &str, rmse_r3: f64, rmse_r2logr: f64, rmse_mgcv: f64, rms_truth: f64) {
+fn report_and_check(
+    label: &str,
+    rmse_r3: f64,
+    rmse_r2logr: f64,
+    rmse_mgcv: f64,
+    rms_truth: f64,
+    mgcv_match_factor: Option<f64>,
+) {
     let winner = if rmse_r3 <= rmse_r2logr && rmse_r3 <= rmse_mgcv {
         "gam r³"
     } else if rmse_r2logr <= rmse_r3 && rmse_r2logr <= rmse_mgcv {
@@ -69,6 +77,17 @@ fn report_and_check(label: &str, rmse_r3: f64, rmse_r2logr: f64, rmse_mgcv: f64,
         rmse_r2logr < floor,
         "{label}: gam r²·log r did not recover (rmse {rmse_r2logr:.4} ≥ {floor:.4})"
     );
+    if let Some(factor) = mgcv_match_factor {
+        let limit = factor * rmse_mgcv;
+        assert!(
+            rmse_r3 <= limit,
+            "{label}: gam r³ should match-or-beat mgcv sharpness (rmse {rmse_r3:.4} > {limit:.4}; mgcv {rmse_mgcv:.4})"
+        );
+        assert!(
+            rmse_r2logr <= limit,
+            "{label}: gam r²·log r should match-or-beat mgcv sharpness (rmse {rmse_r2logr:.4} > {limit:.4}; mgcv {rmse_mgcv:.4})"
+        );
+    }
 }
 
 #[test]
@@ -138,12 +157,22 @@ fn bench_duchon_kernel_accuracy_1d() {
         );
         let mgcv = r.vector("fitted");
 
+        let mgcv_match_factor = if label == "sin 4-cycle σ.05 k20" {
+            // Issue #504: the easy, low-noise case used to over-smooth at
+            // ≈0.034 RMSE while mgcv was ≈0.014. The new center geometry must
+            // keep gam on mgcv's truth-recovery scale without weakening the
+            // hard-case recovery checks below.
+            Some(1.10)
+        } else {
+            None
+        };
         report_and_check(
             label,
             rmse(&r3, &y_truth),
             rmse(&r2logr, &y_truth),
             rmse(mgcv, &y_truth),
             rms(&y_truth),
+            mgcv_match_factor,
         );
     }
 }
@@ -240,6 +269,7 @@ fn bench_duchon_kernel_accuracy_2d() {
             rmse(&r2logr, &y_truth),
             rmse(mgcv, &y_truth),
             rms(&y_truth),
+            None,
         );
     }
 }


### PR DESCRIPTION
**Summary**
* Root-caused the #504 sharpness gap to 1D center geometry rather than a broken Duchon native penalty or null-space ridge: 1D equal-mass midpoint centers under-resolved the domain endpoints, causing REML to compensate with a smoother fit on easy low-noise signals. The fix uses deterministic farthest-point/maximin centers for 1D automatic center selection while preserving existing multivariate defaults. 

* Applied the same 1D maximin-center behavior to explicit `k` / center-count requests, treating 1D `k` as a resolution request rather than a quantile-midpoint-center request. 

* Strengthened the Duchon accuracy bench so the easy low-noise 1D case must remain on mgcv’s truth-recovery scale, while retaining the existing recovery floor and hard-case assertions. 

* Cleared current build-ban blockers encountered during targeted verification by making the influence residualization helper the single production path for BMS and survival callers, with real assertions instead of banned debug-only assertions. 

* Removed stale/rejected build exports/imports and derived `Debug` for CTN stage recipes so the crate builds under the repository’s strict ban/lint rules. 


**Testing**
* ✅ `cargo test -p gam --test duchon_kernel_accuracy_bench -- --nocapture`
  * Easy #504 case: `gam r³=0.0152`, `gam r²·logr=0.0152`, `mgcv=0.0140`.
  * Hard high-frequency case preserved: `gam=0.0297` vs `mgcv=0.7056`.
  * σ=.20 tie preserved/improved: `gam=0.0674` vs `mgcv=0.0697`.
* ✅ `cargo fmt`
* ✅ `git diff --check`

Committed changes on the current branch: `53a9e8f`. PR metadata was created.

Closes #504