### PR TITLE
Audit and fix prediction/design replay

### DIFF
--- a/src/solver/fit_orchestration.rs
+++ b/src/solver/fit_orchestration.rs
@@ -67,7 +67,7 @@ use crate::smooth::{
     build_term_collection_design,
     fit_term_collection_with_coefficient_groups_and_penalty_block_gamma_priors,
     fit_term_collectionwith_latent_coord_optimization,
-    fit_term_collectionwith_spatial_length_scale_optimization,
+    fit_term_collectionwith_spatial_length_scale_optimization, freeze_term_collection_from_design,
 };
 
 use crate::solver::latent_cache::LatentRetractionRegistry;

--- a/src/solver/fit_orchestration/entry.rs
+++ b/src/solver/fit_orchestration/entry.rs
@@ -326,10 +326,16 @@ fn constant_gaussian_standard_fit(
         .map_err(|err| WorkflowError::IntegrationFailed {
             reason: format!("constant Gaussian shortcut produced invalid fit: {err}"),
         })?;
+    let resolvedspec =
+        freeze_term_collection_from_design(&request.spec, &design).map_err(|err| {
+            WorkflowError::InvalidConfig {
+                reason: format!("constant Gaussian shortcut could not freeze design: {err}"),
+            }
+        })?;
     Ok(StandardFitResult {
         fit,
         design,
-        resolvedspec: request.spec.clone(),
+        resolvedspec,
         adaptive_diagnostics: None,
         kappa_timing: None,
         saved_link_state: crate::estimate::FittedLinkState::Standard(None),

--- a/src/solver/fit_orchestration/fit.rs
+++ b/src/solver/fit_orchestration/fit.rs
@@ -184,10 +184,13 @@ pub(crate) fn fit_standard_model(
             &request.options,
         )
         .map_err(|e| e.to_string())?;
+        let resolvedspec =
+            crate::smooth::freeze_term_collection_from_design(&request.spec, &fitted.design)
+                .map_err(|e| e.to_string())?;
         crate::terms::smooth::FittedTermCollectionWithSpec {
             fit: fitted.fit,
             design: fitted.design,
-            resolvedspec: request.spec.clone(),
+            resolvedspec,
             adaptive_diagnostics: fitted.adaptive_diagnostics,
             kappa_timing: None,
         }


### PR DESCRIPTION
### Summary
* Root cause: two standard-fit exits returned the raw request `TermCollectionSpec` as `resolvedspec` after fitting against an already-realized design. That meant later `build_term_collection_design(..., &resolvedspec)` could replay different centers/transforms/identifiability than the fit used.
* Fixed the constant-Gaussian shortcut to freeze `request.spec` against the realized design before returning `StandardFitResult`, so prediction replay uses fit-time geometry. 

---
Auto-extracted from Codex Cloud task `task_e_6a3408fc99408324885f427991f47087` (15 changed lines).
Source: https://chatgpt.com/codex/tasks/task_e_6a3408fc99408324885f427991f47087