### PR TITLE
Improve accuracy diagnostics infrastructure

### DIFF
--- a/src/test_support/reference.rs
+++ b/src/test_support/reference.rs
@@ -418,6 +418,243 @@ pub fn max_abs_diff(a: &[f64], b: &[f64]) -> f64 {
         .fold(0.0, f64::max)
 }
 
+/// Compact, reusable diagnostics for truth/reference quality tests.
+#[derive(Clone, Debug)]
+pub struct QualityDiagnostics {
+    pub label: String,
+    pub rmse_vs_truth: Option<f64>,
+    pub rmse_vs_reference: Option<f64>,
+    pub reference_rmse_vs_truth: Option<f64>,
+    pub edf_total: Option<f64>,
+    pub rho: Vec<f64>,
+    pub lambda: Vec<f64>,
+    pub design: Option<DesignDiagnostics>,
+    pub penalties: Vec<PenaltyDiagnostics>,
+    pub prediction: Option<PredictionFingerprint>,
+}
+
+#[derive(Clone, Debug)]
+pub struct DesignDiagnostics {
+    pub nrows: usize,
+    pub ncols: usize,
+    pub rank: usize,
+    pub condition: f64,
+    pub sigma_min: f64,
+    pub sigma_max: f64,
+}
+
+#[derive(Clone, Debug)]
+pub struct PenaltyDiagnostics {
+    pub index: usize,
+    pub col_start: usize,
+    pub col_end: usize,
+    pub rank: usize,
+    pub lambda: Option<f64>,
+    pub eig_min: f64,
+    pub eig_max: f64,
+    pub trace: f64,
+}
+
+#[derive(Clone, Debug)]
+pub struct PredictionFingerprint {
+    pub n: usize,
+    pub mean: f64,
+    pub sd: f64,
+    pub min: f64,
+    pub max: f64,
+    pub first: f64,
+    pub last: f64,
+}
+
+impl QualityDiagnostics {
+    pub fn from_standard_fit(label: impl Into<String>, fit: &crate::StandardFitResult) -> Self {
+        let design = design_diagnostics(&fit.design.design).ok();
+        let penalties = penalty_diagnostics(
+            &fit.design.penalties,
+            fit.fit.lambdas.as_slice().unwrap_or(&[]),
+        );
+        Self {
+            label: label.into(),
+            rmse_vs_truth: None,
+            rmse_vs_reference: None,
+            reference_rmse_vs_truth: None,
+            edf_total: fit.fit.inference.as_ref().map(|i| i.edf_total),
+            rho: fit.fit.log_lambdas.to_vec(),
+            lambda: fit.fit.lambdas.to_vec(),
+            design,
+            penalties,
+            prediction: None,
+        }
+    }
+    pub fn with_truth_rmse(mut self, pred: &[f64], truth: &[f64]) -> Self {
+        self.rmse_vs_truth = Some(rmse(pred, truth));
+        self.prediction = Some(prediction_fingerprint(pred));
+        self
+    }
+    pub fn with_reference_gap(
+        mut self,
+        pred: &[f64],
+        reference: &[f64],
+        truth: Option<&[f64]>,
+    ) -> Self {
+        self.rmse_vs_reference = Some(rmse(pred, reference));
+        if let Some(truth) = truth {
+            self.reference_rmse_vs_truth = Some(rmse(reference, truth));
+        }
+        self
+    }
+    pub fn emit(&self) {
+        eprintln!("{}", self.report());
+    }
+    pub fn report(&self) -> String {
+        let mut out = format!("[quality-diagnostics] label={}", self.label);
+        if let Some(v) = self.rmse_vs_truth {
+            out.push_str(&format!(" rmse_truth={v:.6}"));
+        }
+        if let Some(v) = self.rmse_vs_reference {
+            out.push_str(&format!(" rmse_reference_gap={v:.6}"));
+        }
+        if let Some(v) = self.reference_rmse_vs_truth {
+            out.push_str(&format!(" reference_rmse_truth={v:.6}"));
+        }
+        if let Some(v) = self.edf_total {
+            out.push_str(&format!(" edf_total={v:.3}"));
+        }
+        if !self.rho.is_empty() {
+            out.push_str(&format!(" rho={:?}", Rounded(&self.rho)));
+        }
+        if !self.lambda.is_empty() {
+            out.push_str(&format!(" lambda={:?}", Rounded(&self.lambda)));
+        }
+        if let Some(d) = &self.design {
+            out.push_str(&format!(
+                " design={}x{} rank={} cond={:.3e} sigma=[{:.3e},{:.3e}]",
+                d.nrows, d.ncols, d.rank, d.condition, d.sigma_min, d.sigma_max
+            ));
+        }
+        if let Some(p) = &self.prediction {
+            out.push_str(&format!(
+                " pred[n={} mean={:.4} sd={:.4} range=[{:.4},{:.4}] edge=[{:.4},{:.4}]]",
+                p.n, p.mean, p.sd, p.min, p.max, p.first, p.last
+            ));
+        }
+        if !self.penalties.is_empty() {
+            out.push_str(" penalties=");
+            for p in &self.penalties {
+                out.push_str(&format!(
+                    " #{} cols={}..{} rank={} lambda={} eig=[{:.3e},{:.3e}] tr={:.3e};",
+                    p.index,
+                    p.col_start,
+                    p.col_end,
+                    p.rank,
+                    p.lambda
+                        .map(|v| format!("{v:.3e}"))
+                        .unwrap_or_else(|| "NA".into()),
+                    p.eig_min,
+                    p.eig_max,
+                    p.trace
+                ));
+            }
+        }
+        out
+    }
+}
+
+struct Rounded<'a>(&'a [f64]);
+impl std::fmt::Debug for Rounded<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("[")?;
+        for (i, v) in self.0.iter().enumerate() {
+            if i > 0 {
+                f.write_str(", ")?;
+            }
+            write!(f, "{v:.3e}")?;
+        }
+        f.write_str("]")
+    }
+}
+
+pub fn prediction_fingerprint(values: &[f64]) -> PredictionFingerprint {
+    let n = values.len();
+    let mean = values.iter().sum::<f64>() / n.max(1) as f64;
+    let var = values.iter().map(|v| (v - mean) * (v - mean)).sum::<f64>() / n.max(1) as f64;
+    PredictionFingerprint {
+        n,
+        mean,
+        sd: var.sqrt(),
+        min: values.iter().copied().fold(f64::INFINITY, f64::min),
+        max: values.iter().copied().fold(f64::NEG_INFINITY, f64::max),
+        first: values.first().copied().unwrap_or(f64::NAN),
+        last: values.last().copied().unwrap_or(f64::NAN),
+    }
+}
+
+pub fn design_diagnostics(
+    design: &crate::matrix::DesignMatrix,
+) -> Result<DesignDiagnostics, String> {
+    use crate::faer_ndarray::FaerSvd;
+    let dense = design
+        .try_to_dense_by_chunks_budgeted("quality diagnostics design SVD", 256 * 1024 * 1024)?;
+    let (_u, s, _vt) = dense.svd(false, false).map_err(|e| e.to_string())?;
+    let sigma_max = s.iter().copied().fold(0.0, f64::max);
+    let tol = (design.nrows().max(design.ncols()) as f64) * f64::EPSILON * sigma_max.max(1.0);
+    let rank = s.iter().filter(|&&v| v > tol).count();
+    let sigma_min = s
+        .iter()
+        .copied()
+        .filter(|v| *v > tol)
+        .fold(0.0_f64, |a, v| if a == 0.0 { v } else { a.min(v) });
+    Ok(DesignDiagnostics {
+        nrows: design.nrows(),
+        ncols: design.ncols(),
+        rank,
+        condition: if sigma_min > 0.0 {
+            sigma_max / sigma_min
+        } else {
+            f64::INFINITY
+        },
+        sigma_min,
+        sigma_max,
+    })
+}
+
+pub fn penalty_diagnostics(
+    penalties: &[crate::terms::smooth::BlockwisePenalty],
+    lambdas: &[f64],
+) -> Vec<PenaltyDiagnostics> {
+    use crate::faer_ndarray::FaerEigh;
+    use faer::Side;
+    penalties
+        .iter()
+        .enumerate()
+        .map(|(index, p)| {
+            let evals = p
+                .local
+                .eigh(Side::Lower)
+                .map(|(e, _)| e)
+                .unwrap_or_else(|_| ndarray::Array1::from_vec(vec![f64::NAN]));
+            let scale = evals
+                .iter()
+                .copied()
+                .map(f64::abs)
+                .fold(0.0, f64::max)
+                .max(1.0);
+            let tol = scale * 1.0e-10;
+            let rank = evals.iter().filter(|&&v| v > tol).count();
+            PenaltyDiagnostics {
+                index,
+                col_start: p.col_range.start,
+                col_end: p.col_range.end,
+                rank,
+                lambda: lambdas.get(index).copied(),
+                eig_min: evals.iter().copied().fold(f64::INFINITY, f64::min),
+                eig_max: evals.iter().copied().fold(f64::NEG_INFINITY, f64::max),
+                trace: p.local.diag().sum(),
+            }
+        })
+        .collect()
+}
+
 /// A Double Machine Learning (DML) reference estimate of the average linear
 /// effect `θ = E[∂E(Y|D,X)/∂D]` of a treatment/dose `D` on outcome `Y` after
 /// partialling out confounders `X`, computed by a mature Python DML library

