### PR TITLE
fix: unblock main — Order2::g accessor, dead ll field, reml import path

### DIFF
--- a/src/families/jet_scalar.rs
+++ b/src/families/jet_scalar.rs
@@ -143,7 +143,7 @@ pub trait JetScalar<const K: usize>: Copy {
 pub struct Order2<const K: usize>(pub super::jet_tower::Tower2<K>);
 
 impl<const K: usize> Order2<K> {
-    /// Read the gradient channel.
+    /// Read the gradient channel `g_a = ∂ℓ/∂p_a`.
     #[inline]
     pub fn g(&self) -> [f64; K] {
         self.0.g

--- a/src/families/jet_scalar.rs
+++ b/src/families/jet_scalar.rs
@@ -143,6 +143,12 @@ pub trait JetScalar<const K: usize>: Copy {
 pub struct Order2<const K: usize>(pub super::jet_tower::Tower2<K>);
 
 impl<const K: usize> Order2<K> {
+    /// Read the gradient channel.
+    #[inline]
+    pub fn g(&self) -> [f64; K] {
+        self.0.g
+    }
+
     /// Read the Hessian channel.
     #[inline]
     pub fn h(&self) -> [[f64; K]; K] {

--- a/src/families/survival/location_scale/row_kernel.rs
+++ b/src/families/survival/location_scale/row_kernel.rs
@@ -91,9 +91,6 @@ impl SurvivalExactRowKernel {
 }
 
 pub(crate) struct SurvivalJointQuantities {
-    /// Per-row log-likelihood `ell_i` (NOT negated). Rows excluded by the
-    /// degeneracy guard (`row_derivatives_rescaled` returns `None`) keep `0.0`,
-    /// matching their zero derivative slots. The RowKernel adapter uses this
     pub(crate) d1_q: Array1<f64>,
     pub(crate) d2_q: Array1<f64>,
     pub(crate) d3_q: Array1<f64>,

--- a/src/families/survival/location_scale/row_kernel.rs
+++ b/src/families/survival/location_scale/row_kernel.rs
@@ -94,8 +94,6 @@ pub(crate) struct SurvivalJointQuantities {
     /// Per-row log-likelihood `ell_i` (NOT negated). Rows excluded by the
     /// degeneracy guard (`row_derivatives_rescaled` returns `None`) keep `0.0`,
     /// matching their zero derivative slots. The RowKernel adapter uses this
-    /// to expose `nll_i = -ell_i` without recomputing row survival values.
-    pub(crate) ll: Array1<f64>,
     pub(crate) d1_q: Array1<f64>,
     pub(crate) d2_q: Array1<f64>,
     pub(crate) d3_q: Array1<f64>,
@@ -1202,7 +1200,6 @@ impl SurvivalLocationScaleFamily {
     ) -> Result<SurvivalJointQuantities, String> {
         let n = self.n;
         let dynamic = self.build_dynamic_geometry(block_states)?;
-        let mut ll = Array1::<f64>::zeros(n);
         let mut d1_q = Array1::<f64>::zeros(n);
         let mut d2_q = Array1::<f64>::zeros(n);
         let mut d3_q = Array1::<f64>::zeros(n);
@@ -1253,7 +1250,6 @@ impl SurvivalLocationScaleFamily {
             }
         }
 
-        let p_ll = SendPtr(ll.as_mut_ptr());
         let p_d1_q = SendPtr(d1_q.as_mut_ptr());
         let p_d2_q = SendPtr(d2_q.as_mut_ptr());
         let p_d3_q = SendPtr(d3_q.as_mut_ptr());
@@ -1291,7 +1287,6 @@ impl SurvivalLocationScaleFamily {
                 // exactly once; pointers target distinct length-`n` `Array1`
                 // buffers not read until the parallel loop completes.
                 unsafe {
-                    p_ll.write(i, row.ll);
                     p_d1_q.write(i, row.d1_q);
                     p_d2_q.write(i, row.d2_q);
                     p_d3_q.write(i, row.d3_q);
@@ -1314,7 +1309,6 @@ impl SurvivalLocationScaleFamily {
             })?;
 
         Ok(SurvivalJointQuantities {
-            ll,
             d1_q,
             d2_q,
             d3_q,

--- a/src/reml_contracts.rs
+++ b/src/reml_contracts.rs
@@ -848,6 +848,6 @@ pub struct ContractedPsiSecondOrder {
 pub type ContractedPsiSecondOrderFn =
     Arc<dyn Fn(&[f64]) -> Result<Option<ContractedPsiSecondOrder>, String> + Send + Sync>;
 
-use crate::solver::reml::reml_outer_engine::dense_linalg::{
+use crate::solver::estimate::reml::reml_outer_engine::{
     dense_bilinear, dense_matvec_into, dense_matvec_scaled_add_into,
 };


### PR DESCRIPTION
## Summary

Three build breaks left by the #1493 rowkernel/jet refactor merge.

## Fixes (3 files, +7/-7)

1. **jet_scalar.rs** — `Order2` lost its `g()` gradient accessor in the refactor (only `h()` survived). `row_kernel.rs:553` calls `out.g()`. Added `pub fn g()` mirroring `h()`, reading `self.0.g` from `Tower2`.

2. **row_kernel.rs** — `SurvivalJointQuantities.ll` field is genuinely dead. The 3 `row.ll` use sites read from `SurvivalRowDerivatives` (a **different** struct that also has `ll`), not from `SurvivalJointQuantities`. Removed the field, its local var, and the `p_ll` write. The ban-scanner forbids `#[allow(dead_code)]`, so dead fields must go.

3. **reml_contracts.rs:851** — `dense_linalg` import path stale after the `estimate/reml` module reorg. Fixed to `solver::estimate::reml::reml_outer_engine::{...}`.

## Verification
- `cargo +1.93.0 check --lib`: clean

— HomunculusLabs (AI-assisted)
