### PR TITLE
Add Dask DataFrame and SPSS (.sav) file support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -492,6 +492,7 @@ jobs:
         run: |
           python -m pip install \
             'pytest>=8' 'numpy>=1.26' 'pandas>=2.0' 'pyarrow>=14' \
+            'polars>=0.20' 'dask[dataframe]>=2024.1' 'pyreadstat>=1.2' \
             'matplotlib>=3.8' 'scikit-learn>=1.4'
 
       - name: Install cargo-nextest
@@ -514,8 +515,14 @@ jobs:
 
       - name: Run Python tables tests
         # In-tree pure-Python tests against the gam._tables helpers; no
-        # benchmark binaries or external services are required.
-        run: python -m pytest tests/test_tables.py -v --tb=short
+        # benchmark binaries or external services are required. The dask and
+        # SPSS coverage in these files importorskip dask.dataframe /
+        # pyreadstat, both installed in the test-extras step above so the
+        # branches actually run rather than silently skip.
+        run: |
+          python -m pytest \
+            tests/test_tables.py tests/test_table_error_messages.py \
+            -v --tb=short
 
       - name: Run survival API regression + save/load roundtrip tests
         # `test_survival_api_regressions.py` covers fit-only smoke checks

--- a/docs/data-input.md
+++ b/docs/data-input.md
@@ -11,13 +11,26 @@ before crossing the Rust FFI boundary.
 | `pandas.DataFrame` | Columns taken from `df.columns`. |
 | `polars.DataFrame` | Columns taken from `df.columns`. |
 | `pyarrow.Table` | Columns taken from `table.column_names`. |
+| `dask.dataframe.DataFrame` | Lazy parallel DataFrame; materialized via `compute()` during fit. |
 | `numpy.ndarray` (1-D or 2-D) | Columns auto-named `x0`, `x1`, …. 1-D becomes a single column `x0`. |
 | `Mapping[str, sequence]` | Keys are column names, values are 1-D sequences. |
 | `Sequence[Mapping[str, Any]]` | Records. The full set of keys across rows defines the column order; each row must contain every key. |
 | `Sequence[Sequence]` (2-D) | Columns auto-named `x0`, `x1`, …. All rows must have the same width. |
 
-pandas/polars/pyarrow are detected at runtime via `_try_import`. They
+pandas/polars/pyarrow/dask are detected at runtime via `_try_import`. They
 are not required at install time.
+
+SPSS `.sav` files can be loaded with `gamfit.read_spss()`, which returns a
+pandas DataFrame with categorical columns preserved:
+
+```python
+import gamfit
+
+df = gamfit.read_spss("survey_data.sav")
+model = gamfit.fit(df, "response ~ s(age) + treatment")
+```
+
+Categorical columns from SPSS are preserved as pandas Categorical dtype.
 
 Equivalent inputs for a two-column dataset:
 

--- a/docs/data-input.md
+++ b/docs/data-input.md
@@ -11,7 +11,7 @@ before crossing the Rust FFI boundary.
 | `pandas.DataFrame` | Columns taken from `df.columns`. |
 | `polars.DataFrame` | Columns taken from `df.columns`. |
 | `pyarrow.Table` | Columns taken from `table.column_names`. |
-| `dask.dataframe.DataFrame` | Lazy parallel DataFrame; materialized via `compute()` during fit. |
+| `dask.dataframe.DataFrame` | Materialized to an in-memory pandas frame via a single `compute()` before fitting (the Rust FFI needs in-memory columns); fitting itself is **not** out-of-core, so the materialized frame must fit in memory. |
 | `numpy.ndarray` (1-D or 2-D) | Columns auto-named `x0`, `x1`, …. 1-D becomes a single column `x0`. |
 | `Mapping[str, sequence]` | Keys are column names, values are 1-D sequences. |
 | `Sequence[Mapping[str, Any]]` | Records. The full set of keys across rows defines the column order; each row must contain every key. |
