### PR TITLE
style: apply rustfmt across source tree (follow-up)

### DIFF
--- a/crates/gam-pyffi/src/inference_instruments.rs
+++ b/crates/gam-pyffi/src/inference_instruments.rs
@@ -1466,8 +1466,9 @@ pub(crate) fn adjudicate_atom_shape<'py>(
         },
     ];
 
-    let verdict = adjudicate_cross_class_race(n, candidates, folds, seed, StackingConfig::default())
-        .map_err(py_value_error)?;
+    let verdict =
+        adjudicate_cross_class_race(n, candidates, folds, seed, StackingConfig::default())
+            .map_err(py_value_error)?;
 
     // Per-candidate stacking weights (present because the race mixes the
     // discrete mixture with the smooth candidates → cross-class stacking).

--- a/src/families/bms/cell_moment_assembly.rs
+++ b/src/families/bms/cell_moment_assembly.rs
@@ -3702,16 +3702,8 @@ mod empirical_flex_jet_oracle_tests {
         let b_t = Tower4::<3>::variable(b0, 1);
         let beta0_t = Tower4::<3>::variable(beta0_0, 2);
         let z = fx.family.z[0];
-        let eta = witness_eta_tower::<3>(
-            fx,
-            &a_tower,
-            &b_t,
-            &beta0_t,
-            &beta,
-            z,
-            basis_arg(z),
-            scale,
-        );
+        let eta =
+            witness_eta_tower::<3>(fx, &a_tower, &b_t, &beta0_t, &beta, z, basis_arg(z), scale);
         let signed = eta.scale(2.0 * fx.family.y[0] - 1.0);
         signed.compose_unary(unary_derivatives_neglog_phi(signed.v, fx.family.weights[0]))
     }

