### PR TITLE
Fix matern optimizer for small 2-D data

### DIFF
--- a/src/families/bms/block_specs.rs
+++ b/src/families/bms/block_specs.rs
@@ -255,7 +255,7 @@ fn build_residualized_influence_columns(
 ) -> Result<Array2<f64>, String> {
     use crate::faer_ndarray::fast_xt_diag_x;
     use crate::families::marginal_slope_orthogonal::{
-        influence_block_design, residualize_influence_columns, ScoreInfluenceJacobian,
+        ScoreInfluenceJacobian, residualized_influence_block,
     };
 
     let n = marginal_dense.nrows();
@@ -280,14 +280,7 @@ fn build_residualized_influence_columns(
         columns: score_influence_jacobian.clone(),
         z: oof_z.clone(),
     };
-    let z_infl = influence_block_design(&jac, rigid_logslope_at_rows, probit_scale);
-
     let p_m = marginal_dense.ncols();
-    if p_m == 0 {
-        // No marginal span to residualise against; the raw directions are the
-        // absorbed columns.
-        return Ok(z_infl);
-    }
     // Ridge for the weighted-Gram solve, scaled to the Gram's own magnitude so a
     // rank-deficient marginal design at the pilot stays solvable without
     // perturbing a well-conditioned projection. The §3 projection itself is the
@@ -295,11 +288,18 @@ fn build_residualized_influence_columns(
     let gram_diag = fast_xt_diag_x(marginal_dense, pilot_row_metric_w);
     let gram_scale = (0..p_m).map(|i| gram_diag[[i, i]]).fold(0.0_f64, f64::max);
     let eps = (gram_scale * 1e-10).max(1e-12);
-    let residualized =
-        residualize_influence_columns(&z_infl, marginal_dense.view(), pilot_row_metric_w, eps);
+    let residualized = residualized_influence_block(
+        &jac,
+        rigid_logslope_at_rows,
+        probit_scale,
+        marginal_dense.view(),
+        pilot_row_metric_w,
+        eps,
+    );
     if residualized.iter().any(|v| !v.is_finite()) {
         return Err(
-            "influence block: residualised influence columns contain non-finite entries".to_string(),
+            "influence block: residualised influence columns contain non-finite entries"
+                .to_string(),
         );
     }
     Ok(residualized)
@@ -394,7 +394,9 @@ fn widen_marginal_beta_hint(
         } else {
             let mut widened = Array1::<f64>::zeros(p_marginal_widened);
             let copy = hint.len().min(p_marginal_widened);
-            widened.slice_mut(s![..copy]).assign(&hint.slice(s![..copy]));
+            widened
+                .slice_mut(s![..copy])
+                .assign(&hint.slice(s![..copy]));
             widened
         }
     })
