### PR TITLE
fix: Gamma deviance-explained contaminated by estimated-shape mismatch

### DIFF
--- a/src/main/model_summary.rs
+++ b/src/main/model_summary.rs
@@ -89,7 +89,20 @@ pub(crate) fn build_model_summary(
                 gam::types::InverseLink::Standard(gam::types::StandardLink::Identity),
             ))
         } else {
-            gam::types::GlmLikelihoodSpec::canonical(family.clone())
+            // Use the fit's *estimated* scale metadata, not the family default.
+            // For Gamma the unit deviance is multiplied by the estimated shape
+            // (calculate_deviance, deviance.rs), and `fit.deviance` already
+            // carries that estimated shape (PIRLS bakes it in via
+            // `with_gamma_shape`). `canonical(family)` would reset the shape to
+            // the default 1.0, so the null deviance would be scaled differently
+            // from the full deviance and the ratio `1 − D_full/D_null` would be
+            // contaminated by the shape factor. Threading the fitted scale here
+            // keeps both deviances on the same scale so it cancels exactly (the
+            // same applies to any other scale-carrying family, e.g. Beta φ).
+            gam::types::GlmLikelihoodSpec {
+                spec: family.clone(),
+                scale: fit.likelihood_scale,
+            }
         };
         gam::pirls::calculate_deviance(y, &nullmu, &null_likelihood, weights)
     };


### PR DESCRIPTION
## Problem

`build_model_summary` computes `deviance_explained = 1 − fit.deviance / null_dev`. For **Gamma** these two deviances are scaled by **different** shapes:

- `fit.deviance` = `pirls_res.deviance`, computed by `calculate_deviance` with the PIRLS likelihood, whose Gamma shape was **estimated and baked in** during fitting (`gam_working_model.rs` → `with_gamma_shape`). `calculate_deviance` multiplies the Gamma unit deviance by that shape (`deviance.rs:236`).
- `null_dev` used `GlmLikelihoodSpec::canonical(family)`, whose `default_scale_metadata()` **resets the shape to the default 1.0**.

So the reported ratio is

```
1 − (est_shape · D_full) / (1.0 · D_null)   ❌   instead of   1 − D_full / D_null   ✓
```

i.e. contaminated by the estimated Gamma shape whenever it ≠ 1. This makes the reported proportion-deviance-explained wrong for every non-trivial Gamma model.

## Why other families are fine

- **Gaussian/Poisson/Binomial** — unit deviance is scale-free (φ ≡ 1 or RSS-based), so nothing to mismatch.
- **NegativeBinomial** — `theta` lives in the `ResponseFamily` enum (`family.clone()` carries the estimated value on both sides), not in the scale metadata that `canonical` discards.
- Only **Gamma** (and structurally **Beta** φ) keep the dispersion-like parameter in the scale metadata, which `canonical` was resetting.

## Fix

Build the null likelihood from the fit's **estimated** scale (`fit.likelihood_scale`, which is `Copy`) instead of the family default, so the full and null deviances are on the same scale and the shape factor cancels exactly. With shape = 1 the result is bit-identical, so no behavioral change for the common case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)