### PR TITLE
fix(#932): SAE beta_border_tower multiplies the channel output, not the decoder

### DIFF
--- a/src/terms/sae/manifold/tests.rs
+++ b/src/terms/sae/manifold/tests.rs
@@ -9828,23 +9828,27 @@ pub(crate) fn sae_row_jet_program_matches_production_row_jets_on_converged_cache
                 }
             }
 
-            // β BORDER CHANNELS (#932): the hand path packs ∂ẑ_c/∂β_{k,b}
-            // (value) and ∂²ẑ_c/∂β_{k,b}∂p_a (the `beta_deriv` / `beta_l_deriv`
-            // mixed second derivatives) term by term in `row_jets_for_logdet`,
-            // with NO tower oracle previously. Reconstruction is LINEAR in β, so
-            // ∂ẑ_c/∂β_{k,b} = ζ_k(ℓ)·Φ_b(t_k)·B_{b,c}: the `beta_border_tower`
-            // sub-jet, built from the SAME gate_tower / basis_tower primitives as
-            // the reconstruction column. Pin every β channel (value + both
-            // mixed-derivative arrays) to that tower at ~1e-9, scaled by √w like
-            // the production packing.
+            // β BORDER CHANNELS (#932): the hand path packs `beta`
+            // (value ∂ẑ_c/∂β = ζ_k·Φ_b·output_c) and `beta_deriv` /
+            // `beta_l_deriv` (the mixed ∂²ẑ_c/∂β∂p_a = ∂(ζ_k·Φ_b)/∂p_a·output_c)
+            // term by term in `row_jets_for_logdet`, with NO tower oracle
+            // previously. The arrow β coefficient multiplies the channel's
+            // (frame / identity) `output` vector — NOT the current decoder
+            // matrix — so the local-variable dependence is exactly
+            // s = ζ_k(ℓ)·Φ_b(t_k) = `beta_border_tower` (built from the SAME
+            // gate_tower / basis_tower primitives as the reconstruction column);
+            // production multiplies that scalar by `channel.output[c]·√w`. Pin
+            // every β channel (value + both mixed-derivative arrays) to it at
+            // ~1e-9.
             for (beta_pos, channel) in border.iter().enumerate() {
+                // The β border channel's LOCAL-variable dependence is
+                // s = ζ_k(ℓ)·Φ_b(t_k); the production packing multiplies that
+                // scalar by the channel's (frame / identity) `output[c]` — NOT
+                // the decoder matrix — and by √w.
+                let s = prog.beta_border_tower::<K>(channel.atom, channel.basis_col);
                 for out_col in 0..p {
-                    let tower = prog.beta_border_tower::<K>(
-                        channel.atom,
-                        channel.basis_col,
-                        out_col,
-                    );
-                    let want_v = sqrt_row_w * tower.v;
+                    let out_c = channel.output[out_col];
+                    let want_v = sqrt_row_w * s.v * out_c;
                     let v_floor = want_v.abs().max(1e-12);
                     assert!(
                         (jets.beta[beta_pos][out_col] - want_v).abs() <= 1e-9 * v_floor,
@@ -9856,12 +9860,12 @@ pub(crate) fn sae_row_jet_program_matches_production_row_jets_on_converged_cache
                         want_v
                     );
                     for a in 0..K {
-                        let want_d = sqrt_row_w * tower.g[a];
+                        let want_d = sqrt_row_w * s.g[a] * out_c;
                         let d_floor = want_d.abs().max(1e-12);
                         // `beta_deriv` and `beta_l_deriv` are the SAME mixed
                         // ∂²ẑ_c/∂β∂p_a derivative the linear-in-β reconstruction
                         // produces (the hand path fills both identically); both
-                        // must equal the tower's first-derivative channel.
+                        // must equal the tower's first-derivative channel × out_c.
                         assert!(
                             (jets.beta_deriv[a][beta_pos][out_col] - want_d).abs()
                                 <= 1e-9 * d_floor,

--- a/src/terms/sae/row_jet_program.rs
+++ b/src/terms/sae/row_jet_program.rs
@@ -267,33 +267,29 @@ impl SaeReconstructionRowProgram {
         acc
     }
 
-    /// The β **border-channel** sub-jet: the derivative of the reconstruction
-    /// output column `out_col` with respect to ONE decoder coefficient
-    /// `β_{atom, basis_col}`, as a `Tower4<K>` in the local (logit/coord)
-    /// primaries.
+    /// The β **border-channel** local-variable sub-jet: the scalar
+    /// `s_{k,b}(p) = ζ_k(ℓ)·Φ_b(t_k)` as a `Tower4<K>` in the local
+    /// (logit/coord) primaries — the gate activation times ONE basis function.
     ///
-    /// The reconstruction is `ẑ_c = Σ_k ζ_k(ℓ)·Σ_b β_{k,b}·Φ_b(t_k)·B_{b,c}`,
-    /// **linear** in every `β_{k,b}`, so
-    /// `∂ẑ_c/∂β_{k,b} = ζ_k(ℓ)·Φ_b(t_k)·B_{b,c}` — the gate times the single
-    /// basis function times the decoder entry, with `β` itself dropping out.
-    /// This is exactly the per-row β border channel the arrow solver carries
-    /// (`SaeBorderChannel{atom, basis_col, output = B_{b,·}}`): the returned
-    /// tower's `.v` is the channel value `ζ_k·Φ_b·B_{b,c}`, `.g[a]` is its
-    /// first derivative `∂(ζ_k·Φ_b)/∂p_a·B_{b,c}` (the `beta_deriv` /
-    /// `beta_l_deriv` channels), and the higher channels follow by Leibniz.
+    /// In the arrow system a β border channel is one free decoder coefficient
+    /// `β_{k,b,channel}` whose per-row reconstruction contribution to output
+    /// column `c` is `ζ_k(ℓ)·Φ_b(t_k)·output_c`, where `output` is the channel's
+    /// (frame / identity) output vector carried by the `SaeBorderChannel`, NOT
+    /// the current decoder matrix. The reconstruction is **linear** in `β`, so
+    /// `∂ẑ_c/∂β_{k,b,channel} = ζ_k(ℓ)·Φ_b(t_k)·output_c = s_{k,b}.v·output_c`
+    /// and `∂²ẑ_c/∂β∂p_a = s_{k,b}.g[a]·output_c` (the production `beta` /
+    /// `beta_deriv` / `beta_l_deriv` channels). The `output_c` factor is a
+    /// per-column constant the caller applies; this tower carries the entire
+    /// local-variable dependence.
     ///
     /// It is built from the SAME `gate_tower` / `basis_tower` primitives as
     /// [`Self::reconstruction_column`], so the β border channel is single
     /// sourced with the local-variable reconstruction tower (#932) — the hand
-    /// path in `row_jets_for_logdet` packs these same products term by term and
-    /// is pinned to this tower by the converged-cache oracle.
+    /// path in `row_jets_for_logdet` packs these same `ζ_k·Φ_b` products (then
+    /// multiplies by `channel.output`) term by term, and is pinned to this
+    /// tower by the converged-cache oracle.
     #[must_use]
-    pub fn beta_border_tower<const K: usize>(
-        &self,
-        atom: usize,
-        basis_col: usize,
-        out_col: usize,
-    ) -> Tower4<K> {
+    pub fn beta_border_tower<const K: usize>(&self, atom: usize, basis_col: usize) -> Tower4<K> {
         assert_eq!(
             self.n_primaries, K,
             "SaeReconstructionRowProgram: tower arity K={K} must equal n_primaries={}",
@@ -301,8 +297,7 @@ impl SaeReconstructionRowProgram {
         );
         let gate = self.gate_tower::<K>(atom);
         let phi = self.atoms[atom].basis_tower::<K>(basis_col, &self.coord_slot[atom]);
-        let decoder = self.atoms[atom].decoder[basis_col][out_col];
-        gate.mul(&phi).scale(decoder)
+        gate.mul(&phi)
     }
 
     /// The number of reconstruction output columns.


### PR DESCRIPTION
## Fixes a wrong oracle merged in #1483

PR #1483 added `SaeReconstructionRowProgram::beta_border_tower` as `gate·Φ_b·decoder[basis_col][out_col]` and the converged-cache oracle compared production `jets.beta` to `√w · tower.v`. **That is incorrect.**

In the SAE arrow system a β border channel is one **free decoder coefficient** `β_{k,b,channel}`, and its per-row reconstruction contribution to output column `c` is `ζ_k·Φ_b·output_c`, where `output` is the channel's **(frame / identity) output vector** carried by `SaeBorderChannel` — `border_channels_for_cache` builds `output[c] = frame[[c, channel]]` (an identity column when frames are inactive), **not** the current decoder matrix. The production hand path (`row_jets_for_logdet`) is `base · channel.output[out_col]` with `base = assignments[atom]·Φ_b·√w`. The merged oracle's `decoder` factor does not match it, so the merged test compares apples to oranges (and would fail / mis-pass).

## Fix

- `beta_border_tower<K>(atom, basis_col)` now returns the **local-variable scalar sub-jet** `s = ζ_k(ℓ)·Φ_b(t_k)` (drops the `out_col` arg and the `decoder` scale). This is the entire local-variable dependence of the β channel; the per-column `output_c` is a constant the caller applies.
- The oracle now multiplies by `channel.output[out_col]`: pins `jets.beta` to `√w·s.v·output_c` and `jets.beta_deriv` / `jets.beta_l_deriv` to `√w·s.g[a]·output_c`.

This matches the production packing term-for-term: gate value `= assignments[atom]`, `basis_tower.v = basis_values[row, basis_col]`, logit-channel `s.g[var] = dz[var][atom]·Φ_b`, matching-atom coord-channel `s.g = gate·basis_jacobian`, non-matching-atom channels `= 0`.

## How it was caught

Static self-audit of the families/jet code (the #932 item-5 bug-hunt): I traced `border_channels_for_cache` and found `output` is the frame/identity column, not the decoder. #1483 merged before its CI test run completed, so this lands the correction.

Refs #932. Fixes the oracle from #1483.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
