### PR TITLE
fix(#584): ALO dispersion uses positive-weight count, not raw row count

### DIFF
--- a/src/inference/alo.rs
+++ b/src/inference/alo.rs
@@ -475,7 +475,14 @@ fn compute_alo_diagnostics_from_pirls_inner(
                     base.finalweights[i] * r * r
                 })
                 .sum();
-            let dof = (n as f64) - base.edf;
+            // Effective sample size for dispersion (#584): a zero prior weight
+            // makes w_i·r_i² = 0, so the row is already excluded from the RSS
+            // numerator and must be excluded from the denominator too. Count only
+            // positive-weight rows, exactly as the main optimizer path does
+            // (optimizer.rs ~1567); using the raw row count over a zero-excluding
+            // numerator biases φ̂ low and shrinks every ALO SE.
+            let n_pos = (0..n).filter(|&i| base.finalweights[i] > 0.0).count();
+            let dof = (n_pos as f64) - base.edf;
             let denom = dof.max(1.0);
             rss / denom
         }


### PR DESCRIPTION
## Problem

`compute_alo_diagnostics_from_pirls_inner` (Identity link) computes the dispersion as

```
rss = Σ_i w_i·(y_i − μ_i)²      // zero-weight rows contribute 0 → excluded
dof = n − edf                   // n = x_dense.nrows() → raw count, INCLUDES them
phi = rss / max(dof, 1)
```

The numerator already excludes zero-weight observations (`w_i·r_i² = 0`), but the denominator counts them. With *k* zero-weight rows this biases φ̂ low by `k/(n_pos − edf)`, **shrinking every ALO standard error and prediction interval** — overconfident diagnostics.

## Root cause

This is the **exact #584 contract** already documented and enforced in the main optimizer dispersion path (`optimizer.rs ~1567`):

> "the dispersion sample size must be the count of positive-weight rows, not the raw row count. Otherwise the Gaussian scale φ̂ = weighted_rss / (n − edf) puts a numerator that already excludes zero-weight rows over a denominator that counts them, biasing φ̂ low and shrinking every SE (#584)."

The fix was never propagated to the ALO diagnostics path.

## Fix

Denominator counts only positive-weight rows (`n_pos`). The RSS loop range stays `0..n` (zero-weight rows contribute exactly 0, so iterating them is harmless and avoids reindexing μ/y/weights). One-line behavioral change, matching the established optimizer contract.

## Impact

Only affects Identity-link ALO diagnostics when zero prior weights are present. With no zero-weight rows, `n_pos == n` — bit-identical. Restores ALO SE/leverage/interval correctness under zero-weight (e.g. masked/held-out) observations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)