### PR TITLE
fix: repair tests, jet scalar cleanup, and dispersion channel wiring

### DIFF
--- a/src/families/bms/gradient_paths.rs
+++ b/src/families/bms/gradient_paths.rs
@@ -1437,9 +1437,7 @@ pub(crate) fn rigid_standard_normal_row_nll_generic<S: crate::families::jet_scal
     // observed slope b = s·g, scale c = √(1 + b²).
     let observed_slope = slope.scale(probit_scale);
     let b2 = observed_slope.mul(&observed_slope);
-    let c = b2
-        .add(&S::constant(1.0))
-        .compose_unary(unary_derivatives_sqrt(observed_slope.value() * observed_slope.value() + 1.0));
+    let c = b2.add(&S::constant(1.0)).sqrt();
     // η = q·c + (s·g)·z, signed margin m = (2y−1)·η.
     let eta = q.mul(&c).add(&observed_slope.scale(z));
     let signed = eta.scale(2.0 * y - 1.0);

--- a/src/families/bms/mod.rs
+++ b/src/families/bms/mod.rs
@@ -2017,8 +2017,8 @@ pub(crate) mod install_flex;
 pub(crate) mod row_kernel;
 #[cfg(test)]
 mod tests {
-    include!("../../../tests/src_modules/families_bms_identifiability_rigid_tests.rs");
-    include!("../../../tests/src_modules/families_bms_joint_hessian_hvp_correction_tests.rs");
+    include!("../../../tests/src_modules/misc/families_bms_identifiability_rigid_tests.rs");
+    include!("../../../tests/src_modules/optimization/families_bms_joint_hessian_hvp_correction_tests.rs");
 }
 pub(crate) mod axis_direction_search;
 pub(crate) mod cell_moment_assembly;

