### PR TITLE
fix: unblock main — resolve #[ignore] ban and private module import

### DIFF
--- a/src/reml_contracts.rs
+++ b/src/reml_contracts.rs
@@ -818,6 +818,6 @@ pub struct ContractedPsiSecondOrder {
 pub type ContractedPsiSecondOrderFn =
     Arc<dyn Fn(&[f64]) -> Result<Option<ContractedPsiSecondOrder>, String> + Send + Sync>;
 
-use crate::solver::estimate::reml::reml_outer_engine::dense_linalg::{
+use crate::solver::estimate::reml::reml_outer_engine::{
     dense_bilinear, dense_matvec_into, dense_matvec_scaled_add_into,
 };

--- a/tests/quality/misc/logdet_probe.rs
+++ b/tests/quality/misc/logdet_probe.rs
@@ -80,7 +80,6 @@ fn make_csv(seed: u64) -> std::path::PathBuf {
 // from the gated set: the suite harness lists it but the per-test run skips it
 // (rc=0 → PASS), so no real quality assertion is touched or weakened.
 #[test]
-#[ignore = "diagnostic dump (panics by design to surface the #1271-diag trace); not a quality gate — run with --ignored to see the dump"]
 fn diag_1271_dump_reml_logdet_internals() {
     init_parallelism();
 
@@ -164,8 +163,17 @@ fn diag_1271_dump_reml_logdet_internals() {
     }
     report.push_str("================================================================\n");
 
-    // Force nextest to surface the captured output even without --nocapture by
-    // failing with the full report as the panic message. This test is a probe,
-    // not a gate; the "failure" is the report.
-    panic!("{report}");
+    // Surface the diagnostic report via eprintln so it appears with --nocapture,
+    // then assert the fit produced a finite EDF with at least one captured
+    // REML evaluation — converting the probe from a deliberate panic into a
+    // legitimate running test (the ban-scanner forbids #[ignore] tests).
+    eprintln!("{report}");
+    assert!(
+        edf_total.is_finite() && edf_total > 0.0,
+        "edf_total must be finite: {edf_total}"
+    );
+    assert!(
+        !lines.is_empty(),
+        "the capture logger must have recorded at least one dense REML evaluation"
+    );
 }


### PR DESCRIPTION
## Summary

Two more pre-existing build breaks on main from active refactoring.

## Fixes (2 files)

1. **tests/quality/misc/logdet_probe.rs** — the `#[ignore]` attribute is now banned unconditionally by the ban-scanner (build.rs:119-125, no exemptions). The `diag_1271_dump_reml_logdet_internals` test was a diagnostic dump that deliberately panicked to surface a trace. Converted to a legitimate running `#[test]`: emits the full trace via `eprintln!` (visible with `--nocapture`) and asserts the fit produced a finite EDF with at least one captured REML evaluation.

2. **src/reml_contracts.rs:821** — import via private submodule `dense_linalg` after module reorganization. Fixed to import from the parent module path (the items are already `pub(crate)`-re-exported via `pub(crate) use dense_linalg::{...}`).

## Known remaining issue (needs owner)
`src/families/survival/location_scale/row_kernel.rs:98` has a `field 'll' is never read` error despite 3 use sites in `family_solver.rs` (lines 1661, 1688, and row_kernel.rs:1294). This is likely a cfg-gate or type-split artifact from the active refactor. `#[allow(dead_code)]` is also banned by the ban-scanner, so the field must be either genuinely used or removed — needs owner judgment.

— HomunculusLabs (AI-assisted)
