### PR TITLE
fix(#861): accept-and-noop --firth for bernoulli marginal-slope (CLI/…

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1686,7 +1686,17 @@ fn run_fit_bernoulli_marginal_slope(
         );
     }
     if args.firth {
-        return Err("--firth is not supported for the bernoulli marginal-slope family".to_string());
+        // #861 / #774: the bernoulli marginal-slope path runs an always-on full-span
+        // Jeffreys/Firth stabilizer by policy, so `--firth` is *redundant*, not
+        // unsupported. Accept-and-noop to match the Python surface (which also accepts
+        // `firth=True` here), and advise the user the flag had no additional effect so
+        // that "is Firth active on marginal-slope?" gets one consistent, truthful answer.
+        inference_notes.push(
+            "--firth is redundant for the bernoulli marginal-slope family: a full-span \
+             Jeffreys/Firth stabilizer is always active by policy (#774), so the flag has \
+             no additional effect."
+                .to_string(),
+        );
     }
     if args.predict_noise.is_some() {
         return Err(
@@ -6768,9 +6778,11 @@ fn validate_fit_args_preflight(args: &FitArgs, parsed: &ParsedFormula) -> Result
                 "--predict-noise cannot be combined with --logslope-formula/--z-column".to_string(),
             );
         }
-        if args.firth {
-            return Err("--firth is not supported for marginal-slope fitting".to_string());
-        }
+        // #861: firth on marginal-slope is no longer rejected in this scattered preflight
+        // branch. Bernoulli marginal-slope accept-and-noops it (always-on Jeffreys/Firth,
+        // #774); survival marginal-slope firth is still rejected by
+        // `validate_cli_firth_configuration` (a `Surv(...)` response sets `is_survival`).
+        // Removing the bespoke gate here is what eliminates the CLI/Python divergence.
         if args.adaptive_regularization {
             return Err(
                 "--adaptive-regularization is only supported for standard GAM fitting".to_string(),

--- a/tests/src_modules/cli_tests.rs
+++ b/tests/src_modules/cli_tests.rs
@@ -1426,6 +1426,62 @@ fn cli_bernoulli_marginal_slope_fit_saves_covariance_so_default_predict_succeeds
 }
 
 #[test]
+fn cli_bernoulli_marginal_slope_accepts_firth_as_redundant_noop() {
+    // Regression for #861: the bernoulli marginal-slope path runs an always-on
+    // full-span Jeffreys/Firth stabilizer by policy (#774), so `--firth` is redundant,
+    // not unsupported. The CLI must accept it (matching the Python API, which already
+    // accepts `firth=True` for this family) instead of hard-erroring. Survival
+    // marginal-slope firth stays rejected by `validate_cli_firth_configuration` and is
+    // covered by `cli_firth_validation_rejects_survival_models`.
+    let td = tempdir().expect("tempdir");
+    let train_path = td.path().join("train.csv");
+    let model_path = td.path().join("model.json");
+    write_bernoulli_marginal_slope_train_csv(&train_path);
+
+    run_fit(FitArgs {
+        data: train_path,
+        formula_positional: "y ~ x".to_string(),
+        predict_noise: None,
+        logslope_formula: Some("1".to_string()),
+        z_column: Some("z".to_string()),
+        weights_column: None,
+        offset_column: None,
+        noise_offset_column: None,
+        frailty_kind: None,
+        frailty_sd: None,
+        hazard_loading: None,
+        transformation_normal: false,
+        firth: true,
+        family: FamilyArg::Auto,
+        negative_binomial_theta: None,
+        survival_likelihood: "transformation".to_string(),
+        survival_time_anchor: None,
+        baseline_target: "linear".to_string(),
+        baseline_scale: None,
+        baseline_shape: None,
+        baseline_rate: None,
+        baseline_makeham: None,
+        time_basis: "ispline".to_string(),
+        time_degree: 3,
+        time_num_internal_knots: 8,
+        time_smooth_lambda: 1e-2,
+        ridge_lambda: 1e-6,
+        threshold_time_k: None,
+        threshold_time_degree: 3,
+        sigma_time_k: None,
+        sigma_time_degree: 3,
+        adaptive_regularization: false,
+        scale_dimensions: false,
+        pilot_subsample_threshold: 0,
+        out: Some(model_path.clone()),
+    })
+    .expect("--firth must be accepted as a redundant no-op for bernoulli marginal-slope (#861)");
+
+    // The fit must actually produce a saved model, not merely avoid erroring.
+    SavedModel::load_from_path(&model_path).expect("fit with --firth should save a model");
+}
+
+#[test]
 fn cli_bernoulli_marginal_slope_rejects_z_column_in_main_formula() {
     let td = tempdir().expect("tempdir");
     let train_path = td.path().join("train.csv");


### PR DESCRIPTION
…Python parity)

The bernoulli marginal-slope path runs an always-on full-span Jeffreys/Firth stabilizer by policy (#774), so `--firth` is redundant, not unsupported. The CLI rejected it via two bespoke gates while the Python API silently accepts firth=True: bernoulli-MS returns from dispatch before the central validate_cli_firth_configuration runs, and Python bypasses CLI validation entirely.

This makes the CLI accept-and-noop, matching Python, and emits a one-time inference note advising the flag is redundant. The flag is consumed only by that note; `run_fit_bernoulli_marginal_slope` does not forward it to the fitter, so the fit proceeds identically to firth=false.

Survival marginal-slope firth remains rejected by validate_cli_firth_configuration (a Surv(...) response sets is_survival and is dispatched before the bernoulli path). supports_firth() is intentionally left unchanged: solver/estimate.rs reads it to decide whether to *apply* Firth, so flipping it would double-stack Firth on top of the always-on stabilizer.

Adds a CLI regression test (cli_bernoulli_marginal_slope_accepts_firth_as_redundant_noop) asserting --firth is accepted as a redundant no-op and still produces a saved model.