--- a/src/families/jet_scalar.rs
+++ b/src/families/jet_scalar.rs
@@ -93,13 +93,6 @@ pub trait JetScalar<const K: usize>: Copy {
     fn sub(&self, o: &Self) -> Self;
     /// Exact truncated Leibniz product `self · o`.
     fn mul(&self, o: &Self) -> Self;
-    /// Exact reciprocal `1/self`. Caller guarantees a non-zero value channel
-    /// (likelihood programs do).
-    fn recip(&self) -> Self;
-    /// Exact quotient `self / o`. Caller guarantees a non-zero `o` value.
-    fn div(&self, o: &Self) -> Self {
-        self.mul(&o.recip())
-    }
     /// Negate every channel.
     fn neg(&self) -> Self;
     /// Multiply every channel by a plain scalar `s`.
@@ -121,13 +114,6 @@ pub trait JetScalar<const K: usize>: Copy {
     fn exp(&self) -> Self {
         let e = self.value().exp();
         self.compose_unary([e, e, e, e, e])
-    }
-
-    /// `ln(self)`. Caller guarantees positivity.
-    fn ln(&self) -> Self {
-        let u = self.value();
-        let r = 1.0 / u;
-        self.compose_unary([u.ln(), r, -r * r, 2.0 * r * r * r, -6.0 * r * r * r * r])
     }
 
     /// `√self`. Caller guarantees positivity.
@@ -160,12 +146,6 @@ pub trait JetScalar<const K: usize>: Copy {
 pub struct Order2<const K: usize>(pub super::jet_tower::Tower2<K>);
 
 impl<const K: usize> Order2<K> {
-    /// Read the gradient channel.
-    #[inline]
-    pub fn g(&self) -> [f64; K] {
-        self.0.g
-    }
-
     /// Read the Hessian channel.
     #[inline]
     pub fn h(&self) -> [[f64; K]; K] {
@@ -193,13 +173,6 @@ impl<const K: usize> JetScalar<K> for Order2<K> {
     }
     fn mul(&self, o: &Self) -> Self {
         Order2(super::jet_tower::Tower2::mul(&self.0, &o.0))
-    }
-    fn recip(&self) -> Self {
-        let r = 1.0 / self.0.v;
-        let r2 = r * r;
-        // Order-≤2 of 1/u: [1/u, −1/u², 2/u³] — the leading three entries of
-        // Tower4::recip's stack, since Tower2 reads only d[0..=2].
-        Order2(self.0.compose_unary([r, -r2, 2.0 * r2 * r]))
     }
     fn neg(&self) -> Self {
         Order2(self.0.scale(-1.0))
@@ -291,13 +264,6 @@ impl<const K: usize> JetScalar<K> for OneSeed<K> {
             base: self.base.mul(&o.base),
             eps: self.base.mul(&o.eps).add(&self.eps.mul(&o.base)),
         }
-    }
-    fn recip(&self) -> Self {
-        // 1/s with s = base + ε eps; treat as the composition recip ∘ s, which
-        // the generic compose_unary handles uniformly.
-        let r = 1.0 / self.base.value();
-        let r2 = r * r;
-        self.compose_unary([r, -r2, 2.0 * r2 * r, -6.0 * r2 * r2, 24.0 * r2 * r2 * r])
     }
     fn neg(&self) -> Self {
         OneSeed {
@@ -431,11 +397,6 @@ impl<const K: usize> JetScalar<K> for TwoSeed<K> {
             eps_del,
         }
     }
-    fn recip(&self) -> Self {
-        let r = 1.0 / self.base.value();
-        let r2 = r * r;
-        self.compose_unary([r, -r2, 2.0 * r2 * r, -6.0 * r2 * r2, 24.0 * r2 * r2 * r])
-    }
     fn neg(&self) -> Self {
         TwoSeed {
             base: self.base.neg(),
@@ -513,9 +474,6 @@ impl<const K: usize> JetScalar<K> for super::jet_tower::Tower4<K> {
     fn mul(&self, o: &Self) -> Self {
         super::jet_tower::Tower4::mul(self, o)
     }
-    fn recip(&self) -> Self {
-        super::jet_tower::Tower4::recip(self)
-    }
     fn neg(&self) -> Self {
         self.scale(-1.0)
     }
@@ -534,11 +492,11 @@ mod tests {
 
     /// A small polynomial-plus-unary row expression written ONCE, generically
     /// over `S: JetScalar<2>`, so it can be evaluated against every scalar:
-    /// `ℓ = ln(e^{p0·p1} + 2) · √(p0·p0 + 1) − p1·p1·0.5`.
-    /// Exercises mul, add/sub, scale, exp, ln, sqrt — every algebra op.
+    /// `ℓ = (e^{p0·p1} + 2) · √(p0·p0 + 1) − p1·p1·0.5`.
+    /// Exercises mul, add/sub, scale, exp, sqrt — every algebra op.
     fn row_expr<S: JetScalar<2>>(p: &[S; 2]) -> S {
         let g = p[0].mul(&p[1]).exp();
-        let inner = g.add(&S::constant(2.0)).ln();
+        let inner = g.add(&S::constant(2.0));
         let radic = p[0].mul(&p[0]).add(&S::constant(1.0)).sqrt();
         inner.mul(&radic).sub(&p[1].mul(&p[1]).scale(0.5))
     }
@@ -590,7 +548,7 @@ mod tests {
         let s = row_expr(&vars);
         close(s.value(), t.v, "value");
         for a in 0..2 {
-            close(s.g()[a], t.g[a], &format!("grad[{a}]"));
+            close(s.0.g[a], t.g[a], &format!("grad[{a}]"));
             for b in 0..2 {
                 close(s.h()[a][b], t.h[a][b], &format!("hess[{a}][{b}]"));
             }
@@ -634,7 +592,7 @@ mod tests {
         let s = row_expr(&vars);
         close(s.value(), t.v, "value");
         for a in 0..2 {
-            close(s.base.g()[a], t.g[a], &format!("grad[{a}]"));
+            close(s.base.0.g[a], t.g[a], &format!("grad[{a}]"));
             for b in 0..2 {
                 close(s.base.h()[a][b], t.h[a][b], &format!("base hess[{a}][{b}]"));
                 close(

--- a/src/inference/predict/dispersion_location_scale.rs
+++ b/src/inference/predict/dispersion_location_scale.rs
@@ -322,19 +322,8 @@ impl PredictableModel for DispersionLocationScalePredictor {
         self.noise_sd(input).map(Some)
     }
 
-    fn predict_dispersion_scale(
-        &self,
-        input: &PredictInput,
-    ) -> Result<Option<Array1<f64>>, EstimationError> {
-        // Per-row precision `exp(eta_d(x))` mapped into the generative
-        // NoiseModel's dispersion units (#1125): NB θ, Gamma shape and Beta φ
-        // ARE the precision; Tweedie φ is its reciprocal.
-        let precision = self.precision(input)?;
-        let dispersion = match self.likelihood.response {
-            ResponseFamily::Tweedie { .. } => precision.mapv(|pr| 1.0 / pr.max(f64::MIN_POSITIVE)),
-            _ => precision,
-        };
-        Ok(Some(dispersion))
+    fn dispersion_channel(&self) -> Option<&dyn PerRowDispersionChannel> {
+        Some(self)
     }
 
     fn predict_full_uncertainty(
@@ -361,5 +350,22 @@ impl PredictableModel for DispersionLocationScalePredictor {
 
     fn block_roles(&self) -> Vec<BlockRole> {
         vec![BlockRole::Location, BlockRole::Scale]
+    }
+}
+
+impl PerRowDispersionChannel for DispersionLocationScalePredictor {
+    fn per_row_dispersion(
+        &self,
+        input: &PredictInput,
+    ) -> Result<Array1<f64>, EstimationError> {
+        // Per-row precision `exp(eta_d(x))` mapped into the generative
+        // NoiseModel's dispersion units (#1125): NB θ, Gamma shape and Beta φ
+        // ARE the precision; Tweedie φ is its reciprocal.
+        let precision = self.precision(input)?;
+        let dispersion = match self.likelihood.response {
+            ResponseFamily::Tweedie { .. } => precision.mapv(|pr| 1.0 / pr.max(f64::MIN_POSITIVE)),
+            _ => precision,
+        };
+        Ok(dispersion)
     }
 }

--- a/src/inference/predict/mod.rs
+++ b/src/inference/predict/mod.rs
@@ -835,6 +835,18 @@ pub struct PredictionWithSE {
     pub mean_se: Option<Array1<f64>>,
 }
 
+/// A per-observation DISPERSION channel (#1125): the generative-units dispersion
+/// surface a dispersion location-scale model learned. Implemented only by models
+/// that carry such a channel; [`PredictableModel::dispersion_channel`] hands one
+/// back so [`PredictableModel::predict_dispersion_scale`] can evaluate it.
+pub trait PerRowDispersionChannel {
+    /// Per-row dispersion in the generative `NoiseModel`'s own units.
+    fn per_row_dispersion(
+        &self,
+        input: &PredictInput,
+    ) -> Result<Array1<f64>, EstimationError>;
+}
+
 /// Trait for models that can produce predictions from new data.
 ///
 /// Implemented by each model class (standard, GAMLSS, survival) to provide
@@ -884,9 +896,21 @@ pub trait PredictableModel {
     /// dispersion surface instead of drawing homoscedastic data at the seed.
     fn predict_dispersion_scale(
         &self,
-        _input: &PredictInput,
+        input: &PredictInput,
     ) -> Result<Option<Array1<f64>>, EstimationError> {
-        Ok(None)
+        match self.dispersion_channel() {
+            Some(channel) => channel.per_row_dispersion(input).map(Some),
+            None => Ok(None),
+        }
+    }
+
+    /// The per-row dispersion channel this model exposes, if any. Dispersion
+    /// location-scale models return `Some(self)` so the provided
+    /// [`predict_dispersion_scale`](Self::predict_dispersion_scale) evaluates
+    /// the channel; every other model inherits `None` and reports no per-row
+    /// dispersion.
+    fn dispersion_channel(&self) -> Option<&dyn PerRowDispersionChannel> {
+        None
     }
 
     /// Full prediction with confidence/observation intervals.

--- a/src/reml_contracts.rs
+++ b/src/reml_contracts.rs
@@ -96,12 +96,35 @@ pub trait HyperOperator: Send + Sync {
             .sum()
     }
 
+    /// Optional stable identity for this operator's action `B`. When `Some`,
+    /// the default cached trace / projected-matrix paths memoize the `B · F`
+    /// product in the shared [`ProjectedFactorCache`] under a
+    /// `(design_id, factor)` key, so repeated projections of the same factor
+    /// against the same operator within one outer iteration build `B · F`
+    /// once. `None` (the default) disables that reuse: an operator with no
+    /// design factor stable across calls cannot key the cache without risking
+    /// a stale `B · F`, so it recomputes every time.
+    fn projection_design_id(&self) -> Option<usize> {
+        None
+    }
+
     fn trace_projected_factor_cached(
         &self,
         factor: &Array2<f64>,
-        _factor_cache: &ProjectedFactorCache,
+        factor_cache: &ProjectedFactorCache,
     ) -> f64 {
-        self.trace_projected_factor(factor)
+        match self.projection_design_id() {
+            Some(design_id) => {
+                let key = ProjectedFactorKey::from_factor_view(design_id, factor.view());
+                let projected = factor_cache.get_or_insert_with(key, || self.mul_mat(factor));
+                factor
+                    .iter()
+                    .zip(projected.iter())
+                    .map(|(&f, &bf)| f * bf)
+                    .sum()
+            }
+            None => self.trace_projected_factor(factor),
+        }
     }
 
     /// Compute the exact projected matrix `F^T B F`.
@@ -115,9 +138,16 @@ pub trait HyperOperator: Send + Sync {
     fn projected_matrix_cached(
         &self,
         factor: &Array2<f64>,
-        _factor_cache: &ProjectedFactorCache,
+        factor_cache: &ProjectedFactorCache,
     ) -> Array2<f64> {
-        self.projected_matrix(factor)
+        match self.projection_design_id() {
+            Some(design_id) => {
+                let key = ProjectedFactorKey::from_factor_view(design_id, factor.view());
+                let projected = factor_cache.get_or_insert_with(key, || self.mul_mat(factor));
+                crate::faer_ndarray::fast_atb(factor, projected.as_ref())
+            }
+            None => self.projected_matrix(factor),
+        }
     }
 
     /// Fill columns `[start, start + out.ncols())` of `B` into `out`.
@@ -813,6 +843,6 @@ pub struct ContractedPsiSecondOrder {
 pub type ContractedPsiSecondOrderFn =
     Arc<dyn Fn(&[f64]) -> Result<Option<ContractedPsiSecondOrder>, String> + Send + Sync>;
 
-use crate::solver::reml::reml_outer_engine::dense_linalg::{
+use crate::solver::estimate::reml::reml_outer_engine::{
     dense_bilinear, dense_matvec_into, dense_matvec_scaled_add_into,
 };

--- a/src/solver/estimate/estimate_policy_tests.rs
+++ b/src/solver/estimate/estimate_policy_tests.rs
@@ -284,8 +284,8 @@ fn prefit_binomial_detects_unpenalized_realized_design_separator() {
         &design,
         &[true, true],
     )
-    .unwrap_or_else(|e| panic!("{} failed: {:?}", "separation screen must complete without a layout error")
-    .expect("second column exactly separates the binary response", e));
+    .unwrap_or_else(|e| panic!("{} failed: {:?}", "separation screen must complete without a layout error", e))
+    .expect("second column exactly separates the binary response");
 
     assert_eq!(diagnostic.column_index, 1);
     assert!(diagnostic.positive_above_threshold);
@@ -307,10 +307,10 @@ fn prefit_binomial_screen_respects_penalties_and_fractional_responses() {
             &design,
             &[true, false],
         )
-        .unwrap_or_else(|e| panic!("{} failed: {:?}", "separation screen must complete without a layout error"),
+        .unwrap_or_else(|e| panic!("{} failed: {:?}", "separation screen must complete without a layout error", e)),
         None,
         "a separating column with effective quadratic penalty should not be pre-fit rejected"
-    , e));
+    );
     assert_eq!(
         detect_prefit_binomial_single_column_separation_in_design(
             fractional_y.view(),
@@ -318,10 +318,10 @@ fn prefit_binomial_screen_respects_penalties_and_fractional_responses() {
             &design,
             &[true, true],
         )
-        .unwrap_or_else(|e| panic!("{} failed: {:?}", "separation screen must complete without a layout error"),
+        .unwrap_or_else(|e| panic!("{} failed: {:?}", "separation screen must complete without a layout error", e)),
         None,
         "fractional binomial proportions are not exact binary separation"
-    , e));
+    );
 }
 
 #[test]
@@ -421,8 +421,8 @@ fn prefit_rank_check_detects_unpenalized_duplicate_column() {
     let design = DesignMatrix::Dense(crate::matrix::DenseDesignMatrix::from(x));
     let diagnostic =
         detect_prefit_unpenalized_rank_deficiency_in_design(w.view(), &design, &[true, true, true])
-            .unwrap_or_else(|e| panic!("{} failed: {:?}", "rank check should stream dense design")
-            .expect("duplicate unpenalized columns are rank deficient", e));
+            .unwrap_or_else(|e| panic!("{} failed: {:?}", "rank check should stream dense design", e))
+            .expect("duplicate unpenalized columns are rank deficient");
 
     match diagnostic {
         PrefitRegularityDiagnostic::RankDeficient {
@@ -505,8 +505,8 @@ fn prefit_rank_check_detects_near_degenerate_unpenalized_design() {
     let design = DesignMatrix::Dense(crate::matrix::DenseDesignMatrix::from(x));
     let diagnostic =
         detect_prefit_unpenalized_rank_deficiency_in_design(w.view(), &design, &[true, true, true])
-            .unwrap_or_else(|e| panic!("{} failed: {:?}", "rank check should stream dense design")
-            .expect("near-collinear unpenalized columns are near-degenerate", e));
+            .unwrap_or_else(|e| panic!("{} failed: {:?}", "rank check should stream dense design", e))
+            .expect("near-collinear unpenalized columns are near-degenerate");
 
     match diagnostic {
         PrefitRegularityDiagnostic::NearDegenerate {
@@ -652,7 +652,7 @@ fn decode_invariant_test_fit() -> UnifiedFitResult {
         artifacts: FitArtifacts::default(),
         inner_cycles: 0,
     })
-    .unwrap_or_else(|e| panic!("{} failed: {:?}", "construct decode invariant test fit")
+    .unwrap_or_else(|e| panic!("{} failed: {:?}", "construct decode invariant test fit", e))
 }
 
 #[test]
@@ -660,7 +660,7 @@ fn dispersion_phi_prefers_inference_then_falls_back_to_standard_deviation() {
     // With a cached `inference` block present, `dispersion_phi()` returns
     // the stored dispersion verbatim so it can never diverge from the φ̂
     // that scaled the covariances at fit time.
-    let fit = decode_invariant_test_fit(, e));
+    let fit = decode_invariant_test_fit();
     assert_eq!(fit.dispersion(), Some(Dispersion::Known(1.0)));
     assert_eq!(fit.dispersion_phi(), 1.0);
 
@@ -773,11 +773,11 @@ fn unified_fit_validation_rejects_edf_smoothing_parameter_drift() {
     let mut fit = decode_invariant_test_fit();
     fit.inference
         .as_mut()
-        .unwrap_or_else(|e| panic!("{} failed: {:?}", "test fit has inference")
+        .expect("test fit has inference")
         .edf_by_block = vec![1.5];
     let err = fit
         .validate_numeric_finiteness()
-        .expect_err("EDF entries should align with smoothing parameters", e));
+        .expect_err("EDF entries should align with smoothing parameters");
     assert!(
         err.to_string()
             .contains("EDF smoothing-parameter count mismatch"),
@@ -895,7 +895,7 @@ fn sas_beta_raw_epsilon_sensitivity_matchesfd_at_seed19() {
                     initial_epsilon: 0.0,
                     initial_log_delta: 0.0,
                 })
-                .unwrap_or_else(|e| panic!("{} failed: {:?}", "valid SAS initial state"),
+                .unwrap_or_else(|e| panic!("{} failed: {:?}", "valid SAS initial state", e)),
             ),
         ),
         latent_cloglog: None,
@@ -921,7 +921,7 @@ fn sas_beta_raw_epsilon_sensitivity_matchesfd_at_seed19() {
     };
 
     let theta = array![0.10, 0.12, -0.18];
-    let (cfg, effective_sas_link) = resolved_external_config(&opts).expect("cfg", e));
+    let (cfg, effective_sas_link) = resolved_external_config(&opts).expect("cfg");
     assert!(effective_sas_link.is_some());
     let (penalty_specs, canonical_penalties, active_nullspace_dims) = dense_penalty_test_inputs(
         &s_list,
@@ -1134,7 +1134,7 @@ fn sas_true_score_beta_jacobian_matchesfd_at_seed19() {
                     initial_epsilon: 0.0,
                     initial_log_delta: 0.0,
                 })
-                .unwrap_or_else(|e| panic!("{} failed: {:?}", "valid SAS initial state"),
+                .unwrap_or_else(|e| panic!("{} failed: {:?}", "valid SAS initial state", e)),
             ),
         ),
         latent_cloglog: None,
@@ -1160,7 +1160,7 @@ fn sas_true_score_beta_jacobian_matchesfd_at_seed19() {
     };
 
     let theta = array![0.10, 0.12, -0.18];
-    let (cfg, effective_sas_link) = resolved_external_config(&opts).expect("cfg", e));
+    let (cfg, effective_sas_link) = resolved_external_config(&opts).expect("cfg");
     assert!(effective_sas_link.is_some());
     let (penalty_specs, canonical_penalties, active_nullspace_dims) = dense_penalty_test_inputs(
         &s_list,
@@ -1304,7 +1304,7 @@ fn sas_pirlshessian_matches_true_score_jacobian_at_seed19() {
                     initial_epsilon: 0.0,
                     initial_log_delta: 0.0,
                 })
-                .unwrap_or_else(|e| panic!("{} failed: {:?}", "valid SAS initial state"),
+                .unwrap_or_else(|e| panic!("{} failed: {:?}", "valid SAS initial state", e)),
             ),
         ),
         latent_cloglog: None,
@@ -1330,7 +1330,7 @@ fn sas_pirlshessian_matches_true_score_jacobian_at_seed19() {
     };
 
     let theta = array![0.10, 0.12, -0.18];
-    let (cfg, effective_sas_link) = resolved_external_config(&opts).expect("cfg", e));
+    let (cfg, effective_sas_link) = resolved_external_config(&opts).expect("cfg");
     assert!(effective_sas_link.is_some());
     let (penalty_specs, canonical_penalties, active_nullspace_dims) = dense_penalty_test_inputs(
         &s_list,

--- a/src/terms/basis/tests.rs
+++ b/src/terms/basis/tests.rs
@@ -4,5 +4,5 @@
 //! pulled in verbatim; every item they reference resolves through the parent
 //! module's re-exports (`use super::*`).
 
-include!("../../../tests/src_modules/basis_radial_periodic_thinplate_tests.rs");
-include!("../../../tests/src_modules/basis_duchon_matern_jet_derivative_tests.rs");
+include!("../../../tests/src_modules/smooths/basis_radial_periodic_thinplate_tests.rs");
+include!("../../../tests/src_modules/smooths/basis_duchon_matern_jet_derivative_tests.rs");

--- a/src/terms/smooth/tests.rs
+++ b/src/terms/smooth/tests.rs
@@ -4,6 +4,6 @@
 //! pulled in verbatim; every item they reference resolves through the parent
 //! module's re-exports (`use super::*`).
 
-include!("../../../tests/src_modules/smooth_design_assembly_constraint_tests.rs");
-include!("../../../tests/src_modules/smooth_adaptive_bounded_duchon_tests.rs");
-include!("../../../tests/src_modules/smooth_matern_nfree_rekey_topology_tests.rs");
+include!("../../../tests/src_modules/smooths/smooth_design_assembly_constraint_tests.rs");
+include!("../../../tests/src_modules/smooths/smooth_adaptive_bounded_duchon_tests.rs");
+include!("../../../tests/src_modules/smooths/smooth_matern_nfree_rekey_topology_tests.rs");


### PR DESCRIPTION
Assorted fixups from a recent multi-file refactor:

1. **Masked HyperOperator cache routing** — fix import path and route cache through the trait.
2. **Per-row dispersion** — split it into a capability channel instead of relying on an unused-input default.
3. **Rigid-probit sqrt** — unify onto the jet algebra and drop unused `JetScalar` operators.
4. **Estimate policy tests** — fix mangled error-argument placement.
5. **Test-module includes** — point `include!` directives at relocated fixture paths under `misc/`, `optimization/`, and `smooths/`.

## Test plan
- [ ] `cargo test` builds and the affected test modules pass
- [ ] Full CI run is green
- [ ] Branch is rebased on latest `main` if merge-check flags it

🤖 Generated with [Code](https://code.noumena.com/code)