### PR TITLE
fix(build): remove dead FlexThirdRowBase.qd1_index field — unblock main's -D-warnings build

### DIFF
--- a/src/families/survival/marginal_slope/primary_geometry.rs
+++ b/src/families/survival/marginal_slope/primary_geometry.rs
@@ -241,7 +241,6 @@ pub(crate) struct CachedPartitionCells {
 pub(crate) struct FlexThirdRowBase {
     pub(crate) row: usize,
     pub(crate) p: usize,
-    pub(crate) qd1_index: usize,
     pub(crate) qd1: f64,
     pub(crate) q0: f64,
     pub(crate) q1: f64,

--- a/src/families/survival/marginal_slope/timepoint_exact/contracted.rs
+++ b/src/families/survival/marginal_slope/timepoint_exact/contracted.rs
@@ -129,7 +129,6 @@ impl SurvivalMarginalSlopeFamily {
         Ok(FlexThirdRowBase {
             row,
             p: primary.total,
-            qd1_index: primary.qd1,
             qd1,
             q0,
             q1,


### PR DESCRIPTION
main's wheel build fails under `-D warnings`: `error: field `qd1_index` is never read` (primary_geometry.rs:244). The agent's #932 WIP added the field to `FlexThirdRowBase` but never wired up its read; local builds (no `-D warnings`) pass, so CI catches it. Removes the dead field + its sole construction (contracted.rs). The `qd1_index` in the gpu `SurvivalFlexBlock10*Inputs` structs is genuinely read and untouched. Follows #1523 (NaturalCubicRegression unblock) — this is the next CI-only -D-warnings break from the same WIP merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)