### PR TITLE
fix(#1384): compare_models refuses cross-family fits (fail-loud comparability guard)

### DIFF
--- a/crates/gam-pyffi/src/model_ffi.rs
+++ b/crates/gam-pyffi/src/model_ffi.rs
@@ -3452,6 +3452,10 @@ const RAW_REML_SCORE_KEYS: &[&str] = &["raw_reml_score"];
 const EDF_KEYS: &[&str] = &["edf_total", "edf", "effective_dof"];
 
 const LOG_LIK_KEYS: &[&str] = &["log_likelihood", "loglik", "log_lik"];
+// Response-family tag, used only by the compare_models comparability guard
+// (#1384). `family_name` is the SummaryPayload field; the aliases cover a
+// dict / .evidence object that exposes it under a shorter key.
+const FAMILY_KEYS: &[&str] = &["family_name", "family"];
 
 const PENALTY_RANK_KEYS: &[&str] = &["penalty_rank", "rank_s", "rank_S", "cache_penalty_rank"];
 
@@ -3543,6 +3547,7 @@ fn compare_reml_fits(
             score: extract_reml_score_from_view(py, &view)?,
             edf: extract_edf_from_view(py, &view)?,
             log_lik: extract_log_lik_from_view(&view)?,
+            family: extract_family_from_view(&view)?,
         });
     }
 
@@ -3732,6 +3737,43 @@ fn extract_edf_from_view(_py: Python<'_>, view: &RemlFitView<'_>) -> PyResult<Op
 /// back to the raw REML/LAML evidence headline.
 fn extract_log_lik_from_view(view: &RemlFitView<'_>) -> PyResult<Option<f64>> {
     extract_float_metadata_from_view(view, LOG_LIK_KEYS)
+}
+
+/// Response-family tag of a candidate fit, for the compare_models comparability
+/// guard (#1384). `None` when the fit does not expose one (legacy payloads),
+/// which the guard treats as unconstrained.
+fn extract_family_from_view(view: &RemlFitView<'_>) -> PyResult<Option<String>> {
+    extract_string_metadata_from_view(view, FAMILY_KEYS)
+}
+
+/// String-valued metadata lookup over the same SavedSummary-JSON / PythonObject
+/// fallback chain as [`extract_float_metadata_from_view`].
+fn extract_string_metadata_from_view(
+    view: &RemlFitView<'_>,
+    keys: &[&str],
+) -> PyResult<Option<String>> {
+    match view {
+        RemlFitView::SavedSummary(payload) => Ok(json_lookup_str(payload, keys)),
+        RemlFitView::PythonObject(_) => {
+            let Some(value) = extract_py_metadata_value(view, keys)? else {
+                return Ok(None);
+            };
+            value.extract::<String>().map(Some)
+        }
+    }
+}
+
+/// First string value found under any of `keys` in a SavedSummary JSON payload.
+fn json_lookup_str(payload: &serde_json::Value, keys: &[&str]) -> Option<String> {
+    let object = payload.as_object()?;
+    for key in keys {
+        if let Some(value) = object.get(*key) {
+            if let Some(s) = value.as_str() {
+                return Some(s.to_string());
+            }
+        }
+    }
+    None
 }
 
 fn extract_float_metadata_from_view(

--- a/src/solver/evidence.rs
+++ b/src/solver/evidence.rs
@@ -1522,6 +1522,12 @@ pub struct RemlCandidate {
     /// constants-omitted scale (same as [`crate::inference::model_comparison`]).
     /// Present when the fit carries it; `None` for legacy payloads.
     pub log_lik: Option<f64>,
+    /// Response-family tag (e.g. "gaussian", "gamma", "binomial"). Carried so
+    /// `compare_reml_fits` can REFUSE to rank fits whose REML/LAML scores are on
+    /// incomparable base measures (a cross-family comparison is meaningless;
+    /// #1384). `None` for legacy payloads that did not record it — those are not
+    /// guarded (back-compatible), but every current FFI candidate carries it.
+    pub family: Option<String>,
 }
 
 impl RemlCandidate {
@@ -1592,6 +1598,29 @@ pub fn log_bayes_factor(reml_score_a: f64, reml_score_b: f64) -> f64 {
 pub fn compare_reml_fits(mut candidates: Vec<RemlCandidate>) -> Result<RemlComparison, String> {
     if candidates.is_empty() {
         return Err("compare_models requires at least one fit".to_string());
+    }
+    // Fail-loud comparability guard (#1384): REML/LAML evidence scores are only
+    // comparable across fits of the SAME response family — a Gaussian score and
+    // a Gamma score live on different log-density base measures, so their
+    // difference is not a Bayes factor. Ranking them anyway returns a confident
+    // but meaningless winner. Refuse when two candidates carry DIFFERENT family
+    // tags. Candidates with no family tag (`None`, legacy payloads) are not
+    // constrained, so this never spuriously rejects an older saved model.
+    {
+        let mut seen_family: Option<&str> = None;
+        for cand in &candidates {
+            if let Some(fam) = cand.family.as_deref() {
+                match seen_family {
+                    None => seen_family = Some(fam),
+                    Some(prev) if prev != fam => {
+                        return Err(format!(
+                            "compare_models: cannot compare fits of different response families                              ('{prev}' vs '{fam}'); their REML/LAML evidence scores are on                              incomparable base measures. Compare models fit to the same response                              under the same family."
+                        ));
+                    }
+                    Some(_) => {}
+                }
+            }
+        }
     }
     candidates = rank_priority_candidates(
         candidates
@@ -3844,6 +3873,7 @@ mod tests {
             score,
             edf: Some(edf),
             log_lik: Some(log_lik),
+            family: None,
         }
     }
 
@@ -3863,6 +3893,7 @@ mod tests {
             score: 151.28,
             edf: Some(6.0),
             log_lik: None,
+            family: None,
         };
         assert_eq!(c.ranking_score(), 151.28);
     }


### PR DESCRIPTION
Closes #1384.

## What

`compare_reml_fits` (gam::solver::evidence) ranked candidates purely on a scalar TK-normalised REML/LAML score with **no comparability check**. REML/LAML evidence is only comparable across fits of the **same response family** — a Gaussian score and a Gamma score live on different log-density base measures, so their difference is not a Bayes factor. Ranking them returned a confident but meaningless "winner".

## Change (fail-loud)

- `RemlCandidate` gains `family: Option<String>`.
- The FFI extracts it per candidate (`extract_family_from_view` → `family_name` from the SummaryPayload / a `family` key on a dict/\.evidence object), mirroring the existing `extract_*_from_view` helpers (new `extract_string_metadata_from_view` + `json_lookup_str`, mirroring the f64 versions).
- `compare_reml_fits` returns `Err` when two candidates carry **different** family tags, with a clear message.
- Candidates with **no** family tag (legacy payloads) stay unconstrained → no older saved model is spuriously rejected.
- Same-family comparisons are byte-unchanged.

## Why a PR (not a direct push)

The shared working tree is on a stale branch, so I could not run a clean local `cargo check -p gam-pyffi` against true main (a temp drop-in surfaced only pre-existing stale-tree `SummaryPayload.log_likelihood` skew — NOT from these edits, which produced zero errors; rustfmt clean). This PR lets CI compile against real main for the definitive green before merge.

## Gate

- same-family `compare_models` still works unchanged;
- cross-family now errors with `"cannot compare fits of different response families ('gaussian' vs 'gamma') …"`.

## Follow-up

`n_obs` / cross-`n` guard is a natural extension once `n_obs` is surfaced onto `SummaryPayload` (currently only `covariance_n` is present, which is coefficient count not observation count).