### PR TITLE
Investigate mixed/factor smooth accuracy gaps

### DIFF
--- a/src/terms/term_builder.rs
+++ b/src/terms/term_builder.rs
@@ -609,10 +609,21 @@ pub fn build_termspec(
                     })? {
                         ColumnKindTag::Categorical => {
                             let levels = encoded_levels_for_column(ds, ColIdx::new(by_col));
-                            // Add an unpenalized treatment-coded fixed main effect for the factor, unless present already.
+                            let penalized_group_owner_present = terms.iter().any(|other| {
+                                matches!(other, ParsedTerm::RandomEffect { name } if name == &by_name)
+                            });
+                            // Add an unpenalized treatment-coded fixed main
+                            // effect for a standalone factor-by smooth, unless
+                            // the same factor already has an explicit
+                            // `group(factor)` term.  In that mixed-model form
+                            // the penalized random intercept is the coherent
+                            // owner of level offsets; adding a no-pooling fixed
+                            // factor effect would bypass random-effect
+                            // shrinkage and degrade BLUP-style predictions.
                             if !random_terms
                                 .iter()
                                 .any(|rt| rt.name == by_name && !rt.penalized)
+                                && !penalized_group_owner_present
                             {
                                 random_terms.push(RandomEffectTermSpec {
                                     name: by_name.clone(),

--- a/tests/basis_smooth/factor_smooths_formula.rs
+++ b/tests/basis_smooth/factor_smooths_formula.rs
@@ -130,3 +130,29 @@ fn termspec_routes_new_constructs_to_new_variants() {
         matches!(spec.smooth_terms[0].basis, SmoothBasisSpec::FactorSmooth { ref spec } if matches!(spec.flavour, FactorSmoothFlavour::Fs { .. }))
     );
 }
+
+#[test]
+fn factor_by_smooth_defers_level_offsets_to_explicit_random_intercept() {
+    let data = ds();
+    let col_map = data.column_map();
+    let policy = ResourcePolicy::default_library();
+
+    let parsed = parse_formula("y ~ s(x, by=fac) + group(fac)").unwrap();
+    let spec = build_termspec(&parsed.terms, &data, &col_map, &mut vec![], &policy).unwrap();
+
+    assert_eq!(
+        spec.random_effect_terms
+            .iter()
+            .filter(|term| term.name == "fac" && term.penalized)
+            .count(),
+        1,
+        "the explicit group(fac) term should own the factor offsets"
+    );
+    assert!(
+        !spec
+            .random_effect_terms
+            .iter()
+            .any(|term| term.name == "fac" && !term.penalized),
+        "factor-by smooths must not add a no-pooling fixed factor effect when group(fac) is present"
+    );
+}


### PR DESCRIPTION
## Codex Cloud task

- Title: Investigate mixed/factor smooth accuracy gaps
- Task: https://chatgpt.com/codex/tasks/task_e_6a3408f6fb1c83249288d69fde2bbe60
- Task id: `task_e_6a3408f6fb1c83249288d69fde2bbe60`
- Status: `ready`
- Updated: 2026-06-18T15:50:25.049173116Z
- Attempt count: 1
- Environment: SauersML/gam
- Branch: `codex/cloud-6a3408f6-investigate-mixed-factor-smooth-accuracy-gaps`
- Base: `main`
- Summary: 2 files changed, +38 / -1

Generated from `codex cloud diff task_e_6a3408f6fb1c83249288d69fde2bbe60` against `origin/main`. The Codex Cloud CLI does not expose a noninteractive log stream or assistant-response body; this PR includes the task title, URL, status metadata, and diff available through the CLI.

<details open>
<summary>Codex Cloud unified diff</summary>

```diff
diff --git a/src/terms/term_builder.rs b/src/terms/term_builder.rs
index 1b39004026e0448f838c36ec64a6de84363f9001..e568be940213e487ea99d9e77f1ff202513cfcb6 100644
--- a/src/terms/term_builder.rs
+++ b/src/terms/term_builder.rs
@@ -587,54 +587,65 @@ pub fn build_termspec(
                         .values
                         .column(by_col)
                         .iter()
                         .map(|v| v.to_bits())
                         .collect();
                     levels.sort_unstable();
                     levels.dedup();
                     smooth_terms.push(SmoothTermSpec {
                         name: label.clone(),
                         basis: SmoothBasisSpec::FactorSumToZero {
                             inner: Box::new(inner_basis),
                             by_col,
                             levels,
                             frozen_global_orthogonality: None,
                         },
                         shape,
                         joint_null_rotation: None,
                     });
                 } else if let Some(by_name) = by_name {
                     let by_col = resolve_col(col_map, &by_name)?;
                     match ds.column_kinds.get(by_col).copied().ok_or_else(|| {
                         format!("internal column-kind lookup failed for by variable '{by_name}'")
                     })? {
                         ColumnKindTag::Categorical => {
                             let levels = encoded_levels_for_column(ds, ColIdx::new(by_col));
-                            // Add an unpenalized treatment-coded fixed main effect for the factor, unless present already.
+                            let penalized_group_owner_present = terms.iter().any(|other| {
+                                matches!(other, ParsedTerm::RandomEffect { name } if name == &by_name)
+                            });
+                            // Add an unpenalized treatment-coded fixed main
+                            // effect for a standalone factor-by smooth, unless
+                            // the same factor already has an explicit
+                            // `group(factor)` term.  In that mixed-model form
+                            // the penalized random intercept is the coherent
+                            // owner of level offsets; adding a no-pooling fixed
+                            // factor effect would bypass random-effect
+                            // shrinkage and degrade BLUP-style predictions.
                             if !random_terms
                                 .iter()
                                 .any(|rt| rt.name == by_name && !rt.penalized)
+                                && !penalized_group_owner_present
                             {
                                 random_terms.push(RandomEffectTermSpec {
                                     name: by_name.clone(),
                                     feature_col: by_col,
                                     drop_first_level: true,
                                     penalized: false,
                                     frozen_levels: None,
                                 });
                             }
                             for (level_bits, level_label) in levels {
                                 smooth_terms.push(SmoothTermSpec {
                                     name: format!("{}:{}", label, level_bits),
                                     basis: SmoothBasisSpec::ByVariable {
                                         inner: Box::new(inner_basis.clone()),
                                         by_col,
                                         kind: BySmoothKind::Level { level_bits },
                                         by: ByVariableSpec::Level {
                                             value_bits: level_bits,
                                             label: level_label,
                                         },
                                     },
                                     shape,
                                     joint_null_rotation: None,
                                 });
                             }
diff --git a/tests/basis_smooth/factor_smooths_formula.rs b/tests/basis_smooth/factor_smooths_formula.rs
index 0e11a1d7a23274dd4228e2017fc56e7c6a70f5ee..2a0c91b9b5625c714740bb8e63b151e76fcc1955 100644
--- a/tests/basis_smooth/factor_smooths_formula.rs
+++ b/tests/basis_smooth/factor_smooths_formula.rs
@@ -108,25 +108,51 @@ fn termspec_routes_new_constructs_to_new_variants() {
     let spec = build_termspec(&parsed.terms, &data, &col_map, &mut vec![], &policy).unwrap();
     assert!(matches!(
         spec.smooth_terms[0].basis,
         SmoothBasisSpec::BySmooth {
             by_kind: ByVarKind::Numeric { .. },
             ..
         }
     ));
 
     let parsed = parse_formula("y ~ s(x, by=fac)").unwrap();
     let spec = build_termspec(&parsed.terms, &data, &col_map, &mut vec![], &policy).unwrap();
     assert!(matches!(
         spec.smooth_terms[0].basis,
         SmoothBasisSpec::BySmooth {
             by_kind: ByVarKind::Factor { .. },
             ..
         }
     ));
 
     let parsed = parse_formula("y ~ fs(x, fac)").unwrap();
     let spec = build_termspec(&parsed.terms, &data, &col_map, &mut vec![], &policy).unwrap();
     assert!(
         matches!(spec.smooth_terms[0].basis, SmoothBasisSpec::FactorSmooth { ref spec } if matches!(spec.flavour, FactorSmoothFlavour::Fs { .. }))
     );
 }
+
+#[test]
+fn factor_by_smooth_defers_level_offsets_to_explicit_random_intercept() {
+    let data = ds();
+    let col_map = data.column_map();
+    let policy = ResourcePolicy::default_library();
+
+    let parsed = parse_formula("y ~ s(x, by=fac) + group(fac)").unwrap();
+    let spec = build_termspec(&parsed.terms, &data, &col_map, &mut vec![], &policy).unwrap();
+
+    assert_eq!(
+        spec.random_effect_terms
+            .iter()
+            .filter(|term| term.name == "fac" && term.penalized)
+            .count(),
+        1,
+        "the explicit group(fac) term should own the factor offsets"
+    );
+    assert!(
+        !spec
+            .random_effect_terms
+            .iter()
+            .any(|term| term.name == "fac" && !term.penalized),
+        "factor-by smooths must not add a no-pooling fixed factor effect when group(fac) is present"
+    );
+}

```
</details>
