### PR TITLE
ci(speed): cache target/ + sccache for the fast Python Contracts workflow

### DIFF
--- a/.github/workflows/python-contracts.yml
+++ b/.github/workflows/python-contracts.yml
@@ -33,6 +33,12 @@ permissions:
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: "0"
+  # Warm the dependency compile across runs via the GitHub Actions sccache
+  # backend, so the maturin wheel build does not recompile the full dep closure
+  # (faer/ndarray/nalgebra/arrow/…) on every run. setup-rust-ci enables the
+  # RUSTC_WRAPPER only after a backend-reachability probe, so a cache outage
+  # degrades to a cold-but-green build rather than a hard failure.
+  SCCACHE_GHA_ENABLED: "true"
 
 jobs:
   python-contracts:
@@ -51,7 +57,12 @@ jobs:
         uses: ./.github/actions/setup-rust-ci
         with:
           free-disk-space: 'true'
-          cache-targets: 'false'
+          # Cache the compiled `target/` (deps + prior gam/gam-pyffi objects)
+          # across runs so the maturin wheel build is incremental: a cold run
+          # populates the cache, subsequent runs restore it and recompile only
+          # the crates whose sources changed (~3-5 min instead of ~13). This is
+          # the dominant cost of the fast Python-contract verification.
+          cache-targets: 'true'
 
       - name: Set up Python 3.11
         uses: actions/setup-python@v5


### PR DESCRIPTION
## Why

The fast Python Contracts workflow (added to verify Python-facing contract fixes like #1464/#1513/#1515 in ~25 min instead of hours behind the Rust suite) is dominated by the **cold maturin wheel build** — it recompiles the full dependency closure (faer/ndarray/nalgebra/arrow/…) on every run (~13 min).

## What

- `cache-targets: 'true'` — cache the compiled `target/` across runs (Swatinem/rust-cache). A cold run populates the cache; subsequent runs restore the deps and recompile only the crates whose sources changed (~3–5 min).
- `SCCACHE_GHA_ENABLED: "true"` — warm the dep compile via the GitHub Actions sccache backend (setup-rust-ci enables the wrapper only after a reachability probe, so a cache outage degrades to cold-but-green).

Cuts the iteration latency of every future Python-facing contract verification. No behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)