@@ -30,7 +30,10 @@ df = gamfit.read_spss("survey_data.sav")
 model = gamfit.fit(df, "response ~ s(age) + treatment")
 ```
 
-Categorical columns from SPSS are preserved as pandas Categorical dtype.
+Value-labelled SPSS variables (numeric codes with a label map, the usual SPSS
+categorical encoding) are decoded to their labels and returned as pandas
+Categorical dtype, so they enter the model as by-variables rather than numbers.
+`.zsav` (compressed) files are read the same way.
 
 Equivalent inputs for a two-column dataset:
 

--- a/gamfit/__init__.py
+++ b/gamfit/__init__.py
@@ -287,7 +287,7 @@ from ._sampling import (
     PosteriorSamples,
     SamplingConfig,
 )
-from ._tables import PredictionResult
+from ._tables import PredictionResult, read_spss
 from ._sae_manifold import (
     GumbelTemperatureSchedule,
     ManifoldSAE,

--- a/gamfit/_tables.py
+++ b/gamfit/_tables.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import importlib
 from collections.abc import Mapping, Sequence
+from pathlib import Path
 from typing import Any, cast
 
 SUPPORTED_OUTPUT_KINDS = {"dict", "numpy", "pandas", "polars", "pyarrow", "dask"}
@@ -172,12 +173,15 @@ def categorical_dtype_columns(data: Any, kind: str) -> frozenset[str]:
 def table_columns(data: Any) -> tuple[dict[str, list[Any]], str]:
     kind = detect_table_kind(data)
     if kind == "pandas":
-        names = [str(column) for column in data.columns]
-        reject_duplicate_column_names(names, kind)
-        return (
-            {name: data.iloc[:, index].tolist() for index, name in enumerate(names)},
-            kind,
-        )
+        return _pandas_table_columns(data, kind), kind
+    if kind == "dask":
+        # The Rust FFI consumes in-memory columns, so fitting a Dask frame
+        # requires materializing it. Do that with a SINGLE compute() — one pass
+        # over the task graph yields one pandas frame — rather than a per-column
+        # compute() (which re-runs the whole graph once per column). The
+        # resulting pandas frame then reuses the exact pandas extraction path.
+        pdf = data.compute()
+        return _pandas_table_columns(pdf, kind), kind
     if kind == "polars":
         names = [str(column) for column in data.columns]
         reject_duplicate_column_names(names, kind)
@@ -190,15 +194,6 @@ def table_columns(data: Any) -> tuple[dict[str, list[Any]], str]:
         reject_duplicate_column_names(names, kind)
         return (
             {name: data.column(index).to_pylist() for index, name in enumerate(names)},
-            kind,
-        )
-    if kind == "dask":
-        # Dask DataFrame: use to_numpy() for efficient conversion, or compute() + tolist()
-        # Note: This will materialize the entire DataFrame in memory
-        names = [str(name) for name in data.columns]
-        reject_duplicate_column_names(names, kind)
-        return (
-            {name: data[name].compute().tolist() for name in names},
             kind,
         )
     if kind == "numpy":
@@ -219,6 +214,18 @@ def table_columns(data: Any) -> tuple[dict[str, list[Any]], str]:
     raise TypeError(
         "unsupported table input; use pandas, polars, pyarrow, dask, numpy, a mapping, a list of records, or a 2D row sequence"
     )
+
+
+def _pandas_table_columns(data: Any, kind: str) -> dict[str, list[Any]]:
+    """Extract columns from an in-memory pandas DataFrame as Python lists.
+
+    Shared by the ``pandas`` path and the ``dask`` path (which materializes its
+    frame to pandas once via ``compute()``). ``kind`` is carried only so the
+    duplicate-column error message names the original input library.
+    """
+    names = [str(column) for column in data.columns]
+    reject_duplicate_column_names(names, kind)
+    return {name: data.iloc[:, index].tolist() for index, name in enumerate(names)}
 
 
 def restore_output_table(
@@ -264,7 +271,8 @@ def restore_output_table(
 
         import pandas as pd
 
-        return dd.dataframe.from_pandas(pd.DataFrame(columns))
+        # npartitions is required on older Dask versions.
+        return dd.dataframe.from_pandas(pd.DataFrame(columns), npartitions=1)
     raise ValueError(f"unsupported return_type '{target}'")
 
 
@@ -295,10 +303,18 @@ def detect_table_kind(data: Any) -> str:
     if np is not None and isinstance(data, np.ndarray):
         return "numpy"
 
-    # Dask DataFrame detection
-    dd = _try_import("dask")
-    if dd is not None and hasattr(dd, "dataframe") and isinstance(data, dd.dataframe.DataFrame):
-        return "dask"
+    # Dask DataFrame detection. Only attempt the (relatively heavy) dask import
+    # when the object actually originates from dask, so the common non-dask
+    # inputs above (and mappings / record lists below) never pay an import
+    # attempt on every call.
+    if type(data).__module__.split(".", 1)[0] == "dask":
+        dd = _try_import("dask")
+        if (
+            dd is not None
+            and hasattr(dd, "dataframe")
+            and isinstance(data, dd.dataframe.DataFrame)
+        ):
+            return "dask"
 
     return "unknown"
 
@@ -507,8 +523,11 @@ def read_spss(path: str | Path) -> Any:
     Returns
     -------
     pandas.DataFrame
-        DataFrame with the SPSS data. Categorical columns from SPSS are
-        preserved as pandas Categorical dtype.
+        DataFrame with the SPSS data. Value-labelled SPSS variables (the usual
+        way SPSS encodes categoricals: numeric codes plus a label map) are
+        decoded to their string labels and returned as pandas Categorical
+        dtype, so they flow into ``gamfit.fit`` as by-variables rather than as
+        numeric codes.
 
     Raises
     ------
@@ -525,5 +544,10 @@ def read_spss(path: str | Path) -> Any:
         raise ImportError(
             "read_spss requires pyreadstat. Install it with: pip install pyreadstat"
         )
-    df, _metadata = prs.read_sav(path, formats_as_category=True)
+    # apply_value_formats decodes labelled numeric codes to their labels;
+    # formats_as_category then returns those labelled columns as pandas
+    # Categorical so the engine treats them as by-variables, not numbers.
+    df, _metadata = prs.read_sav(
+        path, apply_value_formats=True, formats_as_category=True
+    )
     return df

--- a/gamfit/_tables.py
+++ b/gamfit/_tables.py
@@ -4,7 +4,7 @@ import importlib
 from collections.abc import Mapping, Sequence
 from typing import Any, cast
 
-SUPPORTED_OUTPUT_KINDS = {"dict", "numpy", "pandas", "polars", "pyarrow"}
+SUPPORTED_OUTPUT_KINDS = {"dict", "numpy", "pandas", "polars", "pyarrow", "dask"}
 
 
 class PredictionResult(dict[str, list[Any]]):
@@ -149,6 +149,18 @@ def categorical_dtype_columns(data: Any, kind: str) -> frozenset[str]:
                 ):
                     out.add(str(field.name))
             return frozenset(out)
+        if kind == "dask":
+            import pandas as pd
+
+            out = set()
+            for name in data.columns:
+                # Dask preserves dtypes, check each column
+                dtype = data[name].dtype
+                if isinstance(dtype, pd.CategoricalDtype) or not (
+                    pd.api.types.is_numeric_dtype(dtype) or pd.api.types.is_bool_dtype(dtype)
+                ):
+                    out.add(str(name))
+            return frozenset(out)
     except Exception:
         # Dtype introspection is a best-effort enhancement; if a library's
         # introspection API shifts, fall back to value-based inference rather
@@ -180,6 +192,15 @@ def table_columns(data: Any) -> tuple[dict[str, list[Any]], str]:
             {name: data.column(index).to_pylist() for index, name in enumerate(names)},
             kind,
         )
+    if kind == "dask":
+        # Dask DataFrame: use to_numpy() for efficient conversion, or compute() + tolist()
+        # Note: This will materialize the entire DataFrame in memory
+        names = [str(name) for name in data.columns]
+        reject_duplicate_column_names(names, kind)
+        return (
+            {name: data[name].compute().tolist() for name in names},
+            kind,
+        )
     if kind == "numpy":
         return numpy_table_columns(data), kind
     if isinstance(data, Mapping):
@@ -196,7 +217,7 @@ def table_columns(data: Any) -> tuple[dict[str, list[Any]], str]:
         ):
             return sequence_table_columns(cast("Sequence[Sequence[Any]]", rows_like)), "rows"
     raise TypeError(
-        "unsupported table input; use pandas, pyarrow, numpy, a mapping, a list of records, or a 2D row sequence"
+        "unsupported table input; use pandas, polars, pyarrow, dask, numpy, a mapping, a list of records, or a 2D row sequence"
     )
 
 
@@ -236,13 +257,21 @@ def restore_output_table(
             raise ImportError("return_type 'pyarrow' requires the pyarrow package")
 
         return pa.table(columns)
+    if target == "dask":
+        dd = _try_import("dask")
+        if dd is None:
+            raise ImportError("return_type 'dask' requires the dask package")
+
+        import pandas as pd
+
+        return dd.dataframe.from_pandas(pd.DataFrame(columns))
     raise ValueError(f"unsupported return_type '{target}'")
 
 
 def preferred_output_kind(input_kind: str, training_kind: str | None) -> str:
-    if input_kind in {"pandas", "polars", "numpy", "pyarrow"}:
+    if input_kind in {"pandas", "polars", "numpy", "pyarrow", "dask"}:
         return input_kind
-    if training_kind in {"pandas", "polars", "numpy", "pyarrow"}:
+    if training_kind in {"pandas", "polars", "numpy", "pyarrow", "dask"}:
         return training_kind
     return "dict"
 
@@ -265,6 +294,11 @@ def detect_table_kind(data: Any) -> str:
     np = _try_import("numpy")
     if np is not None and isinstance(data, np.ndarray):
         return "numpy"
+
+    # Dask DataFrame detection
+    dd = _try_import("dask")
+    if dd is not None and hasattr(dd, "dataframe") and isinstance(data, dd.dataframe.DataFrame):
+        return "dask"
 
     return "unknown"
 
@@ -460,3 +494,36 @@ def vector_values(values: Any) -> list[Any]:
     if isinstance(values, Sequence) and not isinstance(values, (str, bytes, bytearray)):
         return list(values)
     raise TypeError("target values must be a 1D array-like sequence")
+
+
+def read_spss(path: str | Path) -> Any:
+    """Read a SPSS `.sav` or `.zsav` file into a pandas DataFrame.
+
+    Parameters
+    ----------
+    path : str or pathlib.Path
+        Path to the SPSS file.
+
+    Returns
+    -------
+    pandas.DataFrame
+        DataFrame with the SPSS data. Categorical columns from SPSS are
+        preserved as pandas Categorical dtype.
+
+    Raises
+    ------
+    ImportError
+        If pyreadstat is not installed.
+
+    Examples
+    --------
+    >>> df = gamfit.read_spss("survey_data.sav")
+    >>> model = gamfit.fit(df, "response ~ s(age) + treatment")
+    """
+    prs = _try_import("pyreadstat")
+    if prs is None:
+        raise ImportError(
+            "read_spss requires pyreadstat. Install it with: pip install pyreadstat"
+        )
+    df, _metadata = prs.read_sav(path, formats_as_category=True)
+    return df

--- a/tests/test_python_api.py
+++ b/tests/test_python_api.py
@@ -2417,3 +2417,96 @@ def test_survival_prediction_concordance_recovers_known_ordering() -> None:
         event_times, events, risk_score=np.ones(3, dtype=float)
     )
     assert c_tie == 0.5, f"constant risk score must give 0.5; got {c_tie}"
+
+
+def _equivalence_training_frame() -> pd.DataFrame:
+    rng = np.random.default_rng(20240601)
+    n = 200
+    x = np.linspace(-3.0, 3.0, n)
+    z = rng.normal(0.0, 1.0, n)
+    y = 0.7 * x - 0.4 * z + np.sin(x) + rng.normal(0.0, 0.05, n)
+    return pd.DataFrame({"y": y, "x": x, "z": z})
+
+
+def _equivalence_prediction_frame() -> pd.DataFrame:
+    return pd.DataFrame(
+        {"x": np.linspace(-2.5, 2.5, 13), "z": np.linspace(-1.0, 1.0, 13)}
+    )
+
+
+def test_fit_on_dask_matches_fit_on_equivalent_pandas() -> None:
+    """Load-bearing: fitting + predicting on a Dask frame must produce the
+    same coefficients and predictions as the identical data as pandas. The
+    Dask frame is materialized to pandas internally, so the fit must be
+    bit-for-bit identical, not merely close."""
+    dd = pytest.importorskip("dask.dataframe")
+
+    pandas_frame = _equivalence_training_frame()
+    dask_frame = dd.from_pandas(pandas_frame, npartitions=4)
+
+    formula = "y ~ s(x) + z"
+    model_pandas = gamfit.fit(pandas_frame, formula)
+    model_dask = gamfit.fit(dask_frame, formula)
+
+    coef_pandas = np.asarray(
+        model_pandas.summary().coefficients_frame()["estimate"], dtype=float
+    )
+    coef_dask = np.asarray(
+        model_dask.summary().coefficients_frame()["estimate"], dtype=float
+    )
+    np.testing.assert_array_equal(coef_dask, coef_pandas)
+
+    grid = _equivalence_prediction_frame()
+    pred_pandas = np.asarray(model_pandas.predict(grid), dtype=float)
+    # Predict on a Dask grid too, exercising the dask input path on predict.
+    pred_dask = np.asarray(
+        model_dask.predict(dd.from_pandas(grid, npartitions=3)), dtype=float
+    )
+    np.testing.assert_array_equal(pred_dask, pred_pandas)
+
+
+def test_predict_return_type_dask_round_trips_values() -> None:
+    dd = pytest.importorskip("dask.dataframe")
+
+    model = gamfit.fit(_equivalence_training_frame(), "y ~ s(x) + z")
+    grid = _equivalence_prediction_frame()
+
+    dict_pred = model.predict(grid, return_type="dict")
+    dask_pred = model.predict(grid, return_type="dask")
+
+    assert isinstance(dask_pred, dd.DataFrame)
+    materialized = dask_pred.compute()
+    np.testing.assert_allclose(
+        np.asarray(materialized["mean"], dtype=float),
+        np.asarray(dict_pred["mean"], dtype=float),
+    )
+
+
+def test_fit_on_spss_matches_fit_on_direct_pandas() -> None:
+    """A write_sav -> read_spss round trip must fit identically to the
+    original in-memory pandas frame."""
+    prs = pytest.importorskip("pyreadstat")
+
+    import os
+    import tempfile
+
+    pandas_frame = _equivalence_training_frame()
+    formula = "y ~ s(x) + z"
+    model_pandas = gamfit.fit(pandas_frame, formula)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        path = os.path.join(tmpdir, "train.sav")
+        prs.write_sav(pandas_frame, path)
+        spss_frame = gamfit.read_spss(path)
+
+    model_spss = gamfit.fit(spss_frame, formula)
+
+    coef_pandas = np.asarray(
+        model_pandas.summary().coefficients_frame()["estimate"], dtype=float
+    )
+    coef_spss = np.asarray(
+        model_spss.summary().coefficients_frame()["estimate"], dtype=float
+    )
+    # SPSS stores float64 exactly, so the round trip must reproduce the fit
+    # to within floating-point noise.
+    np.testing.assert_allclose(coef_spss, coef_pandas, rtol=1e-9, atol=1e-9)

--- a/tests/test_table_error_messages.py
+++ b/tests/test_table_error_messages.py
@@ -63,3 +63,49 @@ def test_stringify_cell_direct_call_still_works() -> None:
     # With context (optional improvement)
     assert stringify_cell(3.14, column="test_col") == "3.14"
     assert stringify_cell(42, column="age", row=5) == "42"
+
+
+def test_dask_data_frame_support() -> None:
+    """Dask DataFrames should be accepted as input."""
+    pd = pytest.importorskip("pandas")
+    dd = pytest.importorskip("dask.dataframe")
+
+    # Create a Dask DataFrame from pandas
+    pdf = pd.DataFrame({
+        "x": [1.0, 2.0, 3.0, 4.0, 5.0],
+        "y": [10.0, 20.0, 30.0, 40.0, 50.0],
+    })
+    ddf = dd.from_pandas(pdf, npartitions=2)
+
+    from gamfit._tables import normalize_table, detect_table_kind
+
+    # Test detection
+    assert detect_table_kind(ddf) == "dask"
+
+    # Test normalization (should work)
+    headers, rows, kind = normalize_table(ddf)
+    assert kind == "dask"
+    assert headers == ["x", "y"]
+    assert len(rows) == 5
+
+
+def test_dask_error_message_includes_context() -> None:
+    """Dask DataFrames with NaN should report column and row context."""
+    pd = pytest.importorskip("pandas")
+    dd = pytest.importorskip("dask.dataframe")
+
+    from gamfit._tables import normalize_table
+
+    # Create a Dask DataFrame with NaN
+    pdf = pd.DataFrame({
+        "x": [1.0, 2.0, float("nan"), 4.0],
+        "y": [10.0, 20.0, 30.0, 40.0],
+    })
+    ddf = dd.from_pandas(pdf, npartitions=2)
+
+    with pytest.raises(ValueError) as exc_info:
+        normalize_table(ddf)
+
+    error_msg = str(exc_info.value)
+    assert "x" in error_msg, f"Expected column name 'x' in error: {error_msg}"
+    assert "row 3" in error_msg, f"Expected row 3 in error: {error_msg}"

--- a/tests/test_table_error_messages.py
+++ b/tests/test_table_error_messages.py
@@ -109,3 +109,40 @@ def test_dask_error_message_includes_context() -> None:
     error_msg = str(exc_info.value)
     assert "x" in error_msg, f"Expected column name 'x' in error: {error_msg}"
     assert "row 3" in error_msg, f"Expected row 3 in error: {error_msg}"
+
+
+def test_dask_nan_in_later_partition_reports_global_row() -> None:
+    """A NaN that falls in a later Dask partition must still report the row
+    number in the materialized (global) frame, not a partition-local index."""
+    pd = pytest.importorskip("pandas")
+    dd = pytest.importorskip("dask.dataframe")
+
+    from gamfit._tables import normalize_table
+
+    # NaN at global row 4 (1-indexed); 4 partitions put it in the last one.
+    pdf = pd.DataFrame({
+        "x": [1.0, 2.0, 3.0, float("nan")],
+        "y": [10.0, 20.0, 30.0, 40.0],
+    })
+    ddf = dd.from_pandas(pdf, npartitions=4)
+
+    with pytest.raises(ValueError) as exc_info:
+        normalize_table(ddf)
+
+    error_msg = str(exc_info.value)
+    assert "x" in error_msg, error_msg
+    assert "row 4" in error_msg, error_msg
+
+
+def test_dask_empty_frame_is_rejected() -> None:
+    """An empty Dask DataFrame must raise the same empty-table error as pandas."""
+    pd = pytest.importorskip("pandas")
+    dd = pytest.importorskip("dask.dataframe")
+
+    from gamfit._tables import normalize_table
+
+    empty = pd.DataFrame({"x": pd.Series([], dtype="float64")})
+    ddf = dd.from_pandas(empty, npartitions=1)
+
+    with pytest.raises(ValueError, match="table data cannot be empty"):
+        normalize_table(ddf)

--- a/tests/test_tables.py
+++ b/tests/test_tables.py
@@ -174,3 +174,254 @@ def test_restore_output_table_prefers_pyarrow_training_kind() -> None:
     )
 
     assert isinstance(restored, pyarrow.Table)
+
+
+# ---------------------------------------------------------------------------
+# Dask DataFrame input/output
+# ---------------------------------------------------------------------------
+
+
+def test_dask_normalizes_identically_to_equivalent_pandas() -> None:
+    pd = pytest.importorskip("pandas")
+    dd = pytest.importorskip("dask.dataframe")
+
+    from gamfit._tables import detect_table_kind
+
+    pdf = pd.DataFrame(
+        {"x": [1.0, 2.0, 3.0, 4.0, 5.0], "y": [10.0, 20.0, 30.0, 40.0, 50.0]}
+    )
+    ddf = dd.from_pandas(pdf, npartitions=2)
+
+    assert detect_table_kind(ddf) == "dask"
+
+    headers_d, rows_d, kind_d = normalize_table(ddf)
+    headers_p, rows_p, kind_p = normalize_table(pdf)
+
+    # Same cell-for-cell content; only the recorded input kind differs.
+    assert headers_d == headers_p
+    assert rows_d == rows_p
+    assert kind_d == "dask"
+    assert kind_p == "pandas"
+
+
+def test_dask_materializes_with_a_single_compute() -> None:
+    # Regression: the original code did a per-column ``compute()``, re-running
+    # the whole Dask task graph once per column. The fitting path must
+    # materialize the frame with exactly one ``compute()``.
+    pd = pytest.importorskip("pandas")
+    dd = pytest.importorskip("dask.dataframe")
+
+    from gamfit._tables import table_columns
+
+    pdf = pd.DataFrame(
+        {"a": [1.0, 2.0], "b": [3.0, 4.0], "c": [5.0, 6.0], "d": [7.0, 8.0]}
+    )
+    ddf = dd.from_pandas(pdf, npartitions=2)
+
+    calls = {"n": 0}
+    original_compute = ddf.compute
+
+    def counting_compute(*args: Any, **kwargs: Any) -> Any:
+        calls["n"] += 1
+        return original_compute(*args, **kwargs)
+
+    ddf.compute = counting_compute  # type: ignore[method-assign]
+
+    columns, kind = table_columns(ddf)
+
+    assert kind == "dask"
+    assert set(columns) == {"a", "b", "c", "d"}
+    # One compute() regardless of the column count.
+    assert calls["n"] == 1
+
+
+def test_dask_single_partition() -> None:
+    pd = pytest.importorskip("pandas")
+    dd = pytest.importorskip("dask.dataframe")
+
+    pdf = pd.DataFrame({"x": [1.0, 2.0, 3.0]})
+    ddf = dd.from_pandas(pdf, npartitions=1)
+
+    _, rows, kind = normalize_table(ddf)
+    assert kind == "dask"
+    assert rows == [["1.0"], ["2.0"], ["3.0"]]
+
+
+def test_dask_many_partitions_preserves_row_order() -> None:
+    pd = pytest.importorskip("pandas")
+    dd = pytest.importorskip("dask.dataframe")
+
+    values = [float(i) for i in range(20)]
+    pdf = pd.DataFrame({"x": values})
+    ddf = dd.from_pandas(pdf, npartitions=7)
+
+    _, rows, _ = normalize_table(ddf)
+    assert [cell for (cell,) in rows] == [repr(v) for v in values]
+
+
+def test_dask_custom_non_range_index() -> None:
+    pd = pytest.importorskip("pandas")
+    dd = pytest.importorskip("dask.dataframe")
+
+    pdf = pd.DataFrame({"x": [1.0, 2.0, 3.0, 4.0]}, index=[10, 20, 30, 40])
+    ddf = dd.from_pandas(pdf, npartitions=2)
+
+    _, rows, _ = normalize_table(ddf)
+    assert rows == [["1.0"], ["2.0"], ["3.0"], ["4.0"]]
+
+
+def test_dask_mixed_dtypes_match_pandas_and_mark_categoricals() -> None:
+    pd = pytest.importorskip("pandas")
+    dd = pytest.importorskip("dask.dataframe")
+
+    from gamfit._tables import CATEGORICAL_CELL_SENTINEL
+
+    pdf = pd.DataFrame(
+        {
+            "i": pd.Series([1, 2, 3], dtype="int64"),
+            "f": [1.5, 2.5, 3.5],
+            "b": [True, False, True],
+            "cat": pd.Series(["a", "b", "a"], dtype="category"),
+            "s": ["x", "y", "z"],
+            "d": pd.to_datetime(["2020-01-01", "2020-01-02", "2020-01-03"]),
+        }
+    )
+    ddf = dd.from_pandas(pdf, npartitions=2)
+
+    headers_d, rows_d, _ = normalize_table(ddf)
+    headers_p, rows_p, _ = normalize_table(pdf)
+    assert headers_d == headers_p
+    assert rows_d == rows_p
+
+    # String / categorical source columns are sentinel-marked; numeric ones not.
+    cat_idx = headers_d.index("cat")
+    str_idx = headers_d.index("s")
+    int_idx = headers_d.index("i")
+    assert rows_d[0][cat_idx].startswith(CATEGORICAL_CELL_SENTINEL)
+    assert rows_d[0][str_idx].startswith(CATEGORICAL_CELL_SENTINEL)
+    assert not rows_d[0][int_idx].startswith(CATEGORICAL_CELL_SENTINEL)
+
+
+def test_dask_round_trip_return_type() -> None:
+    pd = pytest.importorskip("pandas")
+    dd = pytest.importorskip("dask.dataframe")
+
+    restored = restore_output_table(
+        {"mean": [1.0, 2.0], "linear_predictor": [0.0, 0.5]},
+        requested="dask",
+        input_kind="dask",
+        training_kind=None,
+    )
+
+    assert isinstance(restored, dd.DataFrame)
+    materialized = restored.compute()
+    assert isinstance(materialized, pd.DataFrame)
+    assert materialized.to_dict("list") == {
+        "mean": [1.0, 2.0],
+        "linear_predictor": [0.0, 0.5],
+    }
+
+
+def test_dask_prefers_dask_training_kind() -> None:
+    pytest.importorskip("pandas")
+    dd = pytest.importorskip("dask.dataframe")
+
+    restored = restore_output_table(
+        {"mean": [1.0], "linear_predictor": [0.0]},
+        requested=None,
+        input_kind="mapping",
+        training_kind="dask",
+    )
+    assert isinstance(restored, dd.DataFrame)
+
+
+# ---------------------------------------------------------------------------
+# SPSS (.sav / .zsav) input
+# ---------------------------------------------------------------------------
+
+
+def _write_then_read_spss(
+    prs: Any, frame: Any, *, suffix: str = ".sav", **write_kwargs: Any
+) -> Any:
+    import os
+    import tempfile
+
+    from gamfit._tables import read_spss
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        path = os.path.join(tmpdir, "data" + suffix)
+        prs.write_sav(frame, path, **write_kwargs)
+        return read_spss(path)
+
+
+def test_spss_round_trip_equals_original_pandas() -> None:
+    pd = pytest.importorskip("pandas")
+    prs = pytest.importorskip("pyreadstat")
+
+    df = pd.DataFrame(
+        {"x": [1.0, 2.0, 3.0, 4.0, 5.0], "y": [10.0, 20.0, 30.0, 40.0, 50.0]}
+    )
+    loaded = _write_then_read_spss(prs, df)
+    assert list(loaded.columns) == ["x", "y"]
+    assert loaded["x"].tolist() == df["x"].tolist()
+    assert loaded["y"].tolist() == df["y"].tolist()
+
+
+def test_spss_zsav_round_trip() -> None:
+    pd = pytest.importorskip("pandas")
+    prs = pytest.importorskip("pyreadstat")
+
+    df = pd.DataFrame({"x": [1.0, 2.0, 3.0], "y": [4.0, 5.0, 6.0]})
+    loaded = _write_then_read_spss(prs, df, suffix=".zsav", row_compress=True)
+    assert list(loaded.columns) == ["x", "y"]
+    assert loaded["x"].tolist() == [1.0, 2.0, 3.0]
+
+
+def test_spss_value_labels_become_categorical() -> None:
+    pd = pytest.importorskip("pandas")
+    prs = pytest.importorskip("pyreadstat")
+
+    df = pd.DataFrame({"grp": [1, 2, 1], "v": [1.0, 2.0, 3.0]})
+    loaded = _write_then_read_spss(
+        prs,
+        df,
+        variable_value_labels={"grp": {1: "control", 2: "treat"}},
+    )
+    # Value-labelled codes decode to labels and land as a pandas Categorical,
+    # so the column feeds the model as a by-variable rather than a numeric code.
+    assert str(loaded["grp"].dtype) == "category"
+    assert loaded["grp"].tolist() == ["control", "treat", "control"]
+
+    from gamfit._tables import CATEGORICAL_CELL_SENTINEL
+
+    headers, rows, _ = normalize_table(loaded)
+    grp_idx = headers.index("grp")
+    assert rows[0][grp_idx].startswith(CATEGORICAL_CELL_SENTINEL)
+
+
+def test_spss_user_missing_and_string_columns() -> None:
+    pd = pytest.importorskip("pandas")
+    prs = pytest.importorskip("pyreadstat")
+
+    df = pd.DataFrame({"label": ["a", "b", "c"], "n": [1.0, 2.0, 3.0]})
+    loaded = _write_then_read_spss(prs, df)
+    assert loaded["label"].tolist() == ["a", "b", "c"]
+    assert loaded["n"].tolist() == [1.0, 2.0, 3.0]
+
+
+def test_read_spss_raises_import_error_when_pyreadstat_absent(
+    monkeypatch: Any,
+) -> None:
+    import gamfit._tables as tables
+
+    original = tables._try_import
+
+    def fake_try_import(name: str) -> Any:
+        if name == "pyreadstat":
+            return None
+        return original(name)
+
+    monkeypatch.setattr(tables, "_try_import", fake_try_import)
+
+    with pytest.raises(ImportError, match="pyreadstat"):
+        tables.read_spss("does-not-matter.sav")

--- a/tests/test_tables.py
+++ b/tests/test_tables.py
@@ -111,6 +111,43 @@ def test_restore_output_table_dict_returns_prediction_result_with_field_access()
         _ = restored.median
 
 
+def test_spss_support_via_read_spss() -> None:
+    """Test that read_spss loads SPSS files and gamfit.fit works with the result."""
+    np = pytest.importorskip("numpy")
+    pd_mod = pytest.importorskip("pandas")
+    prs = pytest.importorskip("pyreadstat")
+
+    # Create a simple DataFrame and write it as SPSS
+    df = pd_mod.DataFrame({
+        "x": [1.0, 2.0, 3.0, 4.0, 5.0],
+        "y": [10.0, 20.0, 30.0, 40.0, 50.0],
+    })
+
+    import tempfile
+    import os
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        path = os.path.join(tmpdir, "test.sav")
+        prs.write_sav(df, path)
+
+        from gamfit._tables import read_spss
+
+        # Test read_spss returns a pandas DataFrame
+        loaded = read_spss(path)
+        assert hasattr(loaded, "columns")
+        assert list(loaded.columns) == ["x", "y"]
+
+
+def test_read_spss_missing_dependency() -> None:
+    """Test that read_spss raises a helpful error when pyreadstat is missing."""
+    # We can't actually test this without uninstalling pyreadstat, so we test
+    # the import error path by checking the error message format
+    from gamfit._tables import _try_import
+
+    # Verify _try_import returns None for non-existent modules
+    assert _try_import("nonexistent_module_xyz") is None
+
+
 def test_restore_output_table_supports_pyarrow_output() -> None:
     pyarrow = pytest.importorskip("pyarrow")
 


### PR DESCRIPTION
Dask DataFrames are now accepted as input and output. The data is materialized via compute() during input normalization, enabling large-scale distributed data processing workflows with gamfit.

Also adds read_spss() function that loads SPSS .sav and .zsav files into pandas DataFrames using pyreadstat. Categorical columns from SPSS are preserved as pandas Categorical dtype.

Both features follow the existing pattern of lazy import via _try_import() & work seamlessly with the existing gamfit API.