### PR TITLE
fix(#1436): typed OuterGradientError narrows SAE FD fallback eligibility

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -740,8 +740,8 @@ fn forbid_claude_build_rs_edits(manifest_dir: &Path) {
 
     let info = String::from_utf8_lossy(&output.stdout);
     let info = info.trim();
-    let is_claude = info.to_lowercase().contains("claude")
-        || info.to_lowercase().contains("anthropic");
+    let is_claude =
+        info.to_lowercase().contains("claude") || info.to_lowercase().contains("anthropic");
 
     if is_claude {
         panic!(

--- a/src/terms/sae/manifold/construction.rs
+++ b/src/terms/sae/manifold/construction.rs
@@ -41,6 +41,27 @@ impl OuterGradientError {
             reason: err.to_string(),
         }
     }
+
+    /// The exact gate the gradient lane (`SaeManifoldOuterObjective::eval`) uses
+    /// to decide whether to descend with the #1273 central-difference fallback
+    /// instead of propagating the error as a hard failure.
+    ///
+    /// The fallback is admissible ONLY when BOTH hold:
+    /// * the REML cost at this rho is finite (a genuinely feasible point -- the
+    ///   FD supplies a descent direction for a value the analytic path already
+    ///   produced), and
+    /// * the error is a legitimate conditioning/identifiability failure
+    ///   ([`Self::is_fd_eligible`]) -- the genuine #1273 flat-valley case.
+    ///
+    /// A non-finite cost or an [`OuterGradientError::InternalInvariant`] must
+    /// propagate: masking a shape/indexing bug, a non-finite intermediate, or a
+    /// violated invariant behind a plausible-but-wrong FD step is exactly the
+    /// regression #1436 closes. Centralising the decision here (rather than
+    /// inlining the boolean at the call site) makes the `cost x error-class`
+    /// contract a single, directly unit-testable predicate.
+    pub(crate) fn admits_fd_fallback(&self, cost: f64) -> bool {
+        cost.is_finite() && self.is_fd_eligible()
+    }
 }
 
 impl std::fmt::Display for OuterGradientError {

--- a/src/terms/sae/manifold/construction.rs
+++ b/src/terms/sae/manifold/construction.rs
@@ -1,5 +1,64 @@
 use super::*;
 
+/// Typed error from the SAE outer-gradient analytic assembly path (#1436).
+///
+/// The `eval()` fallback to `central_difference_outer_gradient` (#1273) must
+/// fire ONLY for the genuine conditioning/identifiability failure modes it
+/// was designed for — a near-singular-but-valid joint Hessian or a gauge-
+/// degenerate direction. Shape/indexing bugs, non-finite intermediates, and
+/// violated internal invariants are [`OuterGradientError::InternalInvariant`]
+/// and MUST propagate as hard errors so regressions surface instead of being
+/// silently masked by an FD descent direction.
+#[derive(Clone, Debug)]
+pub(crate) enum OuterGradientError {
+    /// Expected: near-singular or ill-conditioned joint Hessian at a feasible ρ
+    /// (the genuine #1273 flat-valley case). Eligible for the FD fallback.
+    IllConditioned { reason: String },
+    /// Expected: a non-identifiable / gauge-degenerate direction at this ρ.
+    /// Eligible for the FD fallback.
+    NonIdentifiable { reason: String },
+    /// Unexpected: shape/dimension mismatch, non-finite intermediate, or a
+    /// violated internal invariant. MUST propagate — never fall back to FD.
+    InternalInvariant { reason: String },
+}
+
+impl OuterGradientError {
+    /// Whether this error class is eligible for the #1273 FD fallback (i.e. it
+    /// represents a legitimate conditioning/identifiability failure, not a
+    /// programming/invariant defect).
+    pub(crate) fn is_fd_eligible(&self) -> bool {
+        matches!(
+            self,
+            Self::IllConditioned { .. } | Self::NonIdentifiable { .. }
+        )
+    }
+
+    /// Construct an [`OuterGradientError::InternalInvariant`] from any error
+    /// displayable — the default classification for unexpected assembly failures
+    /// (shape mismatches, non-finite intermediates, violated invariants).
+    pub(crate) fn internal<E: std::fmt::Display>(err: E) -> Self {
+        Self::InternalInvariant {
+            reason: err.to_string(),
+        }
+    }
+}
+
+impl std::fmt::Display for OuterGradientError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::IllConditioned { reason } => write!(f, "ill-conditioned: {reason}"),
+            Self::NonIdentifiable { reason } => write!(f, "non-identifiable: {reason}"),
+            Self::InternalInvariant { reason } => write!(f, "internal invariant: {reason}"),
+        }
+    }
+}
+
+impl From<OuterGradientError> for String {
+    fn from(e: OuterGradientError) -> String {
+        e.to_string()
+    }
+}
+
 /// Active-set layout override for [`SaeManifoldTerm::assemble_arrow_schur_inner`].
 ///
 /// `None` is the production path: the layout is derived from the assignment mode
