### PR TITLE
fix(gpu): restore need_logdet to the non-Linux CUDA-unavailable diagn…

### DIFF
--- a/src/gpu/solver.rs
+++ b/src/gpu/solver.rs
@@ -931,7 +931,7 @@ pub fn iterative_refinement_cholesky_solve(
     {
         let (rows, cols) = hessian.dim();
         return Err(format!(
-            "CUDA support not compiled; hessian={rows}x{cols}, rhs={}x{}",
+            "CUDA support not compiled; hessian={rows}x{cols}, rhs={}x{}, need_logdet={need_logdet}",
             rhs.nrows(),
             rhs.ncols()
         ));


### PR DESCRIPTION
…ostic so the param is consumed on every target

Root cause: the `iterative_refinement_cholesky_solve` signature carries `need_logdet: bool` to let solution-only callers (the PIRLS Newton direction) skip the redundant fp64 logdet POTRF. The parameter is read only inside the `#[cfg(target_os = "linux")]` arm. A prior change dropped `need_logdet` from the `#[cfg(not(target_os = "linux"))]` CUDA-not-compiled error string, which was its sole use on every non-Linux target. With the parameter now unread there, `-D warnings` (unused_variables) turns the non-Linux compile into a hard error — breaking the aarch64-apple-darwin "Build and Release All" job and any other non-Linux release target.

Fix: thread `need_logdet` back into the non-Linux diagnostic. The parameter is consumed on all targets again (clearing the lint at the data-flow level rather than via `_need_logdet`/`#[allow]`), and the value is now visible in the one diagnostic the non-Linux stub emits, which is genuinely useful when triaging a CUDA-unavailable solve.


Claude-Session: https://claude.ai/code/session_01QTikAGkoror7U7tznNzxpa