### PR TITLE
fix(bench): functional dead-latent accounting + manifold total-slot denominator (closes #1435)

### DIFF
--- a/bench/_synth_sae_metrics.py
+++ b/bench/_synth_sae_metrics.py
@@ -151,6 +151,35 @@ def feature_uniqueness(learned: np.ndarray, truth: np.ndarray) -> float:
     return float(np.unique(best).size / learned.shape[0])
 
 
+def firing_latent_mask(activations: np.ndarray, threshold: float = 1e-8) -> np.ndarray:
+    """Functional dead-latent mask (SynthSAEBench): a latent is *live* if it
+    fires (``|activation| > threshold``) on at least one sample of the evaluation
+    set.
+
+    Unlike geometric deadness (zero decoder norm), a latent with a nonzero decoder
+    direction that never activates is *functionally* dead -- wasted capacity that a
+    decoder-norm check misses (#1435). Returns a 1-D boolean mask whose length is
+    the latent count (``activations`` columns). Empty input returns an empty mask;
+    a 1-D array is treated as a single latent.
+    """
+    a = np.abs(np.asarray(activations, dtype=float))
+    if a.size == 0:
+        return np.empty(0, dtype=bool)
+    if a.ndim == 1:
+        a = a[:, None]
+    return np.any(a > threshold, axis=0)
+
+
+def n_firing_latents(activations: np.ndarray, threshold: float = 1e-8) -> int:
+    """Count of latents that fire on at least one evaluation sample.
+
+    Functional (activation-based) live count, complementing the geometric
+    (decoder-norm) live count. ``n_slots - n_firing_latents`` is the functional
+    dead count (#1435).
+    """
+    return int(firing_latent_mask(activations, threshold).sum())
+
+
 @dataclass(frozen=True)
 class RecoveryScores:
     """Quality-aware one-to-one recovery plus the matched-pair MCC.

--- a/bench/synth_sae_bench_manifold.py
+++ b/bench/synth_sae_bench_manifold.py
@@ -27,7 +27,7 @@ import numpy as np
 
 import gamfit
 from gamfit._binding import rust_module
-from _synth_sae_metrics import feature_uniqueness, recovery_scores
+from _synth_sae_metrics import feature_uniqueness, n_firing_latents, recovery_scores
 
 
 @dataclass(frozen=True)
@@ -70,6 +70,8 @@ class BenchmarkMetrics:
     direction_recovery_recall: float
     direction_recovery_f1: float
     direction_recovery_jaccard: float
+    n_latent_slots: int
+    n_firing_latents: int
     probing_precision: float
     probing_recall: float
     probing_f1: float
@@ -225,6 +227,29 @@ def _learned_components(fit: gamfit.ManifoldSAE) -> tuple[np.ndarray, np.ndarray
     return np.vstack(directions), np.column_stack(activations)
 
 
+def _manifold_total_slots(fit: gamfit.ManifoldSAE) -> int:
+    """Architectural latent-slot count for a manifold SAE (#1435).
+
+    A manifold SAE allocates ``atoms`` decoder blocks, each expanded over its
+    basis harmonics (``phi.shape[1]``); the intercept row (``row == 0``) carries
+    no direction and is excluded, matching :func:`_learned_components`. The total
+    is ``sum_k (min(n_harmonics_k, block_rows_k) - 1)`` -- the capacity the fit
+    *could* turn into directions, including geometrically-dead (zero-norm) slots
+    that ``_learned_components`` drops. Passing it as the recovery denominator
+    penalizes wasted atom capacity, consistent with how
+    ``synth_sae_compare`` spans the full decoder width.
+    """
+    total = 0
+    for k, block in enumerate(fit.decoder_blocks):
+        basis = fit.basis_specs[k]
+        coords = np.asarray(fit.coords[k], dtype=float)
+        n_harmonics = fit._n_harmonics[k] if k < len(fit._n_harmonics) else 1
+        phi = _basis_values(basis, coords, n_harmonics)
+        # -1: the intercept row (row 0) is never a direction slot.
+        total += max(min(phi.shape[1], block.shape[0]) - 1, 0)
+    return total
+
+
 def _best_f1(score: np.ndarray, truth: np.ndarray) -> tuple[float, float, float]:
     y = np.asarray(truth, dtype=bool)
     s = np.abs(np.asarray(score, dtype=float))
@@ -310,11 +335,16 @@ def run_one(args: argparse.Namespace, seed: int) -> BenchmarkMetrics:
     # MCC and the direction-recovery precision/recall/F1/Jaccard come from the
     # optimal one-to-one matching. The old `len(set(cols)) / len(rows)` was
     # always 1.0 because the assignment never reuses columns. `_learned_components`
-    # already drops zero-norm atom directions, and a manifold SAE has no single
-    # well-defined "total slot" count (atoms x harmonics), so the recovery
-    # denominator is the live direction count here.
+    # drops zero-norm atom directions; spanning the recovery denominator over the
+    # architectural slot count (atoms x harmonics, excl. intercept) so geometrically
+    # dead atom capacity is penalized, consistent with synth_sae_compare (#1435).
+    n_slots = _manifold_total_slots(fit)
     uniqueness = feature_uniqueness(learned_dirs, synth.dictionary)
-    rec = recovery_scores(learned_dirs, synth.dictionary)
+    rec = recovery_scores(learned_dirs, synth.dictionary, n_learned_total=n_slots)
+    # Functional (activation-based) dead-latent count (#1435): a latent with a
+    # nonzero decoder direction that never fires on the eval set is functionally
+    # dead -- wasted capacity the geometric (decoder-norm) live check misses.
+    n_firing = n_firing_latents(learned_test)
     rows, cols, matching = rec.rows, rec.cols, rec.matching
     if rows.size:
         mcc = rec.mcc
@@ -354,6 +384,8 @@ def run_one(args: argparse.Namespace, seed: int) -> BenchmarkMetrics:
         direction_recovery_recall=rec.recall,
         direction_recovery_f1=rec.f1,
         direction_recovery_jaccard=rec.jaccard,
+        n_latent_slots=n_slots,
+        n_firing_latents=n_firing,
         probing_precision=precision,
         probing_recall=recall,
         probing_f1=f1,
@@ -378,6 +410,8 @@ def _summarize(metrics: list[BenchmarkMetrics]) -> dict[str, Any]:
         "direction_recovery_recall",
         "direction_recovery_f1",
         "direction_recovery_jaccard",
+        "n_latent_slots",
+        "n_firing_latents",
         "probing_precision",
         "probing_recall",
         "probing_f1",

--- a/bench/synth_sae_compare.py
+++ b/bench/synth_sae_compare.py
@@ -383,7 +383,7 @@ def _availability() -> dict[str, bool]:
 
 
 def _summarize(rows: list[ModelResult]) -> dict[str, Any]:
-    metrics = ["train_r2", "test_r2", "mcc", "probing_f1", "learned_l0_test", "seconds"]
+    metrics = ["train_r2", "test_r2", "mcc", "probing_f1", "learned_l0_test", "n_firing_latents", "seconds"]
     out: dict[str, Any] = {}
     for model in sorted({r.model for r in rows}):
         model_rows = [r for r in rows if r.model == model]

--- a/bench/synth_sae_compare.py
+++ b/bench/synth_sae_compare.py
@@ -30,7 +30,7 @@ import torch
 
 import gamfit
 from gamfit._binding import rust_module
-from _synth_sae_metrics import feature_uniqueness, recovery_scores
+from _synth_sae_metrics import feature_uniqueness, n_firing_latents, recovery_scores
 from synth_sae_bench_manifold import SynthConfig, SynthSAEBenchData
 
 
@@ -52,6 +52,8 @@ class ModelResult:
     direction_recovery_recall: float
     direction_recovery_f1: float
     direction_recovery_jaccard: float
+    n_latent_slots: int
+    n_firing_latents: int
     probing_precision: float
     probing_recall: float
     probing_f1: float
@@ -170,6 +172,13 @@ def _score(
     uniqueness = feature_uniqueness(dirs, truth_dirs)
     rec = recovery_scores(dirs, truth_dirs, n_learned_total=int(decoder_dirs.shape[0]))
     rows, cols = rec.rows, rec.cols
+    # Functional (activation-based) dead-latent accounting (#1435): a latent
+    # with a nonzero decoder direction that never fires on the eval set is
+    # functionally dead -- wasted capacity the geometric (decoder-norm) live
+    # check above misses. n_latent_slots is the architectural width; the gap
+    # n_latent_slots - n_firing_latents is the functional dead count.
+    n_slots = int(decoder_dirs.shape[0])
+    n_firing = n_firing_latents(test_latents)
     if rows.size:
         mcc = rec.mcc
         live_train = train_latents[:, live]
@@ -197,6 +206,8 @@ def _score(
         direction_recovery_recall=rec.recall,
         direction_recovery_f1=rec.f1,
         direction_recovery_jaccard=rec.jaccard,
+        n_latent_slots=n_slots,
+        n_firing_latents=n_firing,
         probing_precision=precision,
         probing_recall=recall,
         probing_f1=f1,

--- a/bench/test_synth_sae_metrics.py
+++ b/bench/test_synth_sae_metrics.py
@@ -18,7 +18,9 @@ from itertools import permutations
 from _synth_sae_metrics import (
     _hungarian_max_numpy,
     feature_uniqueness,
+    firing_latent_mask,
     match_directions,
+    n_firing_latents,
     recovery_scores,
 )
 
@@ -158,6 +160,44 @@ def test_empty_learned_is_zero() -> None:
     rec = recovery_scores(empty, truth)
     assert (rec.mcc, rec.precision, rec.recall, rec.f1) == (0.0, 0.0, 0.0, 0.0)
     assert rec.rows.size == 0
+
+
+def test_functional_dead_latents_differ_from_geometric() -> None:
+    # #1435: a latent with a nonzero decoder direction that NEVER fires on the
+    # eval set is functionally dead, even though it is geometrically live.
+    # 4 latents x 6 samples; latent index 1 never exceeds the 1e-8 threshold.
+    activations = np.array(
+        [
+            [1.0, 0.0, 0.5, 0.0],
+            [0.0, 0.0, 0.3, 0.0],
+            [2.0, 0.0, 0.0, 1.1],
+            [0.7, 0.0, 0.9, 0.0],
+            [0.0, 0.0, 0.2, 0.8],
+            [1.3, 0.0, 0.6, 0.4],
+        ],
+        dtype=float,
+    )
+    mask = firing_latent_mask(activations)
+    assert mask.tolist() == [True, False, True, True]
+    assert n_firing_latents(activations) == 3
+    # functional dead count = 4 slots - 3 firing
+    assert 4 - n_firing_latents(activations) == 1
+
+
+def test_firing_threshold_respected() -> None:
+    # A latent firing only below the threshold is treated as dead at that
+    # threshold (consistency with the learned_l0 |a|>1e-8 convention).
+    activations = np.array([[1e-9, 1.0], [2e-9, 0.0]], dtype=float)
+    assert n_firing_latents(activations, threshold=1e-8) == 1
+    assert n_firing_latents(activations, threshold=0.0) == 2
+
+
+def test_firing_empty_and_1d() -> None:
+    assert n_firing_latents(np.zeros((5, 0))) == 0
+    assert firing_latent_mask(np.zeros((5, 0))).size == 0
+    # 1-D treated as a single latent.
+    assert n_firing_latents(np.zeros(5)) == 0
+    assert n_firing_latents(np.array([0.0, 0.0, 0.5])) == 1
 
 
 def main() -> None:


### PR DESCRIPTION
## Summary

SynthSAEBench defines a dead latent *functionally* (never fires across the eval set), not just geometrically (zero decoder norm). Both harnesses accounted for geometric deadness only, so a latent with a nonzero decoder direction that never activated was treated as live — wasted capacity that escaped every penalty (#1435).

## Changes

- **`bench/_synth_sae_metrics.py`** — add `firing_latent_mask` / `n_firing_latents`: activation-based live count (a latent fires if `|activation| > threshold` on ≥1 eval sample). `n_slots - n_firing` is the functional dead count. Numpy-only, unit-tested.
- **`bench/synth_sae_compare.py`** — report `n_latent_slots` (architectural width) and `n_firing_latents` on `ModelResult`. Recovery denominator already spanned the full decoder width (#1434); this adds the functional diagnostic so geometric vs functional deadness read off directly.
- **`bench/synth_sae_bench_manifold.py`** — define a principled total-slot count (`_manifold_total_slots`: atoms × harmonics, excluding the intercept row) and pass it as the recovery `n_learned_total` so **geometrically-dead atom capacity is penalized**, consistent with `synth_sae_compare`. This is the core fix: previously the manifold recovery denominator was the live-direction count, so wasted atom capacity was not penalized at all. Also reports `n_latent_slots` / `n_firing_latents`.
- **`bench/test_synth_sae_metrics.py`** — cover functional-vs-geometric divergence, threshold sensitivity, and empty/1-D edge cases.

## Verification

```
$ python3 bench/test_synth_sae_metrics.py   # 14 tests, all pass
ok  test_functional_dead_latents_differ_from_geometric
ok  test_firing_threshold_respected
ok  test_firing_empty_and_1d
... (14 total)
```

The functional-vs-geometric test is the key one: 4 latents × 6 samples where latent 1 has a nonzero direction but never fires → `firing_latent_mask == [T,F,T,T]`, `n_firing=3`, functional dead = 1.

Threshold default `1e-8` matches the existing `learned_l0` `|a|>1e-8` convention already used in both harnesses.

— HomunculusLabs (AI-assisted)
