### PR TITLE
feat(#932): single-source row_kernel v/g/H (survival-LS, BMS rigid) + exact wiggle joint-Hessian oracle

### DIFF
--- a/src/families/bms/gradient_paths.rs
+++ b/src/families/bms/gradient_paths.rs
@@ -1,6 +1,6 @@
 use super::family::clamp_bernoulli_link_probability;
 use super::*;
-use crate::families::jet_tower::{Tower2, Tower4};
+use crate::families::jet_tower::Tower4;
 use crate::matrix::{LinearOperator, SignedWeightsView};
 
 pub(crate) fn standardize_latent_z_with_policy(
@@ -1651,51 +1651,6 @@ pub(super) fn rigid_standard_normal_towers_batch<T>(
     Ok(())
 }
 
-/// Second-order-only sibling of [`rigid_standard_normal_tower`].
-///
-/// The value/gradient/Hessian path (the inner joint-Newton solve and the
-/// value-only ρ-homotopy pre-warm) consumes ONLY `(v, g, h)`; it never reads
-/// the third/fourth tower tensors, which exist for the outer κ/ψ
-/// 3rd/4th-order calculus. Evaluating over [`Tower2`] instead of [`Tower4`]
-/// drops the `K⁴` fourth-tensor (and `K³` third-tensor) Leibniz/Faà-di-Bruno
-/// arithmetic that dominates the cold marginal-slope fit while returning the
-/// EXACT same `(v, g, h)`: the order-≤2 channels of both towers are computed
-/// by identical formulas that read only order-≤2 inputs (see [`Tower2`]).
-///
-/// The unary derivative stack is the same single source of truth
-/// ([`signed_probit_neglog_derivatives_up_to_fourth`]); only its first three
-/// entries (f, f′, f″) are needed for the Hessian, so the third/fourth
-/// entries are simply not consulted.
-#[inline]
-pub(crate) fn rigid_standard_normal_tower2(
-    marginal: BernoulliMarginalLinkMap,
-    g: f64,
-    z: f64,
-    y: f64,
-    w: f64,
-    probit_scale: f64,
-) -> Result<Tower2<2>, String> {
-    let mut q = Tower2::<2>::constant(marginal.q);
-    q.g[0] = marginal.q1;
-    q.h[0][0] = marginal.q2;
-    let slope = Tower2::<2>::variable(g, 1);
-    let observed_logslope = slope * probit_scale;
-    let c = (observed_logslope * observed_logslope + 1.0).sqrt();
-    let eta = q * c + slope * (probit_scale * z);
-    let signed = eta * (2.0 * y - 1.0);
-    // ONE transcendental per row (see `rigid_standard_normal_tower`): the fused
-    // stack shares a single Mills-ratio evaluation for logΦ and k1..k2. Tower2
-    // consumes only the first three entries, so the (exact) k3/k4 are dropped.
-    if !(signed.v.is_finite() || signed.v == f64::INFINITY) {
-        return Err(format!(
-            "non-finite signed margin in rigid probit tower2: {}",
-            signed.v
-        ));
-    }
-    let stack = signed_probit_neglog_unary_stack(signed.v, w);
-    Ok(signed.compose_unary([stack[0], stack[1], stack[2]]))
-}
-
 #[inline]
 pub(super) fn rigid_standard_normal_row_kernel(
     marginal: BernoulliMarginalLinkMap,
@@ -1705,8 +1660,23 @@ pub(super) fn rigid_standard_normal_row_kernel(
     w: f64,
     probit_scale: f64,
 ) -> Result<(f64, [f64; 2], [[f64; 2]; 2]), String> {
-    let tower = rigid_standard_normal_tower2(marginal, g, z, y, w, probit_scale)?;
-    Ok((tower.v, tower.g, tower.h))
+    // #932 cutover: value/gradient/Hessian derive from the SAME single generic
+    // row-NLL expression (`rigid_standard_normal_row_nll_generic`) every other
+    // channel consumer uses, routed through the `RowNllProgramGeneric` seam at the
+    // packed `Order2<2>` scalar — there is no longer a hand-assembled `Tower2<2>`
+    // here. Seeds `[marginal η, g]` exactly as the deleted inline form did, so it
+    // is bit-identical (the `rigid_bernoulli_*_agrees_with_jet_tower_program_all_channels`
+    // oracle pins v/g/H ≤ 1e-12), while sharing one definition with the third/
+    // fourth/full-tower channels.
+    let program = RigidStandardNormalRow {
+        marginal,
+        g,
+        z,
+        y,
+        w,
+        probit_scale,
+    };
+    crate::families::jet_tower::generic_row_kernel(&program, 0)
 }
 
 /// Mixed `(primary, z)` second derivative of the rigid standard-normal row

--- a/src/families/gamlss/tests.rs
+++ b/src/families/gamlss/tests.rs
@@ -8511,3 +8511,166 @@ pub(crate) fn gaussian_location_scale_psi_joint_hessian_pins_fisher_cross_zero()
         assert_wiggle_crosses_zero(&mixed, "mixed β·ψ");
     }
 }
+
+/// #932 exact-tower oracle for the binomial location-scale WIGGLE joint Hessian.
+///
+/// `BinomialLocationScaleWiggleFamily::wiggle_hessian_row_pieces` hand-derives the
+/// per-row joint-Hessian coefficients for the composed index
+/// `q = q0(η_t, η_ls) + Σ_j βw_j·B_j(q0)` via the chain factors `m = B'·βw + 1`,
+/// `g2 = B''·βw`. The cross-block coefficients (`coeff_tw_*`, `coeff_lw_*`,
+/// `coeffww`: threshold/log-sigma × wiggle and wiggle × wiggle) are exactly the
+/// #736 dropped/sign-flipped cross-term genus, and until now no exact oracle
+/// pinned them to an independent tower — only an operator-vs-dense check (both
+/// built from the same hand pieces) and an FD approximation covered them.
+///
+/// This is the #932 single-source guard. For each row `i` and basis column `j`
+/// we build an INDEPENDENT order-2 jet `Tower2<3>` over `(η_t, η_ls, βw_j)`
+/// (the other `βw_k` held at their fixed values), compose the wiggle basis onto
+/// the non-wiggle index tower
+/// (`q = q0_tower + Σ_k coef_k · q0_tower.compose_unary([B_k, B'_k, B''_k])`),
+/// then compose the binomial neglog objective onto `q`
+/// (`nll = q.compose_unary([·, m1, m2])`). The resulting `3×3` Hessian block IS
+/// every `coeff_*` mechanically:
+///   `h[0][0]=coeff_tt`, `h[0][1]=coeff_tl`, `h[1][1]=coeff_ll`,
+///   `h[0][2]=coeff_tw_b·B_j + coeff_tw_d·B'_j`,
+///   `h[1][2]=coeff_lw_b·B_j + coeff_lw_d·B'_j`,
+///   `h[2][2]=coeffww·B_j²`.
+/// A dropped or sign-flipped hand coefficient shifts a block well outside 1e-9
+/// and fails loudly, for probit / logit / cloglog. The value channel is
+/// irrelevant to the Hessian (`compose_unary`'s `h` reads only `f'`/`f''`), so a
+/// placeholder `0.0` is passed for the objective value.
+#[test]
+pub(crate) fn binomial_location_scale_wiggle_hessian_row_pieces_match_jet_tower_932() {
+    use super::binomial_q_derivs::binomial_neglog_q_derivatives_dispatch;
+    use crate::families::jet_tower::Tower2;
+
+    let (probit_family, states, _specs, _xt, _xls, _wd) = bls_wiggle_workspace_fixture();
+    let n = probit_family.y.len();
+
+    for link in [
+        InverseLink::Standard(StandardLink::Probit),
+        InverseLink::Standard(StandardLink::Logit),
+        InverseLink::Standard(StandardLink::CLogLog),
+    ] {
+        // Designs, knots and the block etas are link-independent (`q0` and the
+        // wiggle basis do not depend on the binomial link), so reuse them and
+        // swap only `link_kind` for each arm.
+        let family = BinomialLocationScaleWiggleFamily {
+            y: probit_family.y.clone(),
+            weights: probit_family.weights.clone(),
+            link_kind: link.clone(),
+            threshold_design: probit_family.threshold_design.clone(),
+            log_sigma_design: probit_family.log_sigma_design.clone(),
+            wiggle_knots: probit_family.wiggle_knots.clone(),
+            wiggle_degree: probit_family.wiggle_degree,
+            policy: probit_family.policy.clone(),
+        };
+
+        let pieces = family
+            .wiggle_hessian_row_pieces(&states)
+            .expect("wiggle hessian row pieces");
+
+        let eta_t = &states[BinomialLocationScaleWiggleFamily::BLOCK_T].eta;
+        let eta_ls = &states[BinomialLocationScaleWiggleFamily::BLOCK_LOG_SIGMA].eta;
+        let etaw = &states[BinomialLocationScaleWiggleFamily::BLOCK_WIGGLE].eta;
+        let betaw = &states[BinomialLocationScaleWiggleFamily::BLOCK_WIGGLE].beta;
+
+        let core0 = binomial_location_scale_core(
+            &family.y,
+            &family.weights,
+            eta_t,
+            eta_ls,
+            Some(etaw),
+            &family.link_kind,
+        )
+        .expect("binomial location-scale core");
+
+        // Same basis tensors the hand path consumes: pieces.{b0,d0} are exactly
+        // B and B' it used; recompute B'' for the order-2 composition.
+        let b0 = &pieces.b0;
+        let d0 = &pieces.d0;
+        let dd0 = family
+            .wiggle_basiswith_options(core0.q0.view(), BasisOptions::second_derivative())
+            .expect("wiggle second-derivative basis");
+        let pw = b0.ncols();
+
+        for i in 0..n {
+            let qi = core0.q0[i] + etaw[i];
+            let (m1, m2, _m3) = binomial_neglog_q_derivatives_dispatch(
+                family.y[i],
+                family.weights[i],
+                qi,
+                core0.mu[i],
+                core0.dmu_dq[i],
+                core0.d2mu_dq2[i],
+                core0.d3mu_dq3[i],
+                &family.link_kind,
+            );
+
+            // Non-wiggle index q0 = -η_t · exp(-η_ls) over axes (η_t, η_ls);
+            // axis 2 is reserved for the per-column wiggle amplitude.
+            let eta_t_t = Tower2::<3>::variable(eta_t[i], 0);
+            let eta_ls_t = Tower2::<3>::variable(eta_ls[i], 1);
+            let q0_tower = (eta_t_t * -1.0) * (eta_ls_t * -1.0).exp();
+
+            for j in 0..pw {
+                let mut q = q0_tower;
+                for k in 0..pw {
+                    let coef = if k == j {
+                        Tower2::<3>::variable(betaw[j], 2)
+                    } else {
+                        Tower2::<3>::constant(betaw[k])
+                    };
+                    let basis_k =
+                        q0_tower.compose_unary([b0[[i, k]], d0[[i, k]], dd0[[i, k]]]);
+                    q = q + coef * basis_k;
+                }
+                let nll = q.compose_unary([0.0, m1, m2]);
+                let h = nll.h;
+
+                let close = |a: f64, b: f64| (a - b).abs() <= 1e-9 * a.abs().max(b.abs()).max(1.0);
+
+                assert!(
+                    close(h[0][0], pieces.coeff_tt[i]),
+                    "{link:?} coeff_tt[{i},{j}]: tower={:.9e} hand={:.9e}",
+                    h[0][0],
+                    pieces.coeff_tt[i]
+                );
+                assert!(
+                    close(h[0][1], pieces.coeff_tl[i]),
+                    "{link:?} coeff_tl[{i},{j}]: tower={:.9e} hand={:.9e}",
+                    h[0][1],
+                    pieces.coeff_tl[i]
+                );
+                assert!(
+                    close(h[1][1], pieces.coeff_ll[i]),
+                    "{link:?} coeff_ll[{i},{j}]: tower={:.9e} hand={:.9e}",
+                    h[1][1],
+                    pieces.coeff_ll[i]
+                );
+
+                let tw = pieces.coeff_tw_b[i] * b0[[i, j]] + pieces.coeff_tw_d[i] * d0[[i, j]];
+                let lw = pieces.coeff_lw_b[i] * b0[[i, j]] + pieces.coeff_lw_d[i] * d0[[i, j]];
+                let ww = pieces.coeffww[i] * b0[[i, j]] * b0[[i, j]];
+                assert!(
+                    close(h[0][2], tw),
+                    "{link:?} (η_t,βw) cross[{i},{j}]: tower={:.9e} hand={:.9e}",
+                    h[0][2],
+                    tw
+                );
+                assert!(
+                    close(h[1][2], lw),
+                    "{link:?} (η_ls,βw) cross[{i},{j}]: tower={:.9e} hand={:.9e}",
+                    h[1][2],
+                    lw
+                );
+                assert!(
+                    close(h[2][2], ww),
+                    "{link:?} (βw,βw)[{i},{j}]: tower={:.9e} hand={:.9e}",
+                    h[2][2],
+                    ww
+                );
+            }
+        }
+    }
+}

--- a/src/families/survival/location_scale/row_kernel.rs
+++ b/src/families/survival/location_scale/row_kernel.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-use crate::families::jet_scalar::{JetScalar, OneSeed, TwoSeed};
+use crate::families::jet_scalar::{JetScalar, Order2, OneSeed, TwoSeed};
 
 #[derive(Clone, Copy, Debug)]
 pub(crate) struct SurvivalExactRowKernel {
@@ -282,18 +282,6 @@ pub(crate) struct SurvivalLsRowKernel<'a> {
     pub(crate) offsets: Vec<usize>,
 }
 
-/// Per-index `(D, D2)` map-derivative tensors for one row, plus the
-/// index-space log-likelihood derivatives. `D[i][a] = ∂(index i)/∂(channel a)`,
-/// `D2[i][a][b] = ∂²(index i)/∂a∂b`.
-pub(crate) struct SlsRowMaps {
-    /// ell_i  = (ell_u0, ell_u1, ell_g)
-    pub(crate) l1: [f64; 3],
-    /// ell_ii = (ell_u0u0, ell_u1u1, ell_gg)
-    pub(crate) l2: [f64; 3],
-    pub(crate) d: [[f64; SLS_ROW_K]; 3],
-    pub(crate) d2: [[[f64; SLS_ROW_K]; SLS_ROW_K]; 3],
-}
-
 impl SurvivalLsRowKernel<'_> {
     /// Resolve the design for a threshold/log-sigma channel, falling back to the
     /// exit design when the entry/derivative variant is absent (time-invariant).
@@ -303,70 +291,6 @@ impl SurvivalLsRowKernel<'_> {
         fallback: &'b DesignMatrix,
     ) -> &'b DesignMatrix {
         opt.as_ref().unwrap_or(fallback)