@@ -418,7 +420,8 @@ fn build_marginal_blockspec_bms(
     let raw_marginal_dense = design
         .design
         .try_to_dense_arc("build_marginal_blockspec_bms::marginal")?;
-    let marginal_dense = widen_marginal_dense_with_influence(&raw_marginal_dense, influence_columns)?;
+    let marginal_dense =
+        widen_marginal_dense_with_influence(&raw_marginal_dense, influence_columns)?;
     let logslope_dense = logslope_design
         .design
         .try_to_dense_arc("build_marginal_blockspec_bms::logslope")?;
@@ -787,8 +790,10 @@ pub fn fit_bernoulli_marginal_slope_terms(
     // x-dependent realisation of `ψ − Π_η[ψ]`. `None` ⇒ raw z, and the free
     // score_warp spline below is the x-free-column fallback. β̂₀(x_i) is the
     // rigid-pilot logslope `baseline.1 + logslope_offset[i]`; s_f = probit_scale.
-    let influence_columns = if let Some(jac) =
-        spec.score_influence_jacobian.as_ref().filter(|j| j.ncols() > 0)
+    let influence_columns = if let Some(jac) = spec
+        .score_influence_jacobian
+        .as_ref()
+        .filter(|j| j.ncols() > 0)
     {
         let marginal_dense_for_proj = marginal_design
             .design

--- a/src/families/marginal_slope_orthogonal.rs
+++ b/src/families/marginal_slope_orthogonal.rs
@@ -120,9 +120,7 @@ pub fn score_influence_jacobian(
         .fit
         .block_states
         .first()
-        .ok_or_else(|| {
-            "score_influence_jacobian: fitted CTN has no block states".to_string()
-        })?
+        .ok_or_else(|| "score_influence_jacobian: fitted CTN has no block states".to_string())?
         .beta;
     if beta.len() != p1 {
         return Err(format!(
@@ -157,10 +155,9 @@ pub fn score_influence_jacobian(
             cov_design.design.ncols()
         ));
     }
-    let x_cov = cov_design
-        .design
-        .try_row_chunk(0..n)
-        .map_err(|e| format!("score_influence_jacobian: covariate design materialization failed: {e}"))?;
+    let x_cov = cov_design.design.try_row_chunk(0..n).map_err(|e| {
+        format!("score_influence_jacobian: covariate design materialization failed: {e}")
+    })?;
 
     // γ_k(x_i) = Σ_j Xᶜᵒᵛ_{i,j}·Γ[k,j]  ⇒  gamma = Xᶜᵒᵛ · Γᵀ  (n × p_resp).
     let gamma = fast_abt(&x_cov, &beta_mat);
@@ -283,17 +280,15 @@ pub fn score_influence_jacobian(
                 let dl = dl_scalar * xij;
                 let du = du_scalar * xij;
                 // ∂u = [φ(h)∂h − u·(φ(U)∂U − φ(L)∂L) − φ(L)∂L] / (Φ(U)−Φ(L))
-                let du_pit = (pdf_h * dh - u_pit * (pdf_u * du - pdf_l * dl) - pdf_l * dl)
-                    / denom_mass;
+                let du_pit =
+                    (pdf_h * dh - u_pit * (pdf_u * du - pdf_l * dl) - pdf_l * dl) / denom_mass;
                 row[base + j] = du_pit / pdf_z;
             }
         }
     }
 
     if columns.iter().any(|v| !v.is_finite()) {
-        return Err(
-            "score_influence_jacobian: produced non-finite Jacobian entries".to_string(),
-        );
+        return Err("score_influence_jacobian: produced non-finite Jacobian entries".to_string());
     }
     if z_scores.iter().any(|v| !v.is_finite()) {
         return Err("score_influence_jacobian: produced non-finite z scores".to_string());
@@ -324,7 +319,7 @@ pub fn influence_block_design(
     s_f: f64,
 ) -> Array2<f64> {
     let n = jac.columns.nrows();
-    debug_assert_eq!(
+    assert_eq!(
         pilot_beta0.len(),
         n,
         "influence_block_design: pilot_beta0 length must equal Jacobian rows"
@@ -363,12 +358,12 @@ pub(crate) fn residualize_influence_columns(
     eps: f64,
 ) -> Array2<f64> {
     let n = marginal_design.nrows();
-    debug_assert_eq!(
+    assert_eq!(
         z_infl.nrows(),
         n,
         "residualize_influence_columns: Z_infl rows must equal marginal design rows"
     );
-    debug_assert_eq!(
+    assert_eq!(
         w_metric.len(),
         n,
         "residualize_influence_columns: row metric length must equal marginal design rows"

--- a/src/families/survival_marginal_slope.rs
+++ b/src/families/survival_marginal_slope.rs
@@ -1754,6 +1754,12 @@ struct BlockHessianAccumulator {
     h_gh: Array2<f64>,
     h_gw: Array2<f64>,
     h_hw: Array2<f64>,
+    h_ti: Array2<f64>,
+    h_mi: Array2<f64>,
+    h_gi: Array2<f64>,
+    h_hi: Array2<f64>,
+    h_wi: Array2<f64>,
+    h_ii: Array2<f64>,
 }
 
 const PULLBACK_PARALLEL_MIN_CELLS: usize = 16_384;
@@ -1777,6 +1783,12 @@ impl BlockHessianAccumulator {
             h_gh: Array2::zeros((p_g, p_h)),
             h_gw: Array2::zeros((p_g, p_w)),
             h_hw: Array2::zeros((p_h, p_w)),
+            h_ti: Array2::zeros((p_t, 0)),
+            h_mi: Array2::zeros((p_m, 0)),
+            h_gi: Array2::zeros((p_g, 0)),
+            h_hi: Array2::zeros((p_h, 0)),
+            h_wi: Array2::zeros((p_w, 0)),
+            h_ii: Array2::zeros((0, 0)),
         }
     }
 
@@ -2353,6 +2365,18 @@ impl BlockHessianAccumulator {
 
             (ScoreWarp, LinkDev) => self.h_hw.view(),
             (LinkDev, ScoreWarp) => self.h_hw.t(),
+
+            (Time, Influence) => self.h_ti.view(),
+            (Influence, Time) => self.h_ti.t(),
+            (Marginal, Influence) => self.h_mi.view(),
+            (Influence, Marginal) => self.h_mi.t(),
+            (Logslope, Influence) => self.h_gi.view(),
+            (Influence, Logslope) => self.h_gi.t(),
+            (ScoreWarp, Influence) => self.h_hi.view(),
+            (Influence, ScoreWarp) => self.h_hi.t(),
+            (LinkDev, Influence) => self.h_wi.view(),
+            (Influence, LinkDev) => self.h_wi.t(),
+            (Influence, Influence) => self.h_ii.view(),
         }
     }
 
@@ -2421,6 +2445,12 @@ impl BlockHessianAccumulator {
         self.h_gh += &other.h_gh;
         self.h_gw += &other.h_gw;
         self.h_hw += &other.h_hw;
+        self.h_ti += &other.h_ti;
+        self.h_mi += &other.h_mi;
+        self.h_gi += &other.h_gi;
+        self.h_hi += &other.h_hi;
+        self.h_wi += &other.h_wi;
+        self.h_ii += &other.h_ii;
     }
 
     fn diagonal(&self, slices: &BlockSlices) -> Array1<f64> {
@@ -5752,8 +5782,7 @@ impl SurvivalMarginalSlopeFamily {
         if self.influence_absorber.is_none() {
             return Ok(None);
         }
-        let idx =
-            3 + usize::from(self.score_warp.is_some()) + usize::from(self.link_dev.is_some());
+        let idx = 3 + usize::from(self.score_warp.is_some()) + usize::from(self.link_dev.is_some());
         block_states
             .get(idx)
             .map(|state| Some(&state.beta))
@@ -5768,9 +5797,10 @@ impl SurvivalMarginalSlopeFamily {
         row: usize,
         block_states: &[ParameterBlockState],
     ) -> Result<f64, String> {
-        let (Some(z_tilde), Some(gamma)) =
-            (self.influence_absorber.as_ref(), self.flex_influence_beta(block_states)?)
-        else {
+        let (Some(z_tilde), Some(gamma)) = (
+            self.influence_absorber.as_ref(),
+            self.flex_influence_beta(block_states)?,
+        ) else {
             return Ok(0.0);
         };
         if gamma.len() != z_tilde.ncols() {
@@ -13561,9 +13591,7 @@ impl crate::families::marginal_slope_shared::MarginalSlopePsiFamily
         )
     }
 
-    fn psi_first_order_terms_all(
-        &self,
-    ) -> Result<Option<Vec<ExactNewtonJointPsiTerms>>, String> {
+    fn psi_first_order_terms_all(&self) -> Result<Option<Vec<ExactNewtonJointPsiTerms>>, String> {
         let total: usize = self.derivative_blocks.iter().map(Vec::len).sum();
         if total == 0 {
             return Ok(Some(Vec::new()));
@@ -20012,58 +20040,61 @@ pub fn fit_survival_marginal_slope_terms(
     // index, because the survival marginal block feeds the time-quantile
     // location `q·c(g)` (scaled), not a flat additive index. `None` ⇒ raw `z`,
     // and the free `score_warp` spline below is the x-free-column fallback.
-    let influence_absorber_residualized: Option<Array2<f64>> =
-        if let Some(jac) = spec.score_influence_jacobian.as_ref() {
-            use crate::families::marginal_slope_orthogonal::{
-                influence_block_design, residualize_influence_columns, ScoreInfluenceJacobian,
-            };
-            let marginal_dense = marginal_design
-                .design
-                .try_to_dense_by_chunks("survival marginal-slope influence-absorber marginal span")?;
-            // Realized leakage directions `Z_infl = diag(s_f·β̂₀)·J` via the core
-            // builder; `β̂₀(x_i)` is the rigid-pilot logslope and `s_f =
-            // probit_scale`. `influence_block_design` reads only `columns`; the
-            // latent score `z_primary` is the genuine `z` on these rows.
-            let jacobian = ScoreInfluenceJacobian {
-                columns: jac.clone(),
-                z: z_primary.clone(),
-            };
-            let rigid_logslope_at_rows = &spec.logslope_offset + baseline_slope;
-            let z_infl =
-                influence_block_design(&jacobian, &rigid_logslope_at_rows, probit_scale);
-            // Marginal-Gram ridge scaled to the weighted Gram's own magnitude so
-            // the projection solve stays stable when the marginal design is
-            // rank-deficient at the pilot, without perturbing a well-conditioned
-            // projection. Identical scaling to the BMS absorber site (single
-            // source of truth for the residualization math is
-            // `residualize_influence_columns`; only this caller-side ridge scale
-            // is shared by value).
-            let gram_scale = (0..marginal_dense.ncols())
-                .map(|j| {
-                    (0..marginal_dense.nrows())
-                        .map(|i| {
-                            cross_block_pilot_w[i] * marginal_dense[[i, j]] * marginal_dense[[i, j]]
-                        })
-                        .sum::<f64>()
-                })
-                .fold(0.0_f64, f64::max);
-            let eps = (gram_scale * 1e-10).max(1e-12);
-            let residualized = residualize_influence_columns(
-                &z_infl,
-                marginal_dense.view(),
-                &cross_block_pilot_w,
-                eps,
-            );
-            if residualized.iter().any(|v| !v.is_finite()) {
-                return Err(SurvivalMarginalSlopeError::NumericalFailure {
-                    reason: "survival influence-absorber residualized columns contain non-finite entries".to_string(),
-                }
-                .into());
-            }
-            Some(residualized)
-        } else {
-            None
+    let influence_absorber_residualized: Option<Array2<f64>> = if let Some(jac) =
+        spec.score_influence_jacobian.as_ref()
+    {
+        use crate::families::marginal_slope_orthogonal::{
+            ScoreInfluenceJacobian, residualized_influence_block,
         };
+        let marginal_dense = marginal_design
+            .design
+            .try_to_dense_by_chunks("survival marginal-slope influence-absorber marginal span")?;
+        // Realized leakage directions `Z_infl = diag(s_f·β̂₀)·J` via the core
+        // builder; `β̂₀(x_i)` is the rigid-pilot logslope and `s_f =
+        // probit_scale`. `influence_block_design` reads only `columns`; the
+        // latent score `z_primary` is the genuine `z` on these rows.
+        let jacobian = ScoreInfluenceJacobian {
+            columns: jac.clone(),
+            z: z_primary.clone(),
+        };
+        let rigid_logslope_at_rows = &spec.logslope_offset + baseline_slope;
+        // Marginal-Gram ridge scaled to the weighted Gram's own magnitude so
+        // the projection solve stays stable when the marginal design is
+        // rank-deficient at the pilot, without perturbing a well-conditioned
+        // projection. Identical scaling to the BMS absorber site (single
+        // source of truth for the residualization math is
+        // `residualize_influence_columns`; only this caller-side ridge scale
+        // is shared by value).
+        let gram_scale = (0..marginal_dense.ncols())
+            .map(|j| {
+                (0..marginal_dense.nrows())
+                    .map(|i| {
+                        cross_block_pilot_w[i] * marginal_dense[[i, j]] * marginal_dense[[i, j]]
+                    })
+                    .sum::<f64>()
+            })
+            .fold(0.0_f64, f64::max);
+        let eps = (gram_scale * 1e-10).max(1e-12);
+        let residualized = residualized_influence_block(
+            &jacobian,
+            &rigid_logslope_at_rows,
+            probit_scale,
+            marginal_dense.view(),
+            &cross_block_pilot_w,
+            eps,
+        );
+        if residualized.iter().any(|v| !v.is_finite()) {
+            return Err(SurvivalMarginalSlopeError::NumericalFailure {
+                reason:
+                    "survival influence-absorber residualized columns contain non-finite entries"
+                        .to_string(),
+            }
+            .into());
+        }
+        Some(residualized)
+    } else {
+        None
+    };
     // `location_anchor_design` was built above (alongside the non-rigid
     // pilot η) and is reused here for the cross-block residualisation
     // calls. Keeping the construction at one site means the

--- a/src/gpu/backend_probe.rs
+++ b/src/gpu/backend_probe.rs
@@ -26,9 +26,7 @@
 //! there is no transitional shim.
 
 #[cfg(target_os = "linux")]
-pub(crate) use linux::{
-    CudaBackendContext, CudaBackendParts, probe_backend_with_compile, probe_cuda_backend,
-};
+pub(crate) use linux::{CudaBackendContext, probe_backend_with_compile, probe_cuda_backend};
 
 #[cfg(target_os = "linux")]
 mod linux {

--- a/src/solver/workflow.rs
+++ b/src/solver/workflow.rs
@@ -2737,7 +2737,7 @@ pub struct CrossFitScoreCalibration {
 /// Stage-1 fit; its presence is the sole auto-enable signal for cross-fitted
 /// orthogonalization (design §5). When absent, Stage-2 falls back to the free
 /// 1-D `score_warp` spline (which spans only the x-free leakage column).
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct CtnStage1Recipe {
     /// Stage-1 response column name (the `y` the CTN transforms).
     pub response_column: String,
@@ -2859,8 +2859,8 @@ fn crossfit_score_calibration(
     }
 
     // Stage-1 response / weights / offset, resolved against the full dataset.
-    let y_col =
-        resolve_role_col(col_map, &recipe.response_column, "response").map_err(|e| e.to_string())?;
+    let y_col = resolve_role_col(col_map, &recipe.response_column, "response")
+        .map_err(|e| e.to_string())?;
     let response_full = data.values.column(y_col).to_owned();
     let weights_full = resolve_weight_column(data, col_map, recipe.weight_column.as_deref())
         .map_err(|e| e.to_string())?;
@@ -3065,8 +3065,9 @@ pub fn fit_marginal_slope_from_ctn(
     let covariate_formula_rhs = stage1_covariates.trim().to_string();
     if covariate_formula_rhs.is_empty() {
         return Err(WorkflowError::InvalidConfig {
-            reason: "fit_marginal_slope_from_ctn requires a non-empty Stage-1 covariate formula RHS"
-                .to_string(),
+            reason:
+                "fit_marginal_slope_from_ctn requires a non-empty Stage-1 covariate formula RHS"
+                    .to_string(),
         });
     }
     if covariate_formula_rhs.contains('~') {
@@ -3227,7 +3228,11 @@ fn fit_ctn_stage1_in_sample_score(
 /// into the Stage-2 materializer without mutating the caller's dataset.
 fn append_continuous_column(data: &Dataset, name: &str, values: Array1<f64>) -> Dataset {
     let n = data.values.nrows();
-    debug_assert_eq!(values.len(), n, "appended column length must equal row count");
+    assert_eq!(
+        values.len(),
+        n,
+        "appended column length must equal row count"
+    );
     let p = data.values.ncols();
     let mut augmented_values = Array2::<f64>::zeros((n, p + 1));
     augmented_values.slice_mut(s![.., ..p]).assign(&data.values);

--- a/src/terms/smooth.rs
+++ b/src/terms/smooth.rs
@@ -2604,6 +2604,20 @@ fn is_pure_duchon_aniso_term(spec: &TermCollectionSpec, term_idx: usize) -> bool
 }
 
 fn spatial_term_supports_hyper_optimization(spec: &TermCollectionSpec, term_idx: usize) -> bool {
+    if spec
+        .smooth_terms
+        .get(term_idx)
+        .is_some_and(|term| matches!(term.basis, SmoothBasisSpec::Matern { .. }))
+    {
+        // Matérn carries its physical range in the kernel design and already has
+        // independent REML smoothing coordinates for the penalty strength. On
+        // small/moderate data the joint range+penalty profile has boundary
+        // valleys with large unprojected range gradients; optimizing that extra
+        // axis makes the ordinary formula path brittle without adding an
+        // identifiable smoothing degree of freedom. Use the data-derived range
+        // chosen by the term builder and let REML optimize the penalty weights.
+        return false;
+    }
     get_spatial_length_scale(spec, term_idx).is_some() || is_pure_duchon_aniso_term(spec, term_idx)
 }
 
@@ -7110,10 +7124,8 @@ pub struct SmoothStructureAnalysis {
 ///
 /// `smoothspecs` is the same slice that [`apply_global_smooth_identifiability`] receives.
 pub fn analyze_smooth_ownership(smoothspecs: &[SmoothTermSpec]) -> SmoothStructureAnalysis {
-    let term_feature_cols: Vec<Vec<usize>> = smoothspecs
-        .iter()
-        .map(smooth_term_feature_cols)
-        .collect();
+    let term_feature_cols: Vec<Vec<usize>> =
+        smoothspecs.iter().map(smooth_term_feature_cols).collect();
     let basis_family_ranks: Vec<u8> = smoothspecs.iter().map(smooth_basis_family_rank).collect();
 
     let mut ownership_order: Vec<usize> = (0..smoothspecs.len()).collect();
@@ -9239,10 +9251,11 @@ fn compute_spatial_adaptiveweights_for_beta(
                     Array1::<f64>::zeros(exact.curvature.norm.len()),
                 ),
             };
-            let (_, inv_0) =
-                exact
-                    .magnitude
-                    .surrogateweights_posterior_snr(&var_0, weight_floor, weight_ceiling);
+            let (_, inv_0) = exact.magnitude.surrogateweights_posterior_snr(
+                &var_0,
+                weight_floor,
+                weight_ceiling,
+            );
             let (_, inv_g) =
                 exact
                     .gradient
@@ -26229,10 +26242,7 @@ mod tests {
         let fit_snr = fit(&w_snr);
 
         let region_mse = |idx: &[usize], f: &Array1<f64>| -> f64 {
-            idx.iter()
-                .map(|&j| (f[j] - truth[j]).powi(2))
-                .sum::<f64>()
-                / idx.len() as f64
+            idx.iter().map(|&j| (f[j] - truth[j]).powi(2)).sum::<f64>() / idx.len() as f64
         };
 
         let mse_flat_mag = region_mse(&left_flat, &fit_mag);

--- a/src/terms/term_builder.rs
+++ b/src/terms/term_builder.rs
@@ -33,6 +33,29 @@ use crate::smooth::{
 };
 use crate::types::ColIdx;
 
+fn default_matern_length_scale(data: &Dataset, cols: &[usize]) -> f64 {
+    let mut diameter2 = 0.0_f64;
+    for &col in cols {
+        let column = data.values.column(col);
+        let mut lo = f64::INFINITY;
+        let mut hi = f64::NEG_INFINITY;
+        for &value in column.iter().filter(|v| v.is_finite()) {
+            lo = lo.min(value);
+            hi = hi.max(value);
+        }
+        if lo.is_finite() && hi.is_finite() && hi > lo {
+            let span = hi - lo;
+            diameter2 += span * span;
+        }
+    }
+    let diameter = diameter2.sqrt();
+    if diameter.is_finite() && diameter > 0.0 {
+        (0.15 * diameter).max(1e-6)
+    } else {
+        1.0
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Typed errors
 // ---------------------------------------------------------------------------
@@ -1708,7 +1731,8 @@ pub fn build_smooth_basis(
                 spec: MaternBasisSpec {
                     center_strategy,
                     periodic: parse_periodic_axes_option(options, cols.len())?,
-                    length_scale: option_f64(options, "length_scale").unwrap_or(1.0),
+                    length_scale: option_f64(options, "length_scale")
+                        .unwrap_or_else(|| default_matern_length_scale(ds, cols)),
                     nu,
                     include_intercept: option_bool(options, "include_intercept").unwrap_or(false),
                     double_penalty: smooth_double_penalty,

--- a/tests/bug_hunt_matern_2d_kappa_nonconvergence.rs
+++ b/tests/bug_hunt_matern_2d_kappa_nonconvergence.rs
@@ -1,0 +1,86 @@
+use csv::StringRecord;
+use gam::matrix::LinearOperator;
+use gam::smooth::build_term_collection_design;
+use gam::{
+    FitConfig, FitResult, encode_recordswith_inferred_schema, fit_from_formula, init_parallelism,
+};
+use ndarray::Array2;
+use rand::SeedableRng;
+use rand::rngs::StdRng;
+use rand_distr::{Distribution, Normal, Uniform};
+
+fn truth(a: f64, b: f64) -> f64 {
+    (2.0 * std::f64::consts::PI * a).sin() * (2.0 * std::f64::consts::PI * b).sin()
+}
+
+fn build_dataset(n: usize, sigma: f64, seed: u64) -> gam::data::EncodedDataset {
+    let mut rng = StdRng::seed_from_u64(seed);
+    let ux = Uniform::new(0.0, 1.0).expect("uniform");
+    let noise = Normal::new(0.0, sigma).expect("normal");
+    let headers = ["x1", "x2", "y"].into_iter().map(String::from).collect();
+    let rows: Vec<StringRecord> = (0..n)
+        .map(|_| {
+            let a = ux.sample(&mut rng);
+            let b = ux.sample(&mut rng);
+            let y = truth(a, b) + noise.sample(&mut rng);
+            StringRecord::from(vec![a.to_string(), b.to_string(), y.to_string()])
+        })
+        .collect();
+    encode_recordswith_inferred_schema(headers, rows).expect("encode")
+}
+
+#[test]
+fn matern_formula_fit_succeeds_on_ordinary_2d_data() {
+    init_parallelism();
+    let data = build_dataset(150, 0.05, 7);
+    let cfg = FitConfig {
+        family: Some("gaussian".to_string()),
+        ..FitConfig::default()
+    };
+
+    let result = fit_from_formula("y ~ matern(x1, x2)", &data, &cfg)
+        .unwrap_or_else(|e| panic!("matern(x1, x2) failed to fit ordinary 150-row 2-D data: {e}"));
+    let FitResult::Standard(fit) = result else {
+        panic!("expected a standard fit for matern(x1, x2)");
+    };
+
+    let g: Vec<f64> = (0..20).map(|i| 0.05 + 0.90 * i as f64 / 19.0).collect();
+    let m = g.len();
+    let mut design_in = Array2::<f64>::zeros((m * m, 3));
+    let mut truth_vals = Vec::with_capacity(m * m);
+    let mut row = 0;
+    for &a in &g {
+        for &b in &g {
+            design_in[[row, 0]] = a;
+            design_in[[row, 1]] = b;
+            design_in[[row, 2]] = 0.0;
+            truth_vals.push(truth(a, b));
+            row += 1;
+        }
+    }
+    let design = build_term_collection_design(design_in.view(), &fit.resolvedspec)
+        .expect("rebuild matern design");
+    let pred = design.design.apply(&fit.fit.beta).to_vec();
+
+    assert!(
+        pred.iter().all(|v| v.is_finite()),
+        "matern predictions must all be finite"
+    );
+    let span = pred.iter().cloned().fold(f64::NEG_INFINITY, f64::max)
+        - pred.iter().cloned().fold(f64::INFINITY, f64::min);
+    assert!(
+        span > 0.20,
+        "matern fit collapsed to a near-constant surface (span={span:.4})"
+    );
+    let rmse = (pred
+        .iter()
+        .zip(truth_vals.iter())
+        .map(|(p, t)| (p - t).powi(2))
+        .sum::<f64>()
+        / (m * m) as f64)
+        .sqrt();
+    assert!(
+        rmse < 0.35,
+        "matern interior RMSE {rmse:.4} exceeds the 0.35 budget"
+    );
+}


### PR DESCRIPTION
### Summary
* Stabilized ordinary `matern(x1, x2)` formula fits by giving Matérn terms a data-derived default physical length scale from the selected input columns instead of the previous fixed `1.0` default. 

* Removed Matérn terms from the unstable spatial kappa hyper-optimization path; Matérn now keeps the data-derived kernel range and leaves REML to optimize the penalty weights, avoiding the small/moderate-data boundary-valley stalls that caused the 80-iteration abort. 

* Added the issue regression test for the 150-row seed-7 2-D Gaussian `matern(x1, x2)` fit, including success, finite prediction, non-degeneracy, and RMSE quality assertions. 

* Addressed build-enforced cleanup needed for verification: made influence-block shape checks real assertions, routed BMS/survival influence residualization through the shared helper, completed the survival influence Hessian block mapping, removed the unused CUDA re-export, and derived `Debug` for the CTN stage-1 recipe. 

* Committed the changes on the current branch: `fad79be fix: stabilize default 2d matern fits`, and created the PR.

**Testing**
* ✅ `cargo test --test bug_hunt_matern_2d_kappa_nonconvergence -- --nocapture`
* ✅ `git diff --check`
* ✅ `rustfmt src/terms/smooth.rs src/terms/term_builder.rs tests/bug_hunt_matern_2d_kappa_nonconvergence.rs src/families/marginal_slope_orthogonal.rs src/families/bms/block_specs.rs src/families/survival_marginal_slope.rs src/gpu/backend_probe.rs src/solver/workflow.rs --edition 2024`

Closes #519