### PR TITLE
Fix numerical exactness in BMS rigid tower

### DIFF
--- a/src/families/bms/gradient_paths.rs
+++ b/src/families/bms/gradient_paths.rs
@@ -1450,6 +1450,136 @@ fn rigid_standard_normal_signed_jet(
     eta * (2.0 * y - 1.0)
 }
 
+#[derive(Clone, Copy)]
+struct RigidStandardNormalChain {
+    u1: f64,
+    u2: f64,
+    u3: f64,
+    u4: f64,
+    c1: f64,
+    c2: f64,
+    c3: f64,
+    c4: f64,
+    eta_q: f64,
+    eta_g: f64,
+}
+
+impl RigidStandardNormalChain {
+    #[inline]
+    fn new(
+        marginal_q: f64,
+        g: f64,
+        z: f64,
+        y: f64,
+        w: f64,
+        probit_scale: f64,
+    ) -> Result<Self, String> {
+        let s = 2.0 * y - 1.0;
+        let observed_logslope = rigid_observed_logslope(g, probit_scale);
+        let g2 = observed_logslope * observed_logslope;
+        let c = (1.0 + g2).sqrt();
+        let c1 = probit_scale * observed_logslope / c;
+        let c_inv3 = 1.0 / (c * c * c);
+        let c_inv5 = c_inv3 / (c * c);
+        let c_inv7 = c_inv5 / (c * c);
+        let eta = marginal_slope_standard_normal_scalar_eta(marginal_q, g, z, probit_scale);
+        let m = s * eta;
+        let (k1, k2, k3, k4) = signed_probit_neglog_derivatives_up_to_fourth(m, w)?;
+        Ok(Self {
+            u1: s * k1,
+            u2: k2,
+            u3: s * k3,
+            u4: k4,
+            c1,
+            c2: probit_scale * probit_scale * c_inv3,
+            c3: -3.0 * probit_scale.powi(3) * observed_logslope * c_inv5,
+            c4: probit_scale.powi(4) * (12.0 * g2 - 3.0) * c_inv7,
+            eta_q: c,
+            eta_g: marginal_q * c1 + probit_scale * z,
+        })
+    }
+
+    #[inline]
+    fn primary_hessian(&self, q: f64) -> [[f64; 2]; 2] {
+        let h00 = self.u2 * self.eta_q * self.eta_q;
+        let h01 = self.u2 * self.eta_q * self.eta_g + self.u1 * self.c1;
+        let h11 = self.u2 * self.eta_g * self.eta_g + self.u1 * q * self.c2;
+        [[h00, h01], [h01, h11]]
+    }
+
+    #[inline]
+    fn third_contracted(&self, q: f64, dq: f64, dg: f64) -> [[f64; 2]; 2] {
+        let dd = self.eta_q * dq + self.eta_g * dg;
+        let dd_q = self.c1 * dg;
+        let dd_g = self.c1 * dq + q * self.c2 * dg;
+        let dd_qg = self.c2 * dg;
+        let dd_gg = self.c2 * dq + q * self.c3 * dg;
+        let t00 = self.u3 * self.eta_q * self.eta_q * dd + self.u2 * 2.0 * self.eta_q * dd_q;
+        let t01 = self.u3 * self.eta_q * self.eta_g * dd
+            + self.u2 * (self.c1 * dd + self.eta_q * dd_g + self.eta_g * dd_q)
+            + self.u1 * dd_qg;
+        let t11 = self.u3 * self.eta_g * self.eta_g * dd
+            + self.u2 * (q * self.c2 * dd + 2.0 * self.eta_g * dd_g)
+            + self.u1 * dd_gg;
+        [[t00, t01], [t01, t11]]
+    }
+
+    #[inline]
+    fn fourth_contracted(&self, q: f64, uq: f64, ug: f64, vq: f64, vg: f64) -> [[f64; 2]; 2] {
+        let du = self.eta_q * uq + self.eta_g * ug;
+        let dv = self.eta_q * vq + self.eta_g * vg;
+        let du_a = [self.c1 * ug, self.c1 * uq + q * self.c2 * ug];
+        let dv_a = [self.c1 * vg, self.c1 * vq + q * self.c2 * vg];
+        let du_ab = [
+            [0.0, self.c2 * ug],
+            [self.c2 * ug, self.c2 * uq + q * self.c3 * ug],
+        ];
+        let dv_ab = [
+            [0.0, self.c2 * vg],
+            [self.c2 * vg, self.c2 * vq + q * self.c3 * vg],
+        ];
+        let dduv = self.c1 * (uq * vg + ug * vq) + q * self.c2 * ug * vg;
+        let dduv_a = [
+            self.c2 * ug * vg,
+            self.c2 * (uq * vg + ug * vq) + q * self.c3 * ug * vg,
+        ];
+        let dduv_ab = [
+            [0.0, self.c3 * ug * vg],
+            [
+                self.c3 * ug * vg,
+                self.c3 * (uq * vg + ug * vq) + q * self.c4 * ug * vg,
+            ],
+        ];
+        let eta_a = [self.eta_q, self.eta_g];
+        let eta_ab = [[0.0, self.c1], [self.c1, q * self.c2]];
+        let mut f = [[0.0; 2]; 2];
+        for a in 0..2 {
+            for b in a..2 {
+                let val = self.u4 * eta_a[a] * eta_a[b] * du * dv
+                    + self.u3
+                        * (eta_ab[a][b] * du * dv
+                            + du_a[a] * eta_a[b] * dv
+                            + dv_a[a] * eta_a[b] * du
+                            + du_a[b] * eta_a[a] * dv
+                            + dv_a[b] * eta_a[a] * du
+                            + dduv * eta_a[a] * eta_a[b])
+                    + self.u2
+                        * (eta_ab[a][b] * dduv
+                            + du_a[a] * dv_a[b]
+                            + dv_a[a] * du_a[b]
+                            + du_ab[a][b] * dv
+                            + dv_ab[a][b] * du
+                            + eta_a[b] * dduv_a[a]
+                            + eta_a[a] * dduv_a[b])
+                    + self.u1 * dduv_ab[a][b];
+                f[a][b] = val;
+                f[b][a] = val;
+            }
+        }
+        f
+    }
+}
+
 /// Batched, two-pass builder of the rigid standard-normal row `Tower4<2>` jets
 /// for a contiguous chunk of rows, written for the auto-vectorizer.
 ///
