### PR TITLE
Unblock main: land NaturalCubicRegression match fix + committed #1074/#932 working state

### DIFF
--- a/src/terms/basis/bspline_build.rs
+++ b/src/terms/basis/bspline_build.rs
@@ -41,6 +41,14 @@ pub fn build_bspline_basis_1d(
     data: ArrayView1<'_, f64>,
     spec: &BSplineBasisSpec,
 ) -> Result<BasisBuildResult, BasisError> {
+    // Natural cubic regression spline (bs="cr"/"cs", #1074): a dense
+    // value-at-knot basis with its own roughness penalty, not a B-spline
+    // difference penalty. Route to the dedicated builder BEFORE the B-spline-only
+    // auto-shrink and periodic logic so neither touches a cr spec.
+    if let BSplineKnotSpec::NaturalCubicRegression { knots } = &spec.knotspec {
+        return build_cubic_regression_basis_1d(data, spec, knots);
+    }
+
     if let OneDimensionalBoundary::Cyclic { start, end } = spec.boundary
         && end <= start
     {
@@ -91,6 +99,9 @@ pub fn build_bspline_basis_1d(
                         + 1
                 }
                 BSplineKnotSpec::Provided(knots) => knots.len().saturating_sub(spec.degree + 1),
+                // cr is routed away by the early dispatch; its basis dimension
+                // equals the knot count (no degree offset).
+                BSplineKnotSpec::NaturalCubicRegression { knots } => knots.len(),
                 BSplineKnotSpec::PeriodicUniform { .. } => {
                     // Filtered upstream by the outer match arm; if we ever
                     // reach this branch, the upstream filter is broken.
@@ -249,6 +260,9 @@ pub fn build_bspline_basis_1d(
                 spec.degree,
             )?),
             BSplineKnotSpec::Provided(knots) => Some(knots.clone()),
+            // cr is routed away by the early dispatch; the knots index the basis
+            // directly, so they are the estimate set verbatim.
+            BSplineKnotSpec::NaturalCubicRegression { knots } => Some(knots.clone()),
             BSplineKnotSpec::Automatic {
                 num_internal_knots,
                 placement,
@@ -366,6 +380,11 @@ pub fn build_bspline_basis_1d(
                 )?;
                 (Some(basis), None, knots)
             }
+            BSplineKnotSpec::NaturalCubicRegression { knots } => {
+                // Unreachable in practice (the early dispatch returns the cr
+                // basis), but keeps this match exhaustive and self-consistent.
+                return build_cubic_regression_basis_1d(data, spec, knots);
+            }
             BSplineKnotSpec::Provided(knots) => {
                 let (basis, knots) = create_basis::<Sparse>(
                     data,
@@ -423,6 +442,11 @@ pub fn build_bspline_basis_1d(
                     BasisOptions::value(),
                 )?;
                 (None, Some((*basis).clone()), knots)
+            }
+            BSplineKnotSpec::NaturalCubicRegression { knots } => {
+                // Unreachable in practice (the early dispatch returns the cr
+                // basis), but keeps this match exhaustive and self-consistent.
+                return build_cubic_regression_basis_1d(data, spec, knots);
             }
             BSplineKnotSpec::Provided(knots) => {
                 let (basis, knots) = create_basis::<Dense>(
@@ -633,6 +657,127 @@ pub fn build_bspline_basis_1d(
             periodic: None,
             degree: Some(spec.degree),
             auto_shrink_note,
+        },
+        kronecker_factored: None,
+        ops,
+        null_eigenvectors,
+        joint_null_rotation: None,
+    })
+}
+
+/// Build a natural cubic regression spline (mgcv `bs="cr"`/`"cs"`, #1074) basis
+/// from a fixed Lancaster–Salkauskas knot set.
+///
+/// Mirrors the dense-penalty tail of the other dense bases (design + penalty
+/// formed, then identifiability congruence → double-penalty nullspace rebuild →
+/// filter), but with the cr design ([`CubicRegressionBasis::design`]) and cr
+/// roughness penalty ([`CubicRegressionBasis::penalty`], null space `{const,
+/// linear}`, dim 2) instead of the B-spline design + difference penalty, and
+/// emits [`BasisMetadata::CubicRegression1D`]. The stored
+/// `identifiability_transform` is the SAME raw→constrained transform a
+/// `BSpline1D` stores, so predict-time replay reconstructs the fit-time design.
+///
+/// `cs` (shrinkage) differs from `cr` only via `spec.double_penalty`: when set,
+/// the Marra & Wood (2011) null-space ridge is emitted as a separate REML
+/// coordinate, then rebuilt in the constrained chart.
+pub fn build_cubic_regression_basis_1d(
+    data: ArrayView1<'_, f64>,
+    spec: &BSplineBasisSpec,
+    knots: &Array1<f64>,
+) -> Result<BasisBuildResult, BasisError> {
+    // cr has no B-spline knot/degree geometry: a `RemoveLinearTrend`
+    // identifiability would mis-apply Greville-based linear removal to the
+    // value-at-knot parameterization. Reject it explicitly; every other
+    // `BSplineIdentifiability` variant is a pure design+penalty congruence and
+    // is delegated to the shared dense policy below.
+    if matches!(spec.identifiability, BSplineIdentifiability::RemoveLinearTrend) {
+        crate::bail_invalid_basis!(
+            "natural cubic regression spline (bs=\"cr\"/\"cs\") does not support \
+             RemoveLinearTrend identifiability; use the default sum-to-zero centering"
+        );
+    }
+
+    let cr = CubicRegressionBasis::new(knots.clone())?;
+    let raw_design = cr.design(data);
+    let s_bend_raw = cr.penalty();
+
+    // Raw (pre-identifiability) candidates: Frobenius-normalized bending penalty
+    // plus, for `cs`/double-penalty, the null-space shrinkage ridge — exactly as
+    // `bspline_penalty_candidates` assembles them.
+    let want_nullspace = spec.double_penalty && spec.boundary_conditions.is_free();
+    let (bend_norm, bend_scale) = normalize_penalty(&s_bend_raw);
+    let mut penalties_raw = vec![PenaltyCandidate {
+        matrix: bend_norm,
+        nullspace_dim_hint: 2,
+        source: PenaltySource::Primary,
+        normalization_scale: bend_scale,
+        kronecker_factors: None,
+        op: None,
+    }];
+    if want_nullspace
+        && let Some(shrinkage) = build_nullspace_shrinkage_penalty(&s_bend_raw)?
+    {
+        let (ridge_norm, ridge_scale) = normalize_penalty(&shrinkage.sym_penalty);
+        penalties_raw.push(PenaltyCandidate {
+            matrix: ridge_norm,
+            nullspace_dim_hint: 0,
+            source: PenaltySource::DoublePenaltyNullspace,
+            normalization_scale: ridge_scale,
+            kronecker_factors: None,
+            op: None,
+        });
+    }
+
+    // Apply the identifiability congruence to the dense (design, penalty) pair.
+    // `apply_bspline_identifiability_policy` is design-generic for every variant
+    // except RemoveLinearTrend (rejected above); the `knots`/`degree` arguments
+    // it takes are only consumed by that rejected branch, so passing the cr
+    // knots and `spec.degree` here is inert. The returned transform is the raw→
+    // constrained map stored in metadata for predict-time replay.
+    let raw_penalty_mats: Vec<Array2<f64>> = penalties_raw
+        .iter()
+        .map(|candidate| candidate.matrix.clone())
+        .collect();
+    let (design_c, penalty_mats_c, identifiability_transform) =
+        apply_bspline_identifiability_policy(
+            raw_design,
+            raw_penalty_mats,
+            knots,
+            spec.degree,
+            &spec.identifiability,
+        )?;
+
+    let transformed_candidates: Vec<PenaltyCandidate> = penalty_mats_c
+        .into_iter()
+        .zip(penalties_raw)
+        .map(|(matrix, candidate)| PenaltyCandidate {
+            nullspace_dim_hint: candidate.nullspace_dim_hint,
+            matrix,
+            source: candidate.source,
+            normalization_scale: candidate.normalization_scale,
+            kronecker_factors: None,
+            op: None,
+        })
+        .collect();
+
+    // Rebuild the double-penalty ridge in the constrained chart (no-op when no
+    // ridge candidate is present) and renormalize every constrained block to
+    // unit Frobenius norm, exactly as the 1-D B-spline path does.
+    let transformed_candidates =
+        rebuild_double_penalty_nullspace_in_constrained_chart(transformed_candidates)?;
+    let (penalties, nullspace_dims, penaltyinfo, null_eigenvectors, ops) =
+        filter_active_penalty_candidates_with_ops(renormalize_constrained_penalty_candidates(
+            transformed_candidates,
+        ))?;
+
+    Ok(BasisBuildResult {
+        design: DesignMatrix::Dense(crate::matrix::DenseDesignMatrix::from(design_c)),
+        penalties,
+        nullspace_dims,
+        penaltyinfo,
+        metadata: BasisMetadata::CubicRegression1D {
+            knots: knots.clone(),
+            identifiability_transform,
         },
         kronecker_factored: None,
         ops,
@@ -2117,9 +2262,11 @@ pub(crate) fn maybe_auto_shrink_bspline_spec(
             };
             (shrunk_spec, Some(note))
         }
-        BSplineKnotSpec::Provided(_) | BSplineKnotSpec::PeriodicUniform { .. } => {
-            (spec.clone(), None)
-        }
+        // cr/cs knots are frozen (value-at-knot), never auto-shrunk; the
+        // explicitly-provided and periodic specs are likewise respected verbatim.
+        BSplineKnotSpec::Provided(_)
+        | BSplineKnotSpec::PeriodicUniform { .. }
+        | BSplineKnotSpec::NaturalCubicRegression { .. } => (spec.clone(), None),
     }
 }
 

--- a/src/terms/smooth/design_construction.rs
+++ b/src/terms/smooth/design_construction.rs
@@ -1492,6 +1492,16 @@ fn with_identifiability_transform(
             degree: *degree,
             auto_shrink_note: auto_shrink_note.clone(),
         }),
+        BasisMetadata::CubicRegression1D {
+            knots,
+            identifiability_transform,
+        } => Ok(BasisMetadata::CubicRegression1D {
+            knots: knots.clone(),
+            identifiability_transform: compose_identifiability_transforms(
+                identifiability_transform.as_ref(),
+                transform,
+            )?,
+        }),
         BasisMetadata::ThinPlate {
             centers,
             length_scale,

--- a/src/terms/smooth/spatial_optimization.rs
+++ b/src/terms/smooth/spatial_optimization.rs
@@ -4653,6 +4653,28 @@ fn freeze_smooth_basis_from_metadata(
             // exactly as fit.
         }
         (
+            SmoothBasisSpec::BSpline1D { spec: s, .. },
+            BasisMetadata::CubicRegression1D {
+                knots,
+                identifiability_transform,
+            },
+        ) => {
+            // #1074: a natural cubic regression spline freezes to its
+            // value-at-knot knot set plus the captured raw→constrained transform,
+            // mirroring the `BSpline1D` arm above. The predict-time builder
+            // reconstructs the cr geometry from `knots` and replays the
+            // `FrozenTransform` exactly, so the design matches fit time.
+            s.knotspec = BSplineKnotSpec::NaturalCubicRegression {
+                knots: knots.clone(),
+            };
+            s.identifiability = match identifiability_transform {
+                Some(z) => BSplineIdentifiability::FrozenTransform {
+                    transform: z.clone(),
+                },
+                None => BSplineIdentifiability::None,
+            };
+        }
+        (
             SmoothBasisSpec::ThinPlate {
                 spec: s,
                 input_scales,

--- a/src/terms/smooth/term_specs.rs
+++ b/src/terms/smooth/term_specs.rs
@@ -631,6 +631,8 @@ fn bspline_basis_min_rows(spec: &crate::terms::basis::BSplineBasisSpec) -> usize
             spec.degree + 2
         }
         BSplineKnotSpec::Provided(knots) => knots.len().saturating_sub(spec.degree + 1).max(1),
+        // cr basis dimension equals the knot count (no degree offset).
+        BSplineKnotSpec::NaturalCubicRegression { knots } => knots.len(),
         BSplineKnotSpec::PeriodicUniform { num_basis, .. } => *num_basis,
     };
     let columns = columns.max(spec.degree + 2);

--- a/src/terms/smooth_overrides.rs
+++ b/src/terms/smooth_overrides.rs
@@ -712,6 +712,14 @@ fn apply_bspline_1d(
                 }
             }
             BSplineKnotSpec::Provided(existing) => BSplineKnotSpec::Provided(existing.clone()),
+            // cr/cs knots index the basis directly; an `n_knots` override does
+            // not map onto a B-spline internal-knot count, so the frozen cr knot
+            // set is respected verbatim.
+            BSplineKnotSpec::NaturalCubicRegression { knots } => {
+                BSplineKnotSpec::NaturalCubicRegression {
+                    knots: knots.clone(),
+                }
+            }
         };
     }
     if let Some(d) = descriptor.get("degree").and_then(JsonValue::as_u64) {
@@ -759,6 +767,13 @@ fn apply_bspline_1d(
             BSplineKnotSpec::PeriodicUniform { .. } => {
                 // Already periodic — nothing to do.
                 return Ok(());
+            }
+            BSplineKnotSpec::NaturalCubicRegression { .. } => {
+                return Err(format!(
+                    "smooths[{symbol:?}]: periodic=True is incompatible with a natural cubic \
+                     regression spline (bs=\"cr\"/\"cs\"), which is non-periodic. Build the \
+                     periodic smooth via the formula DSL `cc()`/`cyclic()` instead."
+                ));
             }
         };
         spec.knotspec = BSplineKnotSpec::PeriodicUniform {

--- a/src/terms/term_builder.rs
+++ b/src/terms/term_builder.rs
@@ -2075,6 +2075,22 @@ pub fn build_smooth_basis(
                         },
                     )
                 }
