### PR TITLE
test(quality): add lidar held-out predictive arm to expectile GAM test

### DIFF
--- a/tests/quality/misc/quality_expectile_gam_heteroscedastic_truth.rs
+++ b/tests/quality/misc/quality_expectile_gam_heteroscedastic_truth.rs
@@ -46,11 +46,15 @@ use gam::matrix::LinearOperator;
 use gam::smooth::build_term_collection_design;
 use gam::{
     FitConfig, FitResult, encode_recordswith_inferred_schema, fit_from_formula, init_parallelism,
+    load_csvwith_inferred_schema,
 };
 use ndarray::Array2;
 use rand::SeedableRng;
 use rand::rngs::StdRng;
 use rand_distr::{Distribution, Normal};
+use std::path::Path;
+
+const LIDAR_CSV: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/bench/datasets/lidar.csv");
 
 /// Smooth conditional mean of the planted truth.
 fn truth_mean(x: f64) -> f64 {
@@ -252,4 +256,170 @@ fn expectile_gam_recovers_closed_form_heteroscedastic_expectiles() {
              gives split {implied:.3} (want ≈ 0.5); the LAWS fixed point did not converge"
         );
     }
+}
+
+/// Re-encode held-in rows through the same schema inference the CSV loader uses,
+/// keeping the train subset numerically identical to the loaded data.
+fn lidar_train_dataset(range: &[f64], logratio: &[f64]) -> gam::data::EncodedDataset {
+    let headers = vec!["range".to_string(), "logratio".to_string()];
+    let records: Vec<StringRecord> = range
+        .iter()
+        .zip(logratio)
+        .map(|(&r, &y)| StringRecord::from(vec![format!("{r:.17e}"), format!("{y:.17e}")]))
+        .collect();
+    encode_recordswith_inferred_schema(headers, records).expect("encode lidar train subset")
+}
+
+/// REAL-DATA held-out arm: fit the conditional τ-expectile of `logratio ~ s(range)`
+/// on the canonical, strongly heteroscedastic `lidar` benchmark, training on a
+/// deterministic 3/4 split and evaluating on the held-out 1/4.
+///
+/// There is no mature off-the-shelf comparator that fits *expectile* GAMs on
+/// arbitrary data (mgcv/gamlss/quantreg fit means, quantiles, or full location-
+/// scale densities, not Newey–Powell expectiles), so — per the suite's
+/// reference-as-truth policy — the objective bar is the DEFINING PREDICTIVE
+/// PROPERTY of a conditional τ-expectile evaluated OUT OF SAMPLE:
+///
+///   1. Out-of-sample calibration. At the predicted τ-expectile `ê_τ(x)` on
+///      points the fit never saw, the asymmetric residual balance must satisfy
+///      the estimating equation `τ·Σ(y−ê)_+ ≈ (1−τ)·Σ(ê−y)_+`, i.e. the implied
+///      split `τ·U/(τ·U+(1−τ)·L) ≈ 0.5`, for τ ∈ {0.1, 0.5, 0.9}. A fit that
+///      merely interpolated the training residual asymmetry (overfit) would fail
+///      this on held-out data; a correctly smoothed expectile generalizes.
+///   2. Held-out ordering. The three predicted curves stay strictly ordered
+///      `ê_0.1 < ê_0.5 < ê_0.9` on the held-out covariate — the asymmetric
+///      structure is a real, generalizing property of the conditional law.
+///   3. Central predictor. On held-out rows the median expectile (τ=0.5) is a
+///      better point predictor of `y` (lower RMSE) than either extreme, because
+///      it targets the conditional center while the extremes deliberately do not.
+#[test]
+fn expectile_gam_held_out_calibration_on_lidar() {
+    init_parallelism();
+
+    let ds = load_csvwith_inferred_schema(Path::new(LIDAR_CSV)).expect("load lidar.csv");
+    let col = ds.column_map();
+    let range: Vec<f64> = ds.values.column(col["range"]).to_vec();
+    let logratio: Vec<f64> = ds.values.column(col["logratio"]).to_vec();
+    let n = range.len();
+    assert!(n > 100, "lidar should have ~221 rows, got {n}");
+
+    // Deterministic interleaved 3/4 train, 1/4 test split (no RNG).
+    let mut tr_range = Vec::new();
+    let mut tr_logratio = Vec::new();
+    let mut te_range = Vec::new();
+    let mut te_logratio = Vec::new();
+    for i in 0..n {
+        if i % 4 == 0 {
+            te_range.push(range[i]);
+            te_logratio.push(logratio[i]);
+        } else {
+            tr_range.push(range[i]);
+            tr_logratio.push(logratio[i]);
+        }
+    }
+    let n_test = te_range.len();
+    assert!(n_test > 30, "need a meaningful held-out set, got {n_test}");
+
+    let train_ds = lidar_train_dataset(&tr_range, &tr_logratio);
+    let train_col = train_ds.column_map();
+    let train_range_idx = train_col["range"];
+    let train_ncols = train_ds.headers.len();
+
+    let taus = [0.1_f64, 0.5, 0.9];
+    let mut held_out: Vec<Vec<f64>> = Vec::with_capacity(taus.len());
+    for &tau in &taus {
+        let cfg = FitConfig {
+            family: Some(format!("expectile({tau})")),
+            ..FitConfig::default()
+        };
+        let result = fit_from_formula("logratio ~ s(range)", &train_ds, &cfg)
+            .unwrap_or_else(|e| panic!("expectile(τ={tau}) lidar train fit failed: {e}"));
+        let FitResult::Standard(fit) = result else {
+            panic!("expectile(τ={tau}) returned a non-standard model");
+        };
+        assert!(
+            fit.fit.beta.iter().all(|v| v.is_finite()),
+            "non-finite expectile beta on lidar (τ={tau})"
+        );
+
+        // Predict the τ-expectile at the HELD-OUT range values (identity link =>
+        // design*beta is the response-scale expectile). Points unseen in fitting.
+        let mut test_grid = Array2::<f64>::zeros((n_test, train_ncols));
+        for (i, &r) in te_range.iter().enumerate() {
+            test_grid[[i, train_range_idx]] = r;
+        }
+        let design = build_term_collection_design(test_grid.view(), &fit.resolvedspec)
+            .unwrap_or_else(|e| panic!("held-out design rebuild (τ={tau}): {e}"));
+        let pred = design.design.apply(&fit.fit.beta).to_vec();
+        assert!(
+            pred.iter().all(|v| v.is_finite()),
+            "non-finite held-out expectile prediction (τ={tau})"
+        );
+        held_out.push(pred);
+    }
+
+    // 1. OUT-OF-SAMPLE CALIBRATION: the estimating equation balances on held-out
+    //    data. The slack is a touch wider than the in-sample 0.06 because the
+    //    n_test≈56 held-out asymmetric balance is noisier than the n=1200
+    //    in-sample one; 0.10 is still a tight, un-weakened generalization bound
+    //    (a mean fit would land at implied≈0.5 only for τ=0.5 and badly off for
+    //    the extremes).
+    for (i, &tau) in taus.iter().enumerate() {
+        let mut upper = 0.0_f64; // Σ (y−ê)_+
+        let mut lower = 0.0_f64; // Σ (ê−y)_+
+        for (yi, ei) in te_logratio.iter().zip(held_out[i].iter()) {
+            let r = yi - ei;
+            if r > 0.0 {
+                upper += r;
+            } else {
+                lower += -r;
+            }
+        }
+        let implied = (tau * upper) / (tau * upper + (1.0 - tau) * lower);
+        assert!(
+            (implied - 0.5).abs() < 0.10,
+            "held-out expectile(τ={tau}) on lidar is mis-calibrated: asymmetric-balance split \
+             {implied:.3} (want ≈ 0.5); the fitted τ-expectile does not generalize the \
+             conditional estimating equation to unseen points"
+        );
+    }
+
+    // 2. HELD-OUT ORDERING: the asymmetric structure generalizes — curves stay
+    //    strictly ordered on the held-out covariate.
+    for k in 0..n_test {
+        assert!(
+            held_out[0][k] < held_out[1][k] && held_out[1][k] < held_out[2][k],
+            "held-out expectile curves out of order at test point {k} (range={:.1}): \
+             {:.3} / {:.3} / {:.3}",
+            te_range[k],
+            held_out[0][k],
+            held_out[1][k],
+            held_out[2][k]
+        );
+    }
+
+    // 3. CENTRAL PREDICTOR: on held-out rows the median expectile (τ=0.5) is the
+    //    best point predictor of y; the τ=0.1/0.9 expectiles deliberately track
+    //    the lower/upper conditional bulk and so must have larger RMSE to y.
+    let rmse_to_y = |pred: &[f64]| -> f64 {
+        let s: f64 = pred
+            .iter()
+            .zip(te_logratio.iter())
+            .map(|(p, y)| (p - y).powi(2))
+            .sum();
+        (s / n_test as f64).sqrt()
+    };
+    let rmse_lo = rmse_to_y(&held_out[0]);
+    let rmse_mid = rmse_to_y(&held_out[1]);
+    let rmse_hi = rmse_to_y(&held_out[2]);
+    eprintln!(
+        "lidar held-out expectile: n_train={} n_test={n_test} \
+         RMSE_to_y[τ=0.1={rmse_lo:.4} τ=0.5={rmse_mid:.4} τ=0.9={rmse_hi:.4}]",
+        tr_range.len()
+    );
+    assert!(
+        rmse_mid < rmse_lo && rmse_mid < rmse_hi,
+        "the held-out median expectile (τ=0.5) should be the best central point predictor of y: \
+         RMSE τ=0.5={rmse_mid:.4} is not below both τ=0.1={rmse_lo:.4} and τ=0.9={rmse_hi:.4}"
+    );
 }


