### PR TITLE
Audit and improve smoothing-parameter selection

### DIFF
--- a/src/solver/estimate/optimizer.rs
+++ b/src/solver/estimate/optimizer.rs
@@ -601,17 +601,18 @@ where
         // those fits stay byte-identical.
         let weight_log_geom_mean: f64 = reml_state.rho_weight_anchor();
         let gaussian_risk = matches!(reml_seed_config.risk_profile, SeedRiskProfile::Gaussian);
-        // The Gaussian path historically skipped the objective-grid prepass and
-        // seeded the outer search from the weight-independent origin 0. That is
-        // exactly correct for an UNWEIGHTED fit (anchor 0), but breaks the
-        // weight-scale invariance of λ̂ the moment a global rescale shifts the
-        // optimum off 0 (issue #877). Run the anchored prepass for Gaussian ONLY
-        // when the weight scale is non-trivial, so unweighted Gaussian fits stay
-        // byte-identical while up-/down-weighted fits seed at the shifted optimum.
+        // The prepass evaluates the *actual* REML/LAML objective on a tiny,
+        // deterministic log-λ grid and only changes startup when that same
+        // criterion improves.  It is therefore part of initialization, not a
+        // compatibility fallback.  Gaussian fits used to skip this when the
+        // weights were on the unit scale, leaving single-start BFGS/ARC tied to
+        // the arbitrary λ=1 origin; flat or multi-penalty REML surfaces could
+        // then spend the finite outer budget getting into the right basin rather
+        // than resolving the optimum that controls EDF and truth recovery.  Run
+        // the same criterion-ranked startup for Gaussian as for GLM/survival,
+        // while retaining the weight-scale anchor from issue #877.
         let run_gaussian_anchored_prepass = gaussian_risk && weight_log_geom_mean.abs() > 1e-12;