-    }
-
-    /// Build the per-row index/map derivative tensors from the cached scalars.
-    /// Symmetric `D2` entries are written in both slots so the
-    /// uniform accumulation loops never have to special-case ordering.
-    pub(crate) fn row_maps(&self, row: usize) -> SlsRowMaps {
-        let q = self.q;
-        let mut m = SlsRowMaps {
-            l1: [q.d1_q0[row], q.d1_q1[row], q.d1_qdot1[row]],
-            l2: [q.d2_q0[row], q.d2_q1[row], q.d2_qdot1[row]],
-            d: [[0.0; SLS_ROW_K]; 3],
-            d2: [[[0.0; SLS_ROW_K]; SLS_ROW_K]; 3],
-        };
-        // helper closures to set symmetric entries
-        let set2 = |t: &mut [[f64; SLS_ROW_K]; SLS_ROW_K], a: usize, b: usize, v: f64| {
-            t[a][b] = v;
-            t[b][a] = v;
-        };
-
-        // Entry-side q-chain derivatives are always populated (equal to the
-        // exit values in the time-invariant case).
-        let dq_t_en = self.q.dq_t_entry.as_ref().map_or(q.dq_t[row], |a| a[row]);
-        let dq_ls_en = self.q.dq_ls_entry.as_ref().map_or(q.dq_ls[row], |a| a[row]);
-        let d2q_tls_en = self
-            .q
-            .d2q_tls_entry
-            .as_ref()
-            .map_or(q.d2q_tls[row], |a| a[row]);
-        let d2q_ls_en = self
-            .q
-            .d2q_ls_entry
-            .as_ref()
-            .map_or(q.d2q_ls[row], |a| a[row]);
-
-        // Index 0: u0 = h0 + q0(eta_t_entry=ch4, eta_ls_entry=ch7).
-        m.d[0][0] = 1.0;
-        m.d[0][4] = dq_t_en;
-        m.d[0][7] = dq_ls_en;
-        set2(&mut m.d2[0], 4, 7, d2q_tls_en);
-        m.d2[0][7][7] = d2q_ls_en;
-
-        // Index 1: u1 = h1 + q1(eta_t_exit=ch3, eta_ls_exit=ch6).
-        m.d[1][1] = 1.0;
-        m.d[1][3] = q.dq_t[row];
-        m.d[1][6] = q.dq_ls[row];
-        set2(&mut m.d2[1], 3, 6, q.d2q_tls[row]);
-        m.d2[1][6][6] = q.d2q_ls[row];
-
-        // Index 2: g = d_raw + qdot1(eta_t_exit=ch3, eta_t_deriv=ch5,
-        // eta_ls_exit=ch6, eta_ls_deriv=ch8).
-        m.d[2][2] = 1.0;
-        m.d[2][3] = q.dqdot_t[row];
-        m.d[2][5] = q.dqdot_td[row];
-        m.d[2][6] = q.dqdot_ls[row];
-        m.d[2][8] = q.dqdot_lsd[row];
-        m.d2[2][3][3] = q.d2qdot_tt[row];
-        set2(&mut m.d2[2], 3, 6, q.d2qdot_tls[row]);
-        set2(&mut m.d2[2], 3, 5, q.d2qdot_ttd[row]);
-        set2(&mut m.d2[2], 3, 8, q.d2qdot_tlsd[row]);
-        m.d2[2][6][6] = q.d2qdot_ls[row];
-        set2(&mut m.d2[2], 6, 5, q.d2qdot_lstd[row]);
-        set2(&mut m.d2[2], 6, 8, q.d2qdot_lslsd[row]);
-
-        m
     }
 
     /// Per-row dense design row for each channel within its coefficient block:
