### PR TITLE
Add response_projection_residual: distance-to-candidate-manifold for response geometries

### DIFF
--- a/src/geometry/manifold.rs
+++ b/src/geometry/manifold.rs
@@ -823,6 +823,45 @@ pub(crate) fn spectral_map_symmetric(
     Ok(fast_abt(&fast_ab(&evecs, &diag), &evecs))
 }
 
+/// Frobenius-nearest matrix with orthonormal columns: the orthogonal factor `U`
+/// of the polar decomposition `Y = U P`, with `UᵀU = Iₖ` and `P` symmetric
+/// positive-definite. For a tall `Y` (`n × k`, `n ≥ k`) this is
+/// `U = Y (YᵀY)^{-1/2}`, the orthogonal projection of `Y` onto the Stiefel
+/// manifold `St(k, n)` — and hence onto the orthonormal-frame representative
+/// set of the Grassmannian `Gr(k, n)` — under the Frobenius norm. So
+/// `‖Y − U‖_F` is the *exact* distance from `Y` to that manifold. This is the
+/// genuine nearest point, unlike the QR retraction `qf(Y)`, which only agrees
+/// to first order.
+///
+/// `(YᵀY)^{-1/2}` is formed from the symmetric spectral map of the `k × k` Gram
+/// matrix. A non-positive Gram eigenvalue means `Y` has rank `< k`, where the
+/// nearest orthonormal frame is not unique; that is surfaced as a
+/// [`GeometryError::Singular`] rather than returning an arbitrary frame.
+pub(crate) fn polar_factor(y: &Array2<f64>) -> GeometryResult<Array2<f64>> {
+    let (n, k) = y.dim();
+    if n < k {
+        return Err(GeometryError::InvalidPoint(
+            "polar factor requires a tall matrix (n >= k)",
+        ));
+    }
+    if !y.iter().all(|v| v.is_finite()) {
+        return Err(GeometryError::InvalidPoint(
+            "polar factor requires finite entries",
+        ));
+    }
+    let gram = y.t().dot(y);
+    let inv_sqrt = spectral_map_symmetric(&gram, |lam| {
+        if !lam.is_finite() || lam <= GEOMETRY_EPS {
+            Err(GeometryError::Singular(
+                "polar factor is undefined for a rank-deficient matrix",
+            ))
+        } else {
+            Ok(1.0 / lam.sqrt())
+        }
+    })?;
+    Ok(y.dot(&inv_sqrt))
+}
+
 /// Dense matrix exponential `exp(A)` via scaling-and-squaring with a truncated
 /// Taylor series. The Frobenius norm of `A` is driven below 1/4 by repeated
 /// halving (`A → A / 2^s`), where Taylor converges rapidly and stably; the

--- a/src/geometry/response_geometry.rs
+++ b/src/geometry/response_geometry.rs
@@ -24,8 +24,11 @@
 use ndarray::{Array1, Array2, ArrayView1, ArrayView2};
 
 use crate::geometry::constant_curvature::ConstantCurvature;
-use crate::geometry::manifold::RiemannianManifold;
-use crate::geometry::{GeometryResult, GrassmannManifold, SpdManifold, StiefelManifold};
+use crate::geometry::manifold::{
+    flatten, from_flat, polar_factor, spectral_map_symmetric, sym, RiemannianManifold,
+    GEOMETRY_EPS,
+};
+use crate::geometry::{GeometryError, GeometryResult, GrassmannManifold, SpdManifold, StiefelManifold};
 
 /// Split a parenthesised `key=value, key=value` parameter list into trimmed,
 /// lower-cased `(key, value)` pairs. An empty list is valid (`spd()`).
@@ -343,6 +346,51 @@ impl ResponseManifold {
         }
     }
 
