### PR TITLE
feat(#1026): corpus discovery locator for the full-width EV-vs-K ladder

### DIFF
--- a/examples/sae_corpus_discover.py
+++ b/examples/sae_corpus_discover.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python
+"""#1026 corpus discovery — locate a full-width (d_model) real residual-stream
+activation cache for the EV-vs-K ladder, or report exactly what is missing.
+
+The #1026 acceptance ladder K in {8,32,128,512} vs the official Qwen-32K
+reference needs REAL LLM activations at the model's native residual width
+(OLMo-3-32B layer-25 is 5120-dim), NOT the PCA-64 fixtures committed under
+tests/data/ (those are linear projections for the in-tree stress regression).
+
+This is a thin numeric LOCATOR (the #977 boundary: activations are a response
+matrix). It does NOT fit anything and does NOT download models. It scans a list
+of candidate paths for a banked `activations.npy` / `.pt` cache, reports the
+native width of the layer slice the EV example would feed, and decides whether
+that width clears a `--min-d-model` bar (default 2048: well above the PCA-64
+fixtures, low enough to admit a real small-model residual stream as a stand-in).
+
+Exit 0 + a `READY <path> <layer-arg>` line on stdout when a usable cache is
+found, so an sbatch can `eval` the discovered `--npy/--pt`+`--olmo-layer` flags
+straight into `sae_ev_vs_k_olmo.py`. Exit 3 + a `MISSING` line (with the
+harvest command to generate one) when nothing qualifies.
+
+USAGE (on an MSI compute node):
+  python examples/sae_corpus_discover.py \
+      --candidate /projects/standard/hsiehph/sauer354/olmo_data/base/activations.npy:25 \
+      --candidate /projects/standard/hsiehph/sauer354/olmo_data/instruct \
+      --min-d-model 2048
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+import numpy as np
+
+
+def _width_of(path: Path, layer: int | None) -> tuple[int, int, str] | None:
+    """Return (n_rows, d_model, layer_arg_str) for the slice the EV example
+    would feed, reading only the npy header (mmap) so a 5120-dim corpus is not
+    pulled into RAM. None if the file is unreadable or not 2D/3D."""
+    try:
+        if path.suffix == ".npy":
+            arr = np.load(path, mmap_mode="r")
+        elif path.suffix in (".pt", ".pth"):
+            import torch
+
+            blob = torch.load(path, map_location="cpu")
+            arr = blob["X"] if isinstance(blob, dict) else blob
+            arr = np.asarray(arr)
+        else:
+            return None
+    except Exception as exc:  # noqa: BLE001 — locator must not crash a sweep
+        print(f"[discover] unreadable {path}: {exc}", file=sys.stderr)
+        return None
+
+    if arr.ndim == 2:
+        return int(arr.shape[0]), int(arr.shape[1]), ""
+    if arr.ndim == 3:
+        # (prompts, layers, d_model) — width is the last axis, independent of
+        # which layer is sliced; report the layer-arg the EV example needs.
+        lyr = 25 if layer is None else layer
+        if not (0 <= lyr < arr.shape[1]):
+            print(f"[discover] {path}: layer {lyr} out of range (n_layers={arr.shape[1]})", file=sys.stderr)
+            return None
+        return int(arr.shape[0]), int(arr.shape[2]), f"--olmo-layer {lyr}"
+    return None
+
+
+def _expand(candidate: str) -> list[tuple[Path, int | None]]:
+    """A candidate is `PATH` or `PATH:LAYER`. A directory is scanned for any
+    `activations.npy` / cache one level deep (the olmo_data/<rev>/ layout)."""
+    raw, _, layer_s = candidate.partition(":")
+    layer = int(layer_s) if layer_s else None
+    p = Path(raw)
+    if p.is_dir():
+        hits: list[tuple[Path, int | None]] = []
+        for name in ("activations.npy",):
+            hits.extend((q, layer) for q in p.glob(f"**/{name}"))
+        return sorted(set(hits))
+    return [(p, layer)] if p.exists() else []
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument(
+        "--candidate",
+        action="append",
+        default=[],
+        help="PATH or PATH:LAYER to probe; a directory is globbed for activations.npy",
+    )
+    ap.add_argument(
+        "--min-d-model",
+        type=int,
+        default=2048,
+        help="native residual width bar a cache must clear to be a real-data stand-in",
+    )
+    ap.add_argument("--harvest-model", default="allenai/OLMo-2-1124-7B")
+    ap.add_argument("--harvest-layer", type=int, default=18)
+    args = ap.parse_args()
+
+    best: tuple[int, Path, int, str] | None = None  # (d_model, path, n, layer_arg)
+    for cand in args.candidate:
+        for path, layer in _expand(cand):
+            info = _width_of(path, layer)
+            if info is None:
+                continue
+            n, d, layer_arg = info
+            qual = "OK" if d >= args.min_d_model else "below-bar"
+            print(f"[discover] {path}  n={n} d_model={d} [{qual}] {layer_arg}".rstrip(), file=sys.stderr)
+            if d >= args.min_d_model and (best is None or d > best[0]):
+                best = (d, path, n, layer_arg)
+
+    if best is not None:
+        d, path, n, layer_arg = best
+        # Machine-parseable: an sbatch can `eval` the flags after READY.
+        print(f"READY --npy {path} {layer_arg}".rstrip())
+        print(f"[discover] selected {path} (n={n}, d_model={d}) for the EV-vs-K ladder", file=sys.stderr)
+        return 0
+
+    print("MISSING")
+    print(
+        "[discover] no full-width activation cache found. Generate one with:\n"
+        f"  python examples/harvest_residual_activations.py --model {args.harvest_model} \\\n"
+        f"      --dataset wikitext --config wikitext-103-raw-v1 --layer {args.harvest_layer} \\\n"
+        "      --n-tokens 4000 --out resid_cache.pt\n"
+        "  then: python examples/sae_ev_vs_k_olmo.py --pt resid_cache.pt --pcs 32 --seed 42",
+        file=sys.stderr,
+    )
+    return 3
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## #1026 corpus acquisition — the data wall, not auth

The EV-vs-K acceptance ladder K{8,32,128,512} vs the official Qwen-32K reference needs REAL residual-stream activations at native model width (OLMo-3-32B L25 = 5120-dim). The only banked in-tree fixtures are PCA-64 projections (`tests/data/olmo_l*_pca64_*.npy`), which are the in-tree stress-regression inputs, not the full-width ladder corpus.

This adds `examples/sae_corpus_discover.py`: a thin numeric LOCATOR (no fitting, no model download) that

- scans candidate paths for a banked `activations.npy` / harvested `.pt` cache,
- header-only width probe via mmap (a 5120-dim corpus is never pulled into RAM),
- rejects anything below a `--min-d-model` bar (default 2048 — above PCA-64, low enough to admit a real small-model residual stream as a stand-in),
- emits a machine-parseable `READY --npy <path> [--olmo-layer N]` line an sbatch `eval`s straight into `sae_ev_vs_k_olmo.py`, or `MISSING` + the exact `harvest_residual_activations.py` command to generate one.

The full pipeline (`harvest_residual_activations.py` -> full-width `.pt` -> `sae_ev_vs_k_olmo.py --pt`) already exists; this is the banked-first / harvest-fallback front door that turns #1026 from "blocked on data" into "acquiring the data." The OLMo-3-32B `activations.npy` (635 x 64 layers x 5120) was banked once on MSI scratch (`$ROOT/olmo_data/base/activations.npy`, already fed to `examples/.hillclimb.sbatch:38`), so the most likely path is recovery, with a real OLMo-2-7B (4096-dim) harvest as the fallback.

Tested locally: rejects the PCA-64 fixture (d=64, below-bar -> exit 3 MISSING), accepts a real-width 2D and a 3D OLMo-style header (-> exit 0 READY with the right `--olmo-layer`).

The A100 run that consumes this (one job: #1017 device-resident bench + #1026 ladder) is staged at `/Users/user/msi-node/gam_gpu_1017_1026.sbatch`, blocked only on MSI re-auth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011SsHxobr9g2wXE5zB2uisR