### PR TITLE
Fix formula routing and external-family policy tests

### DIFF
--- a/src/solver/estimate/estimate_policy_tests.rs
+++ b/src/solver/estimate/estimate_policy_tests.rs
@@ -709,6 +709,24 @@ fn resolve_external_family_rejects_unsupported_firth_request() {
 }
 
 #[test]
+fn resolve_external_family_rejects_beta_regression_route() {
+    let err = resolve_external_family(
+        &LikelihoodSpec::new(
+            ResponseFamily::Beta { phi: 5.0 },
+            InverseLink::Standard(StandardLink::Logit),
+        ),
+        None,
+    )
+    .expect_err("external-design policy should reject beta regression");
+    let message = err.to_string();
+    assert!(
+        message.contains("supported standard GLM family/link")
+            && message.contains("Beta regression is a dispersion-family model"),
+        "unexpected error: {message}"
+    );
+}
+
+#[test]
 fn resolve_external_family_accepts_supported_nonlogit_firth_request() {
     let (_, firth) = resolve_external_family(
         &LikelihoodSpec::new(

--- a/src/solver/estimate/external_options.rs
+++ b/src/solver/estimate/external_options.rs
@@ -83,10 +83,27 @@ pub(crate) fn resolve_external_family(
     family: &crate::types::LikelihoodSpec,
     firth_override: Option<bool>,
 ) -> Result<(GlmLikelihoodSpec, bool), EstimationError> {
-    if family.is_royston_parmar() {
+    let external_glm_supported = match (&family.response, family.link_function()) {
+        (ResponseFamily::Gaussian, LinkFunction::Identity)
+        | (ResponseFamily::Poisson, LinkFunction::Log)
+        | (ResponseFamily::Gamma, LinkFunction::Log)
+        | (ResponseFamily::Tweedie { .. }, LinkFunction::Log)
+        | (ResponseFamily::NegativeBinomial { .. }, LinkFunction::Log)
+        | (ResponseFamily::Binomial, LinkFunction::Logit)
+        | (ResponseFamily::Binomial, LinkFunction::Probit)
+        | (ResponseFamily::Binomial, LinkFunction::CLogLog)
+        | (ResponseFamily::Binomial, LinkFunction::Sas)
+        | (ResponseFamily::Binomial, LinkFunction::BetaLogistic) => true,
+        (ResponseFamily::Beta { .. }, LinkFunction::Logit) => false,
+        _ => false,
+    };
+    if !external_glm_supported {
         crate::bail_invalid_estim!(
-            "optimize_external_design does not support RoystonParmar; use survival training APIs"
-                .to_string(),
+            "optimize_external_design requires a supported standard GLM family/link; got {}. \
+             The external-design route supports Gaussian(identity), Binomial(logit/probit/cloglog/SAS/Beta-Logistic), \
+             and Poisson/Gamma/Tweedie/Negative-Binomial(log). Beta regression is a dispersion-family model; \
+             use the formula location-scale route with noise_formula for Beta precision modeling",
+            family.pretty_name(),
         );
     }
 
@@ -103,10 +120,6 @@ pub(crate) fn resolve_external_family(
             crate::bail_invalid_estim!("optimize_external_design requires a GLM family; Tweedie variance power must be finite and strictly between 1 and 2; use PoissonLog or GammaLog for boundary cases"
                     .to_string(),);
         }
-    }
-    if matches!(family.response, ResponseFamily::RoystonParmar) {
-        crate::bail_invalid_estim!("optimize_external_design requires a GLM family; RoystonParmar is survival-specific and not a GLM likelihood"
-                .to_string(),);
     }
     Ok((
         GlmLikelihoodSpec::canonical(family.clone()),

--- a/src/solver/estimate/fit.rs
+++ b/src/solver/estimate/fit.rs
@@ -208,6 +208,14 @@ where
             "fit_gam external design path does not support RoystonParmar; use survival training APIs"
         );
     }
+    // Validate the external-design family/link policy before looking at response
+    // support so unsupported routes (for example Beta regression, whose
+    // formula path owns the precision channel) report the routing problem
+    // instead of a secondary y-domain violation.
+    super::external_options::resolve_external_family(
+        &resolved_family,
+        Some(opts.firth_bias_reduction),
+    )?;
     // Per-family response-support validation, owned by the family type.
     // Gamma `y > 0`, Poisson / NegativeBinomial / Tweedie `y ≥ 0`, Beta
     // `y ∈ (0, 1)`. Centralising the rule on `ResponseFamily` means the


### PR DESCRIPTION
### Summary
* Tightened the external-design family policy to accept only the supported GLM family/link combinations, while rejecting Beta regression with a clear diagnostic that explains the external route and points users toward the formula location-scale route for Beta precision modeling. 

---
Auto-extracted from Codex Cloud task `task_e_6a3407a41644832499fc9ae38aa610af` (53 changed lines).
Source: https://chatgpt.com/codex/tasks/task_e_6a3407a41644832499fc9ae38aa610af