+    /// Nearest-point projection of an arbitrary ambient row onto the manifold,
+    /// in the flat ambient coordinates. Unlike [`log_point`](Self::log_point) —
+    /// which is gatekept to *genuine* manifold points on both arguments — this
+    /// accepts an off-manifold `value` and returns the closest manifold point
+    /// under the ambient (Euclidean / Frobenius) metric. It is the primitive
+    /// behind [`response_projection_residual`]: how far an observation sits from
+    /// a *candidate* response geometry.
+    ///
+    /// Exact projections are available for every fittable response geometry:
+    /// * Poincaré ball — radial clamp into the ball ([`project_into_ball`]).
+    /// * SPD cone — symmetrise, then clamp eigenvalues to `≥ 0` (the Higham
+    ///   nearest-PSD projector); the residual is the norm of the discarded
+    ///   negative-eigenvalue part.
+    /// * `Gr(k, n)` / `St(k, n)` — the polar factor of the `n × k` frame
+    ///   ([`polar_factor`]), i.e. the Frobenius-nearest orthonormal frame. For
+    ///   `k = 1` this reduces to radial normalisation (the sphere `S^{n-1}`).
+    ///
+    /// Only the non-fittable [`ConstantCurvature`](Self::ConstantCurvature)
+    /// variant, which is never produced by the response-geometry resolver,
+    /// lacks an ambient projector and errors here.
+    fn project_point(&self, value: ArrayView1<'_, f64>) -> GeometryResult<Array1<f64>> {
+        match self {
+            Self::Poincare { curvature, .. } => {
+                crate::geometry::poincare::project_into_ball(value, *curvature)
+            }
+            Self::Spd { n } => {
+                let mat = from_flat(value, *n, *n)?;
+                let symm = sym(&mat);
+                let psd = spectral_map_symmetric(&symm, |lam| Ok(lam.max(0.0)))?;
+                Ok(flatten(&psd))
+            }
+            Self::Grassmann { k, n } | Self::Stiefel { k, n } => {
+                // Project onto the orthonormal-frame representative set via the
+                // polar factor — the exact Frobenius-nearest frame, valid for
+                // all k. For k = 1 this is the radial normalisation onto the
+                // sphere; rank-deficient frames surface a Singular error.
+                let frame = from_flat(value, *n, *k)?;
+                Ok(flatten(&polar_factor(&frame)?))
+            }
+            Self::ConstantCurvature { .. } => Err(GeometryError::InvalidPoint(
+                "projection residual is not implemented for the ConstantCurvature response geometry",
+            )),
+        }
+    }
+
     /// Squared metric norm `‖v‖²_base` of a tangent at `base`. Used by the
     /// Karcher iteration's stationarity test. Poincaré uses the conformal
     /// factor squared; the matrix manifolds and ConstantCurvature use the trait
@@ -438,6 +486,78 @@ pub fn response_exp_map(
         out.row_mut(row).assign(&value);
     }
     Ok(out)
+}
+
+/// Per-row distance from ambient observations to a *candidate* response
+/// manifold — a shape-plausibility diagnostic for geometric-smooth model
+/// selection.
+///
+/// What this is (and is not)
+/// -------------------------
+/// This is **not** the post-fit on/off-manifold membership signal. That signal
+/// comes from a fitted geometric smooth: the residual of an observation against
+/// the *surface gam infers*, plus its posterior predictive density. This
+/// function answers the earlier, cheaper question that gates *which* topology
+/// is worth fitting: given a candidate response geometry (e.g. one proposed by
+/// an external embedding/discovery stage), how far do the raw observations sit
+/// from that geometry's manifold? Aggregated per candidate, it feeds the
+/// shape-selection comparison alongside REML/LAML and held-out predictive
+/// density — and crucially that comparison must include the null/simpler-
+/// topology candidates, so a confidently-wrong proposal cannot win unchecked.
+///
+/// What it computes
+/// ----------------
+/// For each ambient row `x` it forms the nearest manifold point under the
+/// ambient (Euclidean / Frobenius) metric via [`project_point`] — a genuine
+/// projection that, unlike `log_map`, accepts off-manifold input — and returns:
+///
+/// * `residual[i] = ‖x - project(x)‖`              — absolute distance-to-manifold
+/// * `relative[i] = residual[i] / (‖x‖ + eps)`     — scale-free off-manifold fraction
+///
+/// `residual` is the honest orthogonal displacement off the candidate shape
+/// (zero for on-manifold rows, to machine precision); `relative` normalises it
+/// by the ambient magnitude so rows of different scale are comparable in a
+/// membership-style threshold or an aggregate score.
+///
+/// Unlike [`response_log_map`], **no base point is needed**: nearest-point
+/// projection is base-independent. `values` is `(n_rows, ambient)`; both
+/// returned arrays are `(n_rows,)`. Every fittable response geometry has an
+/// exact ambient projector (see [`project_point`]); only the non-fittable
+/// `ConstantCurvature` variant returns a descriptive error.
+pub fn response_projection_residual(
+    manifold: ResponseManifold,
+    values: ArrayView2<'_, f64>,
+) -> Result<(Array1<f64>, Array1<f64>), String> {
+    let ambient = manifold.ambient_dim();
+    let (n_rows, cols) = values.dim();
+    if cols != ambient {
+        return Err(format!(
+            "response geometry values have {cols} columns; expected {ambient}"
+        ));
+    }
+    if !values.iter().all(|v| v.is_finite()) {
+        return Err("response geometry values must contain only finite values".to_string());
+    }
+
+    let mut residual = Array1::<f64>::zeros(n_rows);
+    let mut relative = Array1::<f64>::zeros(n_rows);
+    for row in 0..n_rows {
+        let value = values.row(row);
+        let proj = manifold
+            .project_point(value)
+            .map_err(|e| format!("response geometry projection (row {row}): {e}"))?;
+        let mut sq = 0.0_f64;
+        let mut ambient_sq = 0.0_f64;
+        for (xi, pi) in value.iter().zip(proj.iter()) {
+            let d = xi - pi;
+            sq += d * d;
+            ambient_sq += xi * xi;
+        }
+        let dist = sq.sqrt();
+        residual[row] = dist;
+        relative[row] = dist / (ambient_sq.sqrt() + GEOMETRY_EPS);
+    }
+    Ok((residual, relative))
 }
 
 /// String-driven response-geometry log map: parse the user `label` (with shape
