### PR TITLE
Fix double penalty EDF and shrinkage issues

### DIFF
--- a/src/terms/basis/bspline_build.rs
+++ b/src/terms/basis/bspline_build.rs
@@ -280,7 +280,7 @@ pub fn build_bspline_basis_1d(
             spec.penalty_order,
             greville_for_penalty.as_ref().map(|g| g.view()),
         )?;
-        let penalties_raw = bspline_penalty_candidates(&s_bend_raw, spec)?;
+        let penalties_raw = bspline_primary_penalty_candidates(&s_bend_raw);
         let penalties_raw_mats = penalties_raw
             .iter()
             .map(|candidate| candidate.matrix.clone())
@@ -302,6 +302,8 @@ pub fn build_bspline_basis_1d(
                 penalties_raw_mats,
                 Some(chunk),
             )?;
+        let transformed_candidates =
+            finalize_bspline_penalty_candidates(transformed_candidates, spec)?;
         let (penalties, nullspace_dims, penaltyinfo, null_eigenvectors, ops) =
             filter_active_penalty_candidates_with_ops(transformed_candidates)?;
         return Ok(BasisBuildResult {
@@ -460,7 +462,7 @@ pub fn build_bspline_basis_1d(
         spec.penalty_order,
         greville_for_penalty.as_ref().map(|g| g.view()),
     )?;
-    let penalties_raw = bspline_penalty_candidates(&s_bend_raw, spec)?;
+    let penalties_raw = bspline_primary_penalty_candidates(&s_bend_raw);
     let penalties_raw_mats: Vec<Array2<f64>> = penalties_raw
         .iter()
         .map(|candidate| candidate.matrix.clone())
@@ -599,6 +601,7 @@ pub fn build_bspline_basis_1d(
                 identifiability_transform,
             )
         };
+    let transformed_candidates = finalize_bspline_penalty_candidates(transformed_candidates, spec)?;
     let (penalties, nullspace_dims, penaltyinfo, null_eigenvectors, ops) =
         filter_active_penalty_candidates_with_ops(transformed_candidates)?;
     Ok(BasisBuildResult {
@@ -1609,71 +1612,54 @@ pub(crate) fn validated_kronecker_factors(
     (max_abs_diff <= scale * 1e-10).then_some(factors)
 }
 
-/// Assemble the raw (pre-identifiability) penalty candidates for a 1-D B-spline.
+/// Assemble the primary B-spline wiggliness candidate before chart constraints.
+fn bspline_primary_penalty_candidates(s_bend_raw: &Array2<f64>) -> Vec<PenaltyCandidate> {
+    vec![PenaltyCandidate {
+        matrix: s_bend_raw.clone(),
+        nullspace_dim_hint: 0,
+        source: PenaltySource::Primary,
+        normalization_scale: 1.0,
+        kronecker_factors: None,
+        op: None,
+    }]
+}
+
+/// Add the Marra-Wood null-space shrinkage penalty after all B-spline chart
+/// restrictions have been applied.
 ///
-/// The wiggliness penalty `S_bend` is always present. When `double_penalty` is
-/// enabled on a free (non-boundary-conditioned) basis we additionally emit the
-/// Marra & Wood (2011) null-space shrinkage block `Z Zᵀ` as a *separate* REML
-/// coordinate, so that REML can drive an unsupported term's constant/linear
-/// part to `EDF → 0` independently of its wiggliness (mgcv `select = TRUE`).
-///
-/// Both candidates are Frobenius-normalized to unit norm exactly the way the
-/// Duchon / constant-curvature / tensor-B-spline paths already normalize their
-/// own primary + `DoublePenaltyNullspace` blocks. This normalization is what
-/// makes the second smoothing parameter `λ_nullspace` *identifiable*: an
-/// un-normalized `Z Zᵀ` (largest eigenvalue 1) sits on a wildly different scale
-/// from the raw bending penalty, leaving the outer REML objective nearly flat
-/// along the `λ_nullspace` coordinate. Under that flat coordinate REML weakened
-/// the wiggliness penalty instead of shrinking the term out, which *inflated*
-/// the smooth's EDF rather than reducing it (#1266). With both blocks on a
-/// common (unit-Frobenius) scale the coordinate is identified and the double
-/// penalty shrinks — never inflates — null-space / unsupported terms.
-fn bspline_penalty_candidates(
-    s_bend_raw: &Array2<f64>,
+/// Shrinkage semantics are defined in the realized coefficient chart: the
+/// double-penalty block must penalize exactly `null(S_bend_realized)`, not the
+/// null space of an earlier raw basis that may contain directions removed by
+/// boundary or identifiability constraints. Building `Z Zᵀ` from the realized
+/// bending penalty keeps EDF accounting coherent: the primary and shrinkage
+/// blocks are complementary in the chart actually seen by REML.
+fn finalize_bspline_penalty_candidates(
+    mut candidates: Vec<PenaltyCandidate>,
     spec: &BSplineBasisSpec,
 ) -> Result<Vec<PenaltyCandidate>, BasisError> {
-    let want_nullspace = spec.double_penalty && spec.boundary_conditions.is_free();
-    let shrinkage = if want_nullspace {
-        build_nullspace_shrinkage_penalty(s_bend_raw)?
-    } else {
-        None
+    if !(spec.double_penalty && spec.boundary_conditions.is_free()) {
+        return Ok(candidates);
+    }
+    let Some(primary_pos) = candidates
+        .iter()
+        .position(|candidate| matches!(candidate.source, PenaltySource::Primary))
+    else {
+        return Ok(candidates);
+    };
+    let Some(shrinkage) = build_nullspace_shrinkage_penalty(&candidates[primary_pos].matrix)?
+    else {
+        return Ok(candidates);
     };
 
-    // Without an active null-space block, preserve the historical single-penalty
-    // geometry exactly: the bending penalty ships un-normalized with scale 1.0,
-    // so `double_penalty = False` (and boundary-conditioned) fits are byte-for-
-    // byte unchanged.
-    let Some(shrinkage) = shrinkage else {
-        return Ok(vec![PenaltyCandidate {
-            matrix: s_bend_raw.clone(),
-            nullspace_dim_hint: 0,
-            source: PenaltySource::Primary,
-            normalization_scale: 1.0,
-            kronecker_factors: None,
-            op: None,
-        }]);
-    };
-
-    let (bend_norm, bend_scale) = normalize_penalty(s_bend_raw);
-    let (ridge_norm, ridge_scale) = normalize_penalty(&shrinkage.sym_penalty);
-    Ok(vec![
-        PenaltyCandidate {
-            matrix: bend_norm,
-            nullspace_dim_hint: 0,
-            source: PenaltySource::Primary,
-            normalization_scale: bend_scale,
-            kronecker_factors: None,
-            op: None,
-        },
-        PenaltyCandidate {
-            matrix: ridge_norm,
-            nullspace_dim_hint: 0,
-            source: PenaltySource::DoublePenaltyNullspace,
-            normalization_scale: ridge_scale,
-            kronecker_factors: None,
-            op: None,
-        },
-    ])
+    candidates.push(PenaltyCandidate {
+        matrix: shrinkage.sym_penalty,
+        nullspace_dim_hint: 0,
+        source: PenaltySource::DoublePenaltyNullspace,
+        normalization_scale: 1.0,
+        kronecker_factors: None,
+        op: None,
+    });
+    Ok(candidates)
 }
 
 /// Build the double-penalty ridge from the structural null space of a PSD penalty.


### PR DESCRIPTION
### Summary
* Changed B-spline penalty construction so the raw build emits only the primary wiggliness penalty before chart restrictions, then finalizes the double-penalty nullspace shrinkage block after boundary/identifiability transforms have produced the realized coefficient chart. 

---
Auto-extracted from Codex Cloud task `task_e_6a3407aebd5c8324b117c4e3d758dfff` (108 changed lines).
Source: https://chatgpt.com/codex/tasks/task_e_6a3407aebd5c8324b117c4e3d758dfff