### PR TITLE
fix(bench): real SynthSAEBench direction metrics (closes #1413, supersedes #1432)

### DIFF
--- a/bench/_synth_sae_metrics.py
+++ b/bench/_synth_sae_metrics.py
@@ -1,0 +1,138 @@
+"""Direction-recovery metrics shared by the synthetic SAE benchmarks.
+
+NumPy-only (no ``gamfit``/torch import) so it can be unit-tested in isolation
+by ``bench/test_synth_sae_metrics.py``. The definitions follow SynthSAEBench
+(arXiv:2602.14687), which separates three distinct ground-truth measurements
+that the benchmark harnesses had previously conflated:
+
+* **feature uniqueness** -- a *collision* metric. For each learned latent ``j``
+  its best ground-truth match is ``i*(j) = argmax_i |w_j . d_i|`` and
+  uniqueness is the fraction of *distinct* best targets,
+  ``#unique(i*) / n_learned``. It is 1.0 iff every latent claims a different
+  truth feature; duplicate / collapsed directions that all point at the same
+  truth feature drag it toward ``1 / n_learned``. This is independent
+  per-latent ``argmax`` matching -- NOT one-to-one assignment.
+
+* **MCC** -- a *quality* metric: the optimal one-to-one |cosine| matching
+  (Hungarian), reporting the mean |cosine| of the matched pairs.
+
+* **direction recovery (precision / recall / F1)** -- a *coverage* metric that
+  is aware of match quality. See :func:`recovery_scores`.
+
+Why the split matters (#1413): a raw one-to-one *assignment count* is always
+``min(n_learned, n_truth)`` because both the Hungarian algorithm and the greedy
+fallback fill every row/column they can regardless of similarity. So
+``n_matched / max(...)`` collapses to a pure width ratio ``min/max`` and never
+inspects whether the matched pairs are any good -- equal-width perfect,
+all-duplicate, and random dictionaries all score 1.0. Uniqueness (collisions)
+and recovery F1 (quality-weighted coverage) each look at the actual directions.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+
+
+def match_directions(
+    learned: np.ndarray, truth: np.ndarray
+) -> tuple[np.ndarray, np.ndarray, str]:
+    """Optimal one-to-one ``|cosine|`` matching, Hungarian with greedy fallback.
+
+    ``learned`` (``L x D``) and ``truth`` (``T x D``) rows are assumed already
+    unit-normalized (the callers normalize before matching). Returns
+    ``(rows, cols, method)`` with ``len(rows) == min(L, T)``; ``method`` is one
+    of ``"hungarian"``, ``"greedy"``, or ``"none"`` (empty input).
+    """
+    learned = np.asarray(learned, dtype=float)
+    truth = np.asarray(truth, dtype=float)
+    if learned.size == 0 or truth.size == 0:
+        return np.empty(0, dtype=int), np.empty(0, dtype=int), "none"
+    sim = np.abs(learned @ truth.T)
+    try:
+        from scipy.optimize import linear_sum_assignment  # type: ignore
+
+        rows, cols = linear_sum_assignment(-sim)
+        return np.asarray(rows, dtype=int), np.asarray(cols, dtype=int), "hungarian"
+    except Exception:
+        pairs: list[tuple[int, int]] = []
+        used_rows: set[int] = set()
+        used_cols: set[int] = set()
+        for flat in np.argsort(sim, axis=None)[::-1]:
+            row, col = np.unravel_index(int(flat), sim.shape)
+            if int(row) in used_rows or int(col) in used_cols:
+                continue
+            pairs.append((int(row), int(col)))
+            used_rows.add(int(row))
+            used_cols.add(int(col))
+            if len(pairs) == min(sim.shape):
+                break
+        rows = np.array([p[0] for p in pairs], dtype=int)
+        cols = np.array([p[1] for p in pairs], dtype=int)
+        return rows, cols, "greedy"
+
+
+def feature_uniqueness(learned: np.ndarray, truth: np.ndarray) -> float:
+    """SynthSAEBench feature uniqueness: fraction of distinct ``argmax`` targets.
+
+    ``i*(j) = argmax_i |w_j . d_i|`` for each learned latent ``j``; the score is
+    ``#distinct(i*) / n_learned``. 1.0 means every latent's best match is a
+    different truth feature; duplicate / collapsed directions that share a best
+    match pull it toward ``1 / n_learned``. Returns 0.0 for empty input.
+    """
+    learned = np.asarray(learned, dtype=float)
+    truth = np.asarray(truth, dtype=float)
+    if learned.shape[0] == 0 or truth.shape[0] == 0:
+        return 0.0
+    sim = np.abs(learned @ truth.T)
+    best = np.argmax(sim, axis=1)
+    return float(np.unique(best).size / learned.shape[0])
+
+
+@dataclass(frozen=True)
+class RecoveryScores:
+    """Quality-aware one-to-one recovery plus the matched-pair MCC."""
+
+    mcc: float
+    precision: float
+    recall: float
+    f1: float
+    rows: np.ndarray
+    cols: np.ndarray
+    matching: str
+
+
+def recovery_scores(learned: np.ndarray, truth: np.ndarray) -> RecoveryScores:
+    """Quality-aware recovery (threshold-free) + matched-pair MCC.
+
+    Take the optimal matched ``|cosine|`` values ``q`` (Hungarian). Their
+    *mass* ``sum(q)`` is a soft count of recovered features, which yields::
+
+        precision = mass / n_learned   # junk / excess learned dirs lower it
+        recall    = mass / n_truth     # unrecovered truth features lower it
+        f1        = 2 * mass / (n_learned + n_truth)
+        mcc       = mean(q)            # SynthSAEBench matched-pair quality
+
+    Unlike the raw assignment count (always ``min(L, T)``), every term reflects
+    *how well* the assigned pairs align: equal-width duplicate or random
+    dictionaries score well below 1.0, perfect tight recovery scores 1.0,
+    excess/junk learned dirs lower precision, and unrecovered truth features
+    lower recall. ``rows``/``cols`` are returned so callers can reuse the same
+    one-to-one matching (e.g. for probing metrics) without rematching.
+    """
+    learned = np.asarray(learned, dtype=float)
+    truth = np.asarray(truth, dtype=float)
+    n_learned = int(learned.shape[0])
+    n_truth = int(truth.shape[0])
+    rows, cols, method = match_directions(learned, truth)
+    if rows.size == 0:
+        return RecoveryScores(0.0, 0.0, 0.0, 0.0, rows, cols, method)
+    sim = np.abs(learned @ truth.T)
+    q = sim[rows, cols]
+    mass = float(q.sum())
+    mcc = float(q.mean())
+    precision = mass / max(n_learned, 1)
+    recall = mass / max(n_truth, 1)
+    f1 = 2.0 * mass / max(n_learned + n_truth, 1)
+    return RecoveryScores(mcc, precision, recall, f1, rows, cols, method)

--- a/bench/synth_sae_bench_manifold.py
+++ b/bench/synth_sae_bench_manifold.py
@@ -27,6 +27,7 @@ import numpy as np
 
 import gamfit
 from gamfit._binding import rust_module
+from _synth_sae_metrics import feature_uniqueness, recovery_scores
 
 
 @dataclass(frozen=True)
@@ -65,6 +66,9 @@ class BenchmarkMetrics:
     test_r2: float
     mcc: float
     feature_uniqueness: float
+    direction_recovery_precision: float
+    direction_recovery_recall: float
+    direction_recovery_f1: float
     probing_precision: float
     probing_recall: float
     probing_f1: float
@@ -220,34 +224,6 @@ def _learned_components(fit: gamfit.ManifoldSAE) -> tuple[np.ndarray, np.ndarray
     return np.vstack(directions), np.column_stack(activations)
 
 
-def _match_directions(learned: np.ndarray, truth: np.ndarray) -> tuple[np.ndarray, np.ndarray, str]:
-    if learned.size == 0:
-        return np.array([], dtype=int), np.array([], dtype=int), "none"
-    sim = np.abs(learned @ truth.T)
-    try:
-        from scipy.optimize import linear_sum_assignment  # type: ignore
-
-        rows, cols = linear_sum_assignment(-sim)
-        return np.asarray(rows, dtype=int), np.asarray(cols, dtype=int), "hungarian"
-    except Exception:
-        pairs: list[tuple[int, int]] = []
-        used_rows: set[int] = set()
-        used_cols: set[int] = set()
-        flat_order = np.argsort(sim, axis=None)[::-1]
-        for flat in flat_order:
-            row, col = np.unravel_index(int(flat), sim.shape)
-            if int(row) in used_rows or int(col) in used_cols:
-                continue
-            pairs.append((int(row), int(col)))
-            used_rows.add(int(row))
-            used_cols.add(int(col))
-            if len(used_rows) == min(sim.shape):
-                break
-        rows = np.array([r for r, _c in pairs], dtype=int)
-        cols = np.array([c for _r, c in pairs], dtype=int)
-        return rows, cols, "greedy"
-
-
 def _best_f1(score: np.ndarray, truth: np.ndarray) -> tuple[float, float, float]:
     y = np.asarray(truth, dtype=bool)
     s = np.abs(np.asarray(score, dtype=float))
@@ -328,10 +304,16 @@ def run_one(args: argparse.Namespace, seed: int) -> BenchmarkMetrics:
     test_recon = np.asarray(test_payload["fitted"], dtype=float)
     learned_test = _component_scores_from_payload(fit, test_payload)
     learned_dirs, learned_train = _learned_components(fit)
-    rows, cols, matching = _match_directions(learned_dirs, synth.dictionary)
+    # Three distinct ground-truth measurements (see bench/_synth_sae_metrics.py
+    # and #1413): uniqueness is the SynthSAEBench argmax-collision score, while
+    # MCC and the direction-recovery precision/recall/F1 come from the optimal
+    # one-to-one matching. The old `len(set(cols)) / len(rows)` was always 1.0
+    # because Hungarian/greedy never reuse columns.
+    uniqueness = feature_uniqueness(learned_dirs, synth.dictionary)
+    rec = recovery_scores(learned_dirs, synth.dictionary)
+    rows, cols, matching = rec.rows, rec.cols, rec.matching
     if rows.size:
-        mcc = float(np.mean(np.abs(np.sum(learned_dirs[rows] * synth.dictionary[cols], axis=1))))
-        uniqueness = float(len(set(int(c) for c in cols)) / max(len(rows), 1))
+        mcc = rec.mcc
         precision, recall, f1 = _probing_metrics_for_matches(
             fit,
             test_payload,
@@ -341,7 +323,6 @@ def run_one(args: argparse.Namespace, seed: int) -> BenchmarkMetrics:
         )
     else:
         mcc = 0.0
-        uniqueness = 0.0
         precision = recall = f1 = 0.0
     score_seconds = time.perf_counter() - t1
 
@@ -365,6 +346,9 @@ def run_one(args: argparse.Namespace, seed: int) -> BenchmarkMetrics:
         test_r2=_r2(test_x, np.asarray(test_recon, dtype=float)),
         mcc=mcc,
         feature_uniqueness=uniqueness,
+        direction_recovery_precision=rec.precision,
+        direction_recovery_recall=rec.recall,
+        direction_recovery_f1=rec.f1,
         probing_precision=precision,
         probing_recall=recall,
         probing_f1=f1,
@@ -385,6 +369,9 @@ def _summarize(metrics: list[BenchmarkMetrics]) -> dict[str, Any]:
         "test_r2",
         "mcc",
         "feature_uniqueness",
+        "direction_recovery_precision",
+        "direction_recovery_recall",
+        "direction_recovery_f1",
         "probing_precision",
         "probing_recall",
         "probing_f1",
@@ -415,9 +402,10 @@ def _benchmark_notes() -> dict[str, Any]:
                 "learned_l0",
             ],
             "synthsaebench": [
-                "GT-MCC-style absolute-cosine feature recovery",
+                "GT-MCC-style absolute-cosine feature recovery (Hungarian matched pairs)",
                 "GT-F1-style matched-latent firing precision/recall/F1",
-                "feature uniqueness",
+                "feature uniqueness (argmax-collision: #distinct best matches / n_learned)",
+                "direction recovery precision/recall/F1 (quality-aware matched cosine mass)",
             ],
             "saebench_compatible_synthetic": [
                 "sparse-probing analogue on matched ground-truth features",

--- a/bench/synth_sae_compare.py
+++ b/bench/synth_sae_compare.py
@@ -7,7 +7,8 @@ the same direct ground-truth metrics:
 
 * reconstruction R2
 * decoder/feature MCC using Hungarian matching
-* feature uniqueness
+* feature uniqueness (SynthSAEBench argmax-collision definition)
+* direction recovery precision/recall/F1 (quality-aware coverage)
 * matched-latent firing precision/recall/F1
 
 The manifold row uses the repo's public ``gamfit.sae_manifold_fit`` API. The
@@ -29,6 +30,7 @@ import torch
 
 import gamfit
 from gamfit._binding import rust_module
+from _synth_sae_metrics import feature_uniqueness, recovery_scores
 from synth_sae_bench_manifold import SynthConfig, SynthSAEBenchData
 
 
@@ -46,6 +48,9 @@ class ModelResult:
     test_r2: float
     mcc: float
     feature_uniqueness: float
+    direction_recovery_precision: float
+    direction_recovery_recall: float
+    direction_recovery_f1: float
     probing_precision: float
     probing_recall: float
     probing_f1: float
@@ -132,29 +137,6 @@ def _best_f1(score: np.ndarray, truth: np.ndarray) -> tuple[float, float, float]
     return best
 
 
-def _match(decoder_dirs: np.ndarray, truth_dirs: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
-    sim = np.abs(decoder_dirs @ truth_dirs.T)
-    try:
-        from scipy.optimize import linear_sum_assignment
-
-        rows, cols = linear_sum_assignment(-sim)
-        return np.asarray(rows, dtype=int), np.asarray(cols, dtype=int)
-    except Exception:
-        pairs: list[tuple[int, int]] = []
-        used_r: set[int] = set()
-        used_c: set[int] = set()
-        for flat in np.argsort(sim, axis=None)[::-1]:
-            row, col = np.unravel_index(int(flat), sim.shape)
-            if int(row) in used_r or int(col) in used_c:
-                continue
-            pairs.append((int(row), int(col)))
-            used_r.add(int(row))
-            used_c.add(int(col))
-            if len(pairs) == min(sim.shape):
-                break
-        return np.array([p[0] for p in pairs], dtype=int), np.array([p[1] for p in pairs], dtype=int)
-
-
 def _score(
     *,
     model_name: str,
@@ -176,21 +158,22 @@ def _score(
     norms = np.linalg.norm(decoder_dirs, axis=1)
     live = norms > 1e-10
     dirs = decoder_dirs[live] / np.maximum(norms[live, None], 1e-10)
-    if dirs.size == 0:
-        rows = np.array([], dtype=int)
-        cols = np.array([], dtype=int)
-    else:
-        rows, cols = _match(dirs, truth_dirs)
+    # Three distinct ground-truth measurements (see bench/_synth_sae_metrics.py
+    # and #1413): uniqueness is the SynthSAEBench argmax-collision score, while
+    # MCC and the direction-recovery precision/recall/F1 come from the optimal
+    # one-to-one matching. The old `len(set(cols)) / len(rows)` was always 1.0
+    # because Hungarian/greedy never reuse columns.
+    uniqueness = feature_uniqueness(dirs, truth_dirs)
+    rec = recovery_scores(dirs, truth_dirs)
+    rows, cols = rec.rows, rec.cols
     if rows.size:
-        matched_cos = np.abs(np.sum(dirs[rows] * truth_dirs[cols], axis=1))
-        mcc = float(np.mean(matched_cos))
-        uniqueness = float(len(set(int(c) for c in cols)) / max(len(rows), 1))
+        mcc = rec.mcc
         live_train = train_latents[:, live]
         live_test = test_latents[:, live]
         metrics = [_best_f1(live_test[:, int(row)], test_fire[:, int(col)]) for row, col in zip(rows, cols)]
         precision, recall, f1 = (float(np.mean([m[i] for m in metrics])) for i in range(3))
     else:
-        mcc = uniqueness = precision = recall = f1 = 0.0
+        mcc = precision = recall = f1 = 0.0
         live_train = np.zeros((train_x.shape[0], 0))
         live_test = np.zeros((test_x.shape[0], 0))
     return ModelResult(
@@ -206,6 +189,9 @@ def _score(
         test_r2=_r2(test_x, test_recon),
         mcc=mcc,
         feature_uniqueness=uniqueness,
+        direction_recovery_precision=rec.precision,
+        direction_recovery_recall=rec.recall,
+        direction_recovery_f1=rec.f1,
         probing_precision=precision,
         probing_recall=recall,
         probing_f1=f1,

--- a/bench/test_synth_sae_metrics.py
+++ b/bench/test_synth_sae_metrics.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""NumPy-only tests for bench/_synth_sae_metrics.py (no gamfit/torch needed).
+
+Run directly (``python3 bench/test_synth_sae_metrics.py``) or under pytest.
+These are the direction-matrix cases that the original #1432 "verification"
+could not catch, because it hard-coded the assignment count instead of feeding
+real directions. The decisive point: at equal width, the old width-ratio metric
+``min(L, T) / max(L, T)`` is identically 1.0 for perfect, all-duplicate, and
+random dictionaries alike. The quality-aware metrics here separate them.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from _synth_sae_metrics import (
+    feature_uniqueness,
+    match_directions,
+    recovery_scores,
+)
+
+
+def _orthonormal(n: int, d: int, seed: int = 0) -> np.ndarray:
+    rng = np.random.default_rng(seed)
+    q, _ = np.linalg.qr(rng.standard_normal((d, n)))
+    return q.T[:n]
+
+
+def _old_width_ratio(learned: np.ndarray, truth: np.ndarray) -> float:
+    """The metric proposed in PR #1432, reduced to what it actually computes."""
+    rows, _cols, _ = match_directions(learned, truth)
+    return float(rows.shape[0] / max(learned.shape[0], truth.shape[0]))
+
+
+def test_assignment_count_is_always_min_dim() -> None:
+    # Documents the root cause: matchers always fill min(L, T) pairs.
+    truth = _orthonormal(10, 16, seed=1)
+    for n_learned in (4, 10, 25):
+        learned = _orthonormal(n_learned, 16, seed=n_learned)
+        rows, cols, _ = match_directions(learned, truth)
+        assert rows.shape[0] == min(n_learned, 10)
+        assert cols.shape[0] == rows.shape[0]
+
+
+def test_perfect_recovery_scores_one() -> None:
+    truth = _orthonormal(10, 16, seed=2)
+    learned = truth.copy()
+    assert feature_uniqueness(learned, truth) == 1.0
+    rec = recovery_scores(learned, truth)
+    assert rec.f1 > 0.999
+    assert rec.precision > 0.999
+    assert rec.recall > 0.999
+    assert rec.mcc > 0.999
+
+
+def test_equal_width_duplicates_penalized() -> None:
+    truth = _orthonormal(4, 16, seed=3)
+    learned = np.repeat(truth[:1], 4, axis=0)  # four copies of one feature
+    # Old metric: tautologically 1.0 at equal width.
+    assert _old_width_ratio(learned, truth) == 1.0
+    # New metrics expose the collapse.
+    assert feature_uniqueness(learned, truth) == 0.25
+    assert recovery_scores(learned, truth).f1 < 0.3
+
+
+def test_equal_width_random_penalized_by_recovery() -> None:
+    truth = _orthonormal(16, 64, seed=4)
+    rng = np.random.default_rng(5)
+    learned = rng.standard_normal((16, 64))
+    learned /= np.linalg.norm(learned, axis=1, keepdims=True)
+    assert _old_width_ratio(learned, truth) == 1.0  # old metric blind to quality
+    # Recovery F1 collapses for random directions in a high-dim space.
+    assert recovery_scores(learned, truth).f1 < 0.5
+
+
+def test_overcomplete_excess_lowers_precision() -> None:
+    truth = _orthonormal(10, 32, seed=6)
+    junk = _orthonormal(6, 32, seed=99)
+    learned = np.vstack([truth, junk])  # 10 perfect + 6 junk
+    rec = recovery_scores(learned, truth)
+    assert rec.recall > 0.99  # every truth feature still recovered
+    assert rec.precision < 0.7  # but excess learned dirs drag precision down
+    assert rec.precision < rec.recall
+
+
+def test_undercomplete_lowers_recall() -> None:
+    truth = _orthonormal(10, 32, seed=7)
+    learned = truth[:6].copy()  # only 6 of 10 truth features learned
+    rec = recovery_scores(learned, truth)
+    assert rec.precision > 0.99  # the 6 it has are perfect
+    assert rec.recall < 0.7  # but 4 truth features are unrecovered
+    assert abs(rec.recall - 0.6) < 1e-6
+
+
+def test_empty_learned_is_zero() -> None:
+    truth = _orthonormal(10, 16, seed=8)
+    empty = np.zeros((0, 16))
+    assert feature_uniqueness(empty, truth) == 0.0
+    rec = recovery_scores(empty, truth)
+    assert (rec.mcc, rec.precision, rec.recall, rec.f1) == (0.0, 0.0, 0.0, 0.0)
+    assert rec.rows.size == 0
+
+
+def main() -> None:
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
+    for t in tests:
+        t()
+        print(f"ok  {t.__name__}")
+    print(f"\n{len(tests)} passed")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Lands the **actual SynthSAEBench (arXiv:2602.14687) ground-truth metrics** in the synthetic SAE benchmarks, fixing the tautological `feature_uniqueness` reported in #1413 and superseding #1432.

### The bug (#1413)
Both harnesses computed `feature_uniqueness = len(set(cols)) / len(rows)` over a one-to-one (Hungarian / greedy) match. Both matchers always return `min(n_learned, n_truth)` **distinct** columns, so the metric was identically `1.0` for any non-empty match — regardless of how duplicated/dead/oversized the dictionary was.

### Why #1432 didn't fix it
#1432 proposed `n_matched / max(n_learned, n_truth)`. But `n_matched` is *also* always `min(n_learned, n_truth)`, so it reduces algebraically to the **width ratio** `min/max`. It never inspects match quality — at equal width, perfect, all-duplicate, and random dictionaries **all still score 1.0** — and it isn't the benchmark's definition of uniqueness. (Confirmed against the paper: uniqueness is argmax-collision, MCC is Hungarian, dead latents are firing-based.)

| equal-width case (L=T) | old `min/max` | this PR: uniqueness | this PR: recovery F1 |
|---|---|---|---|
| perfect | 1.000 | 1.000 | 1.000 |
| all-duplicate | 1.000 | **0.250** | **0.250** |
| random | 1.000 | (collision-blind) | **< 0.5** |

## The fix

A shared **numpy-only** helper `bench/_synth_sae_metrics.py` (no `gamfit`/torch, so it is unit-testable in isolation), used by both harnesses:

- **`feature_uniqueness`** — SynthSAEBench argmax-collision score: `#unique(argmax_i |wⱼ·dᵢ|) / n_learned`. `1/n_learned` for a fully collapsed dictionary, `1.0` for distinct best matches. This is the honest meaning of the existing field name.
- **`direction_recovery_{precision,recall,f1}`** *(new fields)* — quality-aware coverage from the matched cosine **mass** `sum(q)`: `precision = mass/n_learned`, `recall = mass/n_truth`, `f1 = 2·mass/(n_learned+n_truth)`. Threshold-free; duplicate/random dicts fall well below 1.0, excess/junk lowers precision, unrecovered truth lowers recall.
- **`mcc`** — unchanged (Hungarian matched-pair mean `|cosine|`).

New fields are **added** rather than overloading existing JSON/CSV keys; `feature_uniqueness` keeps its name but now means what it says.

## Tests

`bench/test_synth_sae_metrics.py` (numpy-only, runs without the fit stack) covers the direction-matrix cases the original verification could not catch — perfect / all-duplicate / random at equal width, overcomplete-plus-junk, undercomplete subset, and empty input. All 7 pass locally; `py_compile` passes on both harnesses.

## Credit

Original tautology diagnosis by @HomunculusLabs in #1432.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
