### PR TITLE
fix(predict): exempt numeric by-variable multipliers from the predict-time axis clip

### DIFF
--- a/.github/workflows/python-contracts.yml
+++ b/.github/workflows/python-contracts.yml
@@ -76,4 +76,12 @@ jobs:
         # s(x, by=z): the numeric by-multiplier must not be axis-clipped to its
         # training range at predict time, so the prediction stays affine in z.
         # Guards the collect_by_variable_numeric_axes exemption in model.rs.
-        run: python -m pytest tests/test_bug_hunt_numeric_by_variable_clamped_to_training_range_at_predict.py -v --tb=short
+        #
+        # Run from runner.temp, NOT the repo root: the maturin wheel installs
+        # gamfit (incl. the compiled gamfit._rust) into site-packages, but the
+        # source tree's ./gamfit has no compiled _rust, so `python -m pytest`
+        # from the repo root imports the source package and fails with
+        # `ModuleNotFoundError: gamfit._rust`. Running from a directory without
+        # ./gamfit makes the installed wheel win the import.
+        working-directory: ${{ runner.temp }}
+        run: python -m pytest "$GITHUB_WORKSPACE/tests/test_bug_hunt_numeric_by_variable_clamped_to_training_range_at_predict.py" -v --tb=short

--- a/.github/workflows/python-contracts.yml
+++ b/.github/workflows/python-contracts.yml
@@ -1,0 +1,79 @@
+name: Python Contracts
+
+# Fast Python full-fit contract checks, decoupled from the heavy Rust suite.
+#
+# The "Rust CI" workflow (test.yml) runs its Python pytest steps only AFTER the
+# full Rust nextest suite in the same job, so a Python-only contract (e.g. the
+# curv #1464 sign-recovery or the by-variable #1513 predict-clip guard) is not
+# observable until hours into that run. This workflow builds just the maturin
+# wheel and runs the targeted Python contract tests, so a fix to a Python-facing
+# contract verifies in ~20-30 min instead of being hostage to the Rust suite.
+# It is also the intended fast home for wiring in the orphaned Python contract
+# tests tracked by #1512.
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - "tests/test_bug_hunt_numeric_by_variable_clamped_to_training_range_at_predict.py"
+      - "src/inference/model.rs"
+      - ".github/workflows/python-contracts.yml"
+
+concurrency:
+  group: python-contracts-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: "0"
+
+jobs:
+  python-contracts:
+    name: Python contracts
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          # build.rs human-author gate needs the real last build.rs editor; a
+          # shallow clone makes git log return HEAD and false-fails the gate.
+          fetch-depth: 0
+
+      - name: Setup Rust CI
+        uses: ./.github/actions/setup-rust-ci
+        with:
+          free-disk-space: 'true'
+          cache-targets: 'false'
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      - name: Install maturin
+        run: python -m pip install --upgrade pip "maturin>=1.7,<2"
+
+      - name: Build and install gam extension (maturin build + wheel install)
+        shell: bash
+        run: |
+          set -euo pipefail
+          rm -rf dist
+          maturin build --release -i python3 -o dist
+          python -m pip install --force-reinstall dist/*.whl
+
+      - name: Install Python test extras
+        run: |
+          python -m pip install \
+            'pytest>=8' 'numpy>=1.26' 'pandas>=2.0' 'pyarrow>=14' \
+            'matplotlib>=3.8' 'scikit-learn>=1.4'
+
+      - name: Run numeric by-variable predict-clip contract (#1513)
+        # s(x, by=z): the numeric by-multiplier must not be axis-clipped to its
+        # training range at predict time, so the prediction stays affine in z.
+        # Guards the collect_by_variable_numeric_axes exemption in model.rs.
+        run: python -m pytest tests/test_bug_hunt_numeric_by_variable_clamped_to_training_range_at_predict.py -v --tb=short

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -555,6 +555,14 @@ jobs:
         # benchmark binaries or external services are required.
         run: python -m pytest tests/test_tables.py -v --tb=short
 
+      - name: Run numeric by-variable predict-clip contract
+        # Full-fit Python contract: a numeric `by=` multiplier of s(x, by=z)
+        # must not be axis-clipped to its training range at predict time, so the
+        # varying-coefficient prediction stays affine in z (z=0 leaves the
+        # baseline; z beyond the training max keeps its slope). Guards the
+        # collect_by_variable_numeric_axes exemption in src/inference/model.rs.
+        run: python -m pytest tests/test_bug_hunt_numeric_by_variable_clamped_to_training_range_at_predict.py -v --tb=short
+
       - name: Run survival API regression + save/load roundtrip tests
         # `test_survival_api_regressions.py` covers fit-only smoke checks
         # across survival likelihood modes; `test_survival_save_load_roundtrip.py`

--- a/src/inference/model.rs
+++ b/src/inference/model.rs
@@ -2147,6 +2147,54 @@ fn collect_smooth_extrapolation_axes(
     }
 }
 
+/// Collect training-column indices that feed a *numeric* `by=` multiplier of a
+/// varying-coefficient smooth (`s(x, by=z)`).
+///
+/// A numeric by-variable enters the model as a linear multiplier of the centred
+/// smooth basis, so the prediction is exactly affine in `z` for any fixed `x`:
+/// `pred(x, z) = intercept + z·f(x)`. The by-multiplier is therefore an
+/// *unbounded linear* extrapolant — exactly like a parametric `linear` axis
+/// (already exempt from the clip via `training_linear_axes`), not a
+/// bounded-basis axis. Clamping it to the training range `[min(z), max(z)]`
+/// before the design is built would make the varying-coefficient effect plateau
+/// outside the sampled range (slope 0 above the max) and silently replace the
+/// natural `z == 0` baseline with the `z == min` prediction — the prediction is
+/// no longer affine in `z`. Exempt it from the predict-time axis clip.
+///
+/// Factor `by=` columns are categorical group labels handled by the
+/// level-lookup / random-effect machinery and are deliberately *not* exempted
+/// here. Returned indices reference `self.training_headers`, matching the
+/// iteration in `axis_clip_to_training_ranges`.
+fn collect_by_variable_numeric_axes(
+    basis: &crate::smooth::SmoothBasisSpec,
+    n_training_headers: usize,
+    out: &mut std::collections::HashSet<usize>,
+) {
+    use crate::smooth::{BySmoothKind, ByVarKind, SmoothBasisSpec};
+    match basis {
+        SmoothBasisSpec::ByVariable {
+            inner, by_col, kind, ..
+        } => {
+            if matches!(kind, BySmoothKind::Numeric) && *by_col < n_training_headers {
+                out.insert(*by_col);
+            }
+            collect_by_variable_numeric_axes(inner, n_training_headers, out);
+        }
+        SmoothBasisSpec::BySmooth { smooth, by_kind } => {
+            if let ByVarKind::Numeric { feature_col } = by_kind
+                && *feature_col < n_training_headers
+            {
+                out.insert(*feature_col);
+            }
+            collect_by_variable_numeric_axes(smooth, n_training_headers, out);
+        }
+        SmoothBasisSpec::FactorSumToZero { inner, .. } => {
+            collect_by_variable_numeric_axes(inner, n_training_headers, out);
+        }
+        _ => {}
+    }
+}
+
 impl FittedModel {
     /// Axis-clip each continuous new-data column to the (min, max) range
     /// observed in training. Categorical and binary columns are left
@@ -2201,6 +2249,12 @@ impl FittedModel {
         // through the single basis-layer extrapolation. See the method doc.
         let smooth_extrapolation_axes =
             self.training_smooth_extrapolation_axes(training_headers.len());
+        // Numeric `by=` multipliers of a varying-coefficient smooth `s(x, by=z)`
+        // are linear multipliers of the centred basis (prediction affine in z),
+        // so — like parametric linear axes — clipping them to the training range
+        // turns the varying-coefficient effect into a boundary plateau and
+        // destroys the z==0 baseline. Exempt them from the clip.
+        let by_variable_axes = self.training_by_variable_numeric_axes(training_headers.len());
         // Sphere latitude is a closed-manifold coordinate: its clip bounds are
         // the manifold's intrinsic domain ([-π/2, π/2] or [-90, 90]), not the
         // sampled range, so a pole prediction reaches the true pole instead of
@@ -2234,6 +2288,9 @@ impl FittedModel {
                 continue;
             }
             if smooth_extrapolation_axes.contains(&col_in_training) {
+                continue;
+            }
+            if by_variable_axes.contains(&col_in_training) {
                 continue;
             }
             let Some(&col_idx) = col_map.get(header) else {
@@ -2413,6 +2470,24 @@ impl FittedModel {
         for spec in self.saved_term_specs() {
             for term in &spec.smooth_terms {
                 collect_smooth_extrapolation_axes(&term.basis, n_training_headers, &mut out);
+            }
+        }
+        out
+    }
+
+    /// Collect the set of training-column indices that feed a *numeric* `by=`
+    /// multiplier of a varying-coefficient smooth. These columns are linear
+    /// multipliers (`pred = intercept + z·f(x)`), so they must be exempt from
+    /// the predict-time axis clip for the same reason parametric linear axes
+    /// are — see `collect_by_variable_numeric_axes` for the full rationale.
+    fn training_by_variable_numeric_axes(
+        &self,
+        n_training_headers: usize,
+    ) -> std::collections::HashSet<usize> {
+        let mut out: std::collections::HashSet<usize> = std::collections::HashSet::new();
+        for spec in self.saved_term_specs() {
+            for term in &spec.smooth_terms {
+                collect_by_variable_numeric_axes(&term.basis, n_training_headers, &mut out);
             }
         }
         out


### PR DESCRIPTION
## The bug

A varying-coefficient smooth `s(x, by=z)` fits `z·f(x)`: the numeric by-variable `z` is a **linear multiplier** of the centred basis, so the prediction is exactly affine in `z`:

```
pred(x, z) = intercept + z · f(x)
```

`FittedModel::axis_clip_to_training_ranges` clamps every continuous input column to its training `[min, max]` **before** building the predict design. The by-multiplier column was in **no exemption set**:

- `collect_smooth_extrapolation_axes` recurses a `ByVariable`/`BySmooth` into its *inner* smooth (exempting the basis `x` axis, #806) but never exempts the `by` column;
- `training_linear_axes` only covers parametric `linear` terms.

So `z` was clipped like an ordinary predictor. With training `z ∈ [1, 2]`:

- `pred(x, z=0) == pred(x, z=1)` — the natural `z==0` baseline is silently replaced by the `z==min` prediction;
- `pred(x, z=3) == pred(x, z=2)` — predictions plateau (slope 0) above the training max;
- the prediction is no longer affine in `z`, so extrapolating the modulating covariate is unboundedly wrong.

## The fix

Exempt the numeric by-variable column from the clip — it is an **unbounded linear** extrapolant, exactly like a parametric `linear` axis (already exempt via `training_linear_axes`). New `collect_by_variable_numeric_axes` / `training_by_variable_numeric_axes` handle both spec shapes (`ByVariable{kind: Numeric}` and `BySmooth{by_kind: Numeric}`); factor `by=` columns stay categorical and are deliberately not exempted. The clip loop skips the collected columns.

## Verification

The contract test `tests/test_bug_hunt_numeric_by_variable_clamped_to_training_range_at_predict.py` (affine-in-z + z=0-not-clamped) already existed but was run by **no** workflow (one of the 161 orphans in #1512). This PR wires it into Rust CI, so the dispatched `Rust CI` run on this branch is the end-to-end verification of the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)