### PR TITLE
Fix failing tests for profiled theta HVP

### DIFF
--- a/src/families/custom_family/psi_hyper.rs
+++ b/src/families/custom_family/psi_hyper.rs
@@ -2124,9 +2124,15 @@ pub(crate) fn derivative_quality_options_and_warm_start(
     // noise below the requested optimization accuracy without rejecting all
     // startup seeds after hundreds of accepted but numerically flat Newton
     // steps.
-    let direct_joint_hyper_inner_tol = eval_options
-        .outer_tol
-        .max(DIRECT_JOINT_HYPER_INNER_TOL_FLOOR);
+    let default_inner_tol = BlockwiseFitOptions::default().inner_tol;
+    let requested_tighter_than_default = eval_options.inner_tol < default_inner_tol;
+    let direct_joint_hyper_inner_tol = if requested_tighter_than_default {
+        eval_options.inner_tol.max(1.0e-12)
+    } else {
+        eval_options
+            .outer_tol
+            .max(DIRECT_JOINT_HYPER_INNER_TOL_FLOOR)
+    };
     let tolerance_differs = eval_options.inner_tol != direct_joint_hyper_inner_tol;
     let tightening = eval_options.inner_tol > direct_joint_hyper_inner_tol;
     let align = eval_options.inner_max_cycles > 1 && tolerance_differs;

--- a/src/families/custom_family/tests.rs
+++ b/src/families/custom_family/tests.rs
@@ -1308,6 +1308,20 @@ pub(crate) fn direct_joint_hyper_inner_tolerance_follows_outer_target() {
     let (rho_only, _) = derivative_quality_options_and_warm_start(&tighter_options, None, false);
     assert_eq!(rho_only.inner_tol, tighter_options.inner_tol);
     assert_eq!(rho_only.inner_max_cycles, tighter_options.inner_max_cycles);
+
+    let explicitly_tight_options = BlockwiseFitOptions {
+        inner_tol: 1e-12,
+        outer_tol: 1e-10,
+        inner_max_cycles: 100,
+        ..BlockwiseFitOptions::default()
+    };
+    let (explicitly_tight, _) =
+        derivative_quality_options_and_warm_start(&explicitly_tight_options, None, true);
+    assert_eq!(
+        explicitly_tight.inner_tol, 1e-12,
+        "an explicitly sub-default inner tolerance should be honored down to the explicit direct joint-hyper floor instead of being loosened to outer_tol"
+    );
+    assert_eq!(explicitly_tight.inner_max_cycles, 100);
 }
 
 #[test]


### PR DESCRIPTION
### Summary
* Preserved explicitly requested sub-default inner tolerances for ψ-bearing direct joint-hyper evaluations, down to a tighter `1e-12` explicit floor instead of always loosening to `outer_tol`. 

---
Auto-extracted from Codex Cloud task `task_e_6a340759e5f08324803f551fc1246227` (26 changed lines).
Source: https://chatgpt.com/codex/tasks/task_e_6a340759e5f08324803f551fc1246227