### PR TITLE
Fix Gaussian posterior sampling refit issue

### DIFF
--- a/src/families/marginal_slope_orthogonal.rs
+++ b/src/families/marginal_slope_orthogonal.rs
@@ -46,15 +46,6 @@ use crate::smooth::build_term_collection_design;
 use faer::Side;
 use ndarray::{Array1, Array2, ArrayView2};
 
-/// Fixed (NOT REML-learned) log-λ for the influence-absorber block's ridge.
-///
-/// The §3 absorbed block `+Z_infl·γ` carries a small fixed ridge `½·ρ·‖γ‖²`
-/// (`ρ = exp(log_λ)`) so the joint solve soaks the `span(Z_infl)` component of
-/// the η-residual into `γ` without that block being treated as a smooth/REML
-/// surface. `log_λ = 0` ⇒ `ρ = 1`: enough to keep `γ` finite and bounded while
-/// the much larger marginal/logslope likelihood curvature dominates the fit.
-pub(crate) const INFLUENCE_ABSORBER_FIXED_LOG_LAMBDA: f64 = 0.0;
-
 /// Per-row, per-θ₁ score-influence Jacobian `∂z/∂θ₁` for a fitted CTN, plus the
 /// latent score `z` itself on the same rows.
 ///
@@ -120,9 +111,7 @@ pub fn score_influence_jacobian(
         .fit
         .block_states
         .first()
-        .ok_or_else(|| {
-            "score_influence_jacobian: fitted CTN has no block states".to_string()
-        })?
+        .ok_or_else(|| "score_influence_jacobian: fitted CTN has no block states".to_string())?
         .beta;
     if beta.len() != p1 {
         return Err(format!(
@@ -157,10 +146,9 @@ pub fn score_influence_jacobian(
             cov_design.design.ncols()
         ));
     }
-    let x_cov = cov_design
-        .design
-        .try_row_chunk(0..n)
-        .map_err(|e| format!("score_influence_jacobian: covariate design materialization failed: {e}"))?;
+    let x_cov = cov_design.design.try_row_chunk(0..n).map_err(|e| {
+        format!("score_influence_jacobian: covariate design materialization failed: {e}")
+    })?;
 
     // γ_k(x_i) = Σ_j Xᶜᵒᵛ_{i,j}·Γ[k,j]  ⇒  gamma = Xᶜᵒᵛ · Γᵀ  (n × p_resp).
     let gamma = fast_abt(&x_cov, &beta_mat);
@@ -283,17 +271,15 @@ pub fn score_influence_jacobian(
                 let dl = dl_scalar * xij;
                 let du = du_scalar * xij;
                 // ∂u = [φ(h)∂h − u·(φ(U)∂U − φ(L)∂L) − φ(L)∂L] / (Φ(U)−Φ(L))
-                let du_pit = (pdf_h * dh - u_pit * (pdf_u * du - pdf_l * dl) - pdf_l * dl)
-                    / denom_mass;
+                let du_pit =
+                    (pdf_h * dh - u_pit * (pdf_u * du - pdf_l * dl) - pdf_l * dl) / denom_mass;
                 row[base + j] = du_pit / pdf_z;
             }
         }
     }
 
     if columns.iter().any(|v| !v.is_finite()) {
-        return Err(
-            "score_influence_jacobian: produced non-finite Jacobian entries".to_string(),
-        );
+        return Err("score_influence_jacobian: produced non-finite Jacobian entries".to_string());
     }
     if z_scores.iter().any(|v| !v.is_finite()) {
         return Err("score_influence_jacobian: produced non-finite z scores".to_string());
@@ -324,7 +310,7 @@ pub fn influence_block_design(
     s_f: f64,
 ) -> Array2<f64> {
     let n = jac.columns.nrows();
-    debug_assert_eq!(
+    assert_eq!(
         pilot_beta0.len(),
         n,
         "influence_block_design: pilot_beta0 length must equal Jacobian rows"
@@ -363,12 +349,12 @@ pub(crate) fn residualize_influence_columns(
     eps: f64,
 ) -> Array2<f64> {
     let n = marginal_design.nrows();
-    debug_assert_eq!(
+    assert_eq!(
         z_infl.nrows(),
         n,
         "residualize_influence_columns: Z_infl rows must equal marginal design rows"
     );
-    debug_assert_eq!(
+    assert_eq!(
         w_metric.len(),
         n,
         "residualize_influence_columns: row metric length must equal marginal design rows"

--- a/src/families/survival_marginal_slope.rs
+++ b/src/families/survival_marginal_slope.rs
@@ -1754,13 +1754,19 @@ struct BlockHessianAccumulator {
     h_gh: Array2<f64>,
     h_gw: Array2<f64>,
     h_hw: Array2<f64>,
+    h_ti: Array2<f64>,
+    h_mi: Array2<f64>,
+    h_gi: Array2<f64>,
+    h_hi: Array2<f64>,
+    h_wi: Array2<f64>,
+    h_ii: Array2<f64>,
 }
 
 const PULLBACK_PARALLEL_MIN_CELLS: usize = 16_384;
 const PULLBACK_PARALLEL_TARGET_CELLS: usize = 65_536;
 
 impl BlockHessianAccumulator {
-    fn new(p_t: usize, p_m: usize, p_g: usize, p_h: usize, p_w: usize) -> Self {
+    fn new(p_t: usize, p_m: usize, p_g: usize, p_h: usize, p_w: usize, p_i: usize) -> Self {
         Self {
             h_tt: Array2::zeros((p_t, p_t)),
             h_mm: Array2::zeros((p_m, p_m)),
@@ -1777,6 +1783,12 @@ impl BlockHessianAccumulator {
             h_gh: Array2::zeros((p_g, p_h)),
             h_gw: Array2::zeros((p_g, p_w)),
             h_hw: Array2::zeros((p_h, p_w)),
+            h_ti: Array2::zeros((p_t, p_i)),
+            h_mi: Array2::zeros((p_m, p_i)),
+            h_gi: Array2::zeros((p_g, p_i)),
+            h_hi: Array2::zeros((p_h, p_i)),
+            h_wi: Array2::zeros((p_w, p_i)),
+            h_ii: Array2::zeros((p_i, p_i)),
         }
     }
 
@@ -2091,6 +2103,88 @@ impl BlockHessianAccumulator {
             }
         }
 
+        if let Some(z_tilde) = family.influence_absorber.as_ref() {
+            let z_row = z_tilde.row(row);
+            let ti_weights = [
+                primary_hessian[[0, 0]] + primary_hessian[[0, 1]],
+                primary_hessian[[1, 0]] + primary_hessian[[1, 1]],
+                primary_hessian[[2, 0]] + primary_hessian[[2, 1]],
+            ];
+            for (des, alpha) in time_designs.iter().zip(ti_weights.iter()) {
+                if *alpha == 0.0 {
+                    continue;
+                }
+                let t_chunk = des.try_row_chunk(row..row + 1).map_err(|e| {
+                    format!("add_pullback influence time design try_row_chunk: {e}")
+                })?;
+                let t_row = t_chunk.row(0);
+                ndarray::linalg::general_mat_mul(
+                    *alpha,
+                    &t_row.view().insert_axis(Axis(1)),
+                    &z_row.view().insert_axis(Axis(0)),
+                    1.0,
+                    &mut self.h_ti,
+                );
+            }
+            if mm_weight != 0.0 {
+                let m_chunk = family
+                    .marginal_design
+                    .try_row_chunk(row..row + 1)
+                    .map_err(|e| {
+                        format!("add_pullback influence marginal_design try_row_chunk: {e}")
+                    })?;
+                let m_row = m_chunk.row(0);
+                ndarray::linalg::general_mat_mul(
+                    mm_weight,
+                    &m_row.view().insert_axis(Axis(1)),
+                    &z_row.view().insert_axis(Axis(0)),
+                    1.0,
+                    &mut self.h_mi,
+                );
+                ndarray::linalg::general_mat_mul(
+                    mm_weight,
+                    &z_row.view().insert_axis(Axis(1)),
+                    &z_row.view().insert_axis(Axis(0)),
+                    1.0,
+                    &mut self.h_ii,
+                );
+            }
+            let gi_weight = primary_hessian[[3, 0]] + primary_hessian[[3, 1]];
+            if gi_weight != 0.0 {
+                ndarray::linalg::general_mat_mul(
+                    gi_weight,
+                    &g_row.view().insert_axis(Axis(1)),
+                    &z_row.view().insert_axis(Axis(0)),
+                    1.0,
+                    &mut self.h_gi,
+                );
+            }
+            if let Some(h_range) = primary.h.as_ref() {
+                for local_idx in 0..h_range.len() {
+                    let alpha = primary_hessian[[h_range.start + local_idx, 0]]
+                        + primary_hessian[[h_range.start + local_idx, 1]];
+                    if alpha == 0.0 {
+                        continue;
+                    }
+                    for infl_idx in 0..z_row.len() {
+                        self.h_hi[[local_idx, infl_idx]] += alpha * z_row[infl_idx];
+                    }
+                }
+            }
+            if let Some(w_range) = primary.w.as_ref() {
+                for local_idx in 0..w_range.len() {
+                    let alpha = primary_hessian[[w_range.start + local_idx, 0]]
+                        + primary_hessian[[w_range.start + local_idx, 1]];
+                    if alpha == 0.0 {
+                        continue;
+                    }
+                    for infl_idx in 0..z_row.len() {
+                        self.h_wi[[local_idx, infl_idx]] += alpha * z_row[infl_idx];
+                    }
+                }
+            }
+        }
+
         Ok(())
     }
 
@@ -2353,6 +2447,17 @@ impl BlockHessianAccumulator {
 
             (ScoreWarp, LinkDev) => self.h_hw.view(),
             (LinkDev, ScoreWarp) => self.h_hw.t(),
+            (Time, Influence) => self.h_ti.view(),
+            (Influence, Time) => self.h_ti.t(),
+            (Marginal, Influence) => self.h_mi.view(),
+            (Influence, Marginal) => self.h_mi.t(),
+            (Logslope, Influence) => self.h_gi.view(),
+            (Influence, Logslope) => self.h_gi.t(),
+            (ScoreWarp, Influence) => self.h_hi.view(),
+            (Influence, ScoreWarp) => self.h_hi.t(),
+            (LinkDev, Influence) => self.h_wi.view(),
+            (Influence, LinkDev) => self.h_wi.t(),
+            (Influence, Influence) => self.h_ii.view(),
         }
     }
 
@@ -2421,6 +2526,12 @@ impl BlockHessianAccumulator {
         self.h_gh += &other.h_gh;
         self.h_gw += &other.h_gw;
         self.h_hw += &other.h_hw;
+        self.h_ti += &other.h_ti;
+        self.h_mi += &other.h_mi;
+        self.h_gi += &other.h_gi;
+        self.h_hi += &other.h_hi;
+        self.h_wi += &other.h_wi;
+        self.h_ii += &other.h_ii;
     }
 
     fn diagonal(&self, slices: &BlockSlices) -> Array1<f64> {
@@ -4836,6 +4947,7 @@ impl SurvivalMarginalSlopeFamily {
         let p_g = slices.logslope.len();
         let p_h = slices.score_warp.as_ref().map_or(0, |range| range.len());
         let p_w = slices.link_dev.as_ref().map_or(0, |range| range.len());
+        let p_i = slices.influence.as_ref().map_or(0, |range| range.len());
         let row_iter = outer_row_indices(options, self.n).to_vec();
         let row_weights = outer_row_weights_by_index(options, self.n);
         // Bit-deterministic reduction: see `chunked_row_reduction`.
@@ -4850,7 +4962,7 @@ impl SurvivalMarginalSlopeFamily {
                         Array1::zeros(p_g),
                         Array1::zeros(p_h),
                         Array1::zeros(p_w),
-                        BlockHessianAccumulator::new(p_t, p_m, p_g, p_h, p_w),
+                        BlockHessianAccumulator::new(p_t, p_m, p_g, p_h, p_w, p_i),
                     )
                 },
                 |row, a| -> Result<(), String> {
@@ -4933,6 +5045,7 @@ impl SurvivalMarginalSlopeFamily {
         let p_g = slices.logslope.len();
         let p_h = slices.score_warp.as_ref().map_or(0, |range| range.len());
         let p_w = slices.link_dev.as_ref().map_or(0, |range| range.len());
+        let p_i = slices.influence.as_ref().map_or(0, |range| range.len());
         let row_iter = outer_row_indices(options, self.n).to_vec();
         let row_weights = outer_row_weights_by_index(options, self.n);
         // Bit-deterministic reduction: see `chunked_row_reduction`.
@@ -4947,7 +5060,7 @@ impl SurvivalMarginalSlopeFamily {
                         Array1::zeros(p_g),
                         Array1::zeros(p_h),
                         Array1::zeros(p_w),
-                        BlockHessianAccumulator::new(p_t, p_m, p_g, p_h, p_w),
+                        BlockHessianAccumulator::new(p_t, p_m, p_g, p_h, p_w, p_i),
                     )
                 },
                 |row, a| -> Result<(), String> {
@@ -5034,6 +5147,7 @@ impl SurvivalMarginalSlopeFamily {
         let p_g = slices.logslope.len();
         let p_h = slices.score_warp.as_ref().map_or(0, |range| range.len());
         let p_w = slices.link_dev.as_ref().map_or(0, |range| range.len());
+        let p_i = slices.influence.as_ref().map_or(0, |range| range.len());
         let primary_dim = N_PRIMARY;
         let row_iter = outer_row_indices(options, self.n).to_vec();
         let row_weights = outer_row_weights_by_index(options, self.n);
@@ -5050,7 +5164,7 @@ impl SurvivalMarginalSlopeFamily {
         // Bit-deterministic reduction: see `chunked_row_reduction`.
         let acc = chunked_row_reduction(
             row_iter.as_slice(),
-            || BlockHessianAccumulator::new(p_t, p_m, p_g, p_h, p_w),
+            || BlockHessianAccumulator::new(p_t, p_m, p_g, p_h, p_w, p_i),
             |row, acc| -> Result<(), String> {
                 let row_dir = self.row_primary_direction_from_flat_dynamic(
                     row,
@@ -5752,8 +5866,7 @@ impl SurvivalMarginalSlopeFamily {
         if self.influence_absorber.is_none() {
             return Ok(None);
         }
-        let idx =
-            3 + usize::from(self.score_warp.is_some()) + usize::from(self.link_dev.is_some());
+        let idx = 3 + usize::from(self.score_warp.is_some()) + usize::from(self.link_dev.is_some());
         block_states
             .get(idx)
             .map(|state| Some(&state.beta))
@@ -5768,9 +5881,10 @@ impl SurvivalMarginalSlopeFamily {
         row: usize,
         block_states: &[ParameterBlockState],
     ) -> Result<f64, String> {
-        let (Some(z_tilde), Some(gamma)) =
-            (self.influence_absorber.as_ref(), self.flex_influence_beta(block_states)?)
-        else {
+        let (Some(z_tilde), Some(gamma)) = (
+            self.influence_absorber.as_ref(),
+            self.flex_influence_beta(block_states)?,
+        ) else {
             return Ok(0.0);
         };
         if gamma.len() != z_tilde.ncols() {
@@ -11794,6 +11908,7 @@ impl SurvivalMarginalSlopeFamily {
         let p_g = slices.logslope.len();
         let p_h = slices.score_warp.as_ref().map_or(0, |range| range.len());
         let p_w = slices.link_dev.as_ref().map_or(0, |range| range.len());
+        let p_i = slices.influence.as_ref().map_or(0, |range| range.len());
 
         // Build the psi design map once; rowwise loop does direct row_vector(row)
         // calls via the PsiDesignMap API.
@@ -11825,7 +11940,7 @@ impl SurvivalMarginalSlopeFamily {
                 Array1::zeros(p_g),
                 Array1::zeros(p_h),
                 Array1::zeros(p_w),
-                BlockHessianAccumulator::new(p_t, p_m, p_g, p_h, p_w),
+                BlockHessianAccumulator::new(p_t, p_m, p_g, p_h, p_w, p_i),
             )
         };
 
@@ -12076,6 +12191,7 @@ impl SurvivalMarginalSlopeFamily {
         let p_g = slices.logslope.len();
         let p_h = slices.score_warp.as_ref().map_or(0, |range| range.len());
         let p_w = slices.link_dev.as_ref().map_or(0, |range| range.len());
+        let p_i = slices.influence.as_ref().map_or(0, |range| range.len());
 
         struct BatchedPsiAxisAcc {
             objective_psi: f64,
@@ -12095,7 +12211,7 @@ impl SurvivalMarginalSlopeFamily {
                     score_g: Array1::zeros(p_g),
                     score_h: Array1::zeros(p_h),
                     score_w: Array1::zeros(p_w),
-                    hessian: BlockHessianAccumulator::new(p_t, p_m, p_g, p_h, p_w),
+                    hessian: BlockHessianAccumulator::new(p_t, p_m, p_g, p_h, p_w, p_i),
                 })
                 .collect()
         };
@@ -12305,6 +12421,7 @@ impl SurvivalMarginalSlopeFamily {
         let p_g = slices.logslope.len();
         let p_h = slices.score_warp.as_ref().map_or(0, |range| range.len());
         let p_w = slices.link_dev.as_ref().map_or(0, |range| range.len());
+        let p_i = slices.influence.as_ref().map_or(0, |range| range.len());
         let same_block = block_idx_i == block_idx_j;
 
         // Build psi design maps once outside the row loop; rowwise calls use
@@ -12360,7 +12477,7 @@ impl SurvivalMarginalSlopeFamily {
                 score_g: Array1::zeros(p_g),
                 score_h: Array1::zeros(p_h),
                 score_w: Array1::zeros(p_w),
-                hessian: BlockHessianAccumulator::new(p_t, p_m, p_g, p_h, p_w),
+                hessian: BlockHessianAccumulator::new(p_t, p_m, p_g, p_h, p_w, p_i),
             }
         };
 
@@ -12790,6 +12907,7 @@ impl SurvivalMarginalSlopeFamily {
         let p_g = slices.logslope.len();
         let p_h = slices.score_warp.as_ref().map_or(0, |range| range.len());
         let p_w = slices.link_dev.as_ref().map_or(0, |range| range.len());
+        let p_i = slices.influence.as_ref().map_or(0, |range| range.len());
 
         // Build the psi design map once; rowwise calls use direct row_vector(row).
         let policy = crate::resource::ResourcePolicy::default_library();
@@ -12808,7 +12926,7 @@ impl SurvivalMarginalSlopeFamily {
         // accumulators in row-chunk order for deterministic timewiggle assembly.
         let acc = chunked_row_reduction(
             row_iter.as_slice(),
-            || BlockHessianAccumulator::new(p_t, p_m, p_g, p_h, p_w),
+            || BlockHessianAccumulator::new(p_t, p_m, p_g, p_h, p_w, p_i),
             |row, acc| -> Result<(), String> {
                 let psi_row = psi_map
                     .row_vector(row)
@@ -13007,8 +13125,9 @@ impl SurvivalMarginalSlopeFamily {
         let p_g = slices.logslope.len();
         let p_h = slices.score_warp.as_ref().map_or(0, |range| range.len());
         let p_w = slices.link_dev.as_ref().map_or(0, |range| range.len());
+        let p_i = slices.influence.as_ref().map_or(0, |range| range.len());
         let p_total = slices.total;
-        let make_acc = || BlockHessianAccumulator::new(p_t, p_m, p_g, p_h, p_w);
+        let make_acc = || BlockHessianAccumulator::new(p_t, p_m, p_g, p_h, p_w, p_i);
 
         // Phase 2d: the same per-row work that yields the block-Hessian pullback
         // also yields the row negative-log-likelihood and the joint gradient.
@@ -13141,11 +13260,12 @@ impl SurvivalMarginalSlopeFamily {
         let p_g = slices.logslope.len();
         let p_h = slices.score_warp.as_ref().map_or(0, |range| range.len());
         let p_w = slices.link_dev.as_ref().map_or(0, |range| range.len());
+        let p_i = slices.influence.as_ref().map_or(0, |range| range.len());
         let row_iter = outer_row_indices(options, self.n).to_vec();
         let row_weights = outer_row_weights_by_index(options, self.n);
         let make_acc_ws = || {
             (
-                BlockHessianAccumulator::new(p_t, p_m, p_g, p_h, p_w),
+                BlockHessianAccumulator::new(p_t, p_m, p_g, p_h, p_w, p_i),
                 SurvivalMarginalSlopeDynamicRow::empty_workspace(),
             )
         };
@@ -13207,11 +13327,12 @@ impl SurvivalMarginalSlopeFamily {
         let p_g = slices.logslope.len();
         let p_h = slices.score_warp.as_ref().map_or(0, |range| range.len());
         let p_w = slices.link_dev.as_ref().map_or(0, |range| range.len());
+        let p_i = slices.influence.as_ref().map_or(0, |range| range.len());
         let row_iter = outer_row_indices(options, self.n).to_vec();
         let row_weights = outer_row_weights_by_index(options, self.n);
         let make_acc_ws = || {
             (
-                BlockHessianAccumulator::new(p_t, p_m, p_g, p_h, p_w),
+                BlockHessianAccumulator::new(p_t, p_m, p_g, p_h, p_w, p_i),
                 SurvivalMarginalSlopeDynamicRow::empty_workspace(),
             )
         };
@@ -13561,9 +13682,7 @@ impl crate::families::marginal_slope_shared::MarginalSlopePsiFamily
         )
     }
 
-    fn psi_first_order_terms_all(
-        &self,
-    ) -> Result<Option<Vec<ExactNewtonJointPsiTerms>>, String> {
+    fn psi_first_order_terms_all(&self) -> Result<Option<Vec<ExactNewtonJointPsiTerms>>, String> {
         let total: usize = self.derivative_blocks.iter().map(Vec::len).sum();
         if total == 0 {
             return Ok(Some(Vec::new()));
@@ -20015,11 +20134,11 @@ pub fn fit_survival_marginal_slope_terms(
     let influence_absorber_residualized: Option<Array2<f64>> =
         if let Some(jac) = spec.score_influence_jacobian.as_ref() {
             use crate::families::marginal_slope_orthogonal::{
-                influence_block_design, residualize_influence_columns, ScoreInfluenceJacobian,
+                ScoreInfluenceJacobian, influence_block_design, residualize_influence_columns,
             };
-            let marginal_dense = marginal_design
-                .design
-                .try_to_dense_by_chunks("survival marginal-slope influence-absorber marginal span")?;
+            let marginal_dense = marginal_design.design.try_to_dense_by_chunks(
+                "survival marginal-slope influence-absorber marginal span",
+            )?;
             // Realized leakage directions `Z_infl = diag(s_f·β̂₀)·J` via the core
             // builder; `β̂₀(x_i)` is the rigid-pilot logslope and `s_f =
             // probit_scale`. `influence_block_design` reads only `columns`; the
@@ -20029,8 +20148,7 @@ pub fn fit_survival_marginal_slope_terms(
                 z: z_primary.clone(),
             };
             let rigid_logslope_at_rows = &spec.logslope_offset + baseline_slope;
-            let z_infl =
-                influence_block_design(&jacobian, &rigid_logslope_at_rows, probit_scale);
+            let z_infl = influence_block_design(&jacobian, &rigid_logslope_at_rows, probit_scale);
             // Marginal-Gram ridge scaled to the weighted Gram's own magnitude so
             // the projection solve stays stable when the marginal design is
             // rank-deficient at the pilot, without perturbing a well-conditioned
@@ -20056,9 +20174,11 @@ pub fn fit_survival_marginal_slope_terms(
             );
             if residualized.iter().any(|v| !v.is_finite()) {
                 return Err(SurvivalMarginalSlopeError::NumericalFailure {
-                    reason: "survival influence-absorber residualized columns contain non-finite entries".to_string(),
-                }
-                .into());
+                reason:
+                    "survival influence-absorber residualized columns contain non-finite entries"
+                        .to_string(),
+            }
+            .into());
             }
             Some(residualized)
         } else {
@@ -27971,7 +28091,7 @@ mod tests {
         p_h: usize,
         p_w: usize,
     ) -> BlockHessianAccumulator {
-        let mut acc = BlockHessianAccumulator::new(p_t, p_m, p_g, p_h, p_w);
+        let mut acc = BlockHessianAccumulator::new(p_t, p_m, p_g, p_h, p_w, p_i);
         // Per-pair base offsets keep the diagonal blocks symmetric (required
         // for a valid Hessian) while making the off-diagonal blocks distinct
         // and asymmetric, so `to_dense` must place each transpose correctly.

--- a/src/gpu/backend_probe.rs
+++ b/src/gpu/backend_probe.rs
@@ -26,9 +26,7 @@
 //! there is no transitional shim.
 
 #[cfg(target_os = "linux")]
-pub(crate) use linux::{
-    CudaBackendContext, CudaBackendParts, probe_backend_with_compile, probe_cuda_backend,
-};
+pub(crate) use linux::{CudaBackendContext, probe_backend_with_compile, probe_cuda_backend};
 
 #[cfg(target_os = "linux")]
 mod linux {

--- a/src/inference/sample.rs
+++ b/src/inference/sample.rs
@@ -4,7 +4,9 @@
 //! both call into [`sample_saved_model`], which dispatches on the saved
 //! model's class (standard GLM, standard with link-wiggle, or survival) and
 //! returns a fully-converged [`NutsResult`] over the original coefficient
-//! space.
+//! space. Gaussian identity standard models are sampled from the saved
+//! closed-form posterior, conditioning on the training fit rather than any
+//! prediction rows supplied by the caller.
 
 use std::collections::HashMap;
 
@@ -13,7 +15,7 @@ use ndarray::{Array1, Array2, ArrayView1, ArrayView2, s};
 use rand::{RngExt, SeedableRng};
 
 use crate::basis::create_difference_penalty_matrix;
-use crate::estimate::{BlockRole, FitOptions, UnifiedFitResult, fit_gam, validate_all_finite};
+use crate::estimate::{BlockRole, UnifiedFitResult, validate_all_finite};
 use crate::faer_ndarray::FaerCholesky;
 use crate::families::royston_parmar::{self, RoystonParmarInputs};
 use crate::families::survival_predict::{
@@ -174,10 +176,13 @@ const fn chain_stream_seed(seed: u64, chain: usize, stream: u64) -> u64 {
 ///
 /// Dispatches on `model.predict_model_class()`:
 ///
-/// * `Standard`: refits the GAM in flat space, whitens with the saved
-///   Hessian, and runs NUTS over the coefficient vector. Link-wiggle models
-///   take a specialised joint-space path that preserves the basis chain
-///   rule.
+/// * `Standard`: Gaussian identity models use the exact saved
+///   `N(mode, φ·H⁻¹)` posterior, where `mode`, `φ`, and `H` all come from the
+///   training fit. Other standard GLMs run NUTS from the saved mode,
+///   smoothing parameters, dispersion, and whitening curvature rather than
+///   refitting/reselecting them on the caller-supplied rows. Link-wiggle
+///   models take a specialised joint-space path that preserves the basis
+///   chain rule.
 /// * `Survival`: rebuilds the survival design (Royston-Parmar baseline +
 ///   wiggle + covariate blocks) on the supplied data, evaluates the mode,
 ///   and runs the survival-flat NUTS path. Latent and location-scale modes
@@ -369,6 +374,9 @@ fn sample_standard(
     likelihood: LikelihoodSpec,
     cfg: &NutsConfig,
 ) -> Result<NutsResult, String> {
+    if likelihood.is_gaussian_identity() {
+        return laplace_gaussian_fallback(model, cfg, "standard gaussian posterior");
+    }
     if model.has_link_wiggle() {
         return sample_standard_link_wiggle(
             model,
@@ -391,44 +399,23 @@ fn sample_standard(
     let design = build_term_collection_design(data, &spec)
         .map_err(|e| format!("failed to build term collection design: {e}"))?;
     let weights = Array1::ones(data.nrows());
-    let offset = Array1::zeros(data.nrows());
     let dense_design_hmc = design.design.to_dense();
     let p = dense_design_hmc.ncols();
-    let fit = fit_gam(
-        dense_design_hmc.view(),
-        y.view(),
-        weights.view(),
-        offset.view(),
-        &design.penalties,
-        likelihood.clone(),
-        &FitOptions {
-            latent_cloglog: None,
-            mixture_link: None,
-            optimize_mixture: false,
-            sas_link: None,
-            optimize_sas: false,
-            // NUTS whitening (line below) calls
-            // `explicit_fit_hessian_for_whitening`, which reads
-            // `fit.penalized_hessian()` from the inference output. With
-            // `compute_inference: false` the refit returns no inference and
-            // sampling fails with "fit result is missing an explicit
-            // penalized Hessian for HMC/NUTS whitening". The fit IS the
-            // upstream whose curvature we then whiten by, so the inference
-            // path is non-optional here.
-            compute_inference: true,
-            max_iter: 80,
-            tol: 1e-6,
-            nullspace_dims: design.nullspace_dims.clone(),
-            linear_constraints: design.linear_constraints.clone(),
-            firth_bias_reduction: false,
-            adaptive_regularization: None,
-            penalty_shrinkage_floor: Some(1e-6),
-            rho_prior: Default::default(),
-            kronecker_penalty_system: None,
-            kronecker_factored: None,
-        },
-    )
-    .map_err(|e| format!("fit_gam failed during sample refit: {e}"))?;
+    let fit = fit_result_from_saved_model_for_prediction(model)?;
+    if fit.beta.len() != p {
+        return Err(format!(
+            "standard sample: saved model has {} coefficients but rebuilt design has {} columns",
+            fit.beta.len(),
+            p,
+        ));
+    }
+    if fit.lambdas.len() != design.penalties.len() {
+        return Err(format!(
+            "standard sample: saved model has {} lambdas but rebuilt design has {} penalties",
+            fit.lambdas.len(),
+            design.penalties.len(),
+        ));
+    }
     let penalty =
         weighted_blockwise_penalty_sum(&design.penalties, fit.lambdas.as_slice().unwrap(), p);
 
@@ -440,11 +427,11 @@ fn sample_standard(
             weights: weights.view(),
             penalty_matrix: penalty.view(),
             mode: fit.beta.view(),
-            hessian: explicit_fit_hessian_for_whitening(&fit, p, "sample refit")?.view(),
+            hessian: explicit_fit_hessian_for_whitening(&fit, p, "saved standard model")?.view(),
             gamma_shape: fit.likelihood_scale.gamma_shape(),
-            // Forward the fitted dispersion so the NUTS posterior whitens
-            // against `Vb = φ·H⁻¹` for Gaussian / Gamma and stays a
-            // no-op for fixed-scale families.
+            // Forward the saved training dispersion so NUTS whitening uses the
+            // posterior scale selected at fit time; fixed-scale families remain
+            // a no-op.
             dispersion: fit.dispersion().unwrap_or_default(),
             firth_bias_reduction: false,
         }),

--- a/src/solver/workflow.rs
+++ b/src/solver/workflow.rs
@@ -2737,7 +2737,7 @@ pub struct CrossFitScoreCalibration {
 /// Stage-1 fit; its presence is the sole auto-enable signal for cross-fitted
 /// orthogonalization (design §5). When absent, Stage-2 falls back to the free
 /// 1-D `score_warp` spline (which spans only the x-free leakage column).
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct CtnStage1Recipe {
     /// Stage-1 response column name (the `y` the CTN transforms).
     pub response_column: String,
@@ -2859,8 +2859,8 @@ fn crossfit_score_calibration(
     }
 
     // Stage-1 response / weights / offset, resolved against the full dataset.
-    let y_col =
-        resolve_role_col(col_map, &recipe.response_column, "response").map_err(|e| e.to_string())?;
+    let y_col = resolve_role_col(col_map, &recipe.response_column, "response")
+        .map_err(|e| e.to_string())?;
     let response_full = data.values.column(y_col).to_owned();
     let weights_full = resolve_weight_column(data, col_map, recipe.weight_column.as_deref())
         .map_err(|e| e.to_string())?;
@@ -3084,8 +3084,9 @@ pub fn fit_marginal_slope_from_ctn(
     let covariate_formula_rhs = stage1_covariates.trim().to_string();
     if covariate_formula_rhs.is_empty() {
         return Err(WorkflowError::InvalidConfig {
-            reason: "fit_marginal_slope_from_ctn requires a non-empty Stage-1 covariate formula RHS"
-                .to_string(),
+            reason:
+                "fit_marginal_slope_from_ctn requires a non-empty Stage-1 covariate formula RHS"
+                    .to_string(),
         });
     }
     if covariate_formula_rhs.contains('~') {
@@ -3244,7 +3245,11 @@ fn fit_ctn_stage1_in_sample_score(
 /// into the Stage-2 materializer without mutating the caller's dataset.
 fn append_continuous_column(data: &Dataset, name: &str, values: Array1<f64>) -> Dataset {
     let n = data.values.nrows();
-    debug_assert_eq!(values.len(), n, "appended column length must equal row count");
+    assert_eq!(
+        values.len(),
+        n,
+        "appended column length must equal row count"
+    );
     let p = data.values.ncols();
     let mut augmented_values = Array2::<f64>::zeros((n, p + 1));
     augmented_values.slice_mut(s![.., ..p]).assign(&data.values);

--- a/tests/bug_hunt_gaussian_sample_refit_dispersion_collapse.rs
+++ b/tests/bug_hunt_gaussian_sample_refit_dispersion_collapse.rs
@@ -1,0 +1,147 @@
+//! Regression for issue #521: sampling a saved Gaussian identity model must
+//! condition on the saved training fit, not refit/re-estimate dispersion on the
+//! rows supplied to `sample_saved_model`.
+//!
+//! The first six rows below lie exactly on the linear plane. The full training
+//! set has real residual noise. The historical standard sampling path rebuilt
+//! `X,y` from the caller's data, refit REML/PIRLS on those six rows, estimated
+//! φ≈0, and returned a coefficient posterior thousands of times too tight for
+//! the very same saved model. A saved-model posterior is conditioned on the
+//! training fit: passing fewer prediction rows cannot make the coefficient
+//! posterior tighter.
+
+use gam::hmc::NutsConfig;
+use gam::inference::model::{
+    FittedFamily, FittedModel, FittedModelPayload, MODEL_PAYLOAD_VERSION, ModelKind,
+};
+use gam::sample::sample_saved_model;
+use gam::smooth::{build_term_collection_design, freeze_term_collection_from_design};
+use gam::types::{LikelihoodSpec, StandardLink};
+use gam::{FitConfig, FitResult, fit_from_formula, init_parallelism, load_csvwith_inferred_schema};
+use ndarray::{Array2, s};
+use std::io::Write;
+
+fn gaussian_training_csv(n: usize) -> String {
+    let mut csv = String::from("x1,x2,y\n");
+    for i in 0..n {
+        let t = i as f64;
+        let x1 = (t / 17.0).sin() + 0.003 * t;
+        let x2 = (t / 29.0).cos() - 0.002 * t;
+        let noise = if i < 6 {
+            0.0
+        } else {
+            0.08 * (t * 1.618_033_988_75).sin() + 0.03 * (t * 0.37).cos()
+        };
+        let y = 1.25 + 2.0 * x1 - 1.5 * x2 + noise;
+        csv.push_str(&format!("{x1:.17e},{x2:.17e},{y:.17e}\n"));
+    }
+    csv
+}
+
+fn write_temp_csv(contents: &str) -> std::path::PathBuf {
+    let mut path = std::env::temp_dir();
+    path.push(format!(
+        "gam_issue_521_gaussian_sample_{}.csv",
+        std::process::id()
+    ));
+    let mut file = std::fs::File::create(&path).expect("create issue #521 synthetic csv");
+    file.write_all(contents.as_bytes())
+        .expect("write issue #521 synthetic csv");
+    path
+}
+
+fn saved_standard_gaussian_model(
+    formula: &str,
+    ds: &gam::inference::data::EncodedDataset,
+) -> (FittedModel, usize) {
+    let cfg = FitConfig::default();
+    let result = fit_from_formula(formula, ds, &cfg).expect("fit full Gaussian model");
+    let FitResult::Standard(fit) = result else {
+        panic!("expected a standard Gaussian identity fit");
+    };
+
+    let design = build_term_collection_design(ds.values.view(), &fit.resolvedspec)
+        .expect("rebuild full training design");
+    let p = design.design.ncols();
+    let frozenspec = freeze_term_collection_from_design(&fit.resolvedspec, &design)
+        .expect("freeze training term collection");
+
+    let mut payload = FittedModelPayload::new(
+        MODEL_PAYLOAD_VERSION,
+        formula.to_string(),
+        ModelKind::Standard,
+        FittedFamily::Standard {
+            likelihood: LikelihoodSpec::gaussian_identity(),
+            link: Some(StandardLink::Identity),
+            latent_cloglog_state: None,
+            mixture_state: None,
+            sas_state: None,
+        },
+        "gaussian".to_string(),
+    );
+    payload.fit_result = Some(fit.fit.clone());
+    payload.unified = Some(fit.fit);
+    payload.data_schema = Some(ds.schema.clone());
+    payload.resolved_termspec = Some(frozenspec);
+    payload.set_training_feature_metadata(ds.headers.clone(), ds.feature_ranges());
+
+    (FittedModel::from_payload(payload), p)
+}
+
+#[test]
+fn gaussian_saved_model_subset_sampling_does_not_tighten_posterior() {
+    init_parallelism();
+
+    let csv = gaussian_training_csv(600);
+    let csv_path = write_temp_csv(&csv);
+    let ds = load_csvwith_inferred_schema(&csv_path).expect("load issue #521 synthetic csv");
+    std::fs::remove_file(&csv_path).expect("remove issue #521 synthetic csv");
+    let col = ds.column_map();
+
+    let (model, p) = saved_standard_gaussian_model("y ~ x1 + x2", &ds);
+    let cfg = NutsConfig {
+        n_samples: 256,
+        nwarmup: 64,
+        n_chains: 2,
+        seed: 521,
+        ..NutsConfig::for_dimension(p)
+    };
+
+    let all_rows = sample_saved_model(
+        &model,
+        ds.values.view(),
+        &col,
+        model.training_headers.as_ref(),
+        &cfg,
+    )
+    .expect("sample saved Gaussian model on all rows");
+    let subset_values: Array2<f64> = ds.values.slice(s![0..6, ..]).to_owned();
+    let subset_rows = sample_saved_model(
+        &model,
+        subset_values.view(),
+        &col,
+        model.training_headers.as_ref(),
+        &cfg,
+    )
+    .expect("sample saved Gaussian model on six-row subset");
+
+    assert!(
+        all_rows.converged,
+        "full-data saved-model sampler converged"
+    );
+    assert!(
+        subset_rows.converged,
+        "subset saved-model sampler converged"
+    );
+    assert_eq!(all_rows.posterior_std.len(), p);
+    assert_eq!(subset_rows.posterior_std.len(), p);
+
+    for j in 0..p {
+        let full_std = all_rows.posterior_std[j];
+        let subset_std = subset_rows.posterior_std[j];
+        assert!(
+            subset_std + 1e-12 >= full_std,
+            "coefficient {j}: subset posterior std {subset_std:.6e} tightened below full-data std {full_std:.6e}"
+        );
+    }
+}


### PR DESCRIPTION
**Summary**
* Fixed issue #521’s root cause by making standard Gaussian identity saved-model sampling use the saved closed-form posterior, `N(mode, φ·H⁻¹)`, rather than refitting on the rows passed to `sample_saved_model`. The Gaussian path now delegates directly to the saved-fit Laplace/Gaussian sampler before any caller-row design rebuild/refit can occur. 

* Updated the standard GLM sampling path so non-Gaussian standard models also source the saved mode, smoothing lambdas, dispersion, and whitening curvature from the saved model instead of reselecting them during sampling. 

* Added the issue regression test: it fits `y ~ x1 + x2` on 600 Gaussian rows with a near-exact six-row subset, samples the same saved model on all rows and the strict subset, and asserts the subset posterior standard deviation does not tighten coefficient-by-coefficient. 

* Addressed build-enforced all-features blockers encountered by the required targeted test: strengthened runtime shape checks instead of debug-only assertions, made the CTN stage-1 recipe debuggable, removed an unused CUDA re-export, and completed the survival marginal-slope influence Hessian block storage/view wiring. 


**Testing**
* ✅ `cargo test --test bug_hunt_gaussian_sample_refit_dispersion_collapse --all-features -- --nocapture`

Committed changes on the current branch and opened the PR: **“Fix Gaussian saved-model sampling refit collapse”**.

Closes #521