### PR TITLE
Improve NaN/None/empty error messages with column and row context

### DIFF
--- a/docs/data-input.md
+++ b/docs/data-input.md
@@ -41,6 +41,9 @@ enforced in `stringify_cell`:
 1. `None` is rejected.
 2. NaN floats and empty strings are rejected.
 
+Error messages include column name and row number when available, making
+data debugging straightforward: `column 'x' has NaN at row 42`.
+
 Booleans become `"1"` / `"0"`. Numbers use `repr()`. Other values are
 passed through `str(...)`. The engine handles numeric coercion from
 strings; explicit casting to float is unnecessary.

--- a/gamfit/_tables.py
+++ b/gamfit/_tables.py
@@ -87,7 +87,12 @@ def normalize_table(data: Any) -> tuple[list[str], list[list[str]], str]:
     categorical = categorical_dtype_columns(data, kind)
     rows = [
         [
-            _stringify_marked(columns[header][row_index], header in categorical)
+            _stringify_marked(
+                columns[header][row_index],
+                header in categorical,
+                column=header,
+                row=row_index,
+            )
             for header in headers
         ]
         for row_index in range(row_count)
@@ -95,8 +100,8 @@ def normalize_table(data: Any) -> tuple[list[str], list[list[str]], str]:
     return headers, rows, kind
 
 
-def _stringify_marked(value: Any, is_categorical: bool) -> str:
-    text = stringify_cell(value)
+def _stringify_marked(value: Any, is_categorical: bool, *, column: str | None = None, row: int | None = None) -> str:
+    text = stringify_cell(value, column=column, row=row)
     if is_categorical:
         return CATEGORICAL_CELL_SENTINEL + text
     return text
@@ -354,18 +359,28 @@ def collect_record_headers(rows: list[Mapping[str, Any]]) -> list[str]:
     return headers
 
 
-def stringify_cell(value: Any) -> str:
+def stringify_cell(value: Any, *, column: str | None = None, row: int | None = None) -> str:
     if isinstance(value, bool):
         return "1" if value else "0"
     if value is None:
-        raise ValueError("table cells cannot be None")
+        if column and row is not None:
+            raise ValueError(f"column '{column}' has None at row {row + 1}")
+        elif column:
+            raise ValueError(f"column '{column}' contains None")
+        else:
+            raise ValueError("table cells cannot be None")
     if isinstance(value, int):
         # bool is handled above; covers Python int and any int subclass
         # (e.g. numpy integers) so the rendered text is always a bare integer.
         return repr(int(value))
     if isinstance(value, float):
         if value != value:
-            raise ValueError("table cells cannot be NaN")
+            if column and row is not None:
+                raise ValueError(f"column '{column}' has NaN at row {row + 1}")
+            elif column:
+                raise ValueError(f"column '{column}' contains NaN")
+            else:
+                raise ValueError("table cells cannot be NaN")
         # float subclasses (e.g. numpy.float64) render via repr() with the
         # type name in NumPy 2.x ("np.float64(-3.0)"), which the Rust core
         # cannot parse and so misclassifies the column as categorical.
@@ -373,7 +388,12 @@ def stringify_cell(value: Any) -> str:
         return repr(float(value))
     text = str(value)
     if not text:
-        raise ValueError("table cells cannot be empty strings")
+        if column and row is not None:
+            raise ValueError(f"column '{column}' has empty string at row {row + 1}")
+        elif column:
+            raise ValueError(f"column '{column}' contains empty string")
+        else:
+            raise ValueError("table cells cannot be empty strings")
     return text
 
 

--- a/tests/test_table_error_messages.py
+++ b/tests/test_table_error_messages.py
@@ -1,0 +1,65 @@
+"""Test improved error messages in table normalization.
+
+This test verifies that NaN/None/empty cell errors include column and row context,
+making them actionable for users debugging their data.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+def test_nan_error_includes_column_and_row() -> None:
+    """NaN values should report which column and row they occur in."""
+    # Skip if pandas not available
+    np = pytest.importorskip("numpy")
+    pd = pytest.importorskip("pandas")
+
+    from gamfit._tables import normalize_table
+
+    # Create a DataFrame with NaN in the 'x' column, row 2 (0-indexed)
+    df = pd.DataFrame({
+        "x": [1.0, 2.0, float("nan"), 4.0],
+        "y": [10.0, 20.0, 30.0, 40.0],
+    })
+
+    with pytest.raises(ValueError) as exc_info:
+        normalize_table(df)
+
+    error_msg = str(exc_info.value)
+    assert "x" in error_msg, f"Expected column name 'x' in error: {error_msg}"
+    assert "row 3" in error_msg, f"Expected row 3 in error: {error_msg}"
+
+
+def test_none_error_includes_context() -> None:
+    """None values should report which column and row they occur in."""
+    pytest.importorskip("pandas")
+
+    from gamfit._tables import normalize_table
+
+    # Using a dict input that can have None
+    data = {
+        "x": [1.0, 2.0, None, 4.0],
+        "y": [10.0, 20.0, 30.0, 40.0],
+    }
+
+    with pytest.raises(ValueError) as exc_info:
+        normalize_table(data)
+
+    error_msg = str(exc_info.value)
+    assert "x" in error_msg, f"Expected column name 'x' in error: {error_msg}"
+    assert "row 3" in error_msg, f"Expected row 3 in error: {error_msg}"
+
+
+def test_stringify_cell_direct_call_still_works() -> None:
+    """Direct calls to stringify_cell should work with or without context."""
+    from gamfit._tables import stringify_cell
+
+    # Without context (backward compatible)
+    assert stringify_cell(3.14) == "3.14"
+    assert stringify_cell(42) == "42"
+    assert stringify_cell(True) == "1"
+
+    # With context (optional improvement)
+    assert stringify_cell(3.14, column="test_col") == "3.14"
+    assert stringify_cell(42, column="age", row=5) == "42"


### PR DESCRIPTION
The error message 'table cells cannot be NaN' was not actionable - users couldn't tell which column or row had the problem. This change enhances stringify_cell() to accept optional column and row context, producing errors like 'column 'x' has NaN at row 42'. Also added tests for the improved error messages and updated documentation.