--- a/src/families/jet_tower.rs
+++ b/src/families/jet_tower.rs
@@ -1856,7 +1856,11 @@ mod tests {
         let flux = moving_limit_boundary_tower_theta_integrand::<3, 2>(&phi_jet, &z_edge);
 
         // Value channel is 0 by construction (boundary, not the integral itself).
-        assert!(flux.v.abs() < 1e-12, "boundary value channel {:+.3e}", flux.v);
+        assert!(
+            flux.v.abs() < 1e-12,
+            "boundary value channel {:+.3e}",
+            flux.v
+        );
 
         // Oracle (1): central FD of the closed-form boundary flux
         //   Bnd(θ) = Φ(z_edge(θ); θ) − Φ(z₀; θ)   (z₀ FROZEN at the base edge).
@@ -1923,8 +1927,7 @@ mod tests {
 
         // Decisive: the `G·z_uv` term the directional path DROPS is present and
         // material in the [1][1] entry (z_uv = 2 there).
-        let pure_no_zuv =
-            g_z * z_edge.g[1] * z_edge.g[1] + 2.0 * g_theta[1] * z_edge.g[1];
+        let pure_no_zuv = g_z * z_edge.g[1] * z_edge.g[1] + 2.0 * g_theta[1] * z_edge.g[1];
         let g_zuv = flux.h[1][1] - pure_no_zuv;
         assert!(
             (g_zuv - gg * 2.0).abs() < 1e-9,

--- a/src/families/survival/location_scale/family_solver.rs
+++ b/src/families/survival/location_scale/family_solver.rs
@@ -1457,25 +1457,30 @@ impl SurvivalLocationScaleFamily {
                 .ok_or_else(|| "joint d_beta must be contiguous".to_string())?;
             // Distinct ordered permutations of a (possibly repeated) index
             // triple — the support of the fully symmetric g‴ tensor.
-            let contract3 =
-                |g3d: &mut [[f64; SLS_ROW_K]; SLS_ROW_K],
-                 idx: [usize; 3],
-                 v: f64,
-                 dch: &[f64; SLS_ROW_K]| {
-                    const PERMS: [[usize; 3]; 6] =
-                        [[0, 1, 2], [0, 2, 1], [1, 0, 2], [1, 2, 0], [2, 0, 1], [2, 1, 0]];
-                    let mut seen: [(usize, usize, usize); 6] = [(usize::MAX, 0, 0); 6];
-                    let mut n_seen = 0usize;
-                    for pm in PERMS {
-                        let key = (idx[pm[0]], idx[pm[1]], idx[pm[2]]);
-                        if seen[..n_seen].contains(&key) {
-                            continue;
-                        }
-                        seen[n_seen] = key;
-                        n_seen += 1;
-                        g3d[key.0][key.1] += v * dch[key.2];
+            let contract3 = |g3d: &mut [[f64; SLS_ROW_K]; SLS_ROW_K],
+                             idx: [usize; 3],
+                             v: f64,
+                             dch: &[f64; SLS_ROW_K]| {
+                const PERMS: [[usize; 3]; 6] = [
+                    [0, 1, 2],
+                    [0, 2, 1],
+                    [1, 0, 2],
+                    [1, 2, 0],
+                    [2, 0, 1],
+                    [2, 1, 0],
+                ];
+                let mut seen: [(usize, usize, usize); 6] = [(usize::MAX, 0, 0); 6];
+                let mut n_seen = 0usize;
+                for pm in PERMS {
+                    let key = (idx[pm[0]], idx[pm[1]], idx[pm[2]]);
+                    if seen[..n_seen].contains(&key) {
+                        continue;
                     }
-                };
+                    seen[n_seen] = key;
+                    n_seen += 1;
+                    g3d[key.0][key.1] += v * dch[key.2];
+                }
+            };
             let g_contrib = (0..self.n)
                 .into_par_iter()
                 .fold(
@@ -1503,10 +1508,11 @@ impl SurvivalLocationScaleFamily {
                         gp[8] = e * p[3];
                         // g″ (symmetric channel Hessian).
                         let mut g2 = [[0.0_f64; SLS_ROW_K]; SLS_ROW_K];
-                        let set2 = |t: &mut [[f64; SLS_ROW_K]; SLS_ROW_K], a: usize, b: usize, v: f64| {
-                            t[a][b] = v;
-                            t[b][a] = v;
-                        };
+                        let set2 =
+                            |t: &mut [[f64; SLS_ROW_K]; SLS_ROW_K], a: usize, b: usize, v: f64| {
+                                t[a][b] = v;
+                                t[b][a] = v;
+                            };
                         set2(&mut g2, 3, 8, e);
                         set2(&mut g2, 3, 6, -e * p[8]);
                         set2(&mut g2, 5, 6, e);

--- a/src/families/survival/predict.rs
+++ b/src/families/survival/predict.rs
@@ -12,9 +12,6 @@ use std::collections::HashMap;
 use ndarray::{Array1, Array2, ArrayView2, s};
 
 use crate::families::scale_design::scale_transform_from_payload;
-use crate::families::survival::{
-    CompetingRisksCifResult, assemble_competing_risks_cif_from_endpoints,
-};
 use crate::families::survival::construction::{
     SurvivalBaselineConfig, SurvivalBaselineTarget, SurvivalLikelihoodMode,
     SurvivalTimeBuildOutput, add_survival_time_derivative_guard_offset, build_survival_time_basis,
@@ -25,6 +22,9 @@ use crate::families::survival::construction::{
     survival_derivative_guard_for_likelihood, survival_likelihood_modename,
 };
 use crate::families::survival::lognormal_kernel::FrailtySpec;
+use crate::families::survival::{
+    CompetingRisksCifResult, assemble_competing_risks_cif_from_endpoints,
+};
 use crate::families::wiggle::buildwiggle_block_input_from_knots;
 use crate::inference::model::{
     FittedFamily, FittedModel as SavedModel, SavedBaselineTimeWiggleRuntime,

--- a/src/identifiability/audit.rs
+++ b/src/identifiability/audit.rs
@@ -1138,7 +1138,8 @@ fn audit_identifiability_impl(
         p_total,
         block_priority_summary.join(", "),
     );
-    let tiered = priority_tiered_rank_from_gram(&joint_gram_aug, &col_priority, joint_rank_m_rows, alpha);
+    let tiered =
+        priority_tiered_rank_from_gram(&joint_gram_aug, &col_priority, joint_rank_m_rows, alpha);
     log::info!(
         "[STAGE] identifiability audit: joint priority-tiered RRQR end rank={}/{} elapsed={:.3}s",
         tiered.rank,
@@ -1147,8 +1148,7 @@ fn audit_identifiability_impl(
     );
     let joint_rank = tiered.rank;
     let joint_rank_tol = tiered.rank_tol;
-    let demoted_joint_cols: Vec<usize> =
-        tiered.column_permutation[tiered.rank..].to_vec();
+    let demoted_joint_cols: Vec<usize> = tiered.column_permutation[tiered.rank..].to_vec();
 
     // Pairwise overlap report on the joint design's normalised
     // columns. O(p_total² · n) — fine at GAM smooth widths. We only

--- a/src/identifiability/canonical.rs
+++ b/src/identifiability/canonical.rs
@@ -1170,8 +1170,7 @@ fn canonicalize_for_identifiability_inner(
             // the per-block `effective_dim` sums to the rank the drop convention
             // kept, i.e. the audit's own joint_rank verdict — the quantity the
             // strict invariant ultimately certifies `T` preserved.
-            let audit_kept_rank: usize =
-                audit.blocks.iter().map(|b| b.effective_dim).sum();
+            let audit_kept_rank: usize = audit.blocks.iter().map(|b| b.effective_dim).sum();
 
             log::info!(
                 "[CANON] post-T invariant ({} convention): \

--- a/src/solver/mod.rs
+++ b/src/solver/mod.rs
@@ -59,10 +59,10 @@ pub use topology_selector::{
     STACKING_CV_SEED, TopologyAutoFitEvidence, TopologyAutoRankedFit, TopologyAutoSelector,
     TopologyAutoSelectorResult, TopologyRaceParallelCandidate, UnionRungFit, UnionRungResult,
     adjudicate_cross_class_race, build_cv_log_density_table, deterministic_cv_folds,
-    deterministic_cv_folds_seeded,
-    fit_mixture_rung, fit_union_candidate, fit_union_rung, mixture_density_provider,
-    parse_union_name, run_topology_race_parallel, select_topology_with_fit,
-    select_topology_with_fit_parallel, tk_normalized_score, union_density_provider,
+    deterministic_cv_folds_seeded, fit_mixture_rung, fit_union_candidate, fit_union_rung,
+    mixture_density_provider, parse_union_name, run_topology_race_parallel,
+    select_topology_with_fit, select_topology_with_fit_parallel, tk_normalized_score,
+    union_density_provider,
 };
 
 /// Process-wide counter of smoothing-corrections that took the sigma-cubature

--- a/src/solver/topology_selector.rs
+++ b/src/solver/topology_selector.rs
@@ -1700,15 +1700,14 @@ mod tests {
                 density_provider: trivial_provider(),
             },
         ];
-        let verdict =
-            adjudicate_cross_class_race(
-                8,
-                near,
-                STACKING_CV_FOLDS,
-                STACKING_CV_SEED,
-                StackingConfig::default(),
-            )
-            .expect("same-class race");
+        let verdict = adjudicate_cross_class_race(
+            8,
+            near,
+            STACKING_CV_FOLDS,
+            STACKING_CV_SEED,
+            StackingConfig::default(),
+        )
+        .expect("same-class race");
         assert!(!verdict.is_cross_class);
         assert_eq!(verdict.winner_index, 0);
         let escalation = verdict
@@ -1734,15 +1733,14 @@ mod tests {
                 density_provider: trivial_provider(),
             },
         ];
-        let verdict_far =
-            adjudicate_cross_class_race(
-                8,
-                far,
-                STACKING_CV_FOLDS,
-                STACKING_CV_SEED,
-                StackingConfig::default(),
-            )
-            .expect("same-class race");
+        let verdict_far = adjudicate_cross_class_race(
+            8,
+            far,
+            STACKING_CV_FOLDS,
+            STACKING_CV_SEED,
+            StackingConfig::default(),
+        )
+        .expect("same-class race");
         assert_eq!(verdict_far.winner_index, 0);
         assert!(
             verdict_far.insufficient_margin.is_none(),
@@ -1800,10 +1798,7 @@ mod tests {
 
         // Flatten a partition into a per-sample fold-of-sample vector so two
         // foldings can be compared sample-by-sample regardless of fold order.
-        fn fold_of_sample(
-            n: usize,
-            partition: &[(Vec<usize>, Vec<usize>)],
-        ) -> Vec<Option<usize>> {
+        fn fold_of_sample(n: usize, partition: &[(Vec<usize>, Vec<usize>)]) -> Vec<Option<usize>> {
             let mut assign = vec![None; n];
             for (fold, (_train, eval)) in partition.iter().enumerate() {
                 for &i in eval {
@@ -1836,7 +1831,10 @@ mod tests {
         // seed, so existing seed-less call sites keep their deterministic folding.
         assert_eq!(
             fold_of_sample(N, &deterministic_cv_folds(N, FOLDS)),
-            fold_of_sample(N, &deterministic_cv_folds_seeded(N, FOLDS, STACKING_CV_SEED)),
+            fold_of_sample(
+                N,
+                &deterministic_cv_folds_seeded(N, FOLDS, STACKING_CV_SEED)
+            ),
             "deterministic_cv_folds must equal the default-seeded folding"
         );
     }

--- a/src/terms/analytic_penalties/tests.rs
+++ b/src/terms/analytic_penalties/tests.rs
@@ -354,7 +354,10 @@ fn ibp_cross_row_woodbury_dd_and_logit_curvature_match_finite_difference() {
             assert_abs_diff_eq!(analytic, fd, epsilon = 1.0e-5);
         }
     }
-    assert!(max_dd < 1.0e-5, "cross_row_dd·J vs FD max err = {max_dd:.3e}");
+    assert!(
+        max_dd < 1.0e-5,
+        "cross_row_dd·J vs FD max err = {max_dd:.3e}"
+    );
 }
 
 #[test]

--- a/src/terms/basis/bspline_build.rs
+++ b/src/terms/basis/bspline_build.rs
@@ -208,9 +208,9 @@ pub fn build_bspline_basis_1d(
                 )
             };
         let (penalties, nullspace_dims, penaltyinfo, null_eigenvectors, ops) =
-            filter_active_penalty_candidates_with_ops(
-            renormalize_constrained_penalty_candidates(transformed_candidates),
-        )?;
+            filter_active_penalty_candidates_with_ops(renormalize_constrained_penalty_candidates(
+                transformed_candidates,
+            ))?;
         return Ok(BasisBuildResult {
             design,
             penalties,
@@ -314,9 +314,9 @@ pub fn build_bspline_basis_1d(
                 Some(chunk),
             )?;
         let (penalties, nullspace_dims, penaltyinfo, null_eigenvectors, ops) =
-            filter_active_penalty_candidates_with_ops(
-            renormalize_constrained_penalty_candidates(transformed_candidates),
-        )?;
+            filter_active_penalty_candidates_with_ops(renormalize_constrained_penalty_candidates(
+                transformed_candidates,
+            ))?;
         return Ok(BasisBuildResult {
             design,
             penalties,
@@ -613,9 +613,9 @@ pub fn build_bspline_basis_1d(
             )
         };
     let (penalties, nullspace_dims, penaltyinfo, null_eigenvectors, ops) =
-        filter_active_penalty_candidates_with_ops(
-            renormalize_constrained_penalty_candidates(transformed_candidates),
-        )?;
+        filter_active_penalty_candidates_with_ops(renormalize_constrained_penalty_candidates(
+            transformed_candidates,
+        ))?;
     Ok(BasisBuildResult {
         design,
         penalties,

--- a/src/terms/basis/periodic_duchon.rs
+++ b/src/terms/basis/periodic_duchon.rs
@@ -1067,8 +1067,7 @@ pub(crate) fn build_duchon_basis_mixed_periodicity(
     // Design = [K @ Z, P(data)] — the kernel columns plus the explicit
     // unpenalised polynomial columns (in the non-periodic coordinates only).
     let design_kernel = fast_ab(&raw_kernel, &z);
-    let poly_block_data =
-        mixed_periodicity_nullspace_poly_block(data, user_m, periodic_per_axis);
+    let poly_block_data = mixed_periodicity_nullspace_poly_block(data, user_m, periodic_per_axis);
     let mut basis = Array2::<f64>::zeros((n_data, kernel_cols + n_poly));
     basis
         .slice_mut(s![.., 0..kernel_cols])

--- a/src/terms/basis/radial_jets_nd.rs
+++ b/src/terms/basis/radial_jets_nd.rs
@@ -1314,8 +1314,7 @@ fn mixed_periodicity_additive_design_and_jets(
     let n_rows = t.nrows();
     let n_centers = centers.nrows();
     let m = duchon_p_from_nullspace_order(nullspace_order);
-    let axis_bounds =
-        crate::basis::mixed_periodicity_axis_bounds(centers, periodic_per_axis);
+    let axis_bounds = crate::basis::mixed_periodicity_axis_bounds(centers, periodic_per_axis);
 
     // Non-periodic-only polynomial null space `Z = null(Pᵀ)`.
     let poly_block_centers =
@@ -1325,8 +1324,7 @@ fn mixed_periodicity_additive_design_and_jets(
 
     // Non-periodic axis order + monomial exponents over the non-periodic axes
     // (used for the explicit polynomial columns + their jet/Hessian).
-    let nonperiodic_axes: Vec<usize> =
-        (0..dim).filter(|&j| !periodic_per_axis[j]).collect();
+    let nonperiodic_axes: Vec<usize> = (0..dim).filter(|&j| !periodic_per_axis[j]).collect();
     let max_degree = m.saturating_sub(1);
     let exps = monomial_exponents(nonperiodic_axes.len(), max_degree);
     let n_poly = exps.len();
@@ -1355,8 +1353,7 @@ fn mixed_periodicity_additive_design_and_jets(
 
     // --- design = [value·Z, P(t)] ---
     let kernel_design = fast_ab(&value, &z);
-    let poly_design =
-        crate::basis::mixed_periodicity_nullspace_poly_block(t, m, periodic_per_axis);
+    let poly_design = crate::basis::mixed_periodicity_nullspace_poly_block(t, m, periodic_per_axis);
     if poly_design.ncols() != n_poly {
         crate::bail_dim_basis!(
             "mixed-periodicity additive jets: polynomial block has {} columns but expected {n_poly}",

--- a/src/terms/basis/sphere_basis.rs
+++ b/src/terms/basis/sphere_basis.rs
@@ -3499,8 +3499,7 @@ pub fn build_matern_basis_log_kappa_aniso_derivatives(
         if !result.penalties_first.is_empty() {
             let num_blocks = result.penalties_first[0].len();
             for block in 0..num_blocks {
-                let mut eta_mean =
-                    Array2::<f64>::zeros(result.penalties_first[0][block].raw_dim());
+                let mut eta_mean = Array2::<f64>::zeros(result.penalties_first[0][block].raw_dim());
                 for axis in 0..dim {
                     if result.penalties_first[axis][block].raw_dim()
                         != result.penalties_first[0][block].raw_dim()

--- a/src/terms/construction.rs
+++ b/src/terms/construction.rs
@@ -1248,8 +1248,7 @@ pub fn canonicalize_penalty_spec(
     // own `rank` / `nullity` / `negative_dim` about which directions are
     // penalized, unpenalized, or non-PSD (#1425).
     let tolerance = analysis.tol;
-    let classes =
-        crate::basis::SpectralClassification::new(&analysis.eigenvalues, tolerance);
+    let classes = crate::basis::SpectralClassification::new(&analysis.eigenvalues, tolerance);
     let rank_k = classes.rank();
     debug_assert_eq!(rank_k, analysis.rank);
 

--- a/src/terms/sae/manifold/construction.rs
+++ b/src/terms/sae/manifold/construction.rs
@@ -3794,7 +3794,11 @@ impl SaeManifoldTerm {
                     .max()
                     .unwrap_or(0)
                     .max(1);
-                let max_q_row = (0..n).map(|r| layout.row_q_active(r)).max().unwrap_or(q).max(1);
+                let max_q_row = (0..n)
+                    .map(|r| layout.row_q_active(r))
+                    .max()
+                    .unwrap_or(q)
+                    .max(1);
                 (max_active, max_q_row)
             }
             None => (k_atoms, q),
@@ -4277,92 +4281,94 @@ impl SaeManifoldTerm {
                     let mut weighted_phi: Vec<(usize, Vec<f64>)> =
                         Vec::with_capacity(row_active.len());
                     if !fixed_decoder {
-                    for &atom_idx in row_active {
-                        let atom = &self.atoms[atom_idx];
-                        let atom_beta_off = beta_offsets[atom_idx];
-                        let m = atom.basis_size();
-                        let a_k = assignments[atom_idx];
-                        let mut wphi = Vec::with_capacity(m);
-                        for basis_col in 0..m {
-                            let phi = atom.basis_values[[row, basis_col]];
-                            // #991 design-honesty seam, β leg: the `√w_row` here pairs
-                            // with the `√w_row` on the residual (β gradient =
-                            // `a·φ · M r` ⇒ w_row) and with itself (β Gram `G` and the
-                            // htbeta Kronecker capture ⇒ w_row). `1.0` when unweighted.
-                            let w = a_k * phi * sqrt_row_w;
-                            a_phi.push((atom_beta_off + basis_col * p, w));
-                            wphi.push(w);
-                        }
-                        weighted_phi.push((atom_idx, wphi));
-                    }
-                    // β data-fit gradient `gᵦ += J_βᵀ M_n r_n`. The β-Jacobian is
-                    // `J_β = φ_nᵀ ⊗ I_p`, so `J_βᵀ M_n r_n = φ_n ⊗ (M_n r_n)` —
-                    // contract the basis weight `a·φ` against the p-space metric-applied
-                    // residual `error_metric` (= `M_n r_n`), the SAME whitening the value
-                    // path and t-block share. When not whitening, `error_metric == error`
-                    // and this is byte-identical to the historical `J_βᵀ r`.
-                    for &(beta_base_i, j_beta_i) in a_phi.iter() {
-                        if j_beta_i == 0.0 {
-                            continue;
-                        }
-                        for out_col in 0..p {
-                            gb_delta
-                                .push((beta_base_i + out_col, j_beta_i * error_metric[out_col]));
-                            // No dense hbb write — the sparse `G ⊗ I_p` op installed
-                            // after the loop carries the data-fit GN β-Hessian.
-                        }
-                    }
-                    if frames_engaged {
                         for &atom_idx in row_active {
                             let atom = &self.atoms[atom_idx];
+                            let atom_beta_off = beta_offsets[atom_idx];
                             let m = atom.basis_size();
                             let a_k = assignments[atom_idx];
+                            let mut wphi = Vec::with_capacity(m);
                             for basis_col in 0..m {
                                 let phi = atom.basis_values[[row, basis_col]];
+                                // #991 design-honesty seam, β leg: the `√w_row` here pairs
+                                // with the `√w_row` on the residual (β gradient =
+                                // `a·φ · M r` ⇒ w_row) and with itself (β Gram `G` and the
+                                // htbeta Kronecker capture ⇒ w_row). `1.0` when unweighted.
                                 let w = a_k * phi * sqrt_row_w;
-                                if w == 0.0 {
-                                    continue;
-                                }
-                                let c_base = frame_projection.border_offsets[atom_idx]
-                                    + basis_col * frame_projection.ranks[atom_idx];
-                                for c in 0..q_row {
-                                    let mut hrow = block.htbeta.row_mut(c);
-                                    let hrow_slice =
-                                        hrow.as_slice_mut().expect("htbeta row is contiguous");
-                                    for out_col in 0..p {
-                                        let value = local_jac_row[[c, out_col]] * w;
-                                        frame_projection.accumulate_output_project(
-                                            atom_idx, c_base, out_col, value, hrow_slice,
-                                        );
+                                a_phi.push((atom_beta_off + basis_col * p, w));
+                                wphi.push(w);
+                            }
+                            weighted_phi.push((atom_idx, wphi));
+                        }
+                        // β data-fit gradient `gᵦ += J_βᵀ M_n r_n`. The β-Jacobian is
+                        // `J_β = φ_nᵀ ⊗ I_p`, so `J_βᵀ M_n r_n = φ_n ⊗ (M_n r_n)` —
+                        // contract the basis weight `a·φ` against the p-space metric-applied
+                        // residual `error_metric` (= `M_n r_n`), the SAME whitening the value
+                        // path and t-block share. When not whitening, `error_metric == error`
+                        // and this is byte-identical to the historical `J_βᵀ r`.
+                        for &(beta_base_i, j_beta_i) in a_phi.iter() {
+                            if j_beta_i == 0.0 {
+                                continue;
+                            }
+                            for out_col in 0..p {
+                                gb_delta.push((
+                                    beta_base_i + out_col,
+                                    j_beta_i * error_metric[out_col],
+                                ));
+                                // No dense hbb write — the sparse `G ⊗ I_p` op installed
+                                // after the loop carries the data-fit GN β-Hessian.
+                            }
+                        }
+                        if frames_engaged {
+                            for &atom_idx in row_active {
+                                let atom = &self.atoms[atom_idx];
+                                let m = atom.basis_size();
+                                let a_k = assignments[atom_idx];
+                                for basis_col in 0..m {
+                                    let phi = atom.basis_values[[row, basis_col]];
+                                    let w = a_k * phi * sqrt_row_w;
+                                    if w == 0.0 {
+                                        continue;
+                                    }
+                                    let c_base = frame_projection.border_offsets[atom_idx]
+                                        + basis_col * frame_projection.ranks[atom_idx];
+                                    for c in 0..q_row {
+                                        let mut hrow = block.htbeta.row_mut(c);
+                                        let hrow_slice =
+                                            hrow.as_slice_mut().expect("htbeta row is contiguous");
+                                        for out_col in 0..p {
+                                            let value = local_jac_row[[c, out_col]] * w;
+                                            frame_projection.accumulate_output_project(
+                                                atom_idx, c_base, out_col, value, hrow_slice,
+                                            );
+                                        }
                                     }
                                 }
                             }
                         }
-                    }
-                    // Data-fit GN β-Hessian: accumulate the channel-independent block
-                    // `G[μ_i, μ_j] += (a_k φ_k)[μ_i] (a_{k'} φ_{k'})[μ_j]` into the
-                    // sparse per-atom-pair map (the `out_col` dimension is carried by
-                    // `I_p`). Only co-occurring `(atom_i, atom_j)` pairs are touched.
-                    for ai in 0..weighted_phi.len() {
-                        let (atom_i, ref wphi_i) = weighted_phi[ai];
-                        let m_i = wphi_i.len();
-                        for aj in 0..weighted_phi.len() {
-                            let (atom_j, ref wphi_j) = weighted_phi[aj];
-                            let m_j = wphi_j.len();
-                            let blk = g_blocks
-                                .entry((atom_i, atom_j))
-                                .or_insert_with(|| Array2::<f64>::zeros((m_i, m_j)));
-                            for li in 0..m_i {
-                                let wi = wphi_i[li];
-                                if wi == 0.0 {
-                                    continue;
-                                }
-                                for lj in 0..m_j {
-                                    blk[[li, lj]] += wi * wphi_j[lj];
+                        // Data-fit GN β-Hessian: accumulate the channel-independent block
+                        // `G[μ_i, μ_j] += (a_k φ_k)[μ_i] (a_{k'} φ_{k'})[μ_j]` into the
+                        // sparse per-atom-pair map (the `out_col` dimension is carried by
+                        // `I_p`). Only co-occurring `(atom_i, atom_j)` pairs are touched.
+                        for ai in 0..weighted_phi.len() {
+                            let (atom_i, ref wphi_i) = weighted_phi[ai];
+                            let m_i = wphi_i.len();
+                            for aj in 0..weighted_phi.len() {
+                                let (atom_j, ref wphi_j) = weighted_phi[aj];
+                                let m_j = wphi_j.len();
+                                let blk = g_blocks
+                                    .entry((atom_i, atom_j))
+                                    .or_insert_with(|| Array2::<f64>::zeros((m_i, m_j)));
+                                for li in 0..m_i {
+                                    let wi = wphi_i[li];
+                                    if wi == 0.0 {
+                                        continue;
+                                    }
+                                    for lj in 0..m_j {
+                                        blk[[li, lj]] += wi * wphi_j[lj];
+                                    }
                                 }
                             }
                         }
-                    }
                     } // #1407 end `if !fixed_decoder` β-tier accumulation
                     let (kron_a_phi, kron_jac) = if !frames_engaged && !fixed_decoder {
                         // Flatten local_jac_row row-major into a plain Vec<f64> (q_row * p entries).
@@ -4450,8 +4456,11 @@ impl SaeManifoldTerm {
                             let htt_e = sys.rows[row_idx].htt.clone();
                             sys.rows[row_idx].gt =
                                 manifold_i.project_gradient_to_tangent(t_i, gt_e.view());
-                            sys.rows[row_idx].htt = manifold_i
-                                .riemannian_hessian_matrix(t_i, gt_e.view(), htt_e.view());
+                            sys.rows[row_idx].htt = manifold_i.riemannian_hessian_matrix(
+                                t_i,
+                                gt_e.view(),
+                                htt_e.view(),
+                            );
                         }
                     }
                 }
@@ -6968,9 +6977,10 @@ impl SaeManifoldTerm {
                         let mut rhs_t = Array1::<f64>::zeros(total_t);
                         let rhs_beta = Array1::<f64>::zeros(cache.k);
                         rhs_t[cache.row_offsets[i] + k] = 1.0;
-                        let solved = solver.solve(rhs_t.view(), rhs_beta.view()).map_err(|err| {
-                            format!("assignment_log_strength_hessian_trace: {err}")
-                        })?;
+                        let solved =
+                            solver.solve(rhs_t.view(), rhs_beta.view()).map_err(|err| {
+                                format!("assignment_log_strength_hessian_trace: {err}")
+                            })?;
                         for j in 0..n {
                             if j == i {
                                 continue;
@@ -8273,8 +8283,7 @@ impl SaeManifoldTerm {
                     let j_wk = channels.z_jac[row * k_atoms + atom];
                     let c_wk = channels.logit_curvature[row * k_atoms + atom];
                     // term A + term B.
-                    gamma_t[t_index] +=
-                        0.5 * dd_k * j_wk * jt_hinv_j + d_k * c_wk * x_k.t[t_index];
+                    gamma_t[t_index] += 0.5 * dd_k * j_wk * jt_hinv_j + d_k * c_wk * x_k.t[t_index];
                 }
             }
         }
@@ -8343,7 +8352,8 @@ impl SaeManifoldTerm {
                 let scale = rho.lambda_sparse() * sparsity * inv_tau * inv_tau;
                 Some((
                     crate::terms::analytic_penalties::SoftmaxAssignmentSparsityPenalty::new(
-                        k_atoms, temperature,
+                        k_atoms,
+                        temperature,
                     ),
                     scale,
                 ))
@@ -8430,13 +8440,17 @@ impl SaeManifoldTerm {
                 let h_entropy = penalty.row_dense_hessian(&row_logits, *scale);
                 let g_fisher = penalty.row_fisher_metric(&row_logits, *scale);
                 for (a, va) in jets.vars.iter().enumerate() {
-                    let SaeLocalRowVar::Logit { atom: ka } = *va else { continue };
+                    let SaeLocalRowVar::Logit { atom: ka } = *va else {
+                        continue;
+                    };
                     if ka >= assignment_dim {
                         continue;
                     }
                     let mut acc = 0.0_f64;
                     for (b, vb) in jets.vars.iter().enumerate() {
-                        let SaeLocalRowVar::Logit { atom: kb } = *vb else { continue };
+                        let SaeLocalRowVar::Logit { atom: kb } = *vb else {
+                            continue;
+                        };
                         if kb >= assignment_dim {
                             continue;
                         }
@@ -8448,7 +8462,9 @@ impl SaeManifoldTerm {
 
             // (3) periodic ARD: ΔC_coord = (V'' − max(V'',0)) = min(V'',0), diagonal.
             for (a, va) in jets.vars.iter().enumerate() {
-                let SaeLocalRowVar::Coord { atom, axis } = *va else { continue };
+                let SaeLocalRowVar::Coord { atom, axis } = *va else {
+                    continue;
+                };
                 if rho.log_ard[atom].is_empty() {
                     continue;
                 }
@@ -8485,24 +8501,26 @@ impl SaeManifoldTerm {
         solver: &DeflatedArrowSolver<'_>,
         rhs: &SaeArrowVector,
     ) -> Result<SaeArrowVector, String> {
-        let x0 = solver.solve(rhs.t.view(), rhs.beta.view()).map_err(|err| {
-            format!("solve_exact_stationarity: B inverse: {err}")
-        })?;
-        let mut x = SaeArrowVector { t: x0.t.clone(), beta: x0.beta.clone() };
+        let x0 = solver
+            .solve(rhs.t.view(), rhs.beta.view())
+            .map_err(|err| format!("solve_exact_stationarity: B inverse: {err}"))?;
+        let mut x = SaeArrowVector {
+            t: x0.t.clone(),
+            beta: x0.beta.clone(),
+        };
         // Fixed-point Neumann iteration with B⁻¹ preconditioner.
         const MAX_ITERS: usize = 24;
         const REL_TOL: f64 = 1.0e-10;
-        let x0_norm = x0
-            .t
-            .iter()
-            .chain(x0.beta.iter())
-            .fold(0.0_f64, |m, &v| m.max(v.abs()))
-            .max(1.0);
+        let x0_norm =
+            x0.t.iter()
+                .chain(x0.beta.iter())
+                .fold(0.0_f64, |m, &v| m.max(v.abs()))
+                .max(1.0);
         for _ in 0..MAX_ITERS {
             let dc = self.apply_exact_hessian_minus_b(rho, target, cache, &x)?;
-            let corr = solver.solve(dc.t.view(), dc.beta.view()).map_err(|err| {
-                format!("solve_exact_stationarity: B preconditioner: {err}")
-            })?;
+            let corr = solver
+                .solve(dc.t.view(), dc.beta.view())
+                .map_err(|err| format!("solve_exact_stationarity: B preconditioner: {err}"))?;
             let mut max_delta = 0.0_f64;
             for idx in 0..x.t.len() {
                 let next = x0.t[idx] - corr.t[idx];
@@ -8590,8 +8608,7 @@ impl SaeManifoldTerm {
         // biased by `(B⁻¹ − A⁻¹)`.
         for coord in 0..n_params {
             let rhs = self.outer_rho_gradient_ift_rhs(rho, target, coord, cache)?;
-            let solved =
-                self.solve_exact_stationarity(rho, target, cache, solver, &rhs)?;
+            let solved = self.solve_exact_stationarity(rho, target, cache, solver, &rhs)?;
             let mut dot = 0.0_f64;
             for idx in 0..gamma.t.len() {
                 dot += gamma.t[idx] * solved.t[idx];

--- a/src/terms/term_builder.rs
+++ b/src/terms/term_builder.rs
@@ -552,8 +552,7 @@ pub fn build_termspec(
                                     smooth: Box::new(inner_basis),
                                     by_kind: ByVarKind::Factor {
                                         feature_col: by_col,
-                                        ordered: option_bool(options, "ordered")
-                                            .unwrap_or(false),
+                                        ordered: option_bool(options, "ordered").unwrap_or(false),
                                         frozen_levels: Some(frozen_levels),
                                     },
                                 },

--- a/tests/audit_penalty_spectrum_three_way_classification.rs
+++ b/tests/audit_penalty_spectrum_three_way_classification.rs
@@ -76,7 +76,10 @@ fn psd_penalty_has_empty_negative_class() {
     let penalty = diag_penalty(&[4.0, 2.0, 1.0, 0.0]);
     let block = analyze_penalty_block(&penalty).expect("analyze");
 
-    assert_eq!(block.negative_dim, 0, "a PSD penalty has no negative curvature");
+    assert_eq!(
+        block.negative_dim, 0,
+        "a PSD penalty has no negative curvature"
+    );
     assert_eq!(block.rank, 3, "three positive eigenvalues");
     assert_eq!(block.nullity, 1, "one null direction");
     assert_eq!(

--- a/tests/diag_numrobust_hunt.rs
+++ b/tests/diag_numrobust_hunt.rs
@@ -65,32 +65,67 @@ fn diag_numrobust() {
 
     // AXIS 1: extreme y scale (1e8) and tiny y scale (1e-8).
     let y_big: Vec<f64> = base_y.iter().map(|y| y * 1e8).collect();
-    summarize("y_scale_1e8", &fit_from_formula("y ~ s(x)", &dataset_xy(base_x.clone(), y_big), &cfg));
+    summarize(
+        "y_scale_1e8",
+        &fit_from_formula("y ~ s(x)", &dataset_xy(base_x.clone(), y_big), &cfg),
+    );
     let y_small: Vec<f64> = base_y.iter().map(|y| y * 1e-8).collect();
-    summarize("y_scale_1e-8", &fit_from_formula("y ~ s(x)", &dataset_xy(base_x.clone(), y_small), &cfg));
+    summarize(
+        "y_scale_1e-8",
+        &fit_from_formula("y ~ s(x)", &dataset_xy(base_x.clone(), y_small), &cfg),
+    );
 
     // AXIS 2: extreme x scale.
     let x_big: Vec<f64> = base_x.iter().map(|x| x * 1e8).collect();
-    summarize("x_scale_1e8", &fit_from_formula("y ~ s(x)", &dataset_xy(x_big, base_y.clone()), &cfg));
+    summarize(
+        "x_scale_1e8",
+        &fit_from_formula("y ~ s(x)", &dataset_xy(x_big, base_y.clone()), &cfg),
+    );
     let x_small: Vec<f64> = base_x.iter().map(|x| x * 1e-8).collect();
-    summarize("x_scale_1e-8", &fit_from_formula("y ~ s(x)", &dataset_xy(x_small, base_y.clone()), &cfg));
+    summarize(
+        "x_scale_1e-8",
+        &fit_from_formula("y ~ s(x)", &dataset_xy(x_small, base_y.clone()), &cfg),
+    );
 
     // AXIS 3: zero-variance y (all identical).
     let y_const: Vec<f64> = vec![3.5; n];
-    summarize("y_zero_variance", &fit_from_formula("y ~ s(x)", &dataset_xy(base_x.clone(), y_const), &cfg));
+    summarize(
+        "y_zero_variance",
+        &fit_from_formula("y ~ s(x)", &dataset_xy(base_x.clone(), y_const), &cfg),
+    );
 
     // AXIS 4: single unique x (collinear / degenerate design).
     let x_const: Vec<f64> = vec![0.5; n];
-    summarize("x_single_value", &fit_from_formula("y ~ s(x)", &dataset_xy(x_const, base_y.clone()), &cfg));
+    summarize(
+        "x_single_value",
+        &fit_from_formula("y ~ s(x)", &dataset_xy(x_const, base_y.clone()), &cfg),
+    );
 
     // AXIS 5: tiny n.
-    summarize("n2", &fit_from_formula("y ~ s(x)", &dataset_xy(vec![0.1, 0.9], vec![1.0, 2.0]), &cfg));
-    summarize("n3", &fit_from_formula("y ~ s(x)", &dataset_xy(vec![0.1, 0.5, 0.9], vec![1.0, 0.5, 2.0]), &cfg));
+    summarize(
+        "n2",
+        &fit_from_formula(
+            "y ~ s(x)",
+            &dataset_xy(vec![0.1, 0.9], vec![1.0, 2.0]),
+            &cfg,
+        ),
+    );
+    summarize(
+        "n3",
+        &fit_from_formula(
+            "y ~ s(x)",
+            &dataset_xy(vec![0.1, 0.5, 0.9], vec![1.0, 0.5, 2.0]),
+            &cfg,
+        ),
+    );
 
     // AXIS 6: x with a single huge outlier (heavy leverage).
     let mut x_out = base_x.clone();
     x_out[0] = 1e12;
-    summarize("x_outlier_1e12", &fit_from_formula("y ~ s(x)", &dataset_xy(x_out, base_y.clone()), &cfg));
+    summarize(
+        "x_outlier_1e12",
+        &fit_from_formula("y ~ s(x)", &dataset_xy(x_out, base_y.clone()), &cfg),
+    );
 
     // AXIS 7: y with one Inf/NaN — should be a CLEAN error not a panic/silent.
     let mut y_inf = base_y.clone();

--- a/tests/issue_1427_factor_by_single_centering.rs
+++ b/tests/issue_1427_factor_by_single_centering.rs
@@ -79,8 +79,8 @@ fn factor_by_level_keeps_k_minus_one_smooth_columns() {
     //   total = L + L*(K-1) = L*K.
     // The #1427 double-centering bug gives K-2 per level, i.e. total = L*(K-1).
     const L: usize = 3;
-    let byfit = fit_from_formula(&format!("y ~ s(x, by=g, k={K})"), &data, &cfg)
-        .expect("by-factor fit ok");
+    let byfit =
+        fit_from_formula(&format!("y ~ s(x, by=g, k={K})"), &data, &cfg).expect("by-factor fit ok");
     let total = ncols(&byfit);
 
     let non_smooth = L; // intercept + (L-1) treatment contrasts

--- a/tests/quality/quality_mixture_rung_vs_reference.rs
+++ b/tests/quality/quality_mixture_rung_vs_reference.rs
@@ -376,15 +376,14 @@ fn cluster_regime_gam_selects_mixture_and_recovers_k_match_or_beat_sklearn() {
 
     // gam cross-class adjudication: must headline the mixture rung.
     let candidates = build_cross_class_candidates(data.view(), cfg);
-    let verdict =
-        adjudicate_cross_class_race(
-            N,
-            candidates,
-            STACKING_CV_FOLDS,
-            STACKING_CV_SEED,
-            StackingConfig::default(),
-        )
-        .expect("cross-class race adjudicates on cluster data");
+    let verdict = adjudicate_cross_class_race(
+        N,
+        candidates,
+        STACKING_CV_FOLDS,
+        STACKING_CV_SEED,
+        StackingConfig::default(),
+    )
+    .expect("cross-class race adjudicates on cluster data");
 
     let winner_name = &verdict.candidate_names[verdict.winner_index];
     assert!(
@@ -436,15 +435,14 @@ fn circle_regime_gam_selects_smooth_circle_not_mixture_via_interpolated_holdout(
 
     // --- METRIC 3 (HEADLINE): cross-class verdict picks the smooth circle. ---
     let candidates = build_cross_class_candidates(data.view(), cfg);
-    let verdict =
-        adjudicate_cross_class_race(
-            N,
-            candidates,
-            STACKING_CV_FOLDS,
-            STACKING_CV_SEED,
-            StackingConfig::default(),
-        )
-        .expect("cross-class race adjudicates on circle data");
+    let verdict = adjudicate_cross_class_race(
+        N,
+        candidates,
+        STACKING_CV_FOLDS,
+        STACKING_CV_SEED,
+        StackingConfig::default(),
+    )
+    .expect("cross-class race adjudicates on circle data");
 
     assert!(
         verdict.is_cross_class,


### PR DESCRIPTION
Fresh rustfmt drift (49 locations) accumulated from recent commits. Applied `cargo fmt --all`; `cargo fmt --all -- --check` now passes (0 diffs). Pure whitespace — no logic changed.

— HomunculusLabs (AI-assisted)