### PR TITLE
ci(#1512): run full pytest suite in CI (continue-on-error initially)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -598,6 +598,20 @@ jobs:
             tests/bench_large_scale_runner_test.py \
             -v --tb=short
 
+      - name: Run full Python test suite (all test_*.py in tests/)
+        # #1512: testpaths=["tests"] means a bare `pytest` collects everything,
+        # but CI only named ~5 files explicitly. This step runs the FULL suite
+        # so orphaned test_bug_hunt_*.py contract repros execute in CI. It is
+        # `continue-on-error` initially — some test_bug_hunt_* files may fail
+        # (documenting still-open bugs); those should be triaged to
+        # @pytest.mark.xfail rather than allowed to stay orphaned. Once the
+        # known failures are triaged, flip this to a hard gate.
+        continue-on-error: true
+        run: |
+          python -m pytest tests/ \
+            --continue-on-collection-errors \
+            -v --tb=short -q
+
       - name: Build gam release binary
         # The integration scripts below shell out to target/release/gam.
         # The maturin wheel build above produces the Python extension, not


### PR DESCRIPTION
## Summary

`pyproject.toml` declares `testpaths=["tests"]` but CI only named ~5 specific files — 161 of 170 `test_*.py` files (958 tests) ran in no workflow. This adds a `Run full Python test suite` step to `.github/workflows/test.yml` that runs `pytest tests/` with `--continue-on-collection-errors`.

## Design

- **`continue-on-error: true`** initially: some `test_bug_hunt_*` files may fail (documenting still-open bugs). This surfaces all results without blocking CI. Once known failures are triaged to `@pytest.mark.xfail`, flip to a hard gate.
- **`--continue-on-collection-errors`**: 2 files currently have collection errors (`test_sae_topology_prior_seed.py` regex-extract broke after refactor; `test_python_api.py` needs matplotlib which CI installs). These don't block the rest of the suite.

## Triage data (from local run)
- 958 tests collected from 168 files
- 2 collection errors (pre-existing)
- The owner's automated harness keeps adding `test_bug_hunt_*.py` repros that get orphaned — this step ensures they execute.

## Security note
The workflow security scanner flagged this edit — false positive. The `run:` command is hardcoded `python -m pytest tests/` with no untrusted input interpolation.

— HomunculusLabs (AI-assisted)
