### PR TITLE
fix(sae): wire trained hybrid-linear images into OOS reconstruction

### DIFF
--- a/crates/gam-pyffi/src/latent_basis_and_sae_ffi.rs
+++ b/crates/gam-pyffi/src/latent_basis_and_sae_ffi.rs
@@ -6419,6 +6419,34 @@ fn sae_manifold_predict_oos<'py>(
         &evaluators,
     )
     .map_err(py_value_error)?;
+    // #1228 — attach the trained dictionary's hybrid-collapsed straight images so
+    // this OOS term decodes verdict-linear `d = 1` slots by the SAME linear image
+    // the training reconstruction used. Both reconstruction paths below —
+    // `term.fitted()` (→ `try_fitted` → collapse=true) and the top-`k`
+    // `reconstruct_from_assignments(.., true)` — read the collapse policy from
+    // `hybrid_linear_image_map()`, which sources it from `oos_linear_images`.
+    // The parameter was previously accepted but never attached, so every held-out
+    // reconstruction silently fell back to the all-curved decoder even when the
+    // trained dictionary had collapsed those slots — a train/test decode
+    // mismatch. `row_codes = None`: an ordinary OOS image evaluates at the atom's
+    // own realized coordinate; the per-row collapse-rescue codes are a train-only
+    // degenerate-circle path that does not transfer to held-out rows.
+    if let Some(images) = hybrid_linear_images {
+        let images: Vec<gam::terms::sae::hybrid_split::AtomLinearImage> = images
+            .into_iter()
+            .map(
+                |(atom_idx, t_bar, b0, b1)| gam::terms::sae::hybrid_split::AtomLinearImage {
+                    atom_idx,
+                    t_bar,
+                    b0: b0.as_array().to_owned(),
+                    b1: b1.as_array().to_owned(),
+                    row_codes: None,
+                },
+            )
+            .collect();
+        term.set_hybrid_linear_images(images)
+            .map_err(py_value_error)?;
+    }
     // #1408/#1409 — fold the inference `top_k` cap into the OOS fixed-decoder
     // encode: for Softmax the frozen-decoder Newton solve below then runs on the
     // compact top-`k` row layout (htt/gt sized by the row's top-`k` atoms), so


### PR DESCRIPTION
Root cause: the SAE manifold out-of-sample predictor `sae_manifold_predict_oos` accepted the `hybrid_linear_images` parameter (#1228) — the trained dictionary's hybrid-collapsed straight sub-models, one per verdict-linear d=1 slot — but never attached it to the OOS term. The binding was dead (an `unused variable` the gam-pyffi crate did not deny, so it never failed a build), so every held-out reconstruction silently fell back to the all-curved decoder even when the trained dictionary had collapsed those slots to straight images during training. That is a train/test decode mismatch: held-out rows of a hybrid-collapsed dictionary were decoded by a different image than the one the training reconstruction used.

Both OOS reconstruction paths — `term.fitted()` (→ `try_fitted` → `try_fitted_with_rho(None, collapse=true)`) and the top-k `reconstruct_from_assignments(.., true)` — read the collapse policy from `hybrid_linear_image_map()`, which sources verdict-linear images from the term's `oos_linear_images` slot. The slot is populated only by `set_hybrid_linear_images`, and that call was missing from the FFI.

Fix: convert the Python `(atom_idx, t_bar, b0[p], b1[p])` payload into `AtomLinearImage` values (row_codes = None — the per-row collapse-rescue codes are a train-only degenerate-circle path that does not transfer to held-out rows) and attach them via `term.set_hybrid_linear_images` immediately after the OOS term is built, before either reconstruction runs. `set_hybrid_linear_images` validates each image's atom index, channel count, and d=1 latent dim, so a stale/mismatched payload now fails loudly instead of being silently dropped. Callers passing no images (the default) are unaffected; the all-curved path is unchanged.