@@ -610,32 +534,23 @@ impl crate::families::row_kernel::RowKernel<SLS_ROW_K> for SurvivalLsRowKernel<'
         &self,
         row: usize,
     ) -> Result<(f64, [f64; SLS_ROW_K], [[f64; SLS_ROW_K]; SLS_ROW_K]), String> {
-        let m = self.row_maps(row);
-        // NLL = -ell. Gradient and Hessian carry the overall minus sign.
-        let mut grad = [0.0_f64; SLS_ROW_K];
-        let mut hess = [[0.0_f64; SLS_ROW_K]; SLS_ROW_K];
-        for i in 0..3 {
-            let l1 = m.l1[i];
-            let l2 = m.l2[i];
-            let di = &m.d[i];
-            for a in 0..SLS_ROW_K {
-                grad[a] -= l1 * di[a];
-                if di[a] != 0.0 {
-                    for b in 0..SLS_ROW_K {
-                        hess[a][b] -= l2 * di[a] * di[b];
-                    }
-                }
-            }
-            let d2i = &m.d2[i];
-            for a in 0..SLS_ROW_K {
-                for b in 0..SLS_ROW_K {
-                    if d2i[a][b] != 0.0 {
-                        hess[a][b] -= l1 * d2i[a][b];
-                    }
-                }
-            }
-        }
-        Ok((-self.q.ll[row], grad, hess))
+        // #932: value, gradient and Hessian derive from the SAME single-sourced
+        // row NLL (`sls_row_nll`) instantiated at the packed `Order2<9>` scalar —
+        // the exact order-≤2 truncation of the Leibniz / Faà di Bruno rules (728
+        // B/row). There is no longer a hand-assembled coefficient-space chain rule
+        // here: the `(v, g, H)` channels are the order-≤2 part of the very
+        // expression whose order-3/4 directional contractions `row_third_contracted`
+        // / `row_fourth_contracted` already evaluate, so all four channels share one
+        // mathematical definition (the #736/#932 single-source contract). Identity
+        // seeding (`Order2::variable`) makes the ε/δ-free tower carry ∂/∂p_a and
+        // ∂²/∂p_a∂p_b directly. Bit-identical to `row_nll_tower(row)?` value/grad/
+        // Hessian by the `survival_ls_joint_row_kernel_agrees_with_jet_tower_program_all_channels`
+        // oracle (≤ 1e-9).
+        let (p, kernel) = self.row_nll_inputs(row)?;
+        let vars: [Order2<SLS_ROW_K>; SLS_ROW_K] =
+            std::array::from_fn(|a| Order2::variable(p[a], a));
+        let out = sls_row_nll(&vars, &kernel)?;
+        Ok((out.value(), out.g(), out.h()))
     }
 
     fn jacobian_action(&self, row: usize, d_beta: &[f64]) -> [f64; SLS_ROW_K] {

--- a/src/solver/estimate/estimate_policy_tests.rs
+++ b/src/solver/estimate/estimate_policy_tests.rs
@@ -789,8 +789,10 @@ fn unified_fit_validation_rejects_edf_smoothing_parameter_drift() {
 fn unified_fit_validation_accepts_persisted_log_lambda_roundoff() {
     let mut fit = decode_invariant_test_fit();
     fit.log_lambdas[0] += 5e-14;
-    fit.validate_numeric_finiteness()
-        .expect("sub-ulp persisted log-lambda roundoff should remain valid");
+    assert!(
+        fit.validate_numeric_finiteness().is_ok(),
+        "sub-ulp persisted log-lambda roundoff should remain valid"
+    );
 }
 
 #[test]


### PR DESCRIPTION
Two direct-compose `RowKernel` v/g/H cutovers to the packed `Order2` scalar (survival location-scale `Order2<9>`, BMS rigid Bernoulli `Order2<2>`), plus the exact-tower oracle the latest #932 comment scoped: an independent `Tower2<3>` over (eta_t, eta_ls, betaw_j) pins every `wiggle_hessian_row_pieces` coefficient (`coeff_tt/tl/ll`, `coeff_tw_*`, `coeff_lw_*`, `coeffww`) for the binomial location-scale wiggle family across probit/logit/cloglog to 1e-9.

Also fixes a pre-existing ban violation on main: `estimate_policy_tests.rs unified_fit_validation_accepts_persisted_log_lambda_roundoff` had only `.expect()` (not a recognized assertion) — give it a real `assert!` on `.is_ok()`.

## Test plan
- [ ] Relevant `issue_932` tests pass locally
- [ ] Full CI run is green
- [ ] Branch rebased on latest `main` if merge-check flags it

🤖 Generated with [Code](https://code.noumena.com/code)