### PR TITLE
fix(#1400,#1273): sound SAE central-difference outer-gradient + close FD lint

### DIFF
--- a/src/terms/sae/certificates.rs
+++ b/src/terms/sae/certificates.rs
@@ -174,6 +174,18 @@ pub fn probe_step(rho_hat: ArrayView1<'_, f64>) -> f64 {
     BASE * scale
 }
 
+/// Per-coordinate probe step for a single outer-ρ axis.
+///
+/// [`probe_step`] collapses the whole vector to one global step
+/// (`1e-4 · max_i|ρ_i|`), which under-resolves a small coordinate whenever some
+/// other axis is large. When differencing one axis at a time, scale the step to
+/// that coordinate's own magnitude, with a unit floor so a near-zero coordinate
+/// still gets a usable step.
+pub fn probe_step_for(rho_i: f64) -> f64 {
+    const BASE: f64 = 1e-4;
+    BASE * rho_i.abs().max(1.0)
+}
+
 /// Samples of the criterion **value path** taken at the four probe points
 /// around `ρ̂` along the unit direction `v`, plus the analytic directional
 /// derivative — everything the certificate needs, with no dependence on the

--- a/src/terms/sae/manifold/mod.rs
+++ b/src/terms/sae/manifold/mod.rs
@@ -84,7 +84,7 @@ pub(crate) use crate::terms::sae::criterion_atoms::SaeCriterion;
 
 pub(crate) use crate::terms::sae::certificates::{
     CriterionCertificate, DirectionalSamples, certificate_from_samples,
-    deterministic_probe_direction, probe_step,
+    deterministic_probe_direction, probe_step, probe_step_for,
 };
 
 pub(crate) use crate::linalg::faer_ndarray::{

--- a/src/terms/sae/manifold/outer_objective.rs
+++ b/src/terms/sae/manifold/outer_objective.rs
@@ -1285,61 +1285,129 @@ impl SaeManifoldOuterObjective {
     /// outside both the chart gauge orbit and the penalised decoder β-null that
     /// the Faddeev-Popov deflation recovers).
     ///
-    /// This is the SAME value path (`reml_criterion`) the optimality certificate
-    /// central-differences to audit the analytic gradient, so it is exact-REML
-    /// clean: the FD never produces the cost the fit consumes (the gradient lane
-    /// returns the analytic REML value), it only supplies a usable direction so
-    /// the outer optimiser can cross the flat valley instead of aborting. Each
-    /// ρ-coordinate is differenced independently with a step scaled to the
-    /// coordinate magnitude (`probe_step`), on a cold clone of the pristine
-    /// baseline term so the probes never alias the live converged warm state.
-    /// A non-finite probe falls back to a zero component on that axis, which
-    /// simply omits a descent contribution there rather than poisoning the step.
+    /// This differences the SAME warm value path (`reml_criterion`) whose value
+    /// the gradient lane reports, so the value and its descent direction belong
+    /// to one function:
+    ///
+    /// * Every probe is evaluated on a FRESH clone of the LIVE warm state
+    ///   (`self.term`, which on the fallback arm already holds the converged
+    ///   inner solve at `rho_state`). `reml_criterion` takes `&mut self` and
+    ///   mutates warm-start/cache state, so a single shared probe term would
+    ///   make the result depend on probe order; a fresh clone per probe keeps
+    ///   every evaluation from an identical snapshot.
+    /// * Each ρ-coordinate uses its own step `probe_step_for(ρ_i)`, not one
+    ///   global step, so a small coordinate is not under-resolved by a large one.
+    /// * The collapse penalty is a discrete wall (`SAE_FIT_DATA_COLLAPSE_COST`);
+    ///   the difference is only meaningful in the smooth flat valley where the
+    ///   wall is inactive, so a probe at or above the wall (or non-finite) is
+    ///   treated as unmeasurable rather than differenced across the barrier.
+    /// * A coordinate that cannot be measured (central ladder, then one-sided,
+    ///   all unmeasurable) yields `Err` — it is NOT reported as a zero (which the
+    ///   optimiser would read as a stationary coordinate and which would poison
+    ///   the BFGS curvature update); the outer step must not proceed on a
+    ///   corrupted direction.
+    // FD-OK: descent-direction-only fallback (#1273); the analytic value path
+    // (`reml_criterion`) remains the single source of truth — this never
+    // produces the cost the fit consumes, only a usable direction across the
+    // near-singular flat valley.
     pub(crate) fn central_difference_outer_gradient(
         &self,
         rho_state: &SaeManifoldRho,
     ) -> Result<Array1<f64>, String> {
         let rho_flat = rho_state.to_flat();
         let n = rho_flat.len();
-        let h = probe_step(rho_flat.view());
-        let mut gradient = Array1::<f64>::zeros(n);
-        if !(h.is_finite() && h > 0.0) {
-            return Ok(gradient);
-        }
-        let mut probe_term = self.baseline_term.clone();
-        let value_at = |term: &mut SaeManifoldTerm, flat: &Array1<f64>| -> Option<f64> {
+        // Snapshot the live warm state once; every probe clones it fresh.
+        let warm_base = self.term.clone();
+        let value_at = |flat: &Array1<f64>| -> Option<f64> {
+            let mut term = warm_base.clone();
             let rho = self.baseline_rho.from_flat(flat.view());
-            let value = term
-                .reml_criterion(
-                    self.target.view(),
-                    &rho,
-                    self.registry.as_ref(),
-                    self.inner_max_iter,
-                    self.learning_rate,
-                    self.ridge_ext_coord,
-                    self.ridge_beta,
-                )
-                .ok()
-                .map(|(cost, _loss)| cost);
-            value.filter(|v| v.is_finite())
+            term.reml_criterion(
+                self.target.view(),
+                &rho,
+                self.registry.as_ref(),
+                self.inner_max_iter,
+                self.learning_rate,
+                self.ridge_ext_coord,
+                self.ridge_beta,
+            )
+            .ok()
+            .map(|(cost, _loss)| cost)
+            // Reject probes on/above the discrete collapse wall: differencing
+            // across it is meaningless. Such a probe counts as unmeasurable.
+            .filter(|v| v.is_finite() && *v < SAE_FIT_DATA_COLLAPSE_COST)
         };
+        // Shrink the step toward the valley centre when a probe lands on the
+        // wall / non-finite, before giving up on a coordinate.
+        const LADDER: [f64; 3] = [1.0, 1.0 / 3.0, 1.0 / 10.0];
+        let mut gradient = Array1::<f64>::zeros(n);
         for i in 0..n {
-            let mut plus = rho_flat.clone();
-            plus[i] += h;
-            let mut minus = rho_flat.clone();
-            minus[i] -= h;
-            if let (Some(vp), Some(vm)) = (
-                value_at(&mut probe_term, &plus),
-                value_at(&mut probe_term, &minus),
-            ) {
-                let derivative = (vp - vm) / (2.0 * h);
-                if derivative.is_finite() {
-                    gradient[i] = derivative;
+            let h_i = probe_step_for(rho_flat[i]);
+            if !(h_i.is_finite() && h_i > 0.0) {
+                return Err(format!(
+                    "[SAE/#1273] outer-ρ probe step for coordinate {i} is non-finite \
+                     (ρ_i={}); the point is pathological and the outer step must not \
+                     proceed on a corrupted direction",
+                    rho_flat[i]
+                ));
+            }
+            let mut measured: Option<f64> = None;
+            // Central difference down the step ladder.
+            for &scale in LADDER.iter() {
+                let h = h_i * scale;
+                let mut plus = rho_flat.clone();
+                plus[i] += h;
+                let mut minus = rho_flat.clone();
+                minus[i] -= h;
+                if let (Some(vp), Some(vm)) = (value_at(&plus), value_at(&minus)) {
+                    let derivative = (vp - vm) / (2.0 * h);
+                    if derivative.is_finite() {
+                        measured = Some(derivative);
+                        break;
+                    }
+                }
+            }
+            // One-sided (forward, then backward) at the base step as a last resort.
+            if measured.is_none()
+                && let Some(v0) = value_at(&rho_flat)
+            {
+                let mut plus = rho_flat.clone();
+                plus[i] += h_i;
+                if let Some(vp) = value_at(&plus) {
+                    let d = (vp - v0) / h_i;
+                    if d.is_finite() {
+                        measured = Some(d);
+                    }
+                }
+                if measured.is_none() {
+                    let mut minus = rho_flat.clone();
+                    minus[i] -= h_i;
+                    if let Some(vm) = value_at(&minus) {
+                        let d = (v0 - vm) / h_i;
+                        if d.is_finite() {
+                            measured = Some(d);
+                        }
+                    }
+                }
+            }
+            match measured {
+                Some(d) => gradient[i] = d,
+                // No fake zeros: a genuinely unmeasurable coordinate (every probe
+                // non-finite or on the collapse wall) is propagated, not silently
+                // reported as a stationary component.
+                None => {
+                    return Err(format!(
+                        "[SAE/#1273] outer-ρ gradient unmeasurable in coordinate {i} \
+                         at finite-cost ρ: every central and one-sided probe (step \
+                         ladder from {h_i:.3e}) was non-finite or hit the collapse \
+                         barrier; the outer step must not proceed on a corrupted \
+                         direction"
+                    ));
                 }
             }
         }
         Ok(gradient)
     }
+    // END-FD-OK
 }
 
 impl OuterObjective for SaeManifoldOuterObjective {
@@ -1479,7 +1547,7 @@ impl OuterObjective for SaeManifoldOuterObjective {
                      gradient of the value path so the near-singular flat valley is crossed \
                      instead of aborting the outer optimisation"
                 );
-                self.central_difference_outer_gradient(&rho_state)
+                self.central_difference_outer_gradient(&rho_state) // fd-ok: analytic outer gradient not cost-consistent here; descent direction only (#1273)
                     .map_err(EstimationError::RemlOptimizationFailed)?
             }
         };


### PR DESCRIPTION
## Summary

Closes **#1400**, and fixes the soundness of the code the lint was pointing at.

After the REML production FD was removed on `main` (the sparse path now uses the exact analytic ρ-gradient on every backend), the only remaining `no_production_finite_differences` violation is the SAE `#1273` fallback `central_difference_outer_gradient` — and `main` is currently **red** on this lint, because the function had merely been renamed `finite_difference_*` → `central_difference_*` (and `central_diff` is *also* a banned substring). Renaming to dodge the lint hides genuinely-present FD; this PR instead makes the FD **correct and audited**.

This branch is based on current `main`; the diff is 3 files, SAE-scoped.

## The fallback was unsound

`central_difference_outer_gradient` supplies a descent direction when the analytic outer gradient is not cost-consistent at a near-singular but finite-cost ρ (e.g. circle/torus latent topology). As written it:

- reused **one** `baseline_term.clone()` across the plus probe, the minus probe, and every coordinate — but `reml_criterion` takes `&mut self` and mutates warm-start/cache state, so probes were **not** from identical state and the result was **coordinate-order dependent**;
- re-solved each probe from the **cold pristine baseline**, while the value the fit consumes comes from the **live warm** state — so the value and its gradient were of **two different functions**;
- used a **single global step** `1e-4·max_i|ρ_i|`, under-resolving small coordinates (the doc even claimed per-coordinate scaling it didn't do);
- left `gradient[i] = 0` on any failed/non-finite probe — a **false "stationary"** signal that also poisons the BFGS curvature update (the doc admitted this).

## The fix (one function)

- **Isolation + value↔gradient identity:** snapshot the **live warm** `self.term`, clone it **fresh per probe**, so every probe differentiates the same warm-started function the value reported.
- **Per-coordinate step:** `probe_step_for(ρ_i) = 1e-4·max(|ρ_i|, 1)`.
- **Collapse-barrier guard:** the collapse penalty is a discrete `1e12` wall; a probe at/above it (or non-finite) is treated as unmeasurable rather than differenced across the barrier.
- **No fake zeros:** central difference down a short step ladder → one-sided → otherwise `Err`, so the outer step never proceeds on a corrupted direction.
- Wrapped in an explicit `FD-OK` audit region (legitimate, audited descent-direction FD), so the lint passes **without** renaming-to-dodge.

## Verification

`tests/autodiff/no_production_finite_differences.rs` passes **6/6** (verified standalone; the lint file itself is unchanged — not weakened). Behavior change is confined to the `#1273` fallback path: it now errors honestly on a genuinely-unmeasurable ρ instead of returning a corrupted/zero-padded direction. A crate build + the SAE suite are worth a CI pass.

— (AI-assisted)
