### PR TITLE
feat+test(#932): single-source SAE beta border channels through the row-program tower

### DIFF
--- a/src/terms/sae/manifold/tests.rs
+++ b/src/terms/sae/manifold/tests.rs
@@ -9827,6 +9827,60 @@ pub(crate) fn sae_row_jet_program_matches_production_row_jets_on_converged_cache
                     }
                 }
             }
+
+            // β BORDER CHANNELS (#932): the hand path packs ∂ẑ_c/∂β_{k,b}
+            // (value) and ∂²ẑ_c/∂β_{k,b}∂p_a (the `beta_deriv` / `beta_l_deriv`
+            // mixed second derivatives) term by term in `row_jets_for_logdet`,
+            // with NO tower oracle previously. Reconstruction is LINEAR in β, so
+            // ∂ẑ_c/∂β_{k,b} = ζ_k(ℓ)·Φ_b(t_k)·B_{b,c}: the `beta_border_tower`
+            // sub-jet, built from the SAME gate_tower / basis_tower primitives as
+            // the reconstruction column. Pin every β channel (value + both
+            // mixed-derivative arrays) to that tower at ~1e-9, scaled by √w like
+            // the production packing.
+            for (beta_pos, channel) in border.iter().enumerate() {
+                for out_col in 0..p {
+                    let tower = prog.beta_border_tower::<K>(
+                        channel.atom,
+                        channel.basis_col,
+                        out_col,
+                    );
+                    let want_v = sqrt_row_w * tower.v;
+                    let v_floor = want_v.abs().max(1e-12);
+                    assert!(
+                        (jets.beta[beta_pos][out_col] - want_v).abs() <= 1e-9 * v_floor,
+                        "weighted={weighted} row {row} col {out_col} \
+                         beta[{beta_pos}] (atom {} basis {}): production {} vs tower {}",
+                        channel.atom,
+                        channel.basis_col,
+                        jets.beta[beta_pos][out_col],
+                        want_v
+                    );
+                    for a in 0..K {
+                        let want_d = sqrt_row_w * tower.g[a];
+                        let d_floor = want_d.abs().max(1e-12);
+                        // `beta_deriv` and `beta_l_deriv` are the SAME mixed
+                        // ∂²ẑ_c/∂β∂p_a derivative the linear-in-β reconstruction
+                        // produces (the hand path fills both identically); both
+                        // must equal the tower's first-derivative channel.
+                        assert!(
+                            (jets.beta_deriv[a][beta_pos][out_col] - want_d).abs()
+                                <= 1e-9 * d_floor,
+                            "weighted={weighted} row {row} col {out_col} \
+                             beta_deriv[{a}][{beta_pos}]: production {} vs tower {}",
+                            jets.beta_deriv[a][beta_pos][out_col],
+                            want_d
+                        );
+                        assert!(
+                            (jets.beta_l_deriv[a][beta_pos][out_col] - want_d).abs()
+                                <= 1e-9 * d_floor,
+                            "weighted={weighted} row {row} col {out_col} \
+                             beta_l_deriv[{a}][{beta_pos}]: production {} vs tower {}",
+                            jets.beta_l_deriv[a][beta_pos][out_col],
+                            want_d
+                        );
+                    }
+                }
+            }
         }
     }
 }

--- a/src/terms/sae/row_jet_program.rs
+++ b/src/terms/sae/row_jet_program.rs
@@ -267,6 +267,44 @@ impl SaeReconstructionRowProgram {
         acc
     }
 
