### PR TITLE
Fix survival location-scale tests

### DIFF
--- a/src/families/survival/location_scale/row_kernel.rs
+++ b/src/families/survival/location_scale/row_kernel.rs
@@ -731,16 +731,30 @@ impl SurvivalLocationScaleFamily {
     /// current trait contract.
     #[inline]
     pub(crate) fn row_kernel_joint_hessian_supported(&self) -> bool {
-        self.x_link_wiggle.is_none()
+        // Keep the coefficient working-set path on the bespoke exact
+        // assembler. Besides avoiding the oversized `Tower4<9>` cache, the
+        // bespoke path is the derivative path that currently tracks the
+        // survival location-scale likelihood for every supported residual
+        // distribution and time-varying channel layout.
+        false
     }
 
     /// First directional derivatives require third qdot map derivatives when
-    /// threshold/log-sigma derivative designs are present; those live in
-    /// `SurvivalJointQuantities`, so every non-wiggle shape can use the
-    /// `RowKernel<9>` path.
+    /// threshold/log-sigma derivative designs are present.
     #[inline]
     pub(crate) fn row_kernel_directional_supported(&self) -> bool {
-        self.x_link_wiggle.is_none()
+        // The dense `Tower4<9>` directional path materializes a complete
+        // fourth-order tensor over the nine survival location-scale primary
+        // channels. That is the wrong representation here: every row program
+        // builds multiple ~50 KiB tower values and operator chains copy them
+        // by value, which has caused stack overflows and severe timeouts in
+        // exact location-scale survival fits.  The non-wiggle family already
+        // has an exact hand-derived first-directional implementation below
+        // this gate (the same path required for link-wiggle, where the
+        // coefficient-to-primary Jacobian is beta-dependent), so route all
+        // first directional derivatives through that exact implementation
+        // until the generic tower grows a packed/heap-backed tensor layout.
+        false
     }
 
     pub(crate) fn survival_ls_row_kernel<'a>(


### PR DESCRIPTION
**Summary**
* Committed change `265ac42` to route survival location-scale exact working-set assembly away from the generic `Tower4<9>` row-kernel path and keep it on the bespoke exact assembler, avoiding the oversized fourth-order row-kernel cache implicated in stack/timeouts. 

---
Auto-extracted from Codex Cloud task `task_e_6a3407757a0c8324a8e84841b676b62f` (24 changed lines).
Source: https://chatgpt.com/codex/tasks/task_e_6a3407757a0c8324a8e84841b676b62f