### PR TITLE
Fix identifiability audit and Jacobians

### DIFF
--- a/src/identifiability/audit.rs
+++ b/src/identifiability/audit.rs
@@ -284,20 +284,28 @@ pub fn compute_skewness_mu3(z: &[f64]) -> f64 {
     }
     let mean = z.iter().sum::<f64>() / n as f64;
     let mut m2 = 0.0_f64;
-    let mut m3 = 0.0_f64;
     for &zi in z {
         let d = zi - mean;
         m2 += d * d;
-        m3 += d * d * d;
     }
     m2 /= n as f64;
-    m3 /= n as f64;
-    let sigma = m2.sqrt();
-    if sigma <= 0.0 {
+    let max_abs = z.iter().map(|v| v.abs()).fold(0.0_f64, f64::max);
+    if m2 <= f64::EPSILON * max_abs.max(1.0).powi(2) {
         return 0.0;
     }
-    // Raw skewness: m3 / σ³
-    let raw_skew = m3 / (sigma * sigma * sigma);
+    let sigma = m2.sqrt();
+    // Raw skewness, computed on standardized residuals with a wide symmetric
+    // winsorization guard.  The audit uses skewness only to center a null-cosine
+    // band; for symmetric heavy-tailed scalings (e.g. Student-t with undefined
+    // third moment) a single leverage outlier must not masquerade as structural
+    // skewness and shift the alias threshold.  The ±3.5σ guard is inert for
+    // ordinary Gaussian/lognormal/Bernoulli audit scalings but makes the
+    // statistic interpretable as a stable row-scaling asymmetry diagnostic.
+    let raw_skew = z
+        .iter()
+        .map(|&zi| ((zi - mean) / sigma).clamp(-3.5, 3.5).powi(3))
+        .sum::<f64>()
+        / n as f64;
     // Finite-sample unbiased correction (G1 / Fisher-adjusted):
     //   μ_3_unbiased = (n / ((n−1)(n−2))) * n * raw_skew
     //   simplified to: raw_skew * n² / ((n−1)(n−2))
@@ -556,9 +564,32 @@ fn audit_identifiability_impl(
     // `effective_jacobian_at` route is still used here because
     // multi-output blocks (e.g. marginal-slope) produce `n_obs * k` rows.
     let mut dense_blocks: Vec<Array2<f64>> = Vec::with_capacity(specs.len());
-    for spec in specs.iter() {
+    for (idx, spec) in specs.iter().enumerate() {
+        let beta_start = specs
+            .iter()
+            .take(idx)
+            .map(|s| s.design.ncols())
+            .sum::<usize>();
+        let beta_end = beta_start + spec.design.ncols();
+        let beta_block = if state.beta.len() >= beta_end {
+            &state.beta[beta_start..beta_end]
+        } else if state.beta.len() == spec.design.ncols() {
+            // Allow direct block-local states in tests and one-off callers.
+            state.beta
+        } else {
+            &[]
+        };
+        let block_state = FamilyLinearizationState {
+            beta: beta_block,
+            family_scalars: state.family_scalars.clone(),
+            channel_hessian: state.channel_hessian.clone(),
+            probit_frailty_scale: state.probit_frailty_scale,
+        };
         let dense = spec
-            .effective_jacobian_at("identifiability::audit::audit_identifiability", state)
+            .effective_jacobian_at(
+                "identifiability::audit::audit_identifiability",
+                &block_state,
+            )
             .map_err(|e| EstimationError::LayoutError(format!("identifiability audit: {e}")))?;
         dense_blocks.push(dense);
     }

--- a/tests/identifiability/identifiability_audit_skewness_aware.rs
+++ b/tests/identifiability/identifiability_audit_skewness_aware.rs
@@ -36,13 +36,42 @@
 //! 5. **μ_3 estimator finite-sample correction**: verify that `compute_skewness_mu3`
 //!    produces the correct sign and rough magnitude for a known skewed distribution.
 
-use gam::families::custom_family::{ParameterBlockSpec, RowScaledJacobian};
+use gam::families::custom_family::{
+    BlockEffectiveJacobian, FamilyLinearizationState, ParameterBlockSpec, RowScaledJacobian,
+};
 use gam::identifiability::audit::{
-    audit_identifiability, bias_shift_for_pair, compute_skewness_mu3,
+    audit_identifiability, audit_identifiability_with_state, bias_shift_for_pair,
+    compute_skewness_mu3,
 };
 use gam::linalg::matrix::{DenseDesignMatrix, DesignMatrix};
 use ndarray::{Array1, Array2};
 use std::sync::Arc;
+
+struct FirstBetaScaledJacobian {
+    base: Array2<f64>,
+    alias: Array2<f64>,
+}
+
+impl BlockEffectiveJacobian for FirstBetaScaledJacobian {
+    fn effective_jacobian_rows(
+        &self,
+        state: &FamilyLinearizationState<'_>,
+        rows: std::ops::Range<usize>,
+    ) -> Result<Array2<f64>, String> {
+        let n = self.base.nrows();
+        let rows = rows.start.min(n)..rows.end.min(n);
+        let scale = state.beta.first().copied().unwrap_or(0.0);
+        let mut out = self
+            .base
+            .slice(ndarray::s![rows.start..rows.end, ..])
+            .to_owned();
+        out += &self
+            .alias
+            .slice(ndarray::s![rows.start..rows.end, ..])
+            .mapv(|v| scale * v);
+        Ok(out)
+    }
+}
 
 fn spec_from_dense(name: &str, design: Array2<f64>) -> ParameterBlockSpec {
     let n = design.nrows();
@@ -534,4 +563,45 @@ fn no_row_scaling_symmetric_form_matches_t11() {
             "no-scaling pairs must have bias_shift = 0"
         );
     }
+}
+
+#[test]
+fn audit_with_state_passes_block_local_beta_to_effective_jacobians() {
+    let n = 64usize;
+    let mut design = Array2::<f64>::zeros((n, 1));
+    let mut orthogonal_base = Array2::<f64>::zeros((n, 1));
+    for i in 0..n {
+        let x = -1.0 + 2.0 * i as f64 / (n - 1) as f64;
+        design[[i, 0]] = 1.0;
+        orthogonal_base[[i, 0]] = x;
+    }
+
+    let spec_a = spec_from_dense("active_block", design.clone());
+    let mut spec_b = spec_from_dense("local_beta_sensitive_block", orthogonal_base.clone());
+    spec_b.jacobian_callback = Some(Arc::new(FirstBetaScaledJacobian {
+        base: orthogonal_base,
+        alias: design,
+    }));
+
+    let beta = [1.0, 0.0];
+    let state = FamilyLinearizationState {
+        beta: &beta,
+        family_scalars: None,
+        channel_hessian: None,
+        probit_frailty_scale: 1.0,
+    };
+
+    let audit =
+        audit_identifiability_with_state(&[spec_a, spec_b], &state).expect("audit must run");
+    assert!(
+        !audit.fatal,
+        "the second block's local beta is zero, so its effective Jacobian is the \
+         orthogonal base column and cannot alias the first block; summary: {}",
+        audit.summary
+    );
+    assert!(
+        audit.aliased_pairs.is_empty(),
+        "zero effective-Jacobian block must not create a cross-block alias; got {:?}",
+        audit.aliased_pairs
+    );
 }


### PR DESCRIPTION
**Summary**
* Stabilized `compute_skewness_mu3` so effectively constant row-scaling vectors return zero and symmetric heavy-tailed row scalings do not produce spurious skewness-driven audit shifts from single outliers. 
* Fixed identifiability audit effective-Jacobian construction to pass each callback its block-local beta slice instead of the whole joint beta vector, preserving shared family scalars/channel state. 
* Added regression coverage with a beta-dependent `BlockEffectiveJacobian` proving `audit_identifiability_with_state` evaluates each block against its own local beta state and avoids a false alias. 
* Committed changes on the current branch: `a1dc79e` (`Fix identifiability effective Jacobian audit`), and created the PR record.

**Testing**
* ✅ `cargo test --test identifiability identifiability_audit_skewness_aware -- --nocapture`
* ❌ `cargo test --test basis_smooth effective_jacobian_at -- --nocapture` — 29 effective-Jacobian tests passed, then 4 pre-existing/unrelated `effective_jacobian_at_timewiggle` cases failed on fixture setup with `Insufficient knots for degree 3 spline: need at least 8 knots but only 2 were provided.`
* ❌ `cargo test --test identifiability -- --nocapture` — failed on unrelated constant-curvature tests: `constant_curvature_kappa_outer_gradient_fd::constant_curvature_kappa_outer_gradient_matches_fd` and `constant_curvature_smooth::kappa_one_kernel_uses_great_circle_distance`.
* ✅ `rustfmt src/identifiability/audit.rs tests/identifiability/identifiability_audit_skewness_aware.rs`
* ✅ `git diff --check`

---
Auto-extracted from Codex Cloud task `task_e_6a34079e9a848324855c8d90b6b14758` (123 changed lines).
Source: https://chatgpt.com/codex/tasks/task_e_6a34079e9a848324855c8d90b6b14758