### PR TITLE
fix(predict): finite delta-method bounds fallback for TransformEta interval (#1515)

### DIFF
--- a/src/inference/predict/mod.rs
+++ b/src/inference/predict/mod.rs
@@ -2420,20 +2420,32 @@ where
         MeanIntervalMethod::TransformEta => {
             let transformed_lower = apply_family_inverse_link(&eta_lower, &likelihood)?;
             let transformed_upper = apply_family_inverse_link(&eta_upper, &likelihood)?;
-            (
-                Array1::from_iter(
-                    transformed_lower
-                        .iter()
-                        .zip(transformed_upper.iter())
-                        .map(|(&lo, &hi)| lo.min(hi)),
-                ),
-                Array1::from_iter(
-                    transformed_lower
-                        .iter()
-                        .zip(transformed_upper.iter())
-                        .map(|(&lo, &hi)| lo.max(hi)),
-                ),
-            )
+            // #1515: on a degenerate fit (all-zero Poisson flat likelihood) the
+            // η-scale CI half-width z·se_eta is astronomically large, so the
+            // transformed endpoint g⁻¹(η ± z·se_eta) overflows to +inf — and the
+            // min/max against it produces a NaN that serializes to None and
+            // crashes the Python table shaper. When a transformed endpoint is not
+            // finite, fall back per-row to the delta-method bound
+            // mean ± z·mean_se, which is finite (mean is the plug-in inverse link
+            // and mean_se was delta-guarded above), so a fitted model always
+            // returns finite interval bounds.
+            let lower = Array1::from_iter((0..mean.len()).map(|i| {
+                let v = transformed_lower[i].min(transformed_upper[i]);
+                if v.is_finite() {
+                    v
+                } else {
+                    mean[i] - z_lower_per_row[i] * mean_standard_error[i]
+                }
+            }));
+            let upper = Array1::from_iter((0..mean.len()).map(|i| {
+                let v = transformed_lower[i].max(transformed_upper[i]);
+                if v.is_finite() {
+                    v
+                } else {
+                    mean[i] + z_upper_per_row[i] * mean_standard_error[i]
+                }
+            }));
+            (lower, upper)
         }
     };
 

--- a/src/inference/predict/mod.rs
+++ b/src/inference/predict/mod.rs
@@ -2429,18 +2429,21 @@ where
             // mean ± z·mean_se, which is finite (mean is the plug-in inverse link
             // and mean_se was delta-guarded above), so a fitted model always
             // returns finite interval bounds.
+            // Check BOTH endpoints' finiteness (not the min/max result): Rust's
+            // f64::max/min return the non-NaN argument, so a single non-finite
+            // endpoint would otherwise slip through as a finite-but-wrong bound.
             let lower = Array1::from_iter((0..mean.len()).map(|i| {
-                let v = transformed_lower[i].min(transformed_upper[i]);
-                if v.is_finite() {
-                    v
+                let (lo, hi) = (transformed_lower[i], transformed_upper[i]);
+                if lo.is_finite() && hi.is_finite() {
+                    lo.min(hi)
                 } else {
                     mean[i] - z_lower_per_row[i] * mean_standard_error[i]
                 }
             }));
             let upper = Array1::from_iter((0..mean.len()).map(|i| {
-                let v = transformed_lower[i].max(transformed_upper[i]);
-                if v.is_finite() {
-                    v
+                let (lo, hi) = (transformed_lower[i], transformed_upper[i]);
+                if lo.is_finite() && hi.is_finite() {
+                    lo.max(hi)
                 } else {
                     mean[i] + z_upper_per_row[i] * mean_standard_error[i]
                 }

--- a/src/terms/basis/cubic_regression.rs
+++ b/src/terms/basis/cubic_regression.rs
@@ -110,7 +110,10 @@ impl CubicRegressionBasis {
     /// `row` is overwritten.
     pub fn eval_row_into(&self, x: f64, row: &mut [f64]) {
         let k = self.knots.len();
-        debug_assert_eq!(row.len(), k);
+        // assert_eq!, not debug_assert_eq!: the ban-scanner forbids debug_assert
+        // (silent in release → debug/release divergence). The length check is a
+        // cheap O(1) guard, so an always-active assert is acceptable here.
+        assert_eq!(row.len(), k);
         for r in row.iter_mut() {
             *r = 0.0;
         }


### PR DESCRIPTION
## Fixes a latent failing test merged in #1519

PR #1519 merged with `test_all_zero_count_interval_predict_finite` failing (`mean_upper` = NaN), so `main` has a latent failing Python-contract test that will block future predict PRs.

**Root cause:** interval bounds use `MeanIntervalMethod::TransformEta` = `g⁻¹(η̂ ± z·se_eta)`. On an all-zero-count degenerate fit, `z·se_eta` is astronomically large, so the transformed upper endpoint overflows to `+inf` and `min`/`max` against it yields **NaN** → serialized as `None` → table-shaper crash. (My #1519 SE-guard fixed the reported `std_error` but not this bound transform.)

**Fix:** in the `TransformEta` branch, when a transformed endpoint is non-finite, fall back per-row to the finite delta-method bound `mean ± z·mean_se` (mean is the finite plug-in inverse link; `mean_se` was delta-guarded in #1519). A fitted model now always returns finite interval bounds.

Verified by `test_all_zero_count_interval_predict_finite` (now passing on CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)