### PR TITLE
Fix SAE JumpReLU value and gradient tests

### DIFF
--- a/src/terms/analytic_penalties/sparsity.rs
+++ b/src/terms/analytic_penalties/sparsity.rs
@@ -1229,7 +1229,9 @@ impl AnalyticPenalty for JumpReLUPenalty {
         //   λτ·g(1−g)(1−2g)/ε²
         // is indefinite (negative once the gate passes the inflection
         // g = ½). The Newton / PIRLS pipeline needs a PSD curvature block, so
-        // expose the re-weighted majorizer  λτ·[g(1−g)]²/ε² ⪰ 0.
+        // expose the PSD upper bound implemented by `psd_hessian_diag_entry`:
+        // the elementwise max of the re-weighted surrogate and the absolute
+        // exact curvature.
         let d = self.latent_dim;
         let n_obs = target.len() / d;
         let mut diag = Array1::<f64>::zeros(target.len());

--- a/tests/sae/jumprelu_ste.rs
+++ b/tests/sae/jumprelu_ste.rs
@@ -152,14 +152,17 @@ fn jumprelu_ste_value_converges_to_hard_threshold_as_eps_shrinks() {
     let n_obs = 100;
     let weight = 1.0;
 
-    // Build targets well clear of each threshold (no boundary cases).
+    // Build targets on an exact grid and compare with the same hard-threshold
+    // predicate as the ε→0 limit. Values may lie near (but not exactly on) a
+    // threshold; for sufficiently small ε their smoothed contribution still
+    // converges to τ · 1[z > τ].
     let mut target = Array1::<f64>::zeros(n_obs * d);
     let mut hard_total = 0.0;
     for row in 0..n_obs {
         for axis in 0..d {
-            let z = (row as f64 + 1.0) / (n_obs as f64) * 1.2;
+            let z = (row as f64 + 0.37) / (n_obs as f64) * 1.2;
             target[row * d + axis] = z;
-            if z > thresholds[axis] + 0.05 {
+            if z > thresholds[axis] {
                 hard_total += weight * thresholds[axis];
             }
         }


### PR DESCRIPTION
**Summary**
* Fixed the JumpReLU STE hard-threshold limiting-behavior oracle to use the actual zero-temperature predicate `z > τ`, and shifted the synthetic grid off exact threshold points so the ε → 0 comparison is mathematically coherent. 

---
Auto-extracted from Codex Cloud task `task_e_6a3407bf4e80832492eda7681aecad90` (13 changed lines).
Source: https://chatgpt.com/codex/tasks/task_e_6a3407bf4e80832492eda7681aecad90