@@ -1492,5 +1612,169 @@ mod tests {
         // Non-finite κ is rejected up front.
         assert!(response_curvature_criterion(values.view(), 2, f64::NAN).is_err());
         assert!(response_curvature_criterion(values.view(), 2, f64::INFINITY).is_err());
+    }
+
+    // ── Projection residual (distance to candidate manifold) ───────────────
+
+    #[test]
+    fn projection_residual_is_zero_for_on_manifold_points() {
+        // On-manifold rows are their own nearest point, so the residual is ~0
+        // row-wise. No base point / Fréchet mean is involved — projection is
+        // base-independent — so this no longer depends on the inputs forming an
+        // admissible Karcher seed.
+        let cases: Vec<(ResponseManifold, Array2<f64>)> = vec![
+            (
+                ResponseManifold::Spd { n: 2 }, // PD: eigenvalues {2,1} and {2,1}
+                array![[2.0, 0.0, 0.0, 1.0], [1.5, 0.5, 0.5, 1.5]],
+            ),
+            (
+                ResponseManifold::Grassmann { k: 1, n: 3 }, // unit columns
+                array![[1.0, 0.0, 0.0], [0.6, 0.8, 0.0]],
+            ),
+            (
+                ResponseManifold::Poincare {
+                    dim: 2,
+                    curvature: -1.0,
+                }, // strictly inside the ball
+                array![[0.1, 0.2], [-0.3, 0.1]],
+            ),
+        ];
+        for (manifold, values) in cases {
+            let (resid, rel) = response_projection_residual(manifold, values.view())
+                .expect("projection residual");
+            for row in 0..values.nrows() {
+                assert!(
+                    resid[row] < 1e-9,
+                    "{manifold:?} on-manifold row {row} should have ~0 residual, got {}",
+                    resid[row]
+                );
+                assert!(rel[row] < 1e-9 && rel[row] >= 0.0);
+            }
+        }
+    }
+
+    #[test]
+    fn projection_residual_recovers_known_off_manifold_displacement() {
+        // Closed-form checks against the exact nearest-point distance.
+
+        // Gr(1,3) / sphere: nearest unit vector to x is x/‖x‖, so the distance
+        // is |‖x‖ − 1|. [2,0,0] ⇒ 1; [0,3,0] ⇒ 2. Relative = dist/‖x‖.
+        let g = ResponseManifold::Grassmann { k: 1, n: 3 };
+        let gv = array![[2.0, 0.0, 0.0], [0.0, 3.0, 0.0]];
+        let (gres, grel) = response_projection_residual(g, gv.view()).expect("grassmann");
+        assert!((gres[0] - 1.0).abs() < 1e-12, "got {}", gres[0]);
+        assert!((gres[1] - 2.0).abs() < 1e-12, "got {}", gres[1]);
+        assert!((grel[0] - 0.5).abs() < 1e-12);
+        assert!((grel[1] - 2.0 / 3.0).abs() < 1e-12);
+
+        // SPD(2): nearest PSD matrix clamps negative eigenvalues to 0, so the
+        // distance is the norm of the discarded negative part. [[1,0],[0,-1]]
+        // has eigenvalue −1 discarded ⇒ distance 1; ‖x‖_F = √2.
+        let s = ResponseManifold::Spd { n: 2 };
+        let sv = array![[1.0, 0.0, 0.0, -1.0]];
+        let (sres, srel) = response_projection_residual(s, sv.view()).expect("spd");
+        assert!((sres[0] - 1.0).abs() < 1e-9, "got {}", sres[0]);
+        assert!((srel[0] - 1.0 / 2.0_f64.sqrt()).abs() < 1e-9);
+
+        // Poincaré ball (c = −1): a point outside the ball clamps radially to
+        // the boundary. [3,0] ⇒ distance ≈ 3 − (1 − BOUNDARY_EPS).
+        let p = ResponseManifold::Poincare {
+            dim: 2,
+            curvature: -1.0,
+        };
+        let pv = array![[3.0, 0.0]];
+        let (pres, _prel) = response_projection_residual(p, pv.view()).expect("poincare");
+        assert!(pres[0] > 1.9 && pres[0] < 2.0001, "got {}", pres[0]);
+    }
+
+    #[test]
+    fn projection_residual_validates_shapes_and_finiteness() {
+        let manifold = ResponseManifold::Spd { n: 2 }; // ambient = 4
+        // Wrong column count.
+        let bad_cols = array![[1.0, 2.0, 3.0]];
+        assert!(response_projection_residual(manifold, bad_cols.view()).is_err());
+        // Non-finite value.
+        let nan_vals = array![[f64::NAN, 0.0, 0.0, 1.0]];
+        assert!(response_projection_residual(manifold, nan_vals.view()).is_err());
+        let inf_vals = array![[f64::INFINITY, 0.0, 0.0, 1.0]];
+        assert!(response_projection_residual(manifold, inf_vals.view()).is_err());
+    }
+
+    #[test]
+    fn projection_residual_separates_on_and_off_manifold() {
+        // The motivating case, now honestly answered: an on-manifold row sits
+        // at zero distance from the candidate shape; a row pushed off it has a
+        // clearly positive distance. This is the shape-plausibility signal that
+        // gates which topology is worth fitting — not the post-fit membership
+        // decision, which comes from the fitted surface's residual instead.
+        let manifold = ResponseManifold::Grassmann { k: 1, n: 3 };
+        let on = array![[0.6, 0.8, 0.0]]; // a genuine unit direction
+        let off = array![[0.6, 0.8, 1.4]]; // same direction, pushed off-sphere
+
+        let (resid_on, _) = response_projection_residual(manifold, on.view()).expect("on");
+        let (resid_off, _) = response_projection_residual(manifold, off.view()).expect("off");
+
+        assert!(resid_on[0] < 1e-9, "on-manifold should be ~0, got {}", resid_on[0]);
+        assert!(
+            resid_off[0] > 1e-2 && resid_off[0] > resid_on[0],
+            "off-manifold distance ({}) must clearly exceed on-manifold ({})",
+            resid_off[0],
+            resid_on[0]
+        );
+    }
+
+    #[test]
+    fn projection_residual_supports_k_greater_than_one_frames() {
+        // k > 1 frames are projected via the polar factor (exact Frobenius-
+        // nearest orthonormal frame). St(2,3), ambient = 6, row-major n×k.
+        let manifold = ResponseManifold::Stiefel { k: 2, n: 3 };
+
+        // An orthonormal frame [e1 | e2] is its own nearest point ⇒ residual 0.
+        let on = array![[1.0, 0.0, 0.0, 1.0, 0.0, 0.0]];
+        let (resid_on, _) = response_projection_residual(manifold, on.view()).expect("on");
+        assert!(resid_on[0] < 1e-9, "orthonormal frame should be ~0, got {}", resid_on[0]);
+
+        // Scale the first column by 2: Y = [2·e1 | e2]. YᵀY = diag(4,1), so the
+        // polar factor restores [e1 | e2] and the distance is ‖Y − U‖_F = 1,
+        // with relative = 1/‖Y‖_F = 1/√5.
+        let off = array![[2.0, 0.0, 0.0, 1.0, 0.0, 0.0]];
+        let (resid_off, rel_off) =
+            response_projection_residual(manifold, off.view()).expect("off");
+        assert!((resid_off[0] - 1.0).abs() < 1e-9, "got {}", resid_off[0]);
+        assert!((rel_off[0] - 1.0 / 5.0_f64.sqrt()).abs() < 1e-9, "got {}", rel_off[0]);
+
+        // Grassmann(2,4) accepts a k>1 frame identically (same polar projector).
+        let g = ResponseManifold::Grassmann { k: 2, n: 4 };
+        let g_on = array![[1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0]];
+        let (g_resid, _) = response_projection_residual(g, g_on.view()).expect("grassmann");
+        assert!(g_resid[0] < 1e-9, "got {}", g_resid[0]);
+    }
+
+    #[test]
+    fn projection_residual_errors_only_for_nonfittable_constant_curvature() {
+        // ConstantCurvature is never produced by the response-geometry resolver
+        // and has no ambient projector wired in, so it errors descriptively
+        // rather than returning an approximate distance.
+        let manifold = ResponseManifold::ConstantCurvature {
+            dim: 3,
+            kappa: 1.0,
+        };
+        let vals = array![[0.1, 0.2, 0.3]];
+        let err = response_projection_residual(manifold, vals.view())
+            .expect_err("ConstantCurvature must error");
+        assert!(
+            err.contains("ConstantCurvature"),
+            "error should name the geometry: {err}"
+        );
+    }
+
+    #[test]
+    fn polar_factor_is_rejected_for_rank_deficient_frames() {
+        // A rank-deficient frame (two identical columns) has no unique nearest
+        // orthonormal frame, so the projector surfaces a Singular error rather
+        // than fabricating an arbitrary one.
+        let manifold = ResponseManifold::Stiefel { k: 2, n: 3 };
+        let degenerate = array![[1.0, 1.0, 0.0, 0.0, 0.0, 0.0]]; // both columns = e1
+        assert!(response_projection_residual(manifold, degenerate.view()).is_err());
     }
 }


