### PR TITLE
test(#1450): large-K from_dense_weights end-to-end coverage

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -898,8 +898,8 @@ fn forbid_claude_build_rs_edits(manifest_dir: &Path) {
 
     let info = String::from_utf8_lossy(&output.stdout);
     let info = info.trim();
-    let is_claude = info.to_lowercase().contains("claude")
-        || info.to_lowercase().contains("anthropic");
+    let is_claude =
+        info.to_lowercase().contains("claude") || info.to_lowercase().contains("anthropic");
 
     if is_claude {
         panic!(
@@ -5344,12 +5344,12 @@ struct CommentBlock {
 /// nouns/verbs of the deferred work, not glue words.
 fn reword_is_stopword(t: &str) -> bool {
     const STOP: &[&str] = &[
-        "the", "and", "for", "this", "that", "with", "from", "into", "over", "each", "can",
-        "will", "its", "are", "was", "were", "has", "have", "had", "not", "but", "use", "uses",
-        "used", "via", "per", "out", "off", "all", "any", "one", "two", "new", "old", "should",
-        "would", "could", "may", "might", "must", "then", "than", "they", "them", "when", "where",
-        "which", "while", "here", "there", "only", "also", "still", "yet", "now", "later", "our",
-        "your", "their", "been", "being", "such", "some", "more", "most", "less", "few",
+        "the", "and", "for", "this", "that", "with", "from", "into", "over", "each", "can", "will",
+        "its", "are", "was", "were", "has", "have", "had", "not", "but", "use", "uses", "used",
+        "via", "per", "out", "off", "all", "any", "one", "two", "new", "old", "should", "would",
+        "could", "may", "might", "must", "then", "than", "they", "them", "when", "where", "which",
+        "while", "here", "there", "only", "also", "still", "yet", "now", "later", "our", "your",
+        "their", "been", "being", "such", "some", "more", "most", "less", "few",
     ];
     STOP.contains(&t)
 }
@@ -5394,31 +5394,31 @@ fn comment_block_has_deferral_cue(lower_text: &str) -> bool {
     static CUES: OnceLock<Vec<String>> = OnceLock::new();
     let cues = CUES.get_or_init(|| {
         vec![
-        format!("{}{}", "to", "do"),
-        format!("{}{}", "fix", "me"),
-        format!("{}-{}", "follow", "up"),
-        format!("{}{}", "follow", "up"),
-        format!("{}{}", "de", "fer"),
-        format!("{}{}", "stop", "gap"),
-        format!("{}{}", "place", "holder"),
-        format!("{}{}", "w", "ip"),
-        format!("{}{}", "t", "bd"),
-        "revisit".to_string(),
-        "punt".to_string(),
-        "eventually".to_string(),
-        "someday".to_string(),
-        "pending".to_string(),
-        "unimplemented".to_string(),
-        "incomplete".to_string(),
-        "stub".to_string(),
-        "not yet".to_string(),
-        "for now".to_string(),
-        "to be done".to_string(),
-        "to be implemented".to_string(),
-        "come back".to_string(),
-        "needs to".to_string(),
-        "remains to".to_string(),
-        "yet to".to_string(),
+            format!("{}{}", "to", "do"),
+            format!("{}{}", "fix", "me"),
+            format!("{}-{}", "follow", "up"),
+            format!("{}{}", "follow", "up"),
+            format!("{}{}", "de", "fer"),
+            format!("{}{}", "stop", "gap"),
+            format!("{}{}", "place", "holder"),
+            format!("{}{}", "w", "ip"),
+            format!("{}{}", "t", "bd"),
+            "revisit".to_string(),
+            "punt".to_string(),
+            "eventually".to_string(),
+            "someday".to_string(),
+            "pending".to_string(),
+            "unimplemented".to_string(),
+            "incomplete".to_string(),
+            "stub".to_string(),
+            "not yet".to_string(),
+            "for now".to_string(),
+            "to be done".to_string(),
+            "to be implemented".to_string(),
+            "come back".to_string(),
+            "needs to".to_string(),
+            "remains to".to_string(),
+            "yet to".to_string(),
         ]
     });
     cues.iter().any(|c| lower_text.contains(c.as_str()))

--- a/src/families/bms/cell_moment_assembly.rs
+++ b/src/families/bms/cell_moment_assembly.rs
@@ -903,7 +903,13 @@ impl BernoulliMarginalSlopeFamily {
             for _ in 0..4 {
                 let scalar_a = MultiDirJet::constant(0, intercept_root);
                 let (f, f_a) = self.empirical_flex_calibration_jets(
-                    primary, &scalar_a, &scalar_mu, &scalar_b, beta_h, beta_w, scalar_dirs,
+                    primary,
+                    &scalar_a,
+                    &scalar_mu,
+                    &scalar_b,
+                    beta_h,
+                    beta_w,
+                    scalar_dirs,
                     grid,
                 )?;
                 let d = f_a.coeff(0);

--- a/src/families/jet_scalar.rs
+++ b/src/families/jet_scalar.rs
@@ -139,7 +139,7 @@ pub trait JetScalar<const K: usize>: Copy {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::families::jet_tower::{evaluate_program, RowNllProgram, Tower2, Tower4};
+    use crate::families::jet_tower::{RowNllProgram, Tower2, Tower4, evaluate_program};
 
     // ── Order-specific oracle scalars (test-only; doc §A.1–A.3) ─────────
     //
@@ -678,7 +678,11 @@ mod tests {
         let truth4 = t.fourth_contracted(&U, &V);
         for a in 0..2 {
             for b in 0..2 {
-                close(fourth[a][b], truth4[a][b], &format!("seam fourth[{a}][{b}]"));
+                close(
+                    fourth[a][b],
+                    truth4[a][b],
+                    &format!("seam fourth[{a}][{b}]"),
+                );
             }
         }
     }

--- a/src/families/multinomial.rs
+++ b/src/families/multinomial.rs
@@ -252,8 +252,7 @@ fn multinomial_formula_min_lambda(y_one_hot: ArrayView2<'_, f64>) -> f64 {
     if !min_class_count.is_finite() || min_class_count <= 0.0 {
         return MULTINOMIAL_FORMULA_MIN_LAMBDA;
     }
-    let information_scale =
-        (MULTINOMIAL_FORMULA_SPARSE_CLASS_MIN_COUNT / min_class_count).max(1.0);
+    let information_scale = (MULTINOMIAL_FORMULA_SPARSE_CLASS_MIN_COUNT / min_class_count).max(1.0);
     (MULTINOMIAL_FORMULA_MIN_LAMBDA * information_scale).clamp(
         MULTINOMIAL_FORMULA_MIN_LAMBDA,
         MULTINOMIAL_FORMULA_SPARSE_CLASS_MIN_LAMBDA,
@@ -1947,13 +1946,20 @@ mod fisher_override_tests {
         assert!((floor_for_min_count(50) - MULTINOMIAL_FORMULA_MIN_LAMBDA).abs() < 1e-18);
         assert!((floor_for_min_count(200) - MULTINOMIAL_FORMULA_MIN_LAMBDA).abs() < 1e-18);
         // Very sparse (count <= c0*base/sparse = 10) clamps to the strong floor.
-        assert!((floor_for_min_count(10) - MULTINOMIAL_FORMULA_SPARSE_CLASS_MIN_LAMBDA).abs() < 1e-18);
-        assert!((floor_for_min_count(5) - MULTINOMIAL_FORMULA_SPARSE_CLASS_MIN_LAMBDA).abs() < 1e-18);
+        assert!(
+            (floor_for_min_count(10) - MULTINOMIAL_FORMULA_SPARSE_CLASS_MIN_LAMBDA).abs() < 1e-18
+        );
+        assert!(
+            (floor_for_min_count(5) - MULTINOMIAL_FORMULA_SPARSE_CLASS_MIN_LAMBDA).abs() < 1e-18
+        );
         // No cliff at the old hard threshold: 49 vs 50 differ by < 5% (the old
         // step jumped 5x). Floor is monotone non-increasing in support.
         let f49 = floor_for_min_count(49);
         let f50 = floor_for_min_count(50);
-        assert!(f49 >= f50 && f49 <= f50 * 1.05, "floor must be continuous across c0, got {f49} vs {f50}");
+        assert!(
+            f49 >= f50 && f49 <= f50 * 1.05,
+            "floor must be continuous across c0, got {f49} vs {f50}"
+        );
         let f25 = floor_for_min_count(25);
         assert!(
             f25 > f50 && f25 < floor_for_min_count(10),

--- a/src/solver/arrow_schur/factorization.rs
+++ b/src/solver/arrow_schur/factorization.rs
@@ -720,10 +720,8 @@ pub(crate) fn factor_one_row_result(
                     // knife-edge a route lands on.
                     if ridge_t == 0.0 && allow_spectral_deflation {
                         let kappa_est = cholesky_factor_kappa_estimate(&factor);
-                        if !cholesky_factor_passes_safe_inversion(
-                            &factor, d, diag_scale, kappa_est,
-                        ) && let Some(deflated) =
-                            factor_spectral_deflated_evidence_row(row, d)
+                        if !cholesky_factor_passes_safe_inversion(&factor, d, diag_scale, kappa_est)
+                            && let Some(deflated) = factor_spectral_deflated_evidence_row(row, d)
                         {
                             return Ok(deflated);
                         }

--- a/src/solver/estimate/fit.rs
+++ b/src/solver/estimate/fit.rs
@@ -277,13 +277,9 @@ where
     // range-block and inner-PIRLS λ ceilings so a fully-smoothed direction carries
     // the SAME finite λ everywhere it is consumed.
     const LAMBDA_CEILING: f64 = 1.0e300;
-    let result_lambdas = result.lambdas.mapv(|v| {
-        if v.is_nan() {
-            v
-        } else {
-            v.min(LAMBDA_CEILING)
-        }
-    });
+    let result_lambdas = result
+        .lambdas
+        .mapv(|v| if v.is_nan() { v } else { v.min(LAMBDA_CEILING) });
     let log_lambdas = result_lambdas.mapv(|v| v.max(1e-300).ln());
     let edf = result
         .inference

--- a/src/terms/basis/center_selection.rs
+++ b/src/terms/basis/center_selection.rs
@@ -562,7 +562,11 @@ mod tests {
     /// Assert two center sets are equal up to ordering, by greedily matching each
     /// row of `expected` to its nearest row of `actual` and requiring the match
     /// residual to be below `tol`. Both sets must have the same number of rows.
-    fn assert_center_sets_match(expected: ArrayView2<'_, f64>, actual: ArrayView2<'_, f64>, tol: f64) {
+    fn assert_center_sets_match(
+        expected: ArrayView2<'_, f64>,
+        actual: ArrayView2<'_, f64>,
+        tol: f64,
+    ) {
         assert_eq!(expected.nrows(), actual.nrows(), "center counts differ");
         let k = expected.nrows();
         let mut used = vec![false; k];

--- a/src/terms/basis/periodic_duchon.rs
+++ b/src/terms/basis/periodic_duchon.rs
@@ -1366,9 +1366,8 @@ fn reject_nonpsd_then_clamp_noise(matrix: &Array2<f64>) -> Result<Array2<f64>, B
     if n == 0 || n != sym.ncols() {
         return Ok(sym);
     }
-    let (evals, _) = FaerEigh::eigh(&sym, Side::Lower).map_err(|e| {
-        BasisError::InvalidInput(format!("Duchon penalty PSD check failed: {e}"))
-    })?;
+    let (evals, _) = FaerEigh::eigh(&sym, Side::Lower)
+        .map_err(|e| BasisError::InvalidInput(format!("Duchon penalty PSD check failed: {e}")))?;
     if evals.is_empty() {
         return Ok(sym);
     }
@@ -1662,12 +1661,8 @@ mod mixed_periodicity_psd_tests {
         // Anchor the periodic span to exactly [0, 2π] so the auto-derived period
         // is the geometric period; this mirrors the Python cylinder fixture.
         let two_pi = std::f64::consts::TAU;
-        let theta = [
-            0.0, 0.6, 1.2, 1.9, 2.5, 3.1, 3.8, 4.4, 5.0, 5.6, two_pi,
-        ];
-        let y = [
-            0.5, 0.1, 0.9, 0.3, 0.7, 0.2, 0.8, 0.4, 0.6, 0.15, 0.5,
-        ];
+        let theta = [0.0, 0.6, 1.2, 1.9, 2.5, 3.1, 3.8, 4.4, 5.0, 5.6, two_pi];
+        let y = [0.5, 0.1, 0.9, 0.3, 0.7, 0.2, 0.8, 0.4, 0.6, 0.15, 0.5];
         let mut centers = Array2::<f64>::zeros((theta.len(), 2));
         for i in 0..theta.len() {
             centers[[i, 0]] = theta[i];
@@ -1764,12 +1759,7 @@ mod mixed_periodicity_psd_tests {
         // null space must therefore have exactly 2 columns: a constant column and
         // a `y` column (NOT a θ column — periodic axes contribute only the
         // constant).
-        let points = array![
-            [0.0_f64, 0.10],
-            [1.0, 0.40],
-            [2.0, 0.70],
-            [3.0, 0.95],
-        ];
+        let points = array![[0.0_f64, 0.10], [1.0, 0.40], [2.0, 0.70], [3.0, 0.95],];
         let periodic_per_axis = [true, false];
         let block = mixed_periodicity_nullspace_poly_block(points.view(), 2, &periodic_per_axis);
         assert_eq!(
@@ -1793,7 +1783,10 @@ mod mixed_periodicity_psd_tests {
             depends_on_theta |= is_theta && !is_const;
         }
         assert!(has_const, "null space must include the constant 1");
-        assert!(has_y, "null space must include the nonperiodic coordinate y (gam#1423)");
+        assert!(
+            has_y,
+            "null space must include the nonperiodic coordinate y (gam#1423)"
+        );
         assert!(
             !depends_on_theta,
             "periodic axis θ must contribute only the constant, never a linear θ column"

--- a/src/terms/basis/sphere_kernels.rs
+++ b/src/terms/basis/sphere_kernels.rs
@@ -272,9 +272,9 @@ fn wahba_sphere_kernel_sobolev_closed_form_derivative_dcos(cos_gamma: f64, m: us
         // any other `m` is a caller-contract violation (a programming error,
         // not runtime data), and panicking surfaces it instead of returning a
         // silently-wrong derivative.
-        other => panic!(
-            "closed-form Sobolev derivative only defined for m in {{1,2,3}}; got m={other}"
-        ),
+        other => {
+            panic!("closed-form Sobolev derivative only defined for m in {{1,2,3}}; got m={other}")
+        }
     };
     // du/d(cos gamma) = -1/2.
     dk_du * (-0.5)

--- a/src/terms/sae/manifold/construction.rs
+++ b/src/terms/sae/manifold/construction.rs
@@ -59,10 +59,7 @@ impl OuterGradientError {
     /// shape/non-finite guards (`vector shapes`, `gauge length`, `must be finite`,
     /// `non-finite`). Everything else — including the `cholesky`/back-solve
     /// near-singular failures — is treated as a genuine conditioning trip.
-    pub(crate) fn classify_arrow_solver_error(
-        message: &str,
-        conditioning_err: Self,
-    ) -> Self {
+    pub(crate) fn classify_arrow_solver_error(message: &str, conditioning_err: Self) -> Self {
         let lower = message.to_ascii_lowercase();
         let is_internal = lower.contains("vector shapes")
             || lower.contains("gauge length")
@@ -9766,8 +9763,7 @@ mod outer_gradient_error_classification_1451_tests {
             "DeflatedArrowSolver: solution length 5 != cache full length 6",
         ];
         for msg in shape_messages {
-            let classified =
-                OuterGradientError::classify_arrow_solver_error(msg, conditioning());
+            let classified = OuterGradientError::classify_arrow_solver_error(msg, conditioning());
             assert!(
                 matches!(classified, OuterGradientError::InternalInvariant { .. }),
                 "shape mismatch must classify to InternalInvariant (#1451); got {classified}"
@@ -9788,8 +9784,7 @@ mod outer_gradient_error_classification_1451_tests {
             "outer_gradient_arrow_solver: non-finite entry in projected gauge Hessian",
         ];
         for msg in nonfinite_messages {
-            let classified =
-                OuterGradientError::classify_arrow_solver_error(msg, conditioning());
+            let classified = OuterGradientError::classify_arrow_solver_error(msg, conditioning());
             assert!(
                 matches!(classified, OuterGradientError::InternalInvariant { .. }),
                 "non-finite intermediate must classify to InternalInvariant (#1451); \
@@ -9810,8 +9805,7 @@ mod outer_gradient_error_classification_1451_tests {
             "DeflatedArrowSolver: gauge back-solve: singular factor",
         ];
         for msg in conditioning_messages {
-            let classified =
-                OuterGradientError::classify_arrow_solver_error(msg, conditioning());
+            let classified = OuterGradientError::classify_arrow_solver_error(msg, conditioning());
             assert!(
                 matches!(classified, OuterGradientError::IllConditioned { .. }),
                 "a finite, correctly-shaped near-singular failure must KEEP \

--- a/src/terms/sae/manifold/sae_contract_probe_tests.rs
+++ b/src/terms/sae/manifold/sae_contract_probe_tests.rs
@@ -5,18 +5,17 @@
 //! coordinate gradients/Hessians match finite differences on the penalized
 //! objective contract.
 
-use super::*;
 use super::tests::{
     TestPeriodicEvaluator, diagonal_latent_cache, periodic_basis,
     warmstart_test_objective_with_evaluator,
 };
+use super::*;
 use crate::terms::{AssignmentMode, LatentManifold, SaeAssignment};
 use approx::assert_abs_diff_eq;
 use ndarray::array;
 use std::sync::Arc;
 
-pub(crate) fn euclidean_line_contract_fixture() -> (SaeManifoldTerm, Array2<f64>, SaeManifoldRho)
-{
+pub(crate) fn euclidean_line_contract_fixture() -> (SaeManifoldTerm, Array2<f64>, SaeManifoldRho) {
     let n = 150usize;
     let p = 8usize;
     let mut coords = Array2::<f64>::zeros((n, 1));
@@ -374,8 +373,7 @@ fn cotrained_criterion_folds_faithful_amortized_encoder_on_known_manifold() {
     let heldout_amplitudes = Array1::<f64>::ones(n_holdout);
     let mut target_norm_bound = 0.0_f64;
     for row in 0..n_holdout {
-        target_norm_bound =
-            target_norm_bound.max(heldout.row(row).dot(&heldout.row(row)).sqrt());
+        target_norm_bound = target_norm_bound.max(heldout.row(row).dot(&heldout.row(row)).sqrt());
     }
     let atlas = crate::terms::sae::encode::EncodeAtlas::build(
         &term.atoms,

--- a/src/terms/sae/manifold/tests.rs
+++ b/src/terms/sae/manifold/tests.rs
@@ -3894,6 +3894,36 @@ pub(crate) fn sae_row_layout_from_dense_weights_top_k_and_cutoff() {
     assert_eq!(full[7], 6.0);
 }
 
+// #1450 — large-K (K=100000) end-to-end `from_dense_weights` coverage.
+#[test]
+pub(crate) fn from_dense_weights_large_k_support_proposal_1450() {
+    let (k_atoms, d, k_true, n) = (100_000_usize, 1, 4, 4);
+    let planted: Vec<usize> = (0..k_true).map(|j| j * k_atoms / k_true).collect();
+    let assignments: Vec<Array1<f64>> = (0..n)
+        .map(|row| {
+            let mut a = vec![1e-9_f64; k_atoms];
+            for (i, &atom) in planted.iter().enumerate() {
+                a[atom] = 0.2 + 0.01 * (row + i) as f64;
+            }
+            Array1::from_vec(a)
+        })
+        .collect();
+    let coord_offsets: Vec<usize> = (0..k_atoms).map(|k| k_atoms + k).collect();
+    let layout = SaeRowLayout::from_dense_weights(
+        &assignments,
+        k_true,
+        1e-3,
+        vec![d; k_atoms],
+        coord_offsets,
+    );
+    for row in 0..n {
+        assert_eq!(layout.active_atoms[row], planted, "row {row} wrong atoms");
+        assert_eq!(layout.row_q_active(row), k_true + k_true * d);
+    }
+    let compact_work: usize = (0..n).map(|r| layout.row_q_active(r).pow(2)).sum();
+    assert!(compact_work < n * (k_atoms * (1 + d)).pow(2) / 1_000_000);
+}
+
 /// MechanismSparsityPenalty must reach the SAE arrow-Schur system's
 /// `gb` (beta-tier gradient) when its target slice is shaped to match a
 /// single-atom decoder block (M, p_out). The group lasso over rows of

--- a/src/terms/term_builder.rs
+++ b/src/terms/term_builder.rs
@@ -28,10 +28,10 @@ use crate::inference::formula_dsl::{
 use crate::inference::model::ColumnKindTag;
 use crate::resource::ResourcePolicy;
 use crate::smooth::{
-    ByVarKind, FactorSmoothFlavour, FactorSmoothSpec,
-    LinearCoefficientGeometry, LinearTermSpec, RandomEffectTermSpec, ShapeConstraint,
-    SmoothBasisSpec, SmoothTermSpec, TensorBSplineIdentifiability,
-    TensorBSplinePenaltyDecomposition, TensorBSplineSpec, TermCollectionSpec,
+    ByVarKind, FactorSmoothFlavour, FactorSmoothSpec, LinearCoefficientGeometry, LinearTermSpec,
+    RandomEffectTermSpec, ShapeConstraint, SmoothBasisSpec, SmoothTermSpec,
+    TensorBSplineIdentifiability, TensorBSplinePenaltyDecomposition, TensorBSplineSpec,
+    TermCollectionSpec,
 };
 use crate::types::ColIdx;
 
@@ -547,19 +547,20 @@ pub fn build_termspec(
                             // unpenalized treatment-coded main effect, which would
                             // double-represent the factor (two `g` design blocks +
                             // a spurious extra smoothing parameter).
-                            let penalized_group_owner_present = terms.iter().any(|other| match other {
-                                ParsedTerm::RandomEffect { name } => name == &by_name,
-                                ParsedTerm::Linear {
-                                    name,
-                                    explicit: false,
-                                    ..
-                                } if name == &by_name => col_map
-                                    .get(name)
-                                    .and_then(|c| ds.column_kinds.get(*c).copied())
-                                    .map(|kind| matches!(kind, ColumnKindTag::Categorical))
-                                    .unwrap_or(false),
-                                _ => false,
-                            });
+                            let penalized_group_owner_present =
+                                terms.iter().any(|other| match other {
+                                    ParsedTerm::RandomEffect { name } => name == &by_name,
+                                    ParsedTerm::Linear {
+                                        name,
+                                        explicit: false,
+                                        ..
+                                    } if name == &by_name => col_map
+                                        .get(name)
+                                        .and_then(|c| ds.column_kinds.get(*c).copied())
+                                        .map(|kind| matches!(kind, ColumnKindTag::Categorical))
+                                        .unwrap_or(false),
+                                    _ => false,
+                                });
                             // Add an unpenalized treatment-coded fixed main
                             // effect for a standalone factor-by smooth, unless
                             // the same factor already has an explicit
@@ -570,9 +571,7 @@ pub fn build_termspec(
                             // owner of level offsets; adding a no-pooling fixed
                             // factor effect would bypass random-effect
                             // shrinkage and degrade BLUP-style predictions.
-                            if !random_terms
-                                .iter()
-                                .any(|rt| rt.name == by_name)
+                            if !random_terms.iter().any(|rt| rt.name == by_name)
                                 && !penalized_group_owner_present
                             {
                                 random_terms.push(RandomEffectTermSpec {
@@ -2179,8 +2178,7 @@ pub fn build_smooth_basis(
             // `k`/`centers` still takes full effect via `parse_countwith_basis_alias`.
             let default_centers = if cols.len() == 1 {
                 let nullspace_dim = crate::basis::duchon_nullspace_dimension(1, 1);
-                let target_centers =
-                    THIN_PLATE_1D_DEFAULT_BASIS_DIM.saturating_sub(nullspace_dim);
+                let target_centers = THIN_PLATE_1D_DEFAULT_BASIS_DIM.saturating_sub(nullspace_dim);
                 plan.centers.min(target_centers.max(1))
             } else {
                 plan.centers

--- a/tests/basis_smooth/matern_formula_integration.rs
+++ b/tests/basis_smooth/matern_formula_integration.rs
@@ -50,7 +50,10 @@ fn matern_2d_dataset() -> gam::data::EncodedDataset {
 /// penalized trace is bounded by the block rank, so clamping it to `[0, rank]`
 /// keeps a fully-penalized redundant direction at its saturated trace instead of
 /// `+∞`. The fit must succeed and recover the signal.
-fn matern_1d_uniform_dataset(n: usize, seed: u64) -> (gam::data::EncodedDataset, Vec<f64>, Vec<f64>) {
+fn matern_1d_uniform_dataset(
+    n: usize,
+    seed: u64,
+) -> (gam::data::EncodedDataset, Vec<f64>, Vec<f64>) {
     // Small deterministic LCG so the test has no extra RNG dependency.
     let mut s = seed
         .wrapping_mul(2862933555777941757)
@@ -64,7 +67,10 @@ fn matern_1d_uniform_dataset(n: usize, seed: u64) -> (gam::data::EncodedDataset,
     let mut xs: Vec<f64> = (0..n).map(|_| nextf()).collect();
     xs.sort_by(|a, b| a.partial_cmp(b).unwrap());
     let mut ys = Vec::with_capacity(n);
-    let headers = ["x", "y"].into_iter().map(str::to_string).collect::<Vec<_>>();
+    let headers = ["x", "y"]
+        .into_iter()
+        .map(str::to_string)
+        .collect::<Vec<_>>();
     let rows = xs
         .iter()
         .map(|&x| {
@@ -92,8 +98,9 @@ fn univariate_matern_fits_ordinary_uniform_1d_data_1379() {
             family: Some("gaussian".to_string()),
             ..FitConfig::default()
         };
-        let result = fit_from_formula("y ~ matern(x)", &data, &config)
-            .unwrap_or_else(|e| panic!("matern(x) failed to fit ordinary 1-D data at seed {seed}: {e}"));
+        let result = fit_from_formula("y ~ matern(x)", &data, &config).unwrap_or_else(|e| {
+            panic!("matern(x) failed to fit ordinary 1-D data at seed {seed}: {e}")
+        });
         let FitResult::Standard(fit) = result else {
             panic!("expected standard Gaussian fit at seed {seed}");
         };
@@ -107,7 +114,11 @@ fn univariate_matern_fits_ordinary_uniform_1d_data_1379() {
         );
         // Gaussian identity link: fitted mean = design · beta (no offset here).
         let fitted = fit.design.design.to_dense().dot(&fit.fit.beta);
-        assert_eq!(fitted.len(), ys.len(), "fitted length mismatch at seed {seed}");
+        assert_eq!(
+            fitted.len(),
+            ys.len(),
+            "fitted length mismatch at seed {seed}"
+        );
         assert!(
             fitted.iter().all(|v| v.is_finite()),
             "matern(x) produced non-finite fitted values at seed {seed}"

--- a/tests/regressions.rs
+++ b/tests/regressions.rs
@@ -10,6 +10,8 @@ mod arrow_schur_bug_hunt;
 mod bernoulli_marginal_slope_bug_hunt_1;
 #[path = "regressions/bug_hunt_1089_small_n_gaussian_double_penalty_terminates.rs"]
 mod bug_hunt_1089_small_n_gaussian_double_penalty_terminates;
+#[path = "regressions/bug_hunt_1379_univariate_matern_gp_degenerate_range_penalty.rs"]
+mod bug_hunt_1379_univariate_matern_gp_degenerate_range_penalty;
 #[path = "regressions/bug_hunt_874_cyclic_bs_cc_outer_loop_terminates.rs"]
 mod bug_hunt_874_cyclic_bs_cc_outer_loop_terminates;
 #[path = "regressions/bug_hunt_979_gaussian_duchon_inference_nuts_not_quadratic.rs"]
@@ -350,5 +352,3 @@ mod warm_start_store_regressions;
 mod wiggle_option_validation_issue_377_373;
 #[path = "regressions/workflow_bug_hunt.rs"]
 mod workflow_bug_hunt;
-#[path = "regressions/bug_hunt_1379_univariate_matern_gp_degenerate_range_penalty.rs"]
-mod bug_hunt_1379_univariate_matern_gp_degenerate_range_penalty;


### PR DESCRIPTION
## Summary

#1450: the compact-path `from_dense_weights` partial-select fix (#1411) had small-K unit coverage (K=3) but no end-to-end test at the production scale (K=100000) the "per-token cost independent of K" contract claims.

This test exercises the actual dense assignment generation + support proposal path at K=100000 with planted sparse active sets:
- K=100000 atoms, d=1, k_true=4 planted active per row
- `from_dense_weights` with `k_active_cap=4`, `relative_cutoff=1e-3`
- Asserts correct atom selection (the 4 planted atoms out of 100000)
- Asserts `q_active = k_true·(1+d) = 8`, not `K·(1+d) = 200000`
- Asserts compact work is 1e6× smaller than dense work

Test passes: 1 passed, 0 failed.

— HomunculusLabs (AI-assisted)