### PR TITLE
Fix periodic parameter handling in bspline_basis_derivative

### DIFF
--- a/crates/gam-pyffi/src/lib.rs
+++ b/crates/gam-pyffi/src/lib.rs
@@ -15095,13 +15095,9 @@ fn bspline_position_derivative_impl(
             "periodic B-spline derivative supports order=1; got order={order}"
         ));
     }
-    periodic_position_domain(knots, period)?;
+    let (left, right, num_basis) = periodic_position_domain(knots, period)?;
     validate_vector("t", t)?;
-    Err(
-        "periodic B-spline first-derivative as a dense (N, K) matrix is no longer exposed; \
-         use periodic_bspline_input_location_first_derivative for the (N, K, 1) jet"
-            .to_string(),
-    )
+    periodic_bspline_dense_first_derivative(t, (left, right), degree, num_basis)
 }
 
 fn periodic_position_domain(
@@ -28335,6 +28331,19 @@ fn periodic_bspline_basis_dense_via_spec(
         .map_err(|err| format!("failed to evaluate periodic B-spline basis: {err}"))
 }
 
+fn periodic_bspline_dense_first_derivative(
+    t: ArrayView1<'_, f64>,
+    domain: (f64, f64),
+    degree: usize,
+    num_basis: usize,
+) -> Result<Array2<f64>, String> {
+    let (left, right) = domain;
+    let t_mat = column_array(t);
+    let jet = periodic_bspline_first_derivative_nd(t_mat.view(), (left, right), degree, num_basis)
+        .map_err(|err| format!("failed to evaluate periodic B-spline derivative: {err}"))?;
+    Ok(jet.index_axis(Axis(2), 0).to_owned())
+}
+
 fn bspline_basis_impl(
     t: ArrayView1<'_, f64>,
     knots: ArrayView1<'_, f64>,
@@ -28368,11 +28377,13 @@ fn bspline_basis_derivative_impl(
     validate_vector("t", t)?;
     validate_vector("knots", knots)?;
     if periodic {
-        return Err(
-            "periodic B-spline first-derivative as a dense (N, K) matrix is no longer exposed; \
-             use periodic_bspline_input_location_first_derivative for the (N, K, 1) jet"
-                .to_string(),
-        );
+        if order != 1 {
+            return Err(format!(
+                "periodic B-spline derivative supports order=1; got order={order}"
+            ));
+        }
+        let (left, right, num_basis) = periodic_knot_domain(knots)?;
+        return periodic_bspline_dense_first_derivative(t, (left, right), degree, num_basis);
     }
     let options = match order {
         0 => BasisOptions::value(),

--- a/gamfit/torch/_basis.py
+++ b/gamfit/torch/_basis.py
@@ -84,11 +84,8 @@ class _BsplineJetFn(torch.autograd.Function):
 
     Forward dispatches to the correct Rust derivative API:
 
-    * ``periodic=False`` → ``bspline_basis_derivative(order=1, periodic=False)``;
-    * ``periodic=True``  →
-      ``periodic_bspline_input_location_first_derivative`` (the dense
-      ``order=1`` API is intentionally not exposed for periodic bases —
-      issue #233).
+    Both open and periodic bases call ``bspline_basis_derivative(order=1)``
+    so the dense NumPy and Torch APIs share the same Rust entry point.
 
     Backward returns the input-location Hessian contraction. For the open
     case it calls ``bspline_basis_derivative(order=2)``; the periodic case
@@ -102,21 +99,9 @@ class _BsplineJetFn(torch.autograd.Function):
     ) -> torch.Tensor:
         t_np = to_numpy_f64(t)
         knots_np = to_numpy_f64(knots)
-        if periodic:
-            from .._binding import rust_module
-
-            left = float(knots_np[0])
-            right = float(knots_np[-1])
-            num_basis = int(knots_np.shape[0] - 1)
-            jet_3d = rust_module().periodic_bspline_input_location_first_derivative(
-                t_np.reshape(-1, 1), left, right, int(degree), num_basis,
-            )
-            # Rust returns (N, K, 1); reduce the trailing intrinsic-dim axis.
-            jet_np = jet_3d.reshape(jet_3d.shape[0], jet_3d.shape[1])
-        else:
-            jet_np = _api.bspline_basis_derivative(
-                t_np, knots_np, degree=int(degree), order=1, periodic=False,
-            )
+        jet_np = _api.bspline_basis_derivative(
+            t_np, knots_np, degree=int(degree), order=1, periodic=bool(periodic),
+        )
         ctx.save_for_backward(t, knots)
         ctx.degree = int(degree)
         ctx.periodic = bool(periodic)

--- a/tests/test_bug_hunt_periodic_bspline_derivative.py
+++ b/tests/test_bug_hunt_periodic_bspline_derivative.py
@@ -1,0 +1,31 @@
+"""Regression for #520: dense periodic B-spline derivatives are public."""
+
+from __future__ import annotations
+
+import numpy as np
+
+import gamfit
+from gamfit._binding import rust_module
+
+
+def test_periodic_bspline_basis_derivative_matches_existing_jet_and_fd() -> None:
+    knots = np.linspace(0.0, 2.0 * np.pi, 13)
+    t = np.linspace(-1.25, 2.0 * np.pi + 1.25, 97)
+
+    basis = gamfit.bspline_basis(t, knots, degree=3, periodic=True)
+    deriv = gamfit.bspline_basis_derivative(t, knots, degree=3, order=1, periodic=True)
+
+    assert deriv.shape == basis.shape
+    assert np.all(np.isfinite(deriv))
+    np.testing.assert_allclose(deriv.sum(axis=1), 0.0, atol=1e-12)
+
+    h = 1e-6
+    plus = gamfit.bspline_basis(t + h, knots, degree=3, periodic=True)
+    minus = gamfit.bspline_basis(t - h, knots, degree=3, periodic=True)
+    finite_difference = (plus - minus) / (2.0 * h)
+    np.testing.assert_allclose(deriv, finite_difference, rtol=0.0, atol=2e-9)
+
+    jet = rust_module().periodic_bspline_input_location_first_derivative(
+        t.reshape(-1, 1), float(knots[0]), float(knots[-1]), 3, knots.size - 1
+    )
+    np.testing.assert_allclose(deriv, jet[:, :, 0], rtol=0.0, atol=0.0)


### PR DESCRIPTION
**Summary**
* Fixed the root cause in the dense Rust FFI path: `bspline_basis_derivative(..., periodic=True, order=1)` now resolves the same periodic knot domain as the value path, calls the existing analytic `periodic_bspline_first_derivative_nd` jet kernel, and squeezes `(N, K, 1)` to the advertised dense `(N, K)` matrix. Higher periodic derivative orders still return the precise unsupported-order error. 

* Wired the position-basis derivative path through the same dense periodic derivative helper instead of validating and then unconditionally returning the stale “not exposed” error. 

* Updated the Torch wrapper to use the now-working dense `bspline_basis_derivative(order=1)` API for both open and periodic bases, keeping the Python layer thin and sharing one Rust entry point. 

* Added a regression test for issue #520 covering shape parity with the periodic basis, finite output, zero row-sums from differentiating partition-of-unity, central finite-difference agreement, and exact parity with the existing `(N, K, 1)` jet API. 

* Committed changes on the current branch: `f548a48 fix: expose dense periodic bspline derivative`.

**Testing**
* ✅ `rustfmt --check crates/gam-pyffi/src/lib.rs --edition 2024`
* ✅ `python -m py_compile gamfit/torch/_basis.py tests/test_bug_hunt_periodic_bspline_derivative.py`
* ⚠️ `python -m pytest tests/test_bug_hunt_periodic_bspline_derivative.py -v --tb=short` — blocked because `gamfit._rust` is not available until the extension wheel is built/installed.
* ⚠️ `maturin build -i python3 -o dist` — blocked by unrelated existing main-branch compile failures outside this change: unused `CudaBackendParts`, missing `Debug` for `CtnStage1Recipe`, and a non-exhaustive `HessBlock::Influence` match.
* ⚠️ `cargo check -p gam-pyffi` — blocked before compiling this patch by existing build-script banned-pattern violations in unrelated files (`debug_assert_eq!` in `src/families/marginal_slope_orthogonal.rs` and `src/solver/workflow.rs`).

Closes #520