+    /// The β **border-channel** sub-jet: the derivative of the reconstruction
+    /// output column `out_col` with respect to ONE decoder coefficient
+    /// `β_{atom, basis_col}`, as a `Tower4<K>` in the local (logit/coord)
+    /// primaries.
+    ///
+    /// The reconstruction is `ẑ_c = Σ_k ζ_k(ℓ)·Σ_b β_{k,b}·Φ_b(t_k)·B_{b,c}`,
+    /// **linear** in every `β_{k,b}`, so
+    /// `∂ẑ_c/∂β_{k,b} = ζ_k(ℓ)·Φ_b(t_k)·B_{b,c}` — the gate times the single
+    /// basis function times the decoder entry, with `β` itself dropping out.
+    /// This is exactly the per-row β border channel the arrow solver carries
+    /// (`SaeBorderChannel{atom, basis_col, output = B_{b,·}}`): the returned
+    /// tower's `.v` is the channel value `ζ_k·Φ_b·B_{b,c}`, `.g[a]` is its
+    /// first derivative `∂(ζ_k·Φ_b)/∂p_a·B_{b,c}` (the `beta_deriv` /
+    /// `beta_l_deriv` channels), and the higher channels follow by Leibniz.
+    ///
+    /// It is built from the SAME `gate_tower` / `basis_tower` primitives as
+    /// [`Self::reconstruction_column`], so the β border channel is single
+    /// sourced with the local-variable reconstruction tower (#932) — the hand
+    /// path in `row_jets_for_logdet` packs these same products term by term and
+    /// is pinned to this tower by the converged-cache oracle.
+    #[must_use]
+    pub fn beta_border_tower<const K: usize>(
+        &self,
+        atom: usize,
+        basis_col: usize,
+        out_col: usize,
+    ) -> Tower4<K> {
+        assert_eq!(
+            self.n_primaries, K,
+            "SaeReconstructionRowProgram: tower arity K={K} must equal n_primaries={}",
+            self.n_primaries
+        );
+        let gate = self.gate_tower::<K>(atom);
+        let phi = self.atoms[atom].basis_tower::<K>(basis_col, &self.coord_slot[atom]);
+        let decoder = self.atoms[atom].decoder[basis_col][out_col];
+        gate.mul(&phi).scale(decoder)
+    }
+
     /// The number of reconstruction output columns.
     #[must_use]
     pub fn out_dim(&self) -> usize {


### PR DESCRIPTION
## What

Single-sources the SAE **β border channels** through the row-program tower and pins the hand-packed production path to it with a bit-identity oracle (~1e-9). Extends the #932 single-source program to the last hand-derived SAE derivative block.

## Why

`SaeReconstructionRowProgram::reconstruction_column` already single-sources the reconstruction value / gradient / Hessian (the `first`/`second` channels) from one expression, oracle-pinned on a converged production cache by `sae_row_jet_program_matches_production_row_jets_on_converged_cache`.

But the **β border channels** that `row_jets_for_logdet` emits — `beta` (the value `∂ẑ_c/∂β_{k,b}`) and `beta_deriv` / `beta_l_deriv` (the mixed second derivatives `∂²ẑ_c/∂β_{k,b}∂p_a`) — are packed **by hand, term by term** (`construction.rs`), with **no tower oracle**. They are exactly the cross-channel `gate × basis × decoder` products the #736/#833 dropped-term genus corrupts. The existing converged-cache oracle asserts only `jets.first`/`jets.second`, never `jets.beta*`.

## What this adds

**Production helper (`src/terms/sae/row_jet_program.rs`):** reconstruction is **linear in β**, so `∂ẑ_c/∂β_{k,b} = ζ_k(logits)·Φ_b(t_k)·B_{b,c}`. New `pub fn beta_border_tower::<K>(atom, basis_col, out_col) -> Tower4<K>` returns that sub-jet, built from the **same** `gate_tower` / `basis_tower` primitives as `reconstruction_column`. The β border channel is now single-sourced with the local-variable reconstruction tower — its `.v` is the channel value and `.g[a]` the `beta_deriv`/`beta_l_deriv` mixed derivative.

**Oracle (`src/terms/sae/manifold/tests.rs`):** the converged-cache test is extended to pin every β channel — value plus both mixed-derivative arrays — to `beta_border_tower` at ~1e-9, scaled by the #977 `√w` row-loss seam, across the unweighted and weighted arms. A dropped or misrouted gate/basis cross term in the hand β packing now fails loudly, no FD slack.

## Verification

Mathematical/structural only (no local compile, per the no-heavy-build constraint). Confirmed line-for-line that the production hand packing (`base = assignments[atom]·φ·√w`, `channel.output[c] = B_{b,c}`, Logit `dz[var][atom]·φ`, matching-atom Coord `assignments·basis_jacobian`) equals `√w · beta_border_tower.{v,g[a]} · 1` term-for-term, including the softmax cross-atom logit coupling and the non-matching-atom zero channels; `beta_border_tower` reuses private same-module primitives (`gate_tower`/`basis_tower`) and satisfies the `n_primaries == K` guard. `pub fn` on the `pub struct` → no dead-code/ban-scanner risk even before a production caller exists. CI builds and runs the oracle.

Refs #932.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
