### PR TITLE
fix(predict): finite plug-in fallback when posterior-mean integral overflows (#1515)

### DIFF
--- a/.github/workflows/python-contracts.yml
+++ b/.github/workflows/python-contracts.yml
@@ -17,7 +17,9 @@ on:
     paths:
       - "tests/test_bug_hunt_numeric_by_variable_clamped_to_training_range_at_predict.py"
       - "tests/test_bug_hunt_curv_smooth_hyperbolic_recovered_as_spherical.py"
+      - "tests/test_bug_hunt_poisson_zero_count_fit_unpredictable_mean.py"
       - "src/inference/model.rs"
+      - "src/inference/predict/mod.rs"
       - "src/terms/smooth/spatial_optimization.rs"
       - ".github/workflows/python-contracts.yml"
 
@@ -101,3 +103,11 @@ jobs:
         # ./gamfit makes the installed wheel win the import.
         working-directory: ${{ runner.temp }}
         run: python -m pytest "$GITHUB_WORKSPACE/tests/test_bug_hunt_curv_smooth_hyperbolic_recovered_as_spherical.py" -v --tb=short
+
+      - name: Run all-zero-count predictable-mean contract (#1515)
+        # A Poisson/NB GAM fitted on identically-zero counts must stay
+        # predictable: the response-scale posterior mean overflows on the
+        # near-singular flat-likelihood Hessian, so predict must fall back to
+        # the finite plug-in mean g^-1(eta_hat) instead of returning None.
+        working-directory: ${{ runner.temp }}
+        run: python -m pytest "$GITHUB_WORKSPACE/tests/test_bug_hunt_poisson_zero_count_fit_unpredictable_mean.py" -v --tb=short

--- a/src/inference/predict/mod.rs
+++ b/src/inference/predict/mod.rs
@@ -1502,7 +1502,24 @@ fn predict_gam_posterior_mean_from_backendwith_bc(
     let quadctx = crate::quadrature::QuadratureContext::new();
     let means: Result<Vec<f64>, EstimationError> = (0..eta.len())
         .into_par_iter()
-        .map(|i| strategy.posterior_mean(&quadctx, eta[i], eta_standard_error[i]))
+        .map(|i| {
+            let pm = strategy.posterior_mean(&quadctx, eta[i], eta_standard_error[i])?;
+            if pm.is_finite() {
+                return Ok(pm);
+            }
+            // #1515: a pathological coefficient posterior — e.g. an all-zero
+            // Poisson fit, whose flat likelihood leaves the penalized Hessian
+            // near-singular with `se_eta` in the thousands — makes the
+            // response-scale posterior integral E[g⁻¹(η)] = exp(η + se_eta²/2)
+            // overflow to +inf. That serializes to a JSON null across the
+            // gam-pyffi boundary and crashes the Python shaper with a `None`
+            // mean, even though the point linear predictor is finite. Degrade
+            // gracefully to the plug-in mean g⁻¹(η̂): it is finite (exp(η̂) for
+            // the log link) and consistent with the reported `linear_predictor`,
+            // so a model the API reports as fitted always yields a finite
+            // response mean.
+            strategy.inverse_link(eta[i])
+        })
         .collect();
 
     Ok(PredictPosteriorMeanResult {

--- a/tests/test_bug_hunt_poisson_zero_count_fit_unpredictable_mean.py
+++ b/tests/test_bug_hunt_poisson_zero_count_fit_unpredictable_mean.py
@@ -1,0 +1,53 @@
+"""#1515 contract: a model the public API reports as fitted must be predictable.
+
+A Poisson (or negative-binomial) GAM fitted on identically-zero counts is accepted
+by ``gamfit.fit`` — it returns a fitted ``Model`` — but the all-zero count response
+makes the likelihood flat as every ``eta -> -inf``, so the penalized Hessian is
+near-singular (per-coefficient ``se_eta`` in the thousands). The response-scale
+posterior-mean integral ``E[exp(eta)] = exp(mu_eta + se_eta**2 / 2)`` then overflows
+to ``+inf``, which serialized across the gam-pyffi boundary as JSON ``null`` and
+surfaced in Python as a ``None`` ``mean`` column — so ``predict()`` crashed with
+``TypeError: float() argument must be a string or a real number, not 'NoneType'``
+even though ``linear_predictor`` (the floored, finite ``ln(1e-10)``) came back fine.
+
+The fix (``predict_gam_posterior_mean_from_backendwith_bc`` in
+``src/inference/predict/mod.rs``) degrades gracefully to the plug-in mean
+``g^-1(eta_hat)`` whenever the posterior integral is non-finite, so a fitted model
+always yields a finite response mean consistent with its linear predictor.
+"""
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+import gamfit
+
+
+def _mean(out: object) -> np.ndarray:
+    if isinstance(out, np.ndarray):
+        return np.asarray(out, dtype=float).ravel()
+    return np.asarray(out["mean"], dtype=float)
+
+
+@pytest.mark.parametrize("formula", ["y ~ s(x)", "y ~ 1"])
+@pytest.mark.parametrize("family", ["poisson", "negative_binomial"])
+def test_all_zero_count_fit_predicts_finite_mean(formula: str, family: str) -> None:
+    n = 200
+    data = {"x": np.linspace(0.0, 1.0, n), "y": np.zeros(n)}
+
+    model = gamfit.fit(data, formula, family=family)
+
+    # Must NOT raise TypeError: float() ... not 'NoneType'.
+    out = model.predict(data)
+    mean = _mean(out)
+
+    assert mean.shape[0] == n
+    assert np.all(np.isfinite(mean)), (
+        "all-zero-count fit produced a non-finite response mean "
+        f"(formula={formula!r}, family={family!r}): {mean[:3]}"
+    )
+    # The MLE rate for all-zero counts is ~0, so the response mean is a small,
+    # non-negative number (the plug-in floor exp(ln(1e-10)) = 1e-10), not a wild
+    # overflow value.
+    assert np.all(mean >= 0.0)
+    assert np.all(mean < 1.0), f"expected near-zero rate, got {mean[:3]}"


### PR DESCRIPTION
## The bug (#1515)

A Poisson GAM fitted on identically-zero counts is **accepted** by `gamfit.fit` but is **unpredictable**:

```python
data = {"x": np.linspace(0, 1, 200), "y": np.zeros(200)}
m = gamfit.fit(data, "y ~ s(x)", family="poisson")   # returns a Model
m.predict(data)   # TypeError: float() argument must be ... not 'NoneType'
```

`linear_predictor` comes back finite for every row (the floored `ln(1e-10) = -23.03`), but the response-scale `mean` is `None` for every row.

## Cause

The all-zero count likelihood is flat as every `eta → -inf`, so the penalized Hessian is genuinely near-singular (`se_eta` in the thousands). The response-scale posterior-mean integral `E[g⁻¹(η)] = exp(η + se_eta²/2)` then **overflows to +inf** in `predict_gam_posterior_mean_from_backendwith_bc` (`src/inference/predict/mod.rs`), which serializes as JSON `null` across the gam-pyffi boundary and becomes `None` in Python.

## Fix

When the posterior integral is non-finite, fall back to the **plug-in mean** `g⁻¹(η̂)` (the `FamilyStrategy` already exposes `inverse_link`). It is finite (`exp(η̂) = 1e-10` for the log link) and consistent with the reported `linear_predictor`, so a model the API reports as fitted always yields a finite response mean. The normal (finite) case is unchanged.

## Verification

Adds `tests/test_bug_hunt_poisson_zero_count_fit_unpredictable_mean.py` (Poisson + negative_binomial, `s(x)` and intercept-only) asserting `predict()` does not crash and returns a finite, non-negative, near-zero mean — wired into the fast **Python Contracts** workflow, which is this PR's verification.

Closes #1515.

🤖 Generated with [Claude Code](https://claude.com/claude-code)