### PR TITLE
fix(#1324): exclude Gaussian-identity from exact-curvature ALO + bound Riesz leverage

### DIFF
--- a/src/inference/alo.rs
+++ b/src/inference/alo.rs
@@ -374,18 +374,26 @@ fn compute_alo_diagnostics_from_pirls_impl(
     compute_alo_diagnostics_from_pirls_inner(base, y, link).map_err(EstimationError::from)
 }
 
-/// True when the fitted GLM uses its canonical link, so that the row NLL score
-/// and curvature satisfy `ℓ_i'(η) = c_i(μ(η)−y_i)` and `ℓ_i''(η) = c_i μ'(η)`
+/// True when the fitted GLM uses a *curved* canonical link, so that the row NLL
+/// score and curvature satisfy `ℓ_i'(η) = c_i(μ(η)−y_i)` and `ℓ_i''(η) = c_i μ'(η)`
 /// with a single per-row scale `c_i = (prior weight)/φ`. This is the exact
 /// condition under which the frozen-curvature ALO scalar fixed point matches
 /// the leave-`i`-out refit; only these families enable the exact refinement.
-fn alo_link_is_canonical(likelihood: &crate::types::GlmLikelihoodSpec) -> bool {
+///
+/// Gaussian identity is canonical too, but its per-row curvature is *constant*
+/// (`μ'(η) ≡ 1`), so the classical Sherman–Morrison one-step ALO is already the
+/// exact frozen-Hessian leave-`i`-out solution. Routing it through the scalar
+/// Newton closure would only add an O(n) nonlinear solve to diagnostics and
+/// quality sweeps without changing the answer, so it is excluded here and falls
+/// back to the (exact, for this family) one-step formula.
+fn alo_link_needs_exact_curvature_refinement(
+    likelihood: &crate::types::GlmLikelihoodSpec,
+) -> bool {
     use crate::types::ResponseFamily;
     matches!(
         (&likelihood.spec.response, likelihood.link_function()),
         (ResponseFamily::Binomial, LinkFunction::Logit)
             | (ResponseFamily::Poisson, LinkFunction::Log)
-            | (ResponseFamily::Gaussian, LinkFunction::Identity)
     )
 }
 
@@ -459,7 +467,8 @@ fn compute_alo_diagnostics_from_pirls_inner(
     // (saturated / near-separation) get c_i = NaN, which makes the exact solver
     // reject that row explicitly rather than substituting the classical one-step
     // ALO.
-    let canonical_scale: Option<Array1<f64>> = if alo_link_is_canonical(&base.likelihood) {
+    let canonical_scale: Option<Array1<f64>> =
+        if alo_link_needs_exact_curvature_refinement(&base.likelihood) {
         let mut c = Array1::<f64>::zeros(n);
         for i in 0..n {
             let dmu = base.solve_dmu_deta[i];

--- a/src/inference/riesz.rs
+++ b/src/inference/riesz.rs
@@ -274,6 +274,17 @@ fn validate_input(input: &RieszInput<'_>) -> Result<(), EstimationError> {
                 leverage.len()
             );
         }
+        // Own-observation removal divides by `1 - h_ii`; a valid hat-matrix
+        // diagonal satisfies `h_ii ∈ [0, 1)`. Reject out-of-range leverage up
+        // front (negative leverage would otherwise slip past the magnitude
+        // check below, and `h_ii ≥ 1` is a structurally singular removal).
+        for (row_idx, &h_ii) in leverage.iter().enumerate() {
+            if !(0.0..1.0).contains(&h_ii) {
+                crate::bail_invalid_estim!(
+                    "Riesz leverage must lie in [0, 1) for own-observation removal; row {row_idx} has {h_ii}"
+                );
+            }
+        }
     }
     if input.beta.iter().any(|value| !value.is_finite())
         || input
@@ -319,7 +330,11 @@ fn influence_values(
             None => raw,
             Some(leverage) => {
                 let denom = 1.0 - leverage[row_idx];
-                if !denom.is_finite() || denom.abs() <= f64::EPSILON {
+                // `validate_input` already guarantees `leverage[row_idx] ∈ [0, 1)`,
+                // so `denom = 1 - h_ii ∈ (0, 1]`; a non-positive or sub-epsilon
+                // value here means a near-1 leverage that makes the removal
+                // singular.
+                if !denom.is_finite() || denom <= f64::EPSILON {
                     crate::bail_invalid_estim!(
                         "Riesz own-observation removal is singular at row {row_idx}: leverage={}",
                         leverage[row_idx]


### PR DESCRIPTION
Salvages the two individually-correct parts of the closed #1324, dropping the rejected ALO extrapolation.

The #1324 close explicitly endorsed these two while rejecting the `2.2*one_step - 1.2*exact` corruption of `eta_tilde`:

> The other two parts are individually fine — excluding Gaussian-identity from the exact-curvature branch (constant curvature, classical one-step is already exact) and the Riesz leverage∈[0,1) validation — but they don't justify the eta_tilde corruption. If the Gaussian-exclusion + Riesz guard are wanted, please resubmit those alone without the 1.2*curvature_step extrapolation (keep `v = exact`).

This PR does exactly that.

## 1. ALO — Gaussian-identity exclusion (efficiency, behavior-preserving)
`alo_link_is_canonical` → `alo_link_needs_exact_curvature_refinement`, restricted to the *curved* canonical links (binomial logit, Poisson log). Gaussian identity has constant per-row curvature (`μ'(η) ≡ 1`), so the classical one-step ALO already **is** the exact frozen-Hessian LOO solution; routing it through the scalar Newton closure only added an O(n) nonlinear solve to diagnostics/quality sweeps with no change in output. For the curved links the exact frozen-curvature predictor `exact` is returned unchanged — **no extrapolation** — so the #1250 frozen-curvature contract and the brute-force LOO quality comparisons are untouched.

## 2. Riesz — leverage ∈ [0,1) validation (correctness guard)
Validate the hat-diagonal up front: a valid hat matrix has `h_ii ∈ [0,1)`. Negative leverage previously slipped past the `|denom|` magnitude check in own-observation removal, and `h_ii ≥ 1` is a structurally singular removal. With the range guard in place, `denom = 1 - h_ii ∈ (0,1]`, so the singularity check tightens from `denom.abs() <= EPSILON` to `denom <= EPSILON`.

The rejected `1.2 * curvature_step` ALO extrapolation is **not** included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GM4BseRnqWPoWq7YiB7xNi