--- a/tests/basis_smooth/duchon_sin8_quality.rs
+++ b/tests/basis_smooth/duchon_sin8_quality.rs
@@ -14,7 +14,7 @@
 use csv::StringRecord;
 use gam::matrix::LinearOperator;
 use gam::smooth::build_term_collection_design;
-use gam::test_support::reference::{Column, rmse, run_r};
+use gam::test_support::reference::{Column, QualityDiagnostics, rmse, run_r};
 use gam::{
     FitConfig, FitResult, encode_recordswith_inferred_schema, fit_from_formula, init_parallelism,
 };
@@ -44,7 +44,13 @@ fn make_sin_dataset(freq: f64, sigma: f64, n: usize, seed: u64) -> gam::data::En
     encode_recordswith_inferred_schema(headers, rows).expect("encode sin dataset")
 }
 
-fn fit_and_predict(formula: &str, data: &gam::data::EncodedDataset, x_test: &[f64]) -> Vec<f64> {
+fn fit_and_predict_diagnostics(
+    label: &str,
+    formula: &str,
+    data: &gam::data::EncodedDataset,
+    x_test: &[f64],
+    truth: &[f64],
+) -> Vec<f64> {
     let cfg = FitConfig {
         family: Some("gaussian".to_string()),
         ..FitConfig::default()
@@ -61,7 +67,11 @@ fn fit_and_predict(formula: &str, data: &gam::data::EncodedDataset, x_test: &[f6
     }
     let test_design = build_term_collection_design(m.view(), &fit.resolvedspec)
         .expect("rebuild design from frozen spec");
-    test_design.design.apply(&fit.fit.beta).to_vec()
+    let pred = test_design.design.apply(&fit.fit.beta).to_vec();
+    QualityDiagnostics::from_standard_fit(label, &fit)
+        .with_truth_rmse(&pred, truth)
+        .emit();
+    pred
 }
 
 fn mgcv_duchon_predict(data: &gam::data::EncodedDataset, x_test: &[f64], k: usize) -> Vec<f64> {
@@ -120,7 +130,13 @@ fn duchon_sin8_max_error_within_budget() {
     ];
     let mut violations = Vec::<String>::new();
     for (label, body) in absolute_cases {
-        let yhat = fit_and_predict(&format!("y ~ {body}"), &data, &x_test);
+        let yhat = fit_and_predict_diagnostics(
+            label,
+            &format!("y ~ {body}"),
+            &data,
+            &x_test,
+            &y_truth_test,
+        );
         let m = max_abs_err(&yhat, &y_truth_test);
         eprintln!("[duchon-sin8] {label:18} max_err={m:.4}");
         if m > budget {
@@ -135,7 +151,13 @@ fn duchon_sin8_max_error_within_budget() {
         violations.join("\n  - "),
     );
 
-    let gam_centers20 = fit_and_predict("y ~ duchon(x, centers=20)", &data, &x_test);
+    let gam_centers20 = fit_and_predict_diagnostics(
+        "duchon-centers20",
+        "y ~ duchon(x, centers=20)",
+        &data,
+        &x_test,
+        &y_truth_test,
+    );
     let mgcv_centers20 = mgcv_duchon_predict(&data, &x_test, 20);
     let gam_max = max_abs_err(&gam_centers20, &y_truth_test);
     let mgcv_max = max_abs_err(&mgcv_centers20, &y_truth_test);


### PR DESCRIPTION
## Codex Cloud task

- Title: Improve accuracy diagnostics infrastructure
- Task: https://chatgpt.com/codex/tasks/task_e_6a34090d31908324951f2403158653b1
- Task id: `task_e_6a34090d31908324951f2403158653b1`
- Status: `ready`
- Updated: 2026-06-18T15:57:52.841892004Z
- Attempt count: 1
- Environment: SauersML/gam
- Branch: `codex/cloud-6a34090d-improve-accuracy-diagnostics-infrastructure`
- Base: `main`
- Summary: 2 files changed, +264 / -5

Generated from `codex cloud diff task_e_6a34090d31908324951f2403158653b1` against `origin/main`. The Codex Cloud CLI does not expose a noninteractive log stream or assistant-response body; this PR includes the task title, URL, status metadata, and diff available through the CLI.

<details open>
<summary>Codex Cloud unified diff</summary>

```diff
diff --git a/src/test_support/reference.rs b/src/test_support/reference.rs
index 56dfd4332fe3c1894ec2556e4e0c7aed3b4ccf3b..d2bc6243116f61210c2980924f5d5c17a1f8524f 100644
--- a/src/test_support/reference.rs
+++ b/src/test_support/reference.rs
@@ -396,50 +396,287 @@ pub fn held_out_r2(pred: &[f64], truth: &[f64]) -> f64 {
 /// train-split width: pad every column to a single `n = max(len)` and slice each
 /// by its own semantic length inside the reference body instead.
 pub fn pad_to(v: &[f64], len: usize) -> Vec<f64> {
     assert!(
         v.len() <= len,
         "pad_to cannot shrink: source has {} rows but the pad target is {len} \
          (a shorter target would drop real data). Pad every column to a common \
          n = max(column length) and slice by semantic length in the reference body.",
         v.len()
     );
     let fill = v.last().copied().unwrap_or(0.0);
     let mut out = v.to_vec();
     out.resize(len, fill);
     out
 }
 
 /// Maximum absolute difference between two equal-length vectors.
 pub fn max_abs_diff(a: &[f64], b: &[f64]) -> f64 {
     assert_eq!(a.len(), b.len(), "max_abs_diff length mismatch");
     a.iter()
         .zip(b)
         .map(|(x, y)| (x - y).abs())
         .fold(0.0, f64::max)
 }
 
+/// Compact, reusable diagnostics for truth/reference quality tests.
+#[derive(Clone, Debug)]
+pub struct QualityDiagnostics {
+    pub label: String,
+    pub rmse_vs_truth: Option<f64>,
+    pub rmse_vs_reference: Option<f64>,
+    pub reference_rmse_vs_truth: Option<f64>,
+    pub edf_total: Option<f64>,
+    pub rho: Vec<f64>,
+    pub lambda: Vec<f64>,
+    pub design: Option<DesignDiagnostics>,
+    pub penalties: Vec<PenaltyDiagnostics>,
+    pub prediction: Option<PredictionFingerprint>,
+}
+
+#[derive(Clone, Debug)]
+pub struct DesignDiagnostics {
+    pub nrows: usize,
+    pub ncols: usize,
+    pub rank: usize,
+    pub condition: f64,
+    pub sigma_min: f64,
+    pub sigma_max: f64,
+}
+
+#[derive(Clone, Debug)]
+pub struct PenaltyDiagnostics {
+    pub index: usize,
+    pub col_start: usize,
+    pub col_end: usize,
+    pub rank: usize,
+    pub lambda: Option<f64>,
+    pub eig_min: f64,
+    pub eig_max: f64,
+    pub trace: f64,
+}
+
+#[derive(Clone, Debug)]
+pub struct PredictionFingerprint {
+    pub n: usize,
+    pub mean: f64,
+    pub sd: f64,
+    pub min: f64,
+    pub max: f64,
+    pub first: f64,
+    pub last: f64,
+}
+
+impl QualityDiagnostics {
+    pub fn from_standard_fit(label: impl Into<String>, fit: &crate::StandardFitResult) -> Self {
+        let design = design_diagnostics(&fit.design.design).ok();
+        let penalties = penalty_diagnostics(
+            &fit.design.penalties,
+            fit.fit.lambdas.as_slice().unwrap_or(&[]),
+        );
+        Self {
+            label: label.into(),
+            rmse_vs_truth: None,
+            rmse_vs_reference: None,
+            reference_rmse_vs_truth: None,
+            edf_total: fit.fit.inference.as_ref().map(|i| i.edf_total),
+            rho: fit.fit.log_lambdas.to_vec(),
+            lambda: fit.fit.lambdas.to_vec(),
+            design,
+            penalties,
+            prediction: None,
+        }
+    }
+    pub fn with_truth_rmse(mut self, pred: &[f64], truth: &[f64]) -> Self {
+        self.rmse_vs_truth = Some(rmse(pred, truth));
+        self.prediction = Some(prediction_fingerprint(pred));
+        self
+    }
+    pub fn with_reference_gap(
+        mut self,
+        pred: &[f64],
+        reference: &[f64],
+        truth: Option<&[f64]>,
+    ) -> Self {
+        self.rmse_vs_reference = Some(rmse(pred, reference));
+        if let Some(truth) = truth {
+            self.reference_rmse_vs_truth = Some(rmse(reference, truth));
+        }
+        self
+    }
+    pub fn emit(&self) {
+        eprintln!("{}", self.report());
+    }
+    pub fn report(&self) -> String {
+        let mut out = format!("[quality-diagnostics] label={}", self.label);
+        if let Some(v) = self.rmse_vs_truth {
+            out.push_str(&format!(" rmse_truth={v:.6}"));
+        }
+        if let Some(v) = self.rmse_vs_reference {
+            out.push_str(&format!(" rmse_reference_gap={v:.6}"));
+        }
+        if let Some(v) = self.reference_rmse_vs_truth {
+            out.push_str(&format!(" reference_rmse_truth={v:.6}"));
+        }
+        if let Some(v) = self.edf_total {
+            out.push_str(&format!(" edf_total={v:.3}"));
+        }
+        if !self.rho.is_empty() {
+            out.push_str(&format!(" rho={:?}", Rounded(&self.rho)));
+        }
+        if !self.lambda.is_empty() {
+            out.push_str(&format!(" lambda={:?}", Rounded(&self.lambda)));
+        }
+        if let Some(d) = &self.design {
+            out.push_str(&format!(
+                " design={}x{} rank={} cond={:.3e} sigma=[{:.3e},{:.3e}]",
+                d.nrows, d.ncols, d.rank, d.condition, d.sigma_min, d.sigma_max
+            ));
+        }
+        if let Some(p) = &self.prediction {
+            out.push_str(&format!(
+                " pred[n={} mean={:.4} sd={:.4} range=[{:.4},{:.4}] edge=[{:.4},{:.4}]]",
+                p.n, p.mean, p.sd, p.min, p.max, p.first, p.last
+            ));
+        }
+        if !self.penalties.is_empty() {
+            out.push_str(" penalties=");
+            for p in &self.penalties {
+                out.push_str(&format!(
+                    " #{} cols={}..{} rank={} lambda={} eig=[{:.3e},{:.3e}] tr={:.3e};",
+                    p.index,
+                    p.col_start,
+                    p.col_end,
+                    p.rank,
+                    p.lambda
+                        .map(|v| format!("{v:.3e}"))
+                        .unwrap_or_else(|| "NA".into()),
+                    p.eig_min,
+                    p.eig_max,
+                    p.trace
+                ));
+            }
+        }
+        out
+    }
+}
+
+struct Rounded<'a>(&'a [f64]);
+impl std::fmt::Debug for Rounded<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("[")?;
+        for (i, v) in self.0.iter().enumerate() {
+            if i > 0 {
+                f.write_str(", ")?;
+            }
+            write!(f, "{v:.3e}")?;
+        }
+        f.write_str("]")
+    }
+}
+
+pub fn prediction_fingerprint(values: &[f64]) -> PredictionFingerprint {
+    let n = values.len();
+    let mean = values.iter().sum::<f64>() / n.max(1) as f64;
+    let var = values.iter().map(|v| (v - mean) * (v - mean)).sum::<f64>() / n.max(1) as f64;
+    PredictionFingerprint {
+        n,
+        mean,
+        sd: var.sqrt(),
+        min: values.iter().copied().fold(f64::INFINITY, f64::min),
+        max: values.iter().copied().fold(f64::NEG_INFINITY, f64::max),
+        first: values.first().copied().unwrap_or(f64::NAN),
+        last: values.last().copied().unwrap_or(f64::NAN),
+    }
+}
+
+pub fn design_diagnostics(
+    design: &crate::matrix::DesignMatrix,
+) -> Result<DesignDiagnostics, String> {
+    use crate::faer_ndarray::FaerSvd;
+    let dense = design
+        .try_to_dense_by_chunks_budgeted("quality diagnostics design SVD", 256 * 1024 * 1024)?;
+    let (_u, s, _vt) = dense.svd(false, false).map_err(|e| e.to_string())?;
+    let sigma_max = s.iter().copied().fold(0.0, f64::max);
+    let tol = (design.nrows().max(design.ncols()) as f64) * f64::EPSILON * sigma_max.max(1.0);
+    let rank = s.iter().filter(|&&v| v > tol).count();
+    let sigma_min = s
+        .iter()
+        .copied()
+        .filter(|v| *v > tol)
+        .fold(0.0_f64, |a, v| if a == 0.0 { v } else { a.min(v) });
+    Ok(DesignDiagnostics {
+        nrows: design.nrows(),
+        ncols: design.ncols(),
+        rank,
+        condition: if sigma_min > 0.0 {
+            sigma_max / sigma_min
+        } else {
+            f64::INFINITY
+        },
+        sigma_min,
+        sigma_max,
+    })
+}
+
+pub fn penalty_diagnostics(
+    penalties: &[crate::terms::smooth::BlockwisePenalty],
+    lambdas: &[f64],
+) -> Vec<PenaltyDiagnostics> {
+    use crate::faer_ndarray::FaerEigh;
+    use faer::Side;
+    penalties
+        .iter()
+        .enumerate()
+        .map(|(index, p)| {
+            let evals = p
+                .local
+                .eigh(Side::Lower)
+                .map(|(e, _)| e)
+                .unwrap_or_else(|_| ndarray::Array1::from_vec(vec![f64::NAN]));
+            let scale = evals
+                .iter()
+                .copied()
+                .map(f64::abs)
+                .fold(0.0, f64::max)
+                .max(1.0);
+            let tol = scale * 1.0e-10;
+            let rank = evals.iter().filter(|&&v| v > tol).count();
+            PenaltyDiagnostics {
+                index,
+                col_start: p.col_range.start,
+                col_end: p.col_range.end,
+                rank,
+                lambda: lambdas.get(index).copied(),
+                eig_min: evals.iter().copied().fold(f64::INFINITY, f64::min),
+                eig_max: evals.iter().copied().fold(f64::NEG_INFINITY, f64::max),
+                trace: p.local.diag().sum(),
+            }
+        })
+        .collect()
+}
+
 /// A Double Machine Learning (DML) reference estimate of the average linear
 /// effect `θ = E[∂E(Y|D,X)/∂D]` of a treatment/dose `D` on outcome `Y` after
 /// partialling out confounders `X`, computed by a mature Python DML library
 /// (DoubleML's partially-linear model, with EconML's `LinearDML` as fallback).
 ///
 /// This is the Neyman-orthogonal scalar-target baseline used by #461's Sim C:
 /// the cross-fitted DML estimator is, by construction, first-order insensitive
 /// to first-stage nuisance estimation error, so its `theta`/`se` are the
 /// reference bias/coverage that gam's orthogonalized marginal-slope target
 /// `θ = E_x[β(x)]` must match-or-beat under x-dependent Stage-1 miscalibration.
 pub struct DmlPartialLinearReference {
     /// Whether a DML library was importable in the reference interpreter. When
     /// `false`, `theta`/`se`/`ci_lo`/`ci_hi` are `NaN` and the caller should
     /// emit a clear skip message rather than asserting against them — DoubleML/
     /// EconML are heavier optional dependencies than scipy/mgcv, so their
     /// absence is treated as a genuine environmental gate (mirroring the
     /// CUDA-only skip in `tests/common/gpu_gate.rs`) rather than the hard
     /// failure that a missing scipy/R would be.
     pub available: bool,
     /// Which backend produced the estimate: "doubleml", "econml", or "none".
     pub backend: String,
     /// Point estimate of the average linear treatment effect `θ`.
     pub theta: f64,
     /// Standard error of `θ̂` reported by the DML library.
     pub se: f64,
diff --git a/tests/basis_smooth/duchon_sin8_quality.rs b/tests/basis_smooth/duchon_sin8_quality.rs
index 23e350021fd156a69e13041e051e24afdc133e74..1e030a66cc81e76f39a8609888c3edcdbfe302c3 100644
--- a/tests/basis_smooth/duchon_sin8_quality.rs
+++ b/tests/basis_smooth/duchon_sin8_quality.rs
@@ -1,89 +1,99 @@
 //! Duchon sin8 quality regression. Default `duchon(x)` and an explicitly
 //! well-resolved `centers=50` basis must recover sin(2π·8·x) at σ=0.10 within
 //! the same absolute max-error budget used by the original failing ticket.
 //!
 //! `centers=20` is different: 20 knots over eight cycles gives only about 2.5
 //! knots per period, a near-Nyquist design. In that regime an arbitrary absolute
 //! max-error cutoff confounds smoother quality with resolution. The objective
 //! assertion for this deliberately under-resolved variant is therefore
 //! match-or-beat-mgcv on truth recovery at the same `k` (`bs="ds"`, REML), with
 //! a small slack factor for robustness near Nyquist. That keeps the quality bar
 //! tied to a mature Duchon implementation without pretending 20 centers can
 //! always resolve eight noisy cycles.
 
 use csv::StringRecord;
 use gam::matrix::LinearOperator;
 use gam::smooth::build_term_collection_design;
-use gam::test_support::reference::{Column, rmse, run_r};
+use gam::test_support::reference::{Column, QualityDiagnostics, rmse, run_r};
 use gam::{
     FitConfig, FitResult, encode_recordswith_inferred_schema, fit_from_formula, init_parallelism,
 };
 use ndarray::Array2;
 use rand::SeedableRng;
 use rand::rngs::StdRng;
 use rand_distr::{Distribution, Normal, Uniform};
 
 fn make_sin_dataset(freq: f64, sigma: f64, n: usize, seed: u64) -> gam::data::EncodedDataset {
     let mut rng = StdRng::seed_from_u64(seed);
     let ux = Uniform::new(0.0, 1.0).expect("uniform");
     let noise = Normal::new(0.0, sigma).expect("normal");
     let mut x: Vec<f64> = (0..n).map(|_| ux.sample(&mut rng)).collect();
     x.sort_by(|a, b| a.partial_cmp(b).unwrap());
     let two_pi_f = 2.0 * std::f64::consts::PI * freq;
     let y_noisy: Vec<f64> = x
         .iter()
         .map(|&t| (two_pi_f * t).sin() + noise.sample(&mut rng))
         .collect();
 
     let headers = ["x", "y"].into_iter().map(String::from).collect();
     let rows: Vec<StringRecord> = x
         .iter()
         .zip(y_noisy.iter())
         .map(|(a, b)| StringRecord::from(vec![a.to_string(), b.to_string()]))
         .collect();
     encode_recordswith_inferred_schema(headers, rows).expect("encode sin dataset")
 }
 
-fn fit_and_predict(formula: &str, data: &gam::data::EncodedDataset, x_test: &[f64]) -> Vec<f64> {
+fn fit_and_predict_diagnostics(
+    label: &str,
+    formula: &str,
+    data: &gam::data::EncodedDataset,
+    x_test: &[f64],
+    truth: &[f64],
+) -> Vec<f64> {
     let cfg = FitConfig {
         family: Some("gaussian".to_string()),
         ..FitConfig::default()
     };
     let result = fit_from_formula(formula, data, &cfg).expect("duchon fit succeeded");
     let FitResult::Standard(fit) = result else {
         panic!("expected standard fit")
     };
     let n = x_test.len();
     let mut m = Array2::<f64>::zeros((n, data.headers.len()));
     let x_col = data.column_map()["x"];
     for (i, &t) in x_test.iter().enumerate() {
         m[[i, x_col]] = t;
     }
     let test_design = build_term_collection_design(m.view(), &fit.resolvedspec)
         .expect("rebuild design from frozen spec");
-    test_design.design.apply(&fit.fit.beta).to_vec()
+    let pred = test_design.design.apply(&fit.fit.beta).to_vec();
+    QualityDiagnostics::from_standard_fit(label, &fit)
+        .with_truth_rmse(&pred, truth)
+        .emit();
+    pred
 }
 
 fn mgcv_duchon_predict(data: &gam::data::EncodedDataset, x_test: &[f64], k: usize) -> Vec<f64> {
     let x_col = data.column_map()["x"];
     let y_col = data.column_map()["y"];
     let mut x_all = data.values.column(x_col).to_vec();
     x_all.extend_from_slice(x_test);
     let mut y_all = data.values.column(y_col).to_vec();
     y_all.extend(std::iter::repeat_n(0.0, x_test.len()));
     let mut is_train = vec![1.0; data.values.nrows()];
     is_train.extend(std::iter::repeat_n(0.0, x_test.len()));
 
     let r = run_r(
         &[
             Column::new("x", &x_all),
             Column::new("y", &y_all),
             Column::new("is_train", &is_train),
         ],
         &format!(
             r#"
             suppressPackageStartupMessages(library(mgcv))
             train <- df[df$is_train > 0.5, ]
             grid  <- df[df$is_train < 0.5, ]
             m <- gam(y ~ s(x, bs = "ds", k = {k}, m = c(2, 0)),
                      data = train, method = "REML")
@@ -98,62 +108,74 @@ fn max_abs_err(yhat: &[f64], y: &[f64]) -> f64 {
     yhat.iter()
         .zip(y.iter())
         .map(|(a, b)| (a - b).abs())
         .fold(0.0, f64::max)
 }
 
 #[test]
 fn duchon_sin8_max_error_within_budget() {
     init_parallelism();
     let data = make_sin_dataset(8.0, 0.10, 240, 11);
     let x_test: Vec<f64> = (0..400).map(|i| 0.001 + 0.998 * i as f64 / 399.0).collect();
     let y_truth_test: Vec<f64> = x_test
         .iter()
         .map(|t| (2.0 * std::f64::consts::PI * 8.0 * t).sin())
         .collect();
 
     // Truth peak-to-peak is 2.0; 30% of that is 0.60. These two cases have
     // enough basis resolution to make the absolute recovery budget meaningful.
     let budget = 0.60_f64;
     let absolute_cases: &[(&str, &str)] = &[
         ("duchon-default", "duchon(x)"),
         ("duchon-centers50", "duchon(x, centers=50)"),
     ];
     let mut violations = Vec::<String>::new();
     for (label, body) in absolute_cases {
-        let yhat = fit_and_predict(&format!("y ~ {body}"), &data, &x_test);
+        let yhat = fit_and_predict_diagnostics(
+            label,
+            &format!("y ~ {body}"),
+            &data,
+            &x_test,
+            &y_truth_test,
+        );
         let m = max_abs_err(&yhat, &y_truth_test);
         eprintln!("[duchon-sin8] {label:18} max_err={m:.4}");
         if m > budget {
             violations.push(format!(
                 "{label}: max_err {m:.4} > {budget:.2} (truth peak=2.0, 30% budget)"
             ));
         }
     }
     assert!(
         violations.is_empty(),
         "resolved Duchon variants oversmooth sin8 at σ=0.10:\n  - {}",
         violations.join("\n  - "),
     );
 
-    let gam_centers20 = fit_and_predict("y ~ duchon(x, centers=20)", &data, &x_test);
+    let gam_centers20 = fit_and_predict_diagnostics(
+        "duchon-centers20",
+        "y ~ duchon(x, centers=20)",
+        &data,
+        &x_test,
+        &y_truth_test,
+    );
     let mgcv_centers20 = mgcv_duchon_predict(&data, &x_test, 20);
     let gam_max = max_abs_err(&gam_centers20, &y_truth_test);
     let mgcv_max = max_abs_err(&mgcv_centers20, &y_truth_test);
     let gam_truth_rmse = rmse(&gam_centers20, &y_truth_test);
     let mgcv_truth_rmse = rmse(&mgcv_centers20, &y_truth_test);
     eprintln!(
         "[duchon-sin8] duchon-centers20 max_err={gam_max:.4} \
          truth_rmse={gam_truth_rmse:.4}; mgcv-ds-k20 max_err={mgcv_max:.4} \
          truth_rmse={mgcv_truth_rmse:.4}"
     );
     // Match-or-beat with a small slack factor: 20 knots over eight cycles is a
     // near-Nyquist design where an exact RMSE tie is fragile, so allow gam to be
     // within 10% of the mature mgcv `bs="ds"` k=20 truth-recovery RMSE.
     let slack = 1.10_f64;
     assert!(
         gam_truth_rmse <= slack * mgcv_truth_rmse,
         "near-Nyquist centers=20 Duchon must match-or-beat (within {slack:.2}×) mgcv \
          bs=\"ds\" k=20 on truth RMSE: gam={gam_truth_rmse:.4}, mgcv={mgcv_truth_rmse:.4} \
          (max_err gam={gam_max:.4}, mgcv={mgcv_max:.4})"
     );
 }

```
</details>
