### PR TITLE
fix(model-comparison): symmetrize smoothing-correction covariance V_corr

### DIFF
--- a/src/solver/estimate/smoothing_correction.rs
+++ b/src/solver/estimate/smoothing_correction.rs
@@ -916,7 +916,15 @@ pub(crate) fn compute_smoothing_correction(
     // V_corr_orig = Qs * V_corr_trans * Qs^T
     let qs = &final_fit.reparam_result.qs;
     let qsv = qs.dot(&v_corr_trans);
-    let v_corr_orig = qsv.dot(&qs.t());
+    let mut v_corr_orig = qsv.dot(&qs.t());
+    // The congruence Qs·M·Qsᵀ is symmetric in exact arithmetic, but the two
+    // matrix products fill v[i,j] and v[j,i] via independent dot-products,
+    // leaving O(ε) asymmetry. This is a genuine covariance (added to the base
+    // Vb to form Vp, and consumed by model_comparison's corrected-EDF trace,
+    // which documents a "both symmetric" invariant it then relies on), so we
+    // symmetrize it like every other covariance-assembly site — unlike the
+    // influence matrix F = H⁻¹X'WX, which is deliberately left asymmetric.
+    crate::matrix::symmetrize_in_place(&mut v_corr_orig);
 
     // Validate the result
     if !v_corr_orig.iter().all(|v| v.is_finite()) {


### PR DESCRIPTION
## Problem

`compute_smoothing_correction` assembles the first-order smoothing-parameter SE inflation as a congruence transform:

```
v_corr_orig = Qs · (J · V_ρ · Jᵀ) · Qsᵀ
```

This is symmetric in exact arithmetic (`V_ρ` is symmetric), but the two `ndarray::dot` products fill `v[i,j]` and `v[j,i]` via **independent** dot-products, leaving O(ε·‖V_corr‖) asymmetry. Unlike every other covariance assembled in this codebase (`s_mat`, `ve`, `xwx` in `optimizer.rs` all call `symmetrize_in_place`), this one was returned un-symmetrized.

The downstream consumer relies on symmetry: `model_comparison.rs` computes the Wood–Pya–Säfken corrected-EDF trace as

```
tr(X'WX · corr/φ) = (1/φ) Σ_{ij} X'WX[i,j] · corr[j,i]
```

with an explicit comment "both symmetric, so this is the nonnegative tr(A^½ B A^½)". The missing symmetrization left that invariant true only to roundoff.

## Fix

Symmetrize `v_corr_orig` immediately after assembly via the canonical `crate::matrix::symmetrize_in_place` helper — the same step the genuine-covariance siblings perform. This is **distinct** from the influence matrix `F = H⁻¹X'WX`, which the codebase deliberately leaves asymmetric (#1027); the inline comment notes the distinction.

## Impact

Roundoff-level numerical hygiene: makes the documented "both symmetric" assumption exact rather than approximate, and ensures the PSD validation (`eigh(Side::Lower)`) and the corrected-EDF trace see an exactly symmetric matrix. No behavioral change beyond removing O(ε) drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)