### PR DESCRIPTION
# Add `response_projection_residual`: distance-to-candidate-manifold for response geometries

## Status
Drafted against `6fffb5e`, then compiled and tested locally on the repo toolchain
(rustc 1.93.0). The new tests pass and the full `geometry::` module is green (121
tests); no new warnings or clippy findings in the changed code. Written with Claude;
mentioning it as invited.

This supersedes an earlier draft (`response_orthogonal_residual`, via `exp∘log`). That
approach doesn't work and the reason is instructive — see "Why not `exp∘log`" below.

## What it computes
A new public function in `src/geometry/response_geometry.rs`:

```rust
pub fn response_projection_residual(
    manifold: ResponseManifold,
    values: ArrayView2<'_, f64>,   // (n_rows, ambient)
) -> Result<(Array1<f64>, Array1<f64>), String>   // (residual, relative), each (n_rows,)
```

For each ambient row `x` it forms the **nearest manifold point** under the ambient
(Euclidean / Frobenius) metric and returns:

- `residual[i] = ‖x − project(x)‖` — absolute distance to the candidate manifold
- `relative[i] = residual[i] / (‖x‖ + eps)` — scale-free off-manifold fraction

No base point is required (nearest-point projection is base-independent), so unlike the
`log`-map path there is no Fréchet-mean dependency.