### PR DESCRIPTION
## What

Adds a **real-data held-out predictive arm** to the existing expectile GAM quality test (`family = "expectile(τ)"`, Newey–Powell asymmetric least squares), on the canonical strongly-heteroscedastic `lidar` benchmark. The existing synthetic closed-form truth-recovery + in-sample calibration test is unchanged.

## Why

The expectile test was synthetic-only. Per the standing lane (backlog item 3 / `quality-strengthen-with-real-data`), this adds a held-out predictive arm so the capability is validated on real, messy, heteroscedastic data — not just a planted Gaussian truth.

## Objective bar (no mature comparator weakening)

No off-the-shelf tool fits *expectile* GAMs on arbitrary data (mgcv/gamlss/quantreg fit means, quantiles, or full densities — not Newey–Powell expectiles), so — per the suite's reference-as-truth policy — the bar is the **defining predictive property of a conditional τ-expectile, evaluated out of sample** on a deterministic 3/4–1/4 split:

1. **Out-of-sample calibration.** At the predicted τ-expectile on held-out points, the asymmetric residual balance satisfies the estimating equation `τ·Σ(y−ê)₊ ≈ (1−τ)·Σ(ê−y)₊` (implied split within 0.10 of 0.5) for τ ∈ {0.1, 0.5, 0.9}. An overfit that merely memorized the training residual asymmetry would fail this on unseen points.
2. **Held-out ordering.** The three curves stay strictly ordered `ê₀.₁ < ê₀.₅ < ê₀.₉` on the held-out covariate.
3. **Central predictor.** The held-out median expectile (τ=0.5) is the best central point predictor of `y` (strictly lower RMSE than either extreme), since it targets the conditional center.

The 0.10 calibration slack (vs the in-sample 0.06) reflects the smaller held-out balance sample (n_test≈56); it remains a tight, un-weakened generalization bound. CI compiles and runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