@@ -1842,7 +1972,30 @@ pub(super) fn rigid_standard_normal_fourth_full(
     w: f64,
     probit_scale: f64,
 ) -> Result<[[[[f64; 2]; 2]; 2]; 2], String> {
-    Ok(rigid_standard_normal_tower(marginal, g, z, y, w, probit_scale)?.t4)
+    let chain = RigidStandardNormalChain::new(marginal.q, g, z, y, w, probit_scale)?;
+    let h_q = chain.primary_hessian(marginal.q);
+    let grad_q = chain.u1 * chain.eta_q;
+    let q_dir = chain.third_contracted(marginal.q, 1.0, 0.0);
+    let f_qqq = q_dir[0][0];
+    let f_qqg = q_dir[0][1];
+    let f_qgg = q_dir[1][1];
+    let qq = chain.fourth_contracted(marginal.q, 1.0, 0.0, 1.0, 0.0);
+    let qg = chain.fourth_contracted(marginal.q, 1.0, 0.0, 0.0, 1.0);
+    let gg = chain.fourth_contracted(marginal.q, 0.0, 1.0, 0.0, 1.0);
+    let q1_sq = marginal.q1 * marginal.q1;
+    let q1_cu = q1_sq * marginal.q1;
+    let q1_q = q1_sq * q1_sq;
+    Ok(fourth_full_from_symmetric_components(
+        qq[0][0] * q1_q
+            + 6.0 * f_qqq * q1_sq * marginal.q2
+            + 3.0 * h_q[0][0] * marginal.q2 * marginal.q2
+            + 4.0 * h_q[0][0] * marginal.q1 * marginal.q3
+            + grad_q * marginal.q4,
+        qq[0][1] * q1_cu + 3.0 * f_qqg * marginal.q1 * marginal.q2 + h_q[0][1] * marginal.q3,
+        qq[1][1] * q1_sq + f_qgg * marginal.q2,
+        qg[1][1] * marginal.q1,
+        gg[1][1],
+    ))
 }
 
 /// Pack the five independent components of a fully-symmetric 4-tensor on a


### PR DESCRIPTION
**Summary**
* Added a focused `RigidStandardNormalChain` helper that evaluates the rigid standard-normal probit derivative chain in grouped analytic form, reusing the exact signed-probit derivative stack and explicit `c(g)` derivatives through fourth order. 

---
Auto-extracted from Codex Cloud task `task_e_6a34076039448324a91075f56ac306db` (155 changed lines).
Source: https://chatgpt.com/codex/tasks/task_e_6a34076039448324a91075f56ac306db