### PR TITLE
perf(#979): build-once flex second-directional Jeffreys all-axes sweep

### DIFF
--- a/src/families/survival/marginal_slope/custom_family_impl.rs
+++ b/src/families/survival/marginal_slope/custom_family_impl.rs
@@ -536,6 +536,27 @@ impl CustomFamily for SurvivalMarginalSlopeFamily {
             return Ok(Some(axes));
         }
 
+        // Flex (no time-wiggle, no per-z): route the fixed-`d_u` all-axes sweep
+        // through the build-once path, which constructs the direction-independent
+        // per-row geometry and the fixed-`d_u` third contraction once and
+        // contracts the mixed fourth tensor against each axis, rather than the
+        // per-axis loop below that rebuilds both `p` times. Same per-row
+        // assembler as the per-axis sweep (equal up to the cross-row reduction
+        // order). This is the #979 flex second-directional Jeffreys hot path,
+        // mirroring the first-directional flex hook in
+        // `joint_jeffreys_information_directional_derivative_all_axes_with_specs`.
+        if !self.per_z_logslope_active()
+            && self.effective_flex_active(block_states)?
+            && !self.flex_timewiggle_active()
+        {
+            let axes = self
+                .exact_newton_joint_hessiansecond_directional_derivative_flex_no_wiggle_all_axes(
+                    block_states,
+                    d_beta_u_flat,
+                )?;
+            return Ok(Some(axes));
+        }
+
         let p = specs.iter().map(|spec| spec.design.ncols()).sum::<usize>();
         use rayon::iter::{IntoParallelIterator, ParallelIterator};
         let results: Vec<Result<Option<Array2<f64>>, String>> = (0..p)

--- a/src/families/survival/marginal_slope/joint_eval.rs
+++ b/src/families/survival/marginal_slope/joint_eval.rs
@@ -1684,6 +1684,88 @@ impl SurvivalMarginalSlopeFamily {
         Ok(result)
     }
 
+    /// Build-once all-axes variant of
+    /// [`Self::exact_newton_joint_hessiansecond_directional_derivative_flex_no_wiggle`].
+    ///
+    /// The second-directional Jeffreys all-axes sweep needs the second
+    /// directional joint-Hessian `D²H[d_u, e_axis]` for a FIXED first direction
+    /// `d_u` and each of the `p` coordinate axes `e_axis`. Calling the
+    /// single-direction routine `p` times rebuilds, per row and per axis, the
+    /// direction-independent flex geometry (`q`-geometry, intercept solves,
+    /// cached partitions, exact base timepoints) AND the fixed-`d_u` pieces (the
+    /// `d_u` primary pullback `ud` and the third contraction `t_d = T·ud`) — a
+    /// `p`-fold redundant cost that is the #979 flex marginal-slope hot path.
+    /// This variant builds the per-row [`FlexThirdRowBase`] once and hoists the
+    /// fixed-`d_u` `ud`/`t_d` out of the per-axis loop, so only the per-axis
+    /// `e_axis` pullback, the mixed fourth contraction `Q[ud, ue]`, and the row
+    /// accumulation are repeated. Each output matrix routes through the same
+    /// per-row assemblers as the corresponding single-axis call
+    /// (`row_flex_fourth_contract_from_base` + `row_flex_third_contract_from_base`
+    /// + `accumulate_directional_joint_hessian_row`), so it equals that call up
+    /// to the cross-row rayon reduction order.
+    pub(crate) fn exact_newton_joint_hessiansecond_directional_derivative_flex_no_wiggle_all_axes(
+        &self,
+        block_states: &[ParameterBlockState],
+        d_u: &Array1<f64>,
+    ) -> Result<Vec<Array2<f64>>, String> {
+        let slices = block_slices(self, block_states);
+        let primary = flex_primary_slices(self);
+        let p_total = slices.total;
+        let identity_blocks = flex_identity_block_pairs(&primary, &slices);
+        let zeros = || vec![Array2::<f64>::zeros((p_total, p_total)); p_total];
+        let result = (0..self.n)
+            .into_par_iter()
+            .try_fold(zeros, |mut acc, row| -> Result<Vec<Array2<f64>>, String> {
+                // Direction-independent per-row geometry + fixed-`d_u` pieces,
+                // built once: the intercept solves / cached partitions / base
+                // timepoints (the base) and the `d_u` pullback `ud` plus its
+                // third contraction `t_d = T·ud`.
+                let q_geom = self.row_dynamic_q_geometry(row, block_states)?;
+                let base =
+                    self.build_row_flex_third_base_with_states(row, block_states, &primary)?;
+                let ud = self.row_primary_direction_from_flat_dynamic_with_q_geometry(
+                    row,
+                    block_states,
+                    &slices,
+                    &q_geom,
+                    d_u,
+                )?;
+                let t_d = self.row_flex_third_contract_from_base(&base, &ud)?;
+                // Per-axis: only the `e_axis` pullback, the mixed fourth
+                // contraction, the `t_d·ue` gamma, and the accumulation repeat.
+                for axis_idx in 0..p_total {
+                    let mut axis = Array1::<f64>::zeros(p_total);
+                    axis[axis_idx] = 1.0;
+                    let ue = self.row_primary_direction_from_flat_dynamic_with_q_geometry(
+                        row,
+                        block_states,
+                        &slices,
+                        &q_geom,
+                        &axis,
+                    )?;
+                    let q_de = self.row_flex_fourth_contract_from_base(&base, &ud, &ue)?;
+                    let gamma = t_d.dot(&ue);
+                    self.accumulate_directional_joint_hessian_row(
+                        row,
+                        &slices,
+                        &q_geom,
+                        &identity_blocks,
+                        gamma.view(),
+                        q_de.view(),
+                        &mut acc[axis_idx],
+                    )?;
+                }
+                Ok(acc)
+            })
+            .try_reduce(zeros, |mut a, b| -> Result<_, String> {
+                for (ai, bi) in a.iter_mut().zip(b.into_iter()) {
+                    *ai += &bi;
+                }
+                Ok(a)
+            })?;
+        Ok(result)
+    }
+
     pub(crate) fn evaluate_blockwise_exact_newton(
         &self,
         block_states: &[ParameterBlockState],

--- a/src/families/survival/marginal_slope/tests.rs
+++ b/src/families/survival/marginal_slope/tests.rs
@@ -6818,6 +6818,61 @@ fn survival_jointhessian_flex_no_wiggle_all_axes_matches_per_axis() {
     }
 }
 
+/// gam#979: the build-once second-directional all-axes flex sweep
+/// (`..._flex_no_wiggle_all_axes`, fixed first direction `d_u`) must reproduce
+/// calling the single-direction second-directional routine once per coordinate
+/// axis. The all-axes path hoists the direction-independent per-row geometry
+/// (intercept solves, cached partitions, base timepoints) AND the fixed-`d_u`
+/// third contraction out of the per-axis loop; this asserts the optimization
+/// changes only the cost, never the result. The two paths feed the same per-row
+/// assemblers but run independent rayon reductions, so equality is to a tight
+/// relative tolerance, not bit-for-bit. The fixed `d_u` is deliberately a dense
+/// (non-axis-aligned) direction so the mixed fourth contraction `Q[ud, ue]` is
+/// exercised, not a single-coordinate special case.
+#[test]
+fn survival_jointhessian_flex_no_wiggle_second_directional_all_axes_matches_per_axis() {
+    let n = 40usize;
+    let family = make_flex_no_wiggle_test_family(n);
+    let states = flex_no_wiggle_test_block_states(&family);
+    assert!(family.effective_flex_active(&states).unwrap());
+    assert!(!family.flex_timewiggle_active());
+    let slices = block_slices(&family, &states);
+    let p = slices.total;
+    assert!(p >= 2, "test family must exercise multiple axes, got p={p}");
+
+    // Dense fixed first direction d_u (not an axis), so the swept axes hit the
+    // genuine mixed second-directional fourth contraction.
+    let mut d_u = Array1::<f64>::zeros(p);
+    for (k, value) in d_u.iter_mut().enumerate() {
+        *value = 0.03 * ((k as f64 + 0.4).sin()) - 0.02 * ((k as f64 + 1.1).cos());
+    }
+
+    let all_axes = family
+        .exact_newton_joint_hessiansecond_directional_derivative_flex_no_wiggle_all_axes(
+            &states, &d_u,
+        )
+        .expect("second-directional all-axes sweep");
+    assert_eq!(all_axes.len(), p);
+
+    for axis_idx in 0..p {
+        let mut axis = Array1::<f64>::zeros(p);
+        axis[axis_idx] = 1.0;
+        let per_axis = family
+            .exact_newton_joint_hessiansecond_directional_derivative_flex_no_wiggle(
+                &states, &d_u, &axis,
+            )
+            .expect("per-axis second-directional derivative");
+        let batched = &all_axes[axis_idx];
+        assert_eq!(batched.dim(), per_axis.dim());
+        let rel = rel_diff_array2_survival(batched, &per_axis);
+        assert!(
+            rel < 1e-10,
+            "axis {axis_idx}: build-once second-directional all-axes path diverged \
+             from per-axis sweep, rel {rel}"
+        );
+    }
+}
+
 #[test]
 fn survival_jointhessian_flex_no_wiggle_operator_subsample_half_scales_correctly() {
     use crate::outer_subsample::OuterScoreSubsample;

--- a/src/families/survival/marginal_slope/timepoint_exact/contracted.rs
+++ b/src/families/survival/marginal_slope/timepoint_exact/contracted.rs
@@ -217,6 +217,151 @@ impl SurvivalMarginalSlopeFamily {
         Ok(Array2::<f64>::from_shape_vec((p, p), flat).map_err(|e| e.to_string())?)
     }
 
+    /// Fourth-order directional contraction reusing a prebuilt
+    /// [`FlexThirdRowBase`], the mixed-direction analogue of
+    /// [`Self::row_flex_third_contract_from_base`].
+    ///
+    /// The base carries the direction-independent per-row geometry (intercept
+    /// solves, cached partitions, exact base timepoints) that
+    /// [`Self::row_flex_primary_fourth_contracted_exact`] otherwise rebuilds on
+    /// every call. Hoisting it lets a fixed-`dir_u` / sweeping-`dir_v` all-axes
+    /// pass pay that geometry once per row instead of `p` times — the #979 flex
+    /// second-directional Jeffreys hot path. Only the per-direction timepoint
+    /// extensions (`dir_u`, `dir_v`), the bidirectional second-order extension,
+    /// and the Block-10 fourth assembly are recomputed; the per-(u, v) assembly
+    /// routes through the same `cpu_oracle_fourth_contraction` as the
+    /// build-each-time path, on identical inputs.
+    pub(crate) fn row_flex_fourth_contract_from_base(
+        &self,
+        base: &FlexThirdRowBase,
+        dir_u: &Array1<f64>,
+        dir_v: &Array1<f64>,
+    ) -> Result<Array2<f64>, String> {
+        let p = base.p;
+        if dir_u.iter().all(|v| v.abs() == 0.0) || dir_v.iter().all(|v| v.abs() == 0.0) {
+            return Ok(Array2::<f64>::zeros((p, p)));
+        }
+        let primary = flex_primary_slices(self);
+        let beta_h = base.beta_h.as_ref();
+        let beta_w = base.beta_w.as_ref();
+
+        let entry_ext_u = self.compute_survival_timepoint_directional_exact_from_cached(
+            base.row,
+            &primary,
+            base.q0,
+            base.q0_index,
+            base.a0,
+            base.g,
+            beta_h,
+            beta_w,
+            &base.entry_cached,
+            dir_u,
+            false,
+        )?;
+        let entry_ext_v = self.compute_survival_timepoint_directional_exact_from_cached(
+            base.row,
+            &primary,
+            base.q0,
+            base.q0_index,
+            base.a0,
+            base.g,
+            beta_h,
+            beta_w,
+            &base.entry_cached,
+            dir_v,
+            false,
+        )?;
+        let exit_ext_u = self.compute_survival_timepoint_directional_exact_from_cached(
+            base.row,
+            &primary,
+            base.q1,
+            base.q1_index,
+            base.a1,
+            base.g,
+            beta_h,
+            beta_w,
+            &base.exit_cached,
+            dir_u,
+            true,
+        )?;
+        let exit_ext_v = self.compute_survival_timepoint_directional_exact_from_cached(
+            base.row,
+            &primary,
+            base.q1,
+            base.q1_index,
+            base.a1,
+            base.g,
+            beta_h,
+            beta_w,
+            &base.exit_cached,
+            dir_v,
+            true,
+        )?;
+        let entry_bi = self.compute_survival_timepoint_bidirectional_exact_from_cached(
+            base.row,
+            &primary,
+            base.q0,
+            base.q0_index,
+            base.a0,
+            base.g,
+            beta_h,
+            beta_w,
+            &base.entry_cached,
+            dir_u,
+            dir_v,
+        )?;
+        let exit_bi = self.compute_survival_timepoint_bidirectional_exact_from_cached(
+            base.row,
+            &primary,
+            base.q1,
+            base.q1_index,
+            base.a1,
+            base.g,
+            beta_h,
+            beta_w,
+            &base.exit_cached,
+            dir_u,
+            dir_v,
+        )?;
+
+        let entry_d1 = block10_pack_dir(&entry_ext_u);
+        let entry_d2 = block10_pack_dir(&entry_ext_v);
+        let exit_d1 = block10_pack_dir(&exit_ext_u);
+        let exit_d2 = block10_pack_dir(&exit_ext_v);
+        let entry_bi_p = block10_pack_bi(&entry_bi);
+        let exit_bi_p = block10_pack_bi(&exit_bi);
+        let dir_u_vec: Vec<f64> = dir_u.to_vec();
+        let dir_v_vec: Vec<f64> = dir_v.to_vec();
+        let inputs =
+            crate::families::survival::marginal_slope::gpu::SurvivalFlexBlock10FourthInputs {
+                p,
+                qd1_index: base.qd1_index,
+                qd1: base.qd1,
+                w: self.weights[base.row],
+                d: self.event[base.row],
+                dir_u: &dir_u_vec,
+                dir_v: &dir_v_vec,
+                entry_base: &base.entry_base,
+                exit_base: &base.exit_base,
+                entry_ext_u: &entry_d1,
+                entry_ext_v: &entry_d2,
+                exit_ext_u: &exit_d1,
+                exit_ext_v: &exit_d2,
+                entry_bi: &entry_bi_p,
+                exit_bi: &exit_bi_p,
+            };
+        let flat =
+            crate::families::survival::marginal_slope::gpu::cpu_oracle_fourth_contraction(&inputs)
+                .map_err(|e| format!("block10 fourth contraction: {e}"))?;
+        let mut out = Array2::<f64>::zeros((p, p));
+        for u in 0..p {
+            for v in 0..p {
+                out[[u, v]] = flat[u * p + v];
+            }
+        }
+        Ok(out)
+    }
+
     /// Fourth-order directional contraction for the flexible survival path.
     ///
     /// The mixed second-directional timepoint transport is carried exactly


### PR DESCRIPTION
## Summary

Removes the lone remaining p-fold flex hot path in the survival marginal-slope outer-REML Jeffreys term: the **flex second-directional all-axes** sweep.

`joint_jeffreys_information_second_directional_all_axes_with_specs` looped over every coefficient axis calling the single-direction `exact_newton_joint_hessiansecond_directional_derivative_flex_no_wiggle` `p` times. Each call rebuilds, per row, the direction-independent flex geometry (q-geometry, intercept solves, cached partitions, exact base timepoints) **and** the fixed-`d_u` pieces (the `d_u` primary pullback `ud` and its third contraction `t_d`). So a `p`-coefficient model paid that geometry + third-contraction `p`-fold per outer-REML Jeffreys cycle.

This is the flex analogue of:
- the **rigid** p-fold cost removed in `81ca742a7` (#979), and
- the **first-directional flex** all-axes sweep already build-once via `exact_newton_joint_hessian_directional_derivative_flex_no_wiggle_all_axes`.

The second-directional flex sweep was the last one still per-axis.

## What changed

- New `exact_newton_joint_hessiansecond_directional_derivative_flex_no_wiggle_all_axes(block_states, d_u)` (joint_eval.rs): builds the per-row `FlexThirdRowBase` once and hoists the fixed-`d_u` `ud` + third contraction `t_d` out of the per-axis loop. Only the per-axis `e_axis` pullback, the mixed fourth contraction `Q[ud, ue]`, the `t_d·ue` gamma, and the row accumulation repeat.
- New `row_flex_fourth_contract_from_base(&base, dir_u, dir_v)` (contracted.rs): mixed-direction analogue of the existing `row_flex_third_contract_from_base`, reusing the prebuilt base instead of rebuilding intercept solves / cached partitions / base timepoints. Routes the per-(u,v) assembly through the same `cpu_oracle_fourth_contraction` as the build-each-time path on identical inputs, so CPU/GPU cannot drift.
- Dispatch the flex-no-wiggle case of `joint_jeffreys_information_second_directional_all_axes_with_specs` to the new build-once path (custom_family_impl.rs), mirroring the first-directional flex hook. Rigid / timewiggle / per-z paths are unchanged.

## Correctness

By construction: same per-row assemblers, same inputs, only the direction-independent geometry and the fixed-`d_u` third contraction are hoisted out of the axis loop. The base built by `build_row_flex_third_base_with_states` uses the identical solve/cache/timepoint sequence the build-each-time fourth contraction runs inline, so the extensions/bidirectional/assembly see byte-identical inputs.

Gated by a new parity regression `survival_jointhessian_flex_no_wiggle_second_directional_all_axes_matches_per_axis`: a dense **non-axis-aligned** fixed `d_u` (so the mixed fourth contraction is genuinely exercised), asserting the build-once all-axes path equals the per-axis single-direction sweep to **rel < 1e-10** on every axis. The tolerance is tight-but-not-bit-for-bit only because the two paths run independent rayon cross-row reductions — the exact same convention the existing first-directional parity test uses.

Per the survival-lane rules I did not build/test locally (OOM risk); CI builds + times it.

Refs #979 #1082.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