-        let prepass_seed: Option<Array1<f64>> = if gaussian_risk && !run_gaussian_anchored_prepass {
-            None
-        } else {
+        let prepass_seed: Option<Array1<f64>> = {
             let bnds = reml_seed_config.bounds;
             let (lo, hi) = if bnds.0 <= bnds.1 {
                 bnds


### PR DESCRIPTION
## Codex Cloud task

- Title: Audit and improve smoothing-parameter selection
- Task: https://chatgpt.com/codex/tasks/task_e_6a3409079f008324ba0e2a05df93d37d
- Task id: `task_e_6a3409079f008324ba0e2a05df93d37d`
- Status: `ready`
- Updated: 2026-06-18T15:51:10.161375045Z
- Attempt count: 1
- Environment: SauersML/gam
- Branch: `codex/cloud-6a340907-audit-and-improve-smoothing-parameter-selection`
- Base: `main`
- Summary: 1 files changed, +11 / -10

Generated from `codex cloud diff task_e_6a3409079f008324ba0e2a05df93d37d` against `origin/main`. The Codex Cloud CLI does not expose a noninteractive log stream or assistant-response body; this PR includes the task title, URL, status metadata, and diff available through the CLI.

<details open>
<summary>Codex Cloud unified diff</summary>

```diff
diff --git a/src/solver/estimate/optimizer.rs b/src/solver/estimate/optimizer.rs
index ea82ad9ac18892e7f90025d5b518d0fa0e409f58..5b5385d289f8fd843818f3c0397f6a7aaf449c01 100644
--- a/src/solver/estimate/optimizer.rs
+++ b/src/solver/estimate/optimizer.rs
@@ -579,61 +579,62 @@ where
         // over the positive-weight rows. The pure-REML optimum for a *profiled*
         // (Gaussian-identity) fit drifts by `ρ̂ → ρ̂ + log c` under a global
         // prior-weight rescale `w → c·w` (`H = XᵀWX + λS`, so λ → c·λ keeps the
         // penalised curvature proportional to the data curvature, β̂ / EDF /
         // predictions fixed). The outer ρ-search seed and the relative-from-seed
         // convergence test would otherwise be referenced to a weight-independent
         // origin (0), so a heavily up-weighted fit starts `log c` further from
         // its (shifted) optimum and the optimiser stops short — exactly the
         // weight-scale non-invariance of λ̂ reported in issue #877. Anchoring the
         // seed at `log g(w)` makes the search start the SAME relative distance
         // from the optimum regardless of the weight magnitude.
         //
         // This is the SAME gated anchor the outer ρ-prior uses
         // ([`RemlState::rho_weight_anchor`]): it is the geometric-mean
         // log-weight for a profiled-dispersion family and *exactly 0* for a
         // fixed-dispersion family (Poisson, binomial, …). For fixed dispersion
         // `w = c` is exact `c`-fold replication: the two encodings share an
         // identical LAML objective and optimum, so anchoring the seed by their
         // (differing) per-row log-weight mean would seed the weighted encoding
         // `log c` above its true optimum and the relative-convergence test would
         // stop it short — over-smoothing vs replication (issue #893). With all
         // weights 1 (or any fixed-dispersion family) the anchor is exactly 0, so
         // those fits stay byte-identical.
         let weight_log_geom_mean: f64 = reml_state.rho_weight_anchor();
         let gaussian_risk = matches!(reml_seed_config.risk_profile, SeedRiskProfile::Gaussian);
-        // The Gaussian path historically skipped the objective-grid prepass and
-        // seeded the outer search from the weight-independent origin 0. That is
-        // exactly correct for an UNWEIGHTED fit (anchor 0), but breaks the
-        // weight-scale invariance of λ̂ the moment a global rescale shifts the
-        // optimum off 0 (issue #877). Run the anchored prepass for Gaussian ONLY
-        // when the weight scale is non-trivial, so unweighted Gaussian fits stay
-        // byte-identical while up-/down-weighted fits seed at the shifted optimum.
+        // The prepass evaluates the *actual* REML/LAML objective on a tiny,
+        // deterministic log-λ grid and only changes startup when that same
+        // criterion improves.  It is therefore part of initialization, not a
+        // compatibility fallback.  Gaussian fits used to skip this when the
+        // weights were on the unit scale, leaving single-start BFGS/ARC tied to
+        // the arbitrary λ=1 origin; flat or multi-penalty REML surfaces could
+        // then spend the finite outer budget getting into the right basin rather
+        // than resolving the optimum that controls EDF and truth recovery.  Run
+        // the same criterion-ranked startup for Gaussian as for GLM/survival,
+        // while retaining the weight-scale anchor from issue #877.
         let run_gaussian_anchored_prepass = gaussian_risk && weight_log_geom_mean.abs() > 1e-12;
-        let prepass_seed: Option<Array1<f64>> = if gaussian_risk && !run_gaussian_anchored_prepass {
-            None
-        } else {
+        let prepass_seed: Option<Array1<f64>> = {
             let bnds = reml_seed_config.bounds;
             let (lo, hi) = if bnds.0 <= bnds.1 {
                 bnds
             } else {
                 (bnds.1, bnds.0)
             };
             // risk_shift is the default seed bias when no caller warm-start is given;
             // it is NOT applied on top of a caller-supplied heuristic_lambdas.
             let risk_shift: f64 = match reml_seed_config.risk_profile {
                 SeedRiskProfile::Gaussian => 0.0,
                 SeedRiskProfile::GeneralizedLinear => 1.0,
                 SeedRiskProfile::Survival => 2.0,
             };
             // Anchor the default seed origin to the weight scale (issue #877). A
             // caller-supplied `heuristic_lambdas` already carries the absolute λ
             // scale, so it is used as-is; only the default risk-shift origin is
             // weight-anchored.
             let base = if let Some(h) = heuristic_lambdas.as_ref().filter(|h| h.len() == k) {
                 Array1::from_iter(h.iter().map(|&v| v.max(1e-12).ln().clamp(lo, hi)))
             } else {
                 Array1::from_elem(k, (risk_shift + weight_log_geom_mean).clamp(lo, hi))
             };
             let refined = crate::seeding::select_objective_seed_on_log_lambda_grid(
                 &base,
                 (lo, hi),

```
</details>