The projection is exact, closed-form, per geometry — added as a private
`ResponseManifold::project_point`:

| Geometry | Projection | `residual` is |
|---|---|---|
| Poincaré ball | radial clamp into the ball (`project_into_ball`) | distance to the ball |
| SPD cone | symmetrise + clamp eigenvalues `≥ 0` (Higham nearest-PSD) | norm of the negative-eigenvalue part |
| `Gr(k,n)` / `St(k,n)` | polar factor `U = Y(YᵀY)^{-1/2}` (new `polar_factor`) | distance to the nearest orthonormal frame; `k=1` ⇒ sphere normalisation |

Only the non-fittable `ConstantCurvature` variant (never produced by the
response-geometry resolver) lacks a projector and returns a descriptive error.

## New primitive: `polar_factor` (`src/geometry/manifold.rs`)
The matrix manifolds had no ambient nearest-point projector — only the QR retraction
`qf(Y)`, which is *not* the nearest frame (first-order agreement only). Added
`polar_factor`, the Frobenius-nearest orthonormal frame `U = Y(YᵀY)^{-1/2}`, computed
from the symmetric spectral map of the `k×k` Gram matrix (reusing
`spectral_map_symmetric`). A rank-deficient `Y` (singular Gram) has no unique nearest
frame, so it surfaces a `Singular` error rather than returning an arbitrary one. This is
the genuine orthogonal projection onto `St(k,n)` / the Grassmann representative set, and
it generalises the `k=1` sphere normalisation.

