### PR TITLE
fix(bench): exact matching + Jaccard + dead-slot penalty for SAE metrics (#1413)

### DIFF
--- a/bench/_synth_sae_metrics.py
+++ b/bench/_synth_sae_metrics.py
@@ -11,21 +11,31 @@ that the benchmark harnesses had previously conflated:
   ``#unique(i*) / n_learned``. It is 1.0 iff every latent claims a different
   truth feature; duplicate / collapsed directions that all point at the same
   truth feature drag it toward ``1 / n_learned``. This is independent
-  per-latent ``argmax`` matching -- NOT one-to-one assignment.
+  per-latent ``argmax`` matching -- NOT one-to-one assignment, and (per the
+  paper) NOT a recovery score: a dictionary of distinct-but-poor directions can
+  still score 1.0.
 
 * **MCC** -- a *quality* metric: the optimal one-to-one |cosine| matching
   (Hungarian), reporting the mean |cosine| of the matched pairs.
 
-* **direction recovery (precision / recall / F1)** -- a *coverage* metric that
-  is aware of match quality. See :func:`recovery_scores`.
+* **direction recovery (precision / recall / F1 / Jaccard)** -- a *coverage*
+  metric that is aware of match quality. See :func:`recovery_scores`.
 
 Why the split matters (#1413): a raw one-to-one *assignment count* is always
-``min(n_learned, n_truth)`` because both the Hungarian algorithm and the greedy
-fallback fill every row/column they can regardless of similarity. So
-``n_matched / max(...)`` collapses to a pure width ratio ``min/max`` and never
-inspects whether the matched pairs are any good -- equal-width perfect,
-all-duplicate, and random dictionaries all score 1.0. Uniqueness (collisions)
-and recovery F1 (quality-weighted coverage) each look at the actual directions.
+``min(n_learned, n_truth)`` because the Hungarian algorithm saturates the
+smaller side regardless of similarity. So ``n_matched / max(...)`` collapses to
+the pure width ratio ``min/max`` and never inspects whether the matched pairs
+are any good -- equal-width perfect, all-duplicate, and orthogonal dictionaries
+all score 1.0. Algebraically ``min/max`` equals the Jaccard recovery one *would*
+get if every forced assignment were perfect (``MCC = 1``), i.e. a recovery
+*ceiling*, not a measurement. Uniqueness (collisions) and the quality-weighted
+recovery scores below each look at the actual matched cosines.
+
+Matching is exact: SciPy's ``linear_sum_assignment`` when available, otherwise
+the dependency-free Hungarian in :func:`_hungarian_max_numpy`. The greedy
+nearest-pair heuristic the harnesses used before is NOT exact (e.g. on
+``[[0.9, 0.8], [0.8, 0.0]]`` it returns mass 0.9 vs the optimal 1.6), so a
+quality metric must not depend on it.
 """
 
 from __future__ import annotations
@@ -35,15 +45,78 @@ from dataclasses import dataclass
 import numpy as np
 
 
+def _hungarian_max_numpy(sim: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+    """Exact maximum-weight one-to-one matching, dependency-free.
+
+    Jonker-Volgenant / Kuhn-Munkres on costs ``-sim`` (n = smaller side).
+    Returns ``(rows, cols)`` saturating the smaller side. Used only when SciPy
+    is unavailable; validated against brute force in the test suite.
+    """
+    sim = np.asarray(sim, dtype=float)
+    transposed = sim.shape[0] > sim.shape[1]
+    cost = (-sim.T if transposed else -sim).astype(float)
+    n, m = cost.shape  # n <= m
+    inf = float("inf")
+    u = [0.0] * (n + 1)
+    v = [0.0] * (m + 1)
+    p = [0] * (m + 1)  # p[j] = 1-indexed row matched to column j (0 = unset)
+    way = [0] * (m + 1)
+    for i in range(1, n + 1):
+        p[0] = i
+        j0 = 0
+        minv = [inf] * (m + 1)
+        used = [False] * (m + 1)
+        while True:
+            used[j0] = True
+            i0 = p[j0]
+            delta = inf
+            j1 = -1
+            for j in range(1, m + 1):
+                if used[j]:
+                    continue
+                cur = cost[i0 - 1][j - 1] - u[i0] - v[j]
+                if cur < minv[j]:
+                    minv[j] = cur
+                    way[j] = j0
+                if minv[j] < delta:
+                    delta = minv[j]
+                    j1 = j
+            for j in range(0, m + 1):
+                if used[j]:
+                    u[p[j]] += delta
+                    v[j] -= delta
+                else:
+                    minv[j] -= delta
+            j0 = j1
+            if p[j0] == 0:
+                break
+        while j0 != 0:
+            j1 = way[j0]
+            p[j0] = p[j1]
+            j0 = j1
+    rows: list[int] = []
+    cols: list[int] = []
+    for j in range(1, m + 1):
+        if p[j] != 0:
+            rows.append(p[j] - 1)
+            cols.append(j - 1)
+    rows_arr = np.asarray(rows, dtype=int)
+    cols_arr = np.asarray(cols, dtype=int)
+    if transposed:
+        rows_arr, cols_arr = cols_arr, rows_arr
+    order = np.argsort(rows_arr)
+    return rows_arr[order], cols_arr[order]
+
+
 def match_directions(
     learned: np.ndarray, truth: np.ndarray
 ) -> tuple[np.ndarray, np.ndarray, str]:
-    """Optimal one-to-one ``|cosine|`` matching, Hungarian with greedy fallback.
+    """Optimal one-to-one ``|cosine|`` matching (exact).
 
     ``learned`` (``L x D``) and ``truth`` (``T x D``) rows are assumed already
     unit-normalized (the callers normalize before matching). Returns
-    ``(rows, cols, method)`` with ``len(rows) == min(L, T)``; ``method`` is one
-    of ``"hungarian"``, ``"greedy"``, or ``"none"`` (empty input).
+    ``(rows, cols, method)`` with ``len(rows) == min(L, T)``; ``method`` is
+    ``"hungarian-scipy"``, ``"hungarian-numpy"``, or ``"none"`` (empty input).
     """
     learned = np.asarray(learned, dtype=float)
     truth = np.asarray(truth, dtype=float)
@@ -54,23 +127,10 @@ def match_directions(
         from scipy.optimize import linear_sum_assignment  # type: ignore
 
         rows, cols = linear_sum_assignment(-sim)
-        return np.asarray(rows, dtype=int), np.asarray(cols, dtype=int), "hungarian"
-    except Exception:
-        pairs: list[tuple[int, int]] = []
-        used_rows: set[int] = set()
-        used_cols: set[int] = set()
-        for flat in np.argsort(sim, axis=None)[::-1]:
-            row, col = np.unravel_index(int(flat), sim.shape)
-            if int(row) in used_rows or int(col) in used_cols:
-                continue
-            pairs.append((int(row), int(col)))
-            used_rows.add(int(row))
-            used_cols.add(int(col))
-            if len(pairs) == min(sim.shape):
-                break
-        rows = np.array([p[0] for p in pairs], dtype=int)
-        cols = np.array([p[1] for p in pairs], dtype=int)
-        return rows, cols, "greedy"
+        return np.asarray(rows, dtype=int), np.asarray(cols, dtype=int), "hungarian-scipy"
+    except ImportError:
+        rows, cols = _hungarian_max_numpy(sim)
+        return rows, cols, "hungarian-numpy"
 
 
 def feature_uniqueness(learned: np.ndarray, truth: np.ndarray) -> float:
@@ -79,7 +139,8 @@ def feature_uniqueness(learned: np.ndarray, truth: np.ndarray) -> float:
     ``i*(j) = argmax_i |w_j . d_i|`` for each learned latent ``j``; the score is
     ``#distinct(i*) / n_learned``. 1.0 means every latent's best match is a
     different truth feature; duplicate / collapsed directions that share a best
-    match pull it toward ``1 / n_learned``. Returns 0.0 for empty input.
+    match pull it toward ``1 / n_learned``. This is a collision/diversity
+    diagnostic, NOT recovery quality. Returns 0.0 for empty input.
     """
     learned = np.asarray(learned, dtype=float)
     truth = np.asarray(truth, dtype=float)
@@ -92,42 +153,65 @@ def feature_uniqueness(learned: np.ndarray, truth: np.ndarray) -> float:
 
 @dataclass(frozen=True)
 class RecoveryScores:
-    """Quality-aware one-to-one recovery plus the matched-pair MCC."""
+    """Quality-aware one-to-one recovery plus the matched-pair MCC.
+
+    ``precision``/``recall``/``f1``/``jaccard`` are soft (cosine-weighted)
+    detection scores; ``mcc`` is the mean matched |cosine|;
+    ``cardinality_ceiling`` is the honestly-named ``min/max`` width ratio (the
+    recovery these widths would reach at perfect quality).
+    """
 
     mcc: float
     precision: float
     recall: float
     f1: float
+    jaccard: float
+    cardinality_ceiling: float
     rows: np.ndarray
     cols: np.ndarray
     matching: str
 
 
-def recovery_scores(learned: np.ndarray, truth: np.ndarray) -> RecoveryScores:
+def recovery_scores(
+    learned: np.ndarray,
+    truth: np.ndarray,
+    n_learned_total: int | None = None,
+) -> RecoveryScores:
     """Quality-aware recovery (threshold-free) + matched-pair MCC.
 
-    Take the optimal matched ``|cosine|`` values ``q`` (Hungarian). Their
-    *mass* ``sum(q)`` is a soft count of recovered features, which yields::
+    Take the optimal matched ``|cosine|`` values ``q`` (exact Hungarian). Their
+    *mass* ``A = sum(q)`` is a soft count of recovered features. With ``L`` the
+    learned-slot count and ``T`` the truth count::
 
-        precision = mass / n_learned   # junk / excess learned dirs lower it
-        recall    = mass / n_truth     # unrecovered truth features lower it
-        f1        = 2 * mass / (n_learned + n_truth)
-        mcc       = mean(q)            # SynthSAEBench matched-pair quality
+        precision = A / L            # junk / excess / dead learned dirs lower it
+        recall    = A / T            # unrecovered truth features lower it
+        f1        = 2A / (L + T)
+        jaccard   = A / (L + T - A)
+        mcc       = mean(q)          # SynthSAEBench matched-pair quality
 
-    Unlike the raw assignment count (always ``min(L, T)``), every term reflects
-    *how well* the assigned pairs align: equal-width duplicate or random
-    dictionaries score well below 1.0, perfect tight recovery scores 1.0,
-    excess/junk learned dirs lower precision, and unrecovered truth features
-    lower recall. ``rows``/``cols`` are returned so callers can reuse the same
-    one-to-one matching (e.g. for probing metrics) without rematching.
+    Each soft score equals the corresponding hard detection metric under the
+    interpretation that a matched pair of quality ``q`` contributes ``q`` to
+    true positives and ``1 - q`` to both false-positive and false-negative
+    mass. F1 (and Jaccard) reach 1.0 only for a perfect bijection over the full
+    truth dictionary; duplicate / random dictionaries score well below 1.0.
+
+    ``n_learned_total`` overrides ``L`` so callers can include *dead* slots
+    (zero-norm decoder directions never enter an optimal positive-mass matching,
+    so ``A`` is unchanged, but counting them in ``L`` correctly penalizes wasted
+    capacity). Defaults to ``learned.shape[0]``.
     """
     learned = np.asarray(learned, dtype=float)
     truth = np.asarray(truth, dtype=float)
-    n_learned = int(learned.shape[0])
+    n_learned = int(learned.shape[0] if n_learned_total is None else n_learned_total)
     n_truth = int(truth.shape[0])
+    ceiling = (
+        min(n_learned, n_truth) / max(n_learned, n_truth)
+        if max(n_learned, n_truth) > 0
+        else 0.0
+    )
     rows, cols, method = match_directions(learned, truth)
     if rows.size == 0:
-        return RecoveryScores(0.0, 0.0, 0.0, 0.0, rows, cols, method)
+        return RecoveryScores(0.0, 0.0, 0.0, 0.0, 0.0, ceiling, rows, cols, method)
     sim = np.abs(learned @ truth.T)
     q = sim[rows, cols]
     mass = float(q.sum())
@@ -135,4 +219,8 @@ def recovery_scores(learned: np.ndarray, truth: np.ndarray) -> RecoveryScores:
     precision = mass / max(n_learned, 1)
     recall = mass / max(n_truth, 1)
     f1 = 2.0 * mass / max(n_learned + n_truth, 1)
-    return RecoveryScores(mcc, precision, recall, f1, rows, cols, method)
+    denom = n_learned + n_truth - mass
+    jaccard = mass / denom if denom > 1e-12 else 0.0
+    return RecoveryScores(
+        mcc, precision, recall, f1, jaccard, ceiling, rows, cols, method
+    )

--- a/bench/synth_sae_bench_manifold.py
+++ b/bench/synth_sae_bench_manifold.py
@@ -69,6 +69,7 @@ class BenchmarkMetrics:
     direction_recovery_precision: float
     direction_recovery_recall: float
     direction_recovery_f1: float
+    direction_recovery_jaccard: float
     probing_precision: float
     probing_recall: float
     probing_f1: float
@@ -306,9 +307,12 @@ def run_one(args: argparse.Namespace, seed: int) -> BenchmarkMetrics:
     learned_dirs, learned_train = _learned_components(fit)
     # Three distinct ground-truth measurements (see bench/_synth_sae_metrics.py
     # and #1413): uniqueness is the SynthSAEBench argmax-collision score, while
-    # MCC and the direction-recovery precision/recall/F1 come from the optimal
-    # one-to-one matching. The old `len(set(cols)) / len(rows)` was always 1.0
-    # because Hungarian/greedy never reuse columns.
+    # MCC and the direction-recovery precision/recall/F1/Jaccard come from the
+    # optimal one-to-one matching. The old `len(set(cols)) / len(rows)` was
+    # always 1.0 because the assignment never reuses columns. `_learned_components`
+    # already drops zero-norm atom directions, and a manifold SAE has no single
+    # well-defined "total slot" count (atoms x harmonics), so the recovery
+    # denominator is the live direction count here.
     uniqueness = feature_uniqueness(learned_dirs, synth.dictionary)
     rec = recovery_scores(learned_dirs, synth.dictionary)
     rows, cols, matching = rec.rows, rec.cols, rec.matching
@@ -349,6 +353,7 @@ def run_one(args: argparse.Namespace, seed: int) -> BenchmarkMetrics:
         direction_recovery_precision=rec.precision,
         direction_recovery_recall=rec.recall,
         direction_recovery_f1=rec.f1,
+        direction_recovery_jaccard=rec.jaccard,
         probing_precision=precision,
         probing_recall=recall,
         probing_f1=f1,
@@ -372,6 +377,7 @@ def _summarize(metrics: list[BenchmarkMetrics]) -> dict[str, Any]:
         "direction_recovery_precision",
         "direction_recovery_recall",
         "direction_recovery_f1",
+        "direction_recovery_jaccard",
         "probing_precision",
         "probing_recall",
         "probing_f1",
@@ -405,7 +411,7 @@ def _benchmark_notes() -> dict[str, Any]:
                 "GT-MCC-style absolute-cosine feature recovery (Hungarian matched pairs)",
                 "GT-F1-style matched-latent firing precision/recall/F1",
                 "feature uniqueness (argmax-collision: #distinct best matches / n_learned)",
-                "direction recovery precision/recall/F1 (quality-aware matched cosine mass)",
+                "direction recovery precision/recall/F1/Jaccard (quality-aware matched cosine mass)",
             ],
             "saebench_compatible_synthetic": [
                 "sparse-probing analogue on matched ground-truth features",

--- a/bench/synth_sae_compare.py
+++ b/bench/synth_sae_compare.py
@@ -8,7 +8,7 @@ the same direct ground-truth metrics:
 * reconstruction R2
 * decoder/feature MCC using Hungarian matching
 * feature uniqueness (SynthSAEBench argmax-collision definition)
-* direction recovery precision/recall/F1 (quality-aware coverage)
+* direction recovery precision/recall/F1/Jaccard (quality-aware coverage)
 * matched-latent firing precision/recall/F1
 
 The manifold row uses the repo's public ``gamfit.sae_manifold_fit`` API. The
@@ -51,6 +51,7 @@ class ModelResult:
     direction_recovery_precision: float
     direction_recovery_recall: float
     direction_recovery_f1: float
+    direction_recovery_jaccard: float
     probing_precision: float
     probing_recall: float
     probing_f1: float
@@ -160,11 +161,14 @@ def _score(
     dirs = decoder_dirs[live] / np.maximum(norms[live, None], 1e-10)
     # Three distinct ground-truth measurements (see bench/_synth_sae_metrics.py
     # and #1413): uniqueness is the SynthSAEBench argmax-collision score, while
-    # MCC and the direction-recovery precision/recall/F1 come from the optimal
-    # one-to-one matching. The old `len(set(cols)) / len(rows)` was always 1.0
-    # because Hungarian/greedy never reuse columns.
+    # MCC and the direction-recovery precision/recall/F1/Jaccard come from the
+    # optimal one-to-one matching. The old `len(set(cols)) / len(rows)` was
+    # always 1.0 because the assignment never reuses columns. The recovery
+    # denominator spans *all* decoder slots (decoder_dirs.shape[0], incl. dead
+    # zero-norm ones) so wasted width is penalized; dead rows carry no matching
+    # mass, so this only affects the denominator.
     uniqueness = feature_uniqueness(dirs, truth_dirs)
-    rec = recovery_scores(dirs, truth_dirs)
+    rec = recovery_scores(dirs, truth_dirs, n_learned_total=int(decoder_dirs.shape[0]))
     rows, cols = rec.rows, rec.cols
     if rows.size:
         mcc = rec.mcc
@@ -192,6 +196,7 @@ def _score(
         direction_recovery_precision=rec.precision,
         direction_recovery_recall=rec.recall,
         direction_recovery_f1=rec.f1,
+        direction_recovery_jaccard=rec.jaccard,
         probing_precision=precision,
         probing_recall=recall,
         probing_f1=f1,

--- a/bench/test_synth_sae_metrics.py
+++ b/bench/test_synth_sae_metrics.py
@@ -13,7 +13,10 @@ from __future__ import annotations
 
 import numpy as np
 
+from itertools import permutations
+
 from _synth_sae_metrics import (
+    _hungarian_max_numpy,
     feature_uniqueness,
     match_directions,
     recovery_scores,
@@ -24,6 +27,19 @@ def _orthonormal(n: int, d: int, seed: int = 0) -> np.ndarray:
     rng = np.random.default_rng(seed)
     q, _ = np.linalg.qr(rng.standard_normal((d, n)))
     return q.T[:n]
+
+
+def _brute_force_max_mass(sim: np.ndarray) -> float:
+    """Optimal one-to-one matched mass by exhaustive search (small matrices)."""
+    n, m = sim.shape
+    if min(n, m) == 0:
+        return 0.0
+    if n <= m:
+        best = 0.0
+        for cols in permutations(range(m), n):
+            best = max(best, float(sum(sim[r, c] for r, c in enumerate(cols))))
+        return best
+    return _brute_force_max_mass(sim.T)
 
 
 def _old_width_ratio(learned: np.ndarray, truth: np.ndarray) -> float:
@@ -90,6 +106,49 @@ def test_undercomplete_lowers_recall() -> None:
     assert rec.precision > 0.99  # the 6 it has are perfect
     assert rec.recall < 0.7  # but 4 truth features are unrecovered
     assert abs(rec.recall - 0.6) < 1e-6
+
+
+def test_exact_hungarian_beats_greedy() -> None:
+    # The old greedy fallback took 0.9 then was forced to 0.0 (mass 0.9); the
+    # optimal assignment takes both 0.8s (mass 1.6). The exact matcher must find
+    # the optimum.
+    sim = np.array([[0.9, 0.8], [0.8, 0.0]])
+    rows, cols = _hungarian_max_numpy(sim)
+    assert abs(sim[rows, cols].sum() - 1.6) < 1e-12
+
+
+def test_hungarian_matches_brute_force() -> None:
+    rng = np.random.default_rng(11)
+    for _ in range(40):
+        n = int(rng.integers(1, 6))
+        m = int(rng.integers(1, 6))
+        sim = rng.random((n, m))
+        rows, cols = _hungarian_max_numpy(sim)
+        assert rows.shape[0] == min(n, m)
+        assert np.unique(cols).size == cols.size  # one-to-one
+        got = float(sim[rows, cols].sum())
+        assert abs(got - _brute_force_max_mass(sim)) < 1e-9
+
+
+def test_jaccard_one_only_for_perfect_bijection() -> None:
+    truth = _orthonormal(10, 16, seed=20)
+    assert recovery_scores(truth.copy(), truth).jaccard > 0.999
+    # Equal width but all-duplicate: Jaccard collapses well below 1.
+    dup = np.repeat(truth[:1], 10, axis=0)
+    assert recovery_scores(dup, truth).jaccard < 0.2
+
+
+def test_dead_slots_penalized_via_total_count() -> None:
+    # 10 perfect + 6 dead (zero-norm) decoder slots. Matching is over the 10
+    # live dirs (mass ~10), but counting all 16 slots in L penalizes the dead
+    # capacity, exactly as a width-16 SAE recovering 10 truths should be scored.
+    truth = _orthonormal(10, 32, seed=21)
+    live = truth.copy()
+    rec_live = recovery_scores(live, truth)  # default L = live count
+    rec_total = recovery_scores(live, truth, n_learned_total=16)
+    assert rec_live.precision > 0.999  # ignoring dead capacity -> perfect
+    assert abs(rec_total.precision - 10.0 / 16.0) < 1e-6  # dead capacity penalized
+    assert abs(rec_total.cardinality_ceiling - 10.0 / 16.0) < 1e-6
 
 
 def test_empty_learned_is_zero() -> None:


### PR DESCRIPTION
## Summary

Follow-up to #1432, hardening the SynthSAEBench (arXiv:2602.14687) direction metrics in response to a detailed review. The merged #1432 fixed the tautology and added quality-aware recovery; this addresses the remaining correctness gaps.

### 1. Exact matching everywhere
The previous greedy nearest-pair fallback is **not** optimal — on `[[0.9, 0.8], [0.8, 0.0]]` it returns matched mass `0.9` vs the optimal `1.6`. A quality metric must not silently change meaning depending on whether SciPy is installed. Replaced with a dependency-free Hungarian (`_hungarian_max_numpy`), **validated against brute force** over 40 random shapes in the test suite. SciPy's `linear_sum_assignment` is still used when available.

### 2. Jaccard
Added `direction_recovery_jaccard = A / (L + T − A)` (where `A = Σ matched |cosine|`) alongside precision/recall/F1. Both F1 and Jaccard equal 1.0 **only** for a perfect bijection over the full truth dictionary (proof: `A ≤ min(L,T) ≤ (L+T)/2`, so `2A = L+T` forces `L=T` and every matched cosine `= 1`).

### 3. Dead-slot penalty
`synth_sae_compare` now counts **all** decoder slots (including zero-norm/dead) in the recovery denominator via the new `n_learned_total` argument. Dead rows carry no matching mass, so `A` is unchanged, but wasted width now lowers precision/F1/Jaccard — a width-16 SAE recovering 10 truths scores `10/16`, not `1.0`. (The manifold harness keeps the live-direction denominator: a manifold SAE has no single well-defined total-slot count.)

### 4. Honestly-named ceiling
Exposed `cardinality_ceiling = min(L,T)/max(L,T)` — which algebraically equals the Jaccard recovery one *would* get at `MCC = 1`, i.e. exactly the number #1432 reported as if it were achieved recovery. It's a ceiling, now labeled as one.

## Tests
`bench/test_synth_sae_metrics.py` adds: exact-vs-greedy counterexample, Hungarian-vs-brute-force (40 random shapes), Jaccard exactness, and the dead-slot penalty. **11/11 pass** locally (numpy-only; the suite exercises the exact in-repo Hungarian since SciPy is absent there); `py_compile` passes on both harnesses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
