### PR TITLE
test(#1464): make the curv hyperbolic-sign contract an asserting CI gate

### DIFF
--- a/.github/workflows/python-contracts.yml
+++ b/.github/workflows/python-contracts.yml
@@ -16,7 +16,9 @@ on:
   pull_request:
     paths:
       - "tests/test_bug_hunt_numeric_by_variable_clamped_to_training_range_at_predict.py"
+      - "tests/test_bug_hunt_curv_smooth_hyperbolic_recovered_as_spherical.py"
       - "src/inference/model.rs"
+      - "src/terms/smooth/spatial_optimization.rs"
       - ".github/workflows/python-contracts.yml"
 
 concurrency:
@@ -85,3 +87,9 @@ jobs:
         # ./gamfit makes the installed wheel win the import.
         working-directory: ${{ runner.temp }}
         run: python -m pytest "$GITHUB_WORKSPACE/tests/test_bug_hunt_numeric_by_variable_clamped_to_training_range_at_predict.py" -v --tb=short
+
+      - name: Run curv() constant-curvature sign-recovery contract (#1464)
+        # Hyperbolic (kappa*<0) data must not be recovered as spherical; the
+        # Python full-fit path must honor the sign-correct kappa-fair fast-path
+        # pin in spatial_optimization.rs. Matches the Rust e2e owed_1464.rs guard.
+        run: python -m pytest tests/test_bug_hunt_curv_smooth_hyperbolic_recovered_as_spherical.py -v --tb=short

--- a/.github/workflows/python-contracts.yml
+++ b/.github/workflows/python-contracts.yml
@@ -92,4 +92,12 @@ jobs:
         # Hyperbolic (kappa*<0) data must not be recovered as spherical; the
         # Python full-fit path must honor the sign-correct kappa-fair fast-path
         # pin in spatial_optimization.rs. Matches the Rust e2e owed_1464.rs guard.
-        run: python -m pytest tests/test_bug_hunt_curv_smooth_hyperbolic_recovered_as_spherical.py -v --tb=short
+        #
+        # Run from runner.temp, NOT the repo root: the maturin wheel installs
+        # gamfit (incl. the compiled gamfit._rust) into site-packages, but the
+        # source tree's ./gamfit has no compiled _rust, so `python -m pytest`
+        # from the repo root imports the source package and fails with
+        # `ModuleNotFoundError: gamfit._rust`. Running from a directory without
+        # ./gamfit makes the installed wheel win the import.
+        working-directory: ${{ runner.temp }}
+        run: python -m pytest "$GITHUB_WORKSPACE/tests/test_bug_hunt_curv_smooth_hyperbolic_recovered_as_spherical.py" -v --tb=short

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -563,6 +563,14 @@ jobs:
         # collect_by_variable_numeric_axes exemption in src/inference/model.rs.
         run: python -m pytest tests/test_bug_hunt_numeric_by_variable_clamped_to_training_range_at_predict.py -v --tb=short
 
+      - name: Run curv() constant-curvature sign-recovery contract (#1464)
+        # Full-fit Python contract: hyperbolic (kappa*<0) data must NOT be
+        # recovered as spherical. This is the Python-path guard matching the
+        # Rust e2e owed_1464.rs / bug_hunt_1464_* tests. The file was a
+        # print-only diagnostic (collected nothing) until it was made an
+        # asserting gate; wiring it here is what actually exercises #1464.
+        run: python -m pytest tests/test_bug_hunt_curv_smooth_hyperbolic_recovered_as_spherical.py -v --tb=short
+
       - name: Run survival API regression + save/load roundtrip tests
         # `test_survival_api_regressions.py` covers fit-only smoke checks
         # across survival likelihood modes; `test_survival_save_load_roundtrip.py`

--- a/tests/test_bug_hunt_curv_smooth_hyperbolic_recovered_as_spherical.py
+++ b/tests/test_bug_hunt_curv_smooth_hyperbolic_recovered_as_spherical.py
@@ -1,21 +1,67 @@
-import io, contextlib, math, numpy as np, pandas as pd
+"""#1464 contract: curv() constant-curvature smooth must recover the *sign* of the
+true curvature through the Python full-fit path.
+
+The bug (#1464) was that hyperbolic data (kappa* < 0) was recovered as spherical —
+`kappa_hat` railed to the positive chart bound because the accept-gate scored a
+sign-blind raw V_p criterion. The fix pins the constant-curvature baseline kappa to
+the sign-correct kappa-fair fast-path scan (spatial_optimization.rs). The Rust e2e
+contract is covered by tests/owed_1464.rs / bug_hunt_1464_*; this is the matching
+guard for the *Python* `gamfit.fit(...).curvature(...)` full-fit path the issue names.
+
+Previously this file was a print-only diagnostic (no test_ function, no asserts) and
+was not collected by pytest, so it guarded nothing — it is now an asserting gate.
+"""
+
+import math
+
+import numpy as np
+import pandas as pd
+import pytest
+
 import gamfit
 
+
 def curved(kappa_star, seed=1, n=600, radius=0.68, noise=0.02):
-    rng = np.random.default_rng(seed); root = math.sqrt(abs(kappa_star))
-    x1=[]; x2=[]; y=[]
+    """Sample a radial response whose decay distance follows the constant-curvature
+    geodesic for the given signed curvature (hyperbolic kappa*<0, spherical kappa*>0,
+    flat kappa*=0)."""
+    rng = np.random.default_rng(seed)
+    root = math.sqrt(abs(kappa_star))
+    x1, x2, y = [], [], []
     while len(y) < n:
-        a, b = 2*rng.random()-1, 2*rng.random()-1
-        if a*a+b*b > 1.0: continue
-        u, v = a*radius, b*radius; r = math.hypot(u, v)
-        if kappa_star < 0:   d = 2*math.atanh(min(root*r, 1-1e-9))/root   # hyperbolic
-        elif kappa_star > 0: d = 2*math.atan(root*r)/root                 # spherical
-        else:                d = 2*r
-        x1.append(u); x2.append(v); y.append(2*math.exp(-d)-1 + noise*rng.standard_normal())
+        a, b = 2 * rng.random() - 1, 2 * rng.random() - 1
+        if a * a + b * b > 1.0:
+            continue
+        u, v = a * radius, b * radius
+        r = math.hypot(u, v)
+        if kappa_star < 0:  # hyperbolic
+            d = 2 * math.atanh(min(root * r, 1 - 1e-9)) / root
+        elif kappa_star > 0:  # spherical
+            d = 2 * math.atan(root * r) / root
+        else:  # flat
+            d = 2 * r
+        x1.append(u)
+        x2.append(v)
+        y.append(2 * math.exp(-d) - 1 + noise * rng.standard_normal())
     return pd.DataFrame({"y": y, "x1": x1, "x2": x2})
 
-for ks in (+2.0, -2.0):
-    df = curved(ks)
+
+@pytest.mark.parametrize("kappa_star", [+2.0, -2.0])
+def test_curv_recovers_constant_curvature_sign(kappa_star):
+    df = curved(kappa_star)
     rep = gamfit.fit(df, "y ~ curv(x1, x2, centers=10)").curvature(df)[0]
-    print(f"truth kappa*={ks:+}: kappa_hat={rep['kappa_hat']:+.4f} "
-          f"ci=({rep['ci_lo']:+.3f},{rep['ci_hi']:+.3f}) verdict={rep['verdict']} flat_p={rep['flatness_p_value']:.3g}")
+    kappa_hat = rep["kappa_hat"]
+    print(
+        f"truth kappa*={kappa_star:+}: kappa_hat={kappa_hat:+.4f} "
+        f"ci=({rep['ci_lo']:+.3f},{rep['ci_hi']:+.3f}) "
+        f"verdict={rep['verdict']} flat_p={rep['flatness_p_value']:.3g}"
+    )
+    assert math.isfinite(kappa_hat), f"kappa_hat is not finite: {kappa_hat}"
+    # #1464 core contract: the recovered curvature must carry the TRUE sign.
+    # The original bug railed hyperbolic (kappa*=-2) data to a positive
+    # (spherical) kappa_hat; the regression is precisely that this no longer
+    # happens for either chart.
+    assert math.copysign(1.0, kappa_hat) == math.copysign(1.0, kappa_star), (
+        f"curv() recovered the WRONG curvature sign: truth kappa*={kappa_star:+}, "
+        f"kappa_hat={kappa_hat:+.4f} (hyperbolic-as-spherical #1464 regression)"
+    )


### PR DESCRIPTION
## Why

The curv() constant-curvature **Python full-fit** contract from #1464 — hyperbolic data (`kappa* < 0`) must **not** be recovered as spherical — was guarded only on the Rust side (`tests/owed_1464.rs`, `tests/bug_hunt_1464_*`). The matching Python test, `tests/test_bug_hunt_curv_smooth_hyperbolic_recovered_as_spherical.py`, was a **print-only diagnostic**: a bare top-level loop, no `test_` function, no assertions — so pytest collected nothing and it was wired into no workflow. It guarded nothing, which is exactly why #1464's *Python path* could not be verified through CI.

## What

- Convert the diagnostic into a parametrized pytest test that asserts `sign(kappa_hat) == sign(kappa*)` for both charts (`+2` spherical, `-2` hyperbolic), keeping the proven data generator and the diagnostic print for debugging.
- Run it in `test.yml` immediately after the Python API smoke tests, where the maturin-built `gamfit` wheel is already installed.

## Effect

This makes CI the verification of #1464's Python full-fit path. The fix itself is already on `main` (the κ-fair fast-path sign pin in `spatial_optimization.rs`); this PR's CI run is what confirms the Python binding honors it and permanently guards against regression. If this check is green, #1464 can be closed with CI evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)