### PR TITLE
fix: plumb covariate-smooth penalty nullspace dim in survival transformation fit

### DIFF
--- a/src/solver/fit_orchestration/fit.rs
+++ b/src/solver/fit_orchestration/fit.rs
@@ -1942,7 +1942,7 @@ pub(crate) fn fit_survival_transformation_model(
             // plain quadratic `λ βᵀSβ`; a non-zero centering would need an offset
             // the survival PenaltyBlock does not model, so such blocks are left to
             // the ridge rather than mis-applied.
-            for cov_penalty in &covariate_design.penalties {
+            for (penalty_idx, cov_penalty) in covariate_design.penalties.iter().enumerate() {
                 let cr = &cov_penalty.col_range;
                 let block_dim = cr.end - cr.start;
                 let matches_dims = cov_penalty.local.nrows() == block_dim
@@ -1956,7 +1956,11 @@ pub(crate) fn fit_survival_transformation_model(
                         matrix: cov_penalty.local.clone(),
                         lambda: 1e-2,
                         range: (p_time_total + cr.start)..(p_time_total + cr.end),
-                        nullspace_dim: 0,
+                        nullspace_dim: covariate_design
+                            .nullspace_dims
+                            .get(penalty_idx)
+                            .copied()
+                            .unwrap_or(0),
                     });
                 }
             }


### PR DESCRIPTION
Salvaged from the independent hunk of closed PR #1307.

PR #1307 was closed as a regression because its main change reverted the #899 Weibull anchor fix. However it contained one independent, valuable hunk that does **not** touch the Weibull anchor logic:

In `fit_survival_transformation_model` (`src/solver/fit_orchestration/fit.rs`), the covariate-smooth penalty blocks stacked into the survival transformation fit hardcoded `nullspace_dim: 0`, discarding the known per-block nullspace dimension that `build_term_collection_design` already computes. `TermCollectionDesign` carries `nullspace_dims: Vec<usize>` index-aligned with `.penalties`, so this reads the matching entry instead.

Effect: REML now accounts for the unpenalized nullspace of each covariate smooth (e.g. `s(x)`, frailty `s(group, bs=\"re\")`) in the survival transformation path, rather than treating the whole block as full-rank penalized. The adjacent fixed stabilization-ridge block (genuinely nullspace 0) is left unchanged.

The Weibull-anchor changes from #1307 (which reverted #899) are deliberately excluded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GM4BseRnqWPoWq7YiB7xNi