## Why not `exp∘log` (the superseded approach)
The earlier draft computed `recon = exp_base(log_base(x))` and read `‖x − recon‖` as
distance-to-manifold. It can't work: `log_map` for these geometries is gatekept to
*genuine manifold points on both arguments* — `sphere.rs` requires unit-norm base **and**
target, `spd.rs` requires a symmetric positive-definite point. So `log_base(x)` rejects
exactly the off-manifold `x` the function exists to measure; the on-manifold case it does
accept is the trivial `residual ≈ 0`. `log` is a manifold→tangent chart, not a projection
from ambient space. The fix is to project properly, which is what this PR does.

## What this is *for* (and what it is not)
This is **not** a post-fit on/off-manifold membership classifier. That signal belongs to
a fitted geometric smooth: the residual of an observation against the *surface gam infers*
plus its posterior predictive density. This function answers the earlier, cheaper question
that gates *which* topology is worth fitting:

> given a candidate response geometry (e.g. one nominated by an external embedding /
> discovery stage), how far do the raw observations sit from that geometry's manifold?

Aggregated per candidate, it is one more score for geometric-smooth model selection,
alongside REML/LAML and held-out predictive density. The intended pipeline:

1. **Propose** candidate topology — an embedding (e.g. ParamRepulsor) gives a cheap,
   discovery-oriented hypothesis about dimensionality / rough topology.
2. **Commit** to a parametric form whose topology matches the hypothesis — a gam
   geometric smooth (sphere? SPD? Poincaré? plain surface?).
3. **Fit and adjudicate** — gam's penalized fit gives the interpretable surface and, via
   residuals / posterior predictive bands, the principled membership signal.
4. **Model-select across shape guesses** — compare candidates by REML/LAML or held-out
   predictive density.

`response_projection_residual` is a fast plausibility gate at step 1→2/4: before
committing to fit a proposed topology, check that the data even lies near it.
**Caveat that matters:** an embedding can confidently propose a wrong topology (e.g.
splitting connected structure into clusters). So the step-4 comparison must always include
the null / simpler-topology candidates — this residual nominates, it does not decide.

## Tests (`src/geometry/response_geometry.rs`)
- `projection_residual_is_zero_for_on_manifold_points` — SPD / Grassmann / Poincaré
  on-manifold clouds give `residual ≈ 0` (no Fréchet mean needed).
- `projection_residual_recovers_known_off_manifold_displacement` — closed-form checks:
  `Gr(1,3)` `[2,0,0]→1`, `[0,3,0]→2`; SPD `[[1,0],[0,−1]]→1`; Poincaré `[3,0]→≈2`.
- `projection_residual_supports_k_greater_than_one_frames` — `St(2,3)` / `Gr(2,4)`:
  orthonormal frame ⇒ 0; a scaled column ⇒ exact `‖Y−U‖_F = 1`, `relative = 1/√5`.
- `polar_factor_is_rejected_for_rank_deficient_frames` — duplicate columns ⇒ `Singular`.
- `projection_residual_validates_shapes_and_finiteness` — column-count / finiteness.
- `projection_residual_separates_on_and_off_manifold` — the motivating contrast.
- `projection_residual_errors_only_for_nonfittable_constant_curvature`.

## Open questions / your read
1. **Grassmann distance semantics.** `polar_factor` measures distance to the
   orthonormal-frame *representative set* (`St(k,n)`), which is the consistent choice
   given the module stores frames. If you'd rather the diagnostic report a subspace
   (principal-angle) distance for Grassmann specifically, that's a different projector —
   easy to add behind the same entry point.
2. **Where this should surface.** It's a sibling of `response_log_map` for now. The
   natural next step is an FFI binding + an optional aggregate score in `summary()` /
   model selection so Python can compare candidate geometries — held off until the
   framing is blessed.
3. **SPD floor.** Eigenvalues are clamped to `≥ 0` (distance to the closed PSD cone). If
   you want strict-PD targets, a small positive floor is a one-line change, at the cost of
   the residual no longer being the exact cone distance.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