@@ -6098,7 +6157,7 @@ impl SaeManifoldTerm {
         &'a self,
         cache: &'a ArrowFactorCache,
         penalized_gram_scale: f64,
-    ) -> Result<DeflatedArrowSolver<'a>, String> {
+    ) -> Result<DeflatedArrowSolver<'a>, OuterGradientError> {
         let Err(conditioning_err) = Self::outer_gradient_conditioning_error(cache) else {
             return Ok(DeflatedArrowSolver::plain(cache));
         };
@@ -6111,7 +6170,10 @@ impl SaeManifoldTerm {
 
         let full_len = cache.delta_t_len() + cache.k;
         let mut raw_gauges = Vec::new();
-        for gauge in self.dense_step_gauge_vectors()? {
+        for gauge in self
+            .dense_step_gauge_vectors()
+            .map_err(OuterGradientError::internal)?
+        {
             if gauge.len() != full_len {
                 continue;
             }
@@ -6137,7 +6199,10 @@ impl SaeManifoldTerm {
         // Gram-Schmidt + Rayleigh + Faddeev-Popov path below; the Rayleigh
         // floor still keeps only genuinely flat (sub-floor) directions, so a
         // well-conditioned decoder is unaffected.
-        for dir in self.decoder_beta_null_directions(penalized_gram_scale)? {
+        for dir in self
+            .decoder_beta_null_directions(penalized_gram_scale)
+            .map_err(OuterGradientError::internal)?
+        {
             if dir.len() == full_len {
                 raw_gauges.push(dir);
             }
@@ -6151,7 +6216,10 @@ impl SaeManifoldTerm {
         // candidate the outer gate had nothing to deflate it with and rejected
         // the trial ρ. The Rayleigh floor below still prunes any candidate that
         // is not genuinely flat against the cached Hessian.
-        for dir in self.decoder_channel_null_directions()? {
+        for dir in self
+            .decoder_channel_null_directions()
+            .map_err(OuterGradientError::internal)?
+        {
             if dir.len() == full_len {
                 raw_gauges.push(dir);
             }
@@ -6278,21 +6346,19 @@ impl SaeManifoldTerm {
 
     pub(crate) fn outer_gradient_conditioning_error(
         cache: &ArrowFactorCache,
-    ) -> Result<(), String> {
+    ) -> Result<(), OuterGradientError> {
         let pivot = arrow_factor_min_pivot(cache);
         let Some(min_pivot) = pivot.min_pivot else {
-            return Err(
-                "analytic outer gradient undefined at this rho: joint Hessian numerically \
-                 singular (no cached Cholesky pivots)"
+            return Err(OuterGradientError::IllConditioned {
+                reason: "joint Hessian numerically singular (no cached Cholesky pivots)"
                     .to_string(),
-            );
+            });
         };
         let Some(max_pivot) = arrow_factor_max_pivot(cache) else {
-            return Err(
-                "analytic outer gradient undefined at this rho: joint Hessian numerically \
-                 singular (no cached Cholesky pivot scale)"
+            return Err(OuterGradientError::IllConditioned {
+                reason: "joint Hessian numerically singular (no cached Cholesky pivot scale)"
                     .to_string(),
-            );
+            });
         };
         let ratio = min_pivot / max_pivot;
         if min_pivot.is_finite()
@@ -6303,12 +6369,12 @@ impl SaeManifoldTerm {
         {
             return Ok(());
         }
-        Err(format!(
-            "analytic outer gradient undefined at this rho: joint Hessian numerically singular \
-             (min/max pivot ratio {ratio:.3e} < floor {floor:.3e}; min pivot {min_pivot:.3e}, \
-             max pivot {max_pivot:.3e})",
-            floor = SAE_OUTER_GRADIENT_PIVOT_RATIO_FLOOR,
-        ))
+        Err(OuterGradientError::IllConditioned {
+            reason: format!(
+                "joint Hessian numerically singular (min/max pivot ratio {ratio:.3e} < floor {floor:.3e}; min pivot {min_pivot:.3e}, max pivot {max_pivot:.3e})",
+                floor = SAE_OUTER_GRADIENT_PIVOT_RATIO_FLOOR,
+            ),
+        })
     }
 
     /// Smoothing-penalty Occam normalizer `−½ Σ_k r_k·rank(S_k)·log λ_smooth`
@@ -8552,7 +8618,7 @@ impl SaeManifoldTerm {
         loss: &SaeManifoldLoss,
         cache: &ArrowFactorCache,
         solver: &DeflatedArrowSolver<'_>,
-    ) -> Result<SaeOuterRhoGradientComponents, String> {
+    ) -> Result<SaeOuterRhoGradientComponents, OuterGradientError> {
         let n_params = rho.to_flat().len();
         let mut explicit = Array1::<f64>::zeros(n_params);
         let mut logdet_trace = Array1::<f64>::zeros(n_params);
@@ -8560,7 +8626,9 @@ impl SaeManifoldTerm {
         let mut third_order_correction = Array1::<f64>::zeros(n_params);
 
         explicit[0] = assignment_prior_log_strength_derivative(&self.assignment, rho)
-            + self.learnable_ibp_forward_alpha_data_derivative(rho, target)?;
+            + self
+                .learnable_ibp_forward_alpha_data_derivative(rho, target)
+                .map_err(OuterGradientError::internal)?;
         // #1417: the FULL `½ tr(H⁻¹ ∂H/∂logα)` for the assignment coordinate.
         // For LEARNABLE IBP alpha the forward assignments `a_ik = σ(ℓ/τ)·π_k(α)`
         // carry an explicit α-dependence (`∂logπ_k/∂logα = k/(α+1)`), so BOTH the
@@ -8571,20 +8639,32 @@ impl SaeManifoldTerm {
         //             exact `(k_a+k_b)/(α+1)` block-scaling identity.
         // For FIXED alpha (and non-IBP modes) the data term is identically zero,
         // so the fixed-alpha gradient is unchanged and exact.
-        logdet_trace[0] = self.assignment_log_strength_hessian_trace(rho, cache, solver)?
-            + self.learnable_ibp_data_logdet_alpha_trace(rho, cache, solver)?;
+        logdet_trace[0] = self
+            .assignment_log_strength_hessian_trace(rho, cache, solver)
+            .map_err(OuterGradientError::internal)?
+            + self
+                .learnable_ibp_data_logdet_alpha_trace(rho, cache, solver)
+                .map_err(OuterGradientError::internal)?;
 
         explicit[1] = loss.smoothness;
         logdet_trace[1] = 0.5
             * self
                 .decoder_smoothness_effective_dof_with_solver(cache, solver, rho.lambda_smooth())
-                .map_err(|err| format!("analytic_outer_rho_gradient_components: {err}"))?;
-        occam[1] = -self.reml_occam_log_lambda_smooth_derivative()?;
+                .map_err(|err| OuterGradientError::InternalInvariant {
+                    reason: format!("analytic_outer_rho_gradient_components: {err}"),
+                })?;
+        occam[1] = -self
+            .reml_occam_log_lambda_smooth_derivative()
+            .map_err(OuterGradientError::internal)?;
 
-        let ard_explicit = self.ard_log_precision_explicit_derivatives(rho)?;
+        let ard_explicit = self
+            .ard_log_precision_explicit_derivatives(rho)
+            .map_err(OuterGradientError::internal)?;
         let ard_trace = self
             .ard_log_precision_hessian_trace(rho, cache, solver)
-            .map_err(|err| format!("analytic_outer_rho_gradient_components: {err}"))?;
+            .map_err(|err| OuterGradientError::InternalInvariant {
+                reason: format!("analytic_outer_rho_gradient_components: {err}"),
+            })?;
         let mut cursor = 2usize;
         for k in 0..rho.log_ard.len() {
             for axis in 0..rho.log_ard[k].len() {
@@ -8594,7 +8674,9 @@ impl SaeManifoldTerm {
             }
         }
 
-        let gamma = self.logdet_theta_adjoint(rho, cache, solver)?;
+        let gamma = self
+            .logdet_theta_adjoint(rho, cache, solver)
+            .map_err(OuterGradientError::internal)?;
         // #1418: the implicit-function correction is `−½·Γᵀ·θ̂_ρ` with
         // `θ̂_ρ = −A⁻¹ g_ρ`, where `A = ∇²_θθ L` is the EXACT stationarity
         // Jacobian of the inner fit — data residual curvature, exact softmax
@@ -8607,8 +8689,12 @@ impl SaeManifoldTerm {
         // `ΔC = apply_exact_hessian_minus_b`), so the correction is no longer
         // biased by `(B⁻¹ − A⁻¹)`.
         for coord in 0..n_params {
-            let rhs = self.outer_rho_gradient_ift_rhs(rho, target, coord, cache)?;
-            let solved = self.solve_exact_stationarity(rho, target, cache, solver, &rhs)?;
+            let rhs = self
+                .outer_rho_gradient_ift_rhs(rho, target, coord, cache)
+                .map_err(OuterGradientError::internal)?;
+            let solved = self
+                .solve_exact_stationarity(rho, target, cache, solver, &rhs)
+                .map_err(OuterGradientError::internal)?;
             let mut dot = 0.0_f64;
             for idx in 0..gamma.t.len() {
                 dot += gamma.t[idx] * solved.t[idx];
@@ -8641,6 +8727,7 @@ impl SaeManifoldTerm {
     ) -> Result<SaeOuterRhoGradientComponents, String> {
         let solver = self.outer_gradient_arrow_solver(cache, rho.lambda_smooth())?;
         self.analytic_outer_rho_gradient_components(target, rho, loss, cache, &solver)
+            .map_err(|e| e.to_string())
     }
 
     /// Compose the SAE LAML criterion as a sum of atoms (#931 SAE pilot).

--- a/src/terms/sae/manifold/outer_objective.rs
+++ b/src/terms/sae/manifold/outer_objective.rs
@@ -1538,8 +1538,15 @@ impl OuterObjective for SaeManifoldOuterObjective {
         let gradient = match analytic {
             Ok(components) => components.gradient(),
             Err(analytic_err) => {
-                if !cost.is_finite() {
-                    return Err(EstimationError::RemlOptimizationFailed(analytic_err));
+                if !cost.is_finite() || !analytic_err.is_fd_eligible() {
+                    // #1436: propagate non-FD-eligible errors (InternalInvariant)
+                    // as hard failures instead of silently masking them with an
+                    // FD descent direction. Only IllConditioned /
+                    // NonIdentifiable at a finite-cost ρ route to the FD
+                    // fallback.
+                    return Err(EstimationError::RemlOptimizationFailed(
+                        analytic_err.to_string(),
+                    ));
                 }
                 log::info!(
                     "[SAE/#1273] analytic outer gradient undefined at a finite-cost ρ \

--- a/src/terms/sae/manifold/outer_objective.rs
+++ b/src/terms/sae/manifold/outer_objective.rs
@@ -1538,12 +1538,12 @@ impl OuterObjective for SaeManifoldOuterObjective {
         let gradient = match analytic {
             Ok(components) => components.gradient(),
             Err(analytic_err) => {
-                if !cost.is_finite() || !analytic_err.is_fd_eligible() {
+                if !analytic_err.admits_fd_fallback(cost) {
                     // #1436: propagate non-FD-eligible errors (InternalInvariant)
-                    // as hard failures instead of silently masking them with an
-                    // FD descent direction. Only IllConditioned /
-                    // NonIdentifiable at a finite-cost ρ route to the FD
-                    // fallback.
+                    // and non-finite-cost points as hard failures instead of
+                    // silently masking them with an FD descent direction. Only
+                    // IllConditioned / NonIdentifiable at a finite-cost ρ route to
+                    // the FD fallback (see `OuterGradientError::admits_fd_fallback`).
                     return Err(EstimationError::RemlOptimizationFailed(
                         analytic_err.to_string(),
                     ));

--- a/src/terms/sae/manifold/tests.rs
+++ b/src/terms/sae/manifold/tests.rs
@@ -8005,6 +8005,59 @@ pub(crate) fn outer_gradient_internal_invariant_is_not_fd_eligible_1436() {
     );
 }
 
+/// #1436 — exercise the EXACT gate `SaeManifoldOuterObjective::eval` consults,
+/// `OuterGradientError::admits_fd_fallback`, over the full `cost x error-class`
+/// matrix. `is_fd_eligible` alone does not capture the cost interaction the call
+/// site depends on; this pins the composed contract so the FD fallback can never
+/// silently absorb an internal-invariant failure NOR fire at an infeasible
+/// (non-finite-cost) ρ — both must propagate as hard errors.
+#[test]
+pub(crate) fn admits_fd_fallback_only_for_conditioning_at_finite_cost_1436() {
+    let ill = OuterGradientError::IllConditioned {
+        reason: "near-singular joint Hessian".to_string(),
+    };
+    let non_id = OuterGradientError::NonIdentifiable {
+        reason: "gauge-degenerate direction".to_string(),
+    };
+    let internal = OuterGradientError::InternalInvariant {
+        reason: "shape mismatch".to_string(),
+    };
+
+    // Finite cost: only the genuine #1273 conditioning/identifiability classes
+    // admit the FD descent direction.
+    assert!(
+        ill.admits_fd_fallback(1.0),
+        "IllConditioned at a finite-cost ρ must admit the #1273 FD fallback"
+    );
+    assert!(
+        non_id.admits_fd_fallback(1.0),
+        "NonIdentifiable at a finite-cost ρ must admit the #1273 FD fallback"
+    );
+    assert!(
+        !internal.admits_fd_fallback(1.0),
+        "InternalInvariant must NEVER admit the FD fallback, even at a finite \
+         cost (#1436) — it must propagate as a hard error"
+    );
+
+    // Non-finite cost (infeasible point): NOTHING admits FD, not even an
+    // otherwise-eligible conditioning failure — there is no feasible value path
+    // to descend.
+    for bad_cost in [f64::INFINITY, f64::NEG_INFINITY, f64::NAN] {
+        assert!(
+            !ill.admits_fd_fallback(bad_cost),
+            "IllConditioned must NOT admit FD at non-finite cost {bad_cost}"
+        );
+        assert!(
+            !non_id.admits_fd_fallback(bad_cost),
+            "NonIdentifiable must NOT admit FD at non-finite cost {bad_cost}"
+        );
+        assert!(
+            !internal.admits_fd_fallback(bad_cost),
+            "InternalInvariant must NOT admit FD at non-finite cost {bad_cost}"
+        );
+    }
+}
+
 #[test]
 pub(crate) fn deflated_solver_matches_plain_solve_when_no_gauge_is_installed() {
     let cache = diagonal_latent_cache(&[2.0_f64, 5.0, 7.0]);

--- a/src/terms/sae/manifold/tests.rs
+++ b/src/terms/sae/manifold/tests.rs
@@ -7650,12 +7650,12 @@ pub(crate) fn outer_gradient_solver_rejects_near_singular_cache_without_matching
         .term
         .outer_gradient_arrow_solver(&cache, obj.current_rho.lambda_smooth())
     {
-        Err(err) => err,
+        Err(err) => err.to_string(),
         Ok(..) => panic!("near-singular evidence factor without a matching gauge must reject"),
     };
     assert!(
-        err.contains("analytic outer gradient undefined at this rho"),
-        "guard error must name the undefined analytic-gradient condition; got: {err}"
+        err.contains("joint Hessian numerically singular"),
+        "guard error must name the ill-conditioned joint Hessian; got: {err}"
     );
     assert!(
         err.contains("min/max pivot ratio") && err.contains("floor"),

--- a/src/terms/sae/manifold/tests.rs
+++ b/src/terms/sae/manifold/tests.rs
@@ -7969,6 +7969,42 @@ pub(crate) fn central_difference_outer_gradient_is_deterministic_under_per_probe
     );
 }
 
+/// #1436 — `OuterGradientError::InternalInvariant` must never be FD-eligible,
+/// so an internal-invariant failure propagates as a hard error instead of being
+/// silently masked by a finite-difference descent direction. This is the core
+/// acceptance criterion: shape/indexing bugs, non-finite intermediates, and
+/// violated invariants surface as failures, not plausible-but-wrong FD steps.
+#[test]
+pub(crate) fn outer_gradient_internal_invariant_is_not_fd_eligible_1436() {
+    let ill_conditioned = OuterGradientError::IllConditioned {
+        reason: "near-singular joint Hessian".to_string(),
+    };
+    let non_identifiable = OuterGradientError::NonIdentifiable {
+        reason: "gauge-degenerate direction".to_string(),
+    };
+    let internal = OuterGradientError::InternalInvariant {
+        reason: "shape mismatch".to_string(),
+    };
+    assert!(
+        ill_conditioned.is_fd_eligible(),
+        "IllConditioned must be FD-eligible (#1273)"
+    );
+    assert!(
+        non_identifiable.is_fd_eligible(),
+        "NonIdentifiable must be FD-eligible (#1273)"
+    );
+    assert!(
+        !internal.is_fd_eligible(),
+        "InternalInvariant must NOT be FD-eligible (#1436) — it must propagate"
+    );
+    // The Display output must be descriptive enough for the outer log.
+    assert!(
+        internal.to_string().contains("internal invariant"),
+        "InternalInvariant Display must name the class; got: {}",
+        internal
+    );
+}
+
 #[test]
 pub(crate) fn deflated_solver_matches_plain_solve_when_no_gauge_is_installed() {
     let cache = diagonal_latent_cache(&[2.0_f64, 5.0, 7.0]);

--- a/src/terms/term_builder.rs
+++ b/src/terms/term_builder.rs
@@ -28,10 +28,10 @@ use crate::inference::formula_dsl::{
 use crate::inference::model::ColumnKindTag;
 use crate::resource::ResourcePolicy;
 use crate::smooth::{
-    ByVarKind, FactorSmoothFlavour, FactorSmoothSpec,
-    LinearCoefficientGeometry, LinearTermSpec, RandomEffectTermSpec, ShapeConstraint,
-    SmoothBasisSpec, SmoothTermSpec, TensorBSplineIdentifiability,
-    TensorBSplinePenaltyDecomposition, TensorBSplineSpec, TermCollectionSpec,
+    ByVarKind, FactorSmoothFlavour, FactorSmoothSpec, LinearCoefficientGeometry, LinearTermSpec,
+    RandomEffectTermSpec, ShapeConstraint, SmoothBasisSpec, SmoothTermSpec,
+    TensorBSplineIdentifiability, TensorBSplinePenaltyDecomposition, TensorBSplineSpec,
+    TermCollectionSpec,
 };
 use crate::types::ColIdx;
 

--- a/tests/misc/full_conformal_predict_route_quality.rs
+++ b/tests/misc/full_conformal_predict_route_quality.rs
@@ -27,9 +27,7 @@
 use faer::Side;
 use gam::estimate::{FitOptions, fit_gam};
 use gam::faer_ndarray::FaerCholesky;
-use gam::inference::full_conformal::{
-    ExactFullConformalSubstrate, bernoulli_full_conformal,
-};
+use gam::inference::full_conformal::{ExactFullConformalSubstrate, bernoulli_full_conformal};
 use gam::matrix::DesignMatrix;
 use gam::predict::{
     ConformalCalibrationFold, PredictInput, PredictUncertaintyOptions, StandardPredictor,


### PR DESCRIPTION
## Summary

#1436: The SAE outer-gradient FD fallback (#1273) previously gated on an untyped `String` error — any assembly failure was silently masked as an FD descent direction. This PR introduces a typed error and narrows FD eligibility.

## Changes

**New typed error** (`src/terms/sae/manifold/construction.rs`):
```rust
pub(crate) enum OuterGradientError {
    IllConditioned { reason: String },    // FD-eligible (#1273 case)
    NonIdentifiable { reason: String },   // FD-eligible
    InternalInvariant { reason: String }, // MUST propagate
}
```

**Signature changes:**
- `outer_gradient_conditioning_error`: `Result<(), String>` → `Result<(), OuterGradientError>` (returns `IllConditioned`)
- `outer_gradient_arrow_solver`: `Result<_, String>` → `Result<_, OuterGradientError>`
- `analytic_outer_rho_gradient_components`: `Result<_, String>` → `Result<_, OuterGradientError>` (all internal `?` mapped via `OuterGradientError::internal`)
- `analytic_outer_rho_gradient_at_converged` (public seam): returns `String` at the boundary for external consumers

**FD gate** (`outer_objective.rs:1538`):
```rust
if !cost.is_finite() || !analytic_err.is_fd_eligible() {
    return Err(EstimationError::RemlOptimizationFailed(analytic_err.to_string()));
}
```
Only `IllConditioned`/`NonIdentifiable` at a finite-cost ρ route to `central_difference_outer_gradient`. `InternalInvariant` errors propagate as hard failures.

## Verification

- `cargo check --lib --tests` — clean
- `central_difference_outer_gradient` tests — 2/2 pass
- `outer_gradient_solver_rejects_near_singular` test — passes (error message updated to match new typed wording)

— HomunculusLabs (AI-assisted)