+            } else if type_opt == "cr" || type_opt == "cs" {
+                // mgcv `bs="cr"`/`"cs"`: a natural cubic regression spline whose
+                // basis is indexed by `k` values at quantile-placed knots (#1074),
+                // NOT a B-spline knot vector. Match gam's `k=` convention by
+                // requesting the same total basis size the B-spline arm would
+                // produce (`n_knots` internal + degree + 1), floored at the cr
+                // minimum of 3 knots. `cr` vs `cs` (shrinkage) is carried by the
+                // `double_penalty` flag resolved below, which the cr builder reads.
+                let k_cr = (n_knots + effective_degree + 1).max(3);
+                let cr_knots =
+                    crate::terms::basis::select_cr_knots(ds.values.column(c), k_cr)
+                        .map_err(|e| e.to_string())?;
+                (
+                    BSplineKnotSpec::NaturalCubicRegression { knots: cr_knots },
+                    parse_cyclic_boundary(options, minv, maxv)?,
+                )
             } else {
                 (
                     resolve_nonperiodic_bspline_knotspec(


### PR DESCRIPTION
## Why

main has not compiled for an extended period: the `NaturalCubicRegression` / `CubicRegression1D` cr-basis refactor added the enum variants (`types.rs`) but left non-exhaustive matches in `bspline_build.rs` and the smooth dispatch (E0004), aborting every build for every PR. The **complete, correct fix** (proper cr-semantics arms: `NaturalCubicRegression { knots } => knots.len()` for num_basis, `=> Some(knots.clone())` for knot-estimate, etc.) was sitting **uncommitted** in the shared working tree — local builds passed with it, so it kept not getting committed while other files landed on main.

This commits + lands that working state (per maintainer "commit and push all local changes"), unblocking the build for everyone. Merges cleanly (no conflicts; main's recent commits didn't touch these files).

## Verification

CI (Python Contracts) confirms the tree compiles + the Python contracts pass. If green, merging clears the persistent build break and unblocks all pending verification (#1520 interval fix, etc.).

🤖 Generated with [Claude Code](https://claude.com/claude-code)