### PR TITLE
fix(build): remove #1074 debug sweep block (E0502 borrow conflict)

### DIFF
--- a/src/solver/estimate/optimizer.rs
+++ b/src/solver/estimate/optimizer.rs
@@ -758,47 +758,6 @@ where
         } else {
             problem
         };
-        // #1074 DIAGNOSTIC (debug-log-gated, no behavior change unless debug
-        // logging is enabled): sweep each outer log-λ coordinate over a grid
-        // while holding the others at the baseline, logging the REML cost. Used
-        // to decide whether the spatial range railing is an interior optimum the
-        // optimizer misses (optimizer bug) or a genuine criterion preference for
-        // λ→∞ (criterion). Placed BEFORE the objective takes its `&mut
-        // reml_state` borrow so the immutable `compute_cost` reads are valid.
-        // Enable with `RUST_LOG=debug` (the ban-scanner forbids direct stderr
-        // printing and process-env reads, so this routes through `log`).
-        if log::log_enabled!(log::Level::Debug) {
-            let grid = [
-                -5.0_f64, -2.0, 0.0, 2.0, 5.0, 8.0, 10.0, 12.0, 16.0, 20.0, 25.0, 30.0,
-            ];
-            let mut sweep_from = |label: &str, baseline: &Array1<f64>| {
-                log::debug!("[#1074-sweep] k={k} baseline={label}={baseline:?}");
-                for coord in 0..k {
-                    let mut line = format!("[#1074-sweep:{label}] coord={coord}:");
-                    for &rho in &grid {
-                        let mut p = baseline.clone();
-                        p[coord] = rho;
-                        let c = reml_state
-                            .compute_cost(&p)
-                            .map(|v| format!("{v:.4}"))
-                            .unwrap_or_else(|_| "ERR".to_string());
-                        line.push_str(&format!(" {rho:.0}->{c}"));
-                    }
-                    log::debug!("{line}");
-                }
-            };
-            // (1) from the all-λ=1 origin.
-            sweep_from("zeros", &Array1::<f64>::zeros(k));
-            // (2) from the observed quakes converged proxy [30,9,12,9] so the
-            // per-coordinate slice is taken THROUGH the joint railing point —
-            // the only way to see whether the spatial coord has an interior min
-            // once the OTHER terms hold their absorbed allocation.
-            if k == 4 {
-                let conv = Array1::from(vec![30.0_f64, 9.0, 12.0, 9.0]);
-                sweep_from("conv", &conv);
-            }
-        }
-
         // Attach the outer-loop cache session. The session shares its
         // realized-fit-context key with the inner beta record (different
         // payload namespace), so a SIGKILL mid-outer-iter leaves both the


### PR DESCRIPTION
Removes the #1074 debug-log-gated diagnostic sweep in optimizer.rs — scaffolding that broke the build repeatedly (eprintln/env-var ban, now E0502 borrow conflict between the sweep's immutable reml_state.compute_cost and the objective's &mut reml_state). Debug-only, no behavior change. Continues the unblock chain (#1523/#1525).