### PR TITLE
Audit penalty scaling and nullspace invariants

### DIFF
--- a/src/terms/basis/sphere_basis.rs
+++ b/src/terms/basis/sphere_basis.rs
@@ -655,13 +655,18 @@ pub(crate) fn build_spherical_harmonic_basis(
             col += 1;
         }
     }
-    let mut ridge = Array2::<f64>::eye(p);
+    // Double-penalty shrinkage lives on the primary penalty's null space.
+    // The harmonic basis omits the constant mode, so the unpenalized Wahba
+    // low-degree span is exactly the l <= SPHERE_UNPENALIZED_LOW_DEGREE block.
+    // Penalizing the complement here would duplicate the curvature penalty and
+    // leave the nominal null-space penalty inert.
+    let mut ridge = Array2::<f64>::zeros((p, p));
     {
         let mut col = 0usize;
         for l in 1..=l_max {
             for _ in 0..(2 * l + 1) {
                 if l <= SPHERE_UNPENALIZED_LOW_DEGREE {
-                    ridge[[col, col]] = 0.0;
+                    ridge[[col, col]] = 1.0;
                 }
                 col += 1;
             }
@@ -3377,4 +3382,59 @@ pub fn build_matern_basis_log_kappa_aniso_derivatives(
     }
 
     Ok(result)
+}
+
+#[cfg(test)]
+mod harmonic_penalty_invariants_tests {
+    use super::*;
+    use ndarray::array;
+
+    #[test]
+    fn harmonic_double_penalty_targets_primary_nullspace() {
+        let data = array![
+            [-0.9, 0.0],
+            [-0.4, 1.0],
+            [0.0, 2.0],
+            [0.4, 3.0],
+            [0.9, 4.0],
+            [0.2, 5.0],
+        ];
+        let spec = SphericalSplineBasisSpec {
+            center_strategy: CenterStrategy::FarthestPoint { num_centers: 6 },
+            penalty_order: 2,
+            double_penalty: true,
+            radians: true,
+            method: SphereMethod::Harmonic,
+            max_degree: Some(3),
+            wahba_kernel: SphereWahbaKernel::Sobolev,
+            identifiability: SphericalSplineIdentifiability::CenterSumToZero,
+        };
+        let built = build_spherical_harmonic_basis(data.view(), &spec).expect("harmonic basis");
+        assert_eq!(built.penalties.len(), 2);
+        let primary = &built.penalties[0];
+        let shrink = &built.penalties[1];
+        for col in 0..primary.ncols() {
+            let primary_diag = primary[[col, col]].abs();
+            let shrink_diag = shrink[[col, col]].abs();
+            if col < SPHERE_UNPENALIZED_LOW_DEGREE * (SPHERE_UNPENALIZED_LOW_DEGREE + 2) {
+                assert!(
+                    primary_diag <= 1e-12,
+                    "low-degree column {col} must be primary-null"
+                );
+                assert!(
+                    shrink_diag > 0.0,
+                    "low-degree column {col} must be shrink-penalized"
+                );
+            } else {
+                assert!(
+                    primary_diag > 0.0,
+                    "higher-degree column {col} must carry roughness"
+                );
+                assert!(
+                    shrink_diag <= 1e-12,
+                    "higher-degree column {col} must not be in null shrinkage"
+                );
+            }
+        }
+    }
 }


### PR DESCRIPTION
## Codex Cloud task

- Title: Audit penalty scaling and nullspace invariants
- Task: https://chatgpt.com/codex/tasks/task_e_6a3409026fdc8324b900d8c7e9ba666a
- Task id: `task_e_6a3409026fdc8324b900d8c7e9ba666a`
- Status: `ready`
- Updated: 2026-06-18T15:54:13.057491064Z
- Attempt count: 1
- Environment: SauersML/gam
- Branch: `codex/cloud-6a340902-audit-penalty-scaling-and-nullspace-invariants`
- Base: `main`
- Summary: 1 files changed, +62 / -2

Generated from `codex cloud diff task_e_6a3409026fdc8324b900d8c7e9ba666a` against `origin/main`. The Codex Cloud CLI does not expose a noninteractive log stream or assistant-response body; this PR includes the task title, URL, status metadata, and diff available through the CLI.

<details open>
<summary>Codex Cloud unified diff</summary>

```diff
diff --git a/src/terms/basis/sphere_basis.rs b/src/terms/basis/sphere_basis.rs
index 38902c27cd910c367ec69286c8addd2b9b5d0b25..908a96db308b454112dca112619d36a2b13d97b0 100644
--- a/src/terms/basis/sphere_basis.rs
+++ b/src/terms/basis/sphere_basis.rs
@@ -598,57 +598,62 @@ pub(crate) fn build_spherical_harmonic_basis(
     // with separately under-penalized high-degree modes and then degrading in
     // sparse polar latitude bands.
     //
     // This is already in the natural coefficient coordinates for the real
     // spherical harmonics: the basis is orthonormal on S², so X'X/n is O(1)
     // under uniform sampling, while the diagonal entries are the physical
     // roughness eigenvalues of the final function. Frobenius-normalizing this
     // matrix would divide away that meaningful spectral scale (≈1261 for
     // L=4, m=2), making REML optimize against an artificially tiny physical
     // penalty. Keep the raw operator with normalization_scale=1 so optimizer
     // lambdas are physical lambdas for this smooth.
     let mut penalty = Array2::<f64>::zeros((p, p));
     let mut col = 0usize;
     for l in 1..=l_max {
         let laplace = l as f64 * (l as f64 + 1.0);
         let eig = if l <= SPHERE_UNPENALIZED_LOW_DEGREE {
             0.0
         } else {
             laplace.powi((spec.penalty_order + 1) as i32)
         };
         for _ in 0..(2 * l + 1) {
             penalty[[col, col]] = eig;
             col += 1;
         }
     }
-    let mut ridge = Array2::<f64>::eye(p);
+    // Double-penalty shrinkage lives on the primary penalty's null space.
+    // The harmonic basis omits the constant mode, so the unpenalized Wahba
+    // low-degree span is exactly the l <= SPHERE_UNPENALIZED_LOW_DEGREE block.
+    // Penalizing the complement here would duplicate the curvature penalty and
+    // leave the nominal null-space penalty inert.
+    let mut ridge = Array2::<f64>::zeros((p, p));
     {
         let mut col = 0usize;
         for l in 1..=l_max {
             for _ in 0..(2 * l + 1) {
                 if l <= SPHERE_UNPENALIZED_LOW_DEGREE {
-                    ridge[[col, col]] = 0.0;
+                    ridge[[col, col]] = 1.0;
                 }
                 col += 1;
             }
         }
     }
 
     // Realized-design identifiability gauge (#1246). The global smooth
     // identifiability pipeline can residualize this harmonic term against the
     // model intercept / overlapping parametric columns and FREEZES the resulting
     // column transform onto `spec.identifiability` as a `FrozenTransform` so that
     // prediction reproduces the exact fit-time basis. Unlike the Wahba path the
     // harmonic builder used to ignore that frozen transform entirely: at predict
     // time it rebuilt the RAW (un-residualized) harmonic design while the fitted
     // coefficients lived in the transformed coordinate system. Applying those
     // coefficients to the raw design produced finite-but-wrong predictions even
     // on the training rows (observed RMSE-vs-truth ≈ 0.59 for a degree-≤2 truth
     // that the basis recovers exactly, i.e. the coefficients were correct but the
     // replayed design was not). Honor the frozen transform here exactly as the
     // Wahba builder does: apply it to the design and every penalty through a
     // `Gauge`, and re-freeze it into the metadata for the next rebuild. A
     // `CenterSumToZero` (fresh-fit) spec carries the identity, so first-fit
     // builds are unchanged.
     let transform = match &spec.identifiability {
         SphericalSplineIdentifiability::FrozenTransform { transform } => {
             if transform.nrows() != p {
@@ -3321,25 +3326,80 @@ pub fn build_matern_basis_log_kappa_aniso_derivatives(
         // the κ-optimizer off the true signal-axis contrast.)
         let inv_dim = 1.0 / dim as f64;
         let num_blocks = result.penalties_first[0].len();
         for block in 0..num_blocks {
             let mut eta_mean = Array2::<f64>::zeros(result.penalties_first[0][block].raw_dim());
             for axis in 0..dim {
                 if result.penalties_first[axis][block].raw_dim()
                     != result.penalties_first[0][block].raw_dim()
                 {
                     return Err(BasisError::InvalidInput(format!(
                         "Matérn aniso raw-psi penalty derivative shape mismatch on axis {axis}, block {block}"
                     )));
                 }
                 eta_mean += &result.penalties_first[axis][block];
             }
             eta_mean.mapv_inplace(|value| value * inv_dim);
             for axis in 0..dim {
                 result.penalties_first[axis][block] =
                     &result.penalties_first[axis][block] - &eta_mean;
             }
         }
     }
 
     Ok(result)
 }
+
+#[cfg(test)]
+mod harmonic_penalty_invariants_tests {
+    use super::*;
+    use ndarray::array;
+
+    #[test]
+    fn harmonic_double_penalty_targets_primary_nullspace() {
+        let data = array![
+            [-0.9, 0.0],
+            [-0.4, 1.0],
+            [0.0, 2.0],
+            [0.4, 3.0],
+            [0.9, 4.0],
+            [0.2, 5.0],
+        ];
+        let spec = SphericalSplineBasisSpec {
+            center_strategy: CenterStrategy::FarthestPoint { num_centers: 6 },
+            penalty_order: 2,
+            double_penalty: true,
+            radians: true,
+            method: SphereMethod::Harmonic,
+            max_degree: Some(3),
+            wahba_kernel: SphereWahbaKernel::Sobolev,
+            identifiability: SphericalSplineIdentifiability::CenterSumToZero,
+        };
+        let built = build_spherical_harmonic_basis(data.view(), &spec).expect("harmonic basis");
+        assert_eq!(built.penalties.len(), 2);
+        let primary = &built.penalties[0];
+        let shrink = &built.penalties[1];
+        for col in 0..primary.ncols() {
+            let primary_diag = primary[[col, col]].abs();
+            let shrink_diag = shrink[[col, col]].abs();
+            if col < SPHERE_UNPENALIZED_LOW_DEGREE * (SPHERE_UNPENALIZED_LOW_DEGREE + 2) {
+                assert!(
+                    primary_diag <= 1e-12,
+                    "low-degree column {col} must be primary-null"
+                );
+                assert!(
+                    shrink_diag > 0.0,
+                    "low-degree column {col} must be shrink-penalized"
+                );
+            } else {
+                assert!(
+                    primary_diag > 0.0,
+                    "higher-degree column {col} must carry roughness"
+                );
+                assert!(
+                    shrink_diag <= 1e-12,
+                    "higher-degree column {col} must not be in null shrinkage"
+                );
+            }
+        }
+    }
+}

```
</details>
