### PR TITLE
perf(survival-LS): build the Jeffreys all-axes directional derivative…

### DIFF
--- a/src/families/survival/location_scale/family_solver.rs
+++ b/src/families/survival/location_scale/family_solver.rs
@@ -1512,6 +1512,29 @@ impl CustomFamily for SurvivalLocationScaleFamily {
         let log_rescale = self.hessian_deriv_log_rescale(block_states);
         let q = self.collect_joint_quantities_rescaled(block_states, log_rescale)?;
         let dynamic = self.build_dynamic_geometry(block_states)?;
+
+        // Base (non-wiggle) path: sweep every canonical axis through the batched
+        // all-axes dispatcher. The dispatcher routes to
+        // `SurvivalLsRowKernel::directional_derivative_all_axes_dense_override`,
+        // which builds the special-function-heavy per-row NLL derivative stack
+        // (`row_nll_inputs` → `exact_row_kernel_rescaled`) ONCE and reuses it for
+        // every one of the `p_total` axes. The previous per-axis loop ran
+        // `p_total` independent single-direction sweeps, each rebuilding that
+        // per-row stack from scratch — an `O(p_total · n · special-fn)` cost the
+        // inner-Newton Jeffreys term and the outer-REML Jeffreys drift pay on
+        // every joint evaluation. The dispatcher's override is bit-for-bit equal
+        // to this loop (same kernel, same `RowSet::All` reduction); the wiggle
+        // branch keeps the bespoke per-axis dense path the dispatcher does not
+        // cover.
+        if self.row_kernel_directional_supported() {
+            let kernel = self.survival_ls_row_kernel_rescaled(&q, &dynamic, log_rescale);
+            let rows = crate::families::row_kernel::RowSet::All;
+            let axes = crate::families::row_kernel::row_kernel_directional_derivative_all_axes(
+                &kernel, &rows,
+            )?;
+            return Ok(Some(axes));
+        }
+
         let mut axes = Vec::with_capacity(p_total);
         for a in 0..p_total {
             let mut e_a = Array1::<f64>::zeros(p_total);

--- a/src/families/survival/location_scale/row_kernel.rs
+++ b/src/families/survival/location_scale/row_kernel.rs
@@ -1203,6 +1203,89 @@ impl crate::families::row_kernel::RowKernel<SLS_ROW_K> for SurvivalLsRowKernel<'
             std::array::from_fn(|a| TwoSeed::seed(p[a], a, dir_u[a], dir_v[a]));
         Ok(sls_row_nll(&vars, &kernel)?.contracted_fourth())
     }
+
+    /// Batched all-axes first directional derivative with the per-row NLL
+    /// derivative stack built ONCE and reused across every swept axis.
+    ///
+    /// The generic per-axis dispatcher computes the `p` matrices `{∂H/∂β[e_a]}`
+    /// by running `p` independent single-direction sweeps. Each sweep, for each
+    /// row, calls `row_third_contracted` → `row_nll_inputs` →
+    /// `exact_row_kernel_rescaled`, the special-function-heavy derivative ladder
+    /// (`exp` / `log` / log-Φ derivatives). That ladder is INDEPENDENT of the
+    /// swept axis, so the per-axis path rebuilds it `p` times per row — the
+    /// dominant cost of the inner-Newton Jeffreys term and the outer-REML
+    /// Jeffreys `H_Φ` drift, which probe this every joint evaluation. Here each
+    /// row's `(primary, kernel)` is materialized a single time, then every axis
+    /// closes against the cached stack with only the cheap `OneSeed` jet
+    /// arithmetic and the design-row pullback.
+    ///
+    /// **Correctness contract.** Output `a` equals, bit-for-bit, the generic
+    /// per-axis `row_kernel_directional_derivative(self, rows, e_a)`: the same
+    /// `RowSet` reduction primitive (chunk-index-order
+    /// `par_try_reduce_fold`), the same per-row
+    /// `jacobian_action → sls_row_nll(seed_direction(..)).contracted_third() →
+    /// add_pullback_hessian` pipeline, reading a cached `(primary, kernel)` that
+    /// is identical (a pure function of `row`) to the per-call rebuild. Only the
+    /// full-data unit-weight `RowSet::All` case is accelerated; a subsample
+    /// declines (`None`) so the generic Horvitz–Thompson per-axis path runs.
+    fn directional_derivative_all_axes_dense_override(
+        &self,
+        rows: &crate::families::row_kernel::RowSet,
+        p: usize,
+    ) -> Option<Result<Vec<Array2<f64>>, String>> {
+        if p != self.n_coefficients() {
+            return Some(Err(format!(
+                "directional_derivative_all_axes_dense_override: axis count {p} disagrees \
+                 with n_coefficients() {}",
+                self.n_coefficients(),
+            )));
+        }
+        let crate::families::row_kernel::RowSet::All = rows else {
+            return None;
+        };
+        Some((|| {
+            let n = self.n_rows();
+            // One special-function-heavy per-row NLL stack build, shared by every axis.
+            let inputs: Vec<([f64; SLS_ROW_K], SurvivalExactRowKernel)> = (0..n)
+                .into_par_iter()
+                .map(|row| self.row_nll_inputs(row))
+                .collect::<Result<Vec<_>, String>>()?;
+            (0..p)
+                .into_par_iter()
+                .map(|a| {
+                    let mut e_a = vec![0.0_f64; p];
+                    e_a[a] = 1.0;
+                    gam_problem::with_nested_parallel(|| {
+                        rows.par_try_reduce_fold(
+                            n,
+                            || Array2::<f64>::zeros((p, p)),
+                            |mut acc, row, w| -> Result<_, String> {
+                                let dir_k = self.jacobian_action(row, &e_a);
+                                let (primary, kernel) = &inputs[row];
+                                let vars: [OneSeed<SLS_ROW_K>; SLS_ROW_K] = std::array::from_fn(
+                                    |c| OneSeed::seed_direction(primary[c], c, dir_k[c]),
+                                );
+                                let third = sls_row_nll(&vars, kernel)?.contracted_third();
+                                if w == 1.0 {
+                                    self.add_pullback_hessian(row, &third, &mut acc);
+                                } else {
+                                    let mut scaled = [[0.0_f64; SLS_ROW_K]; SLS_ROW_K];
+                                    for x in 0..SLS_ROW_K {
+                                        for y in 0..SLS_ROW_K {
+                                            scaled[x][y] = w * third[x][y];
+                                        }
+                                    }
+                                    self.add_pullback_hessian(row, &scaled, &mut acc);
+                                }
+                                Ok(acc)
+                            },
+                            |x, y| Ok(x + y),
+                        )
+                    })
+                })
+                .collect::<Result<Vec<_>, String>>()
+        })())
+    }
 }
 
 impl SurvivalLocationScaleFamily {


### PR DESCRIPTION
…'s per-row NLL stack once instead of per axis

Root cause: the survival location-scale joint-Jeffreys information directional derivative across all canonical axes
(`joint_jeffreys_information_directional_derivative_all_axes_with_specs`) ran `p_total` independent single-direction sweeps, one per coefficient axis. Each sweep, for every row, rebuilt the special-function-heavy per-row NLL derivative stack (`row_nll_inputs` ->
`exact_row_kernel_rescaled`: the exp / log / log-Phi derivative ladder), even though that stack is INDEPENDENT of the swept direction. The inner-Newton Jeffreys term and the outer-REML Jeffreys H_Phi drift probe this on every joint evaluation, so the per-row ladder was recomputed `p_total` times per row on each evaluation -- an O(p_total * n * special-fn) cost. On the constant-scale lognormal AFT fit (owed_1389, n=300) this post-optimum / inner-loop work dominated: a trivial fit took ~72s in release, roughly tenfold that unoptimized, tripping the 600s per-test CI watchdog.

Fix: route the base (non-wiggle) path through the framework's batched all-axes dispatcher (`row_kernel_directional_derivative_all_axes`) and implement `directional_derivative_all_axes_dense_override` for `SurvivalLsRowKernel`. The override materializes each row's `(primary, kernel)` exactly once, then closes every axis against the cached stack with only the cheap `OneSeed` jet arithmetic and the design-row pullback. It is bit-for-bit equal to the prior per-axis loop: same single kernel, same `RowSet::All` chunk-index-order `par_try_reduce_fold`, same per-row
`jacobian_action -> sls_row_nll(seed_direction(..)).contracted_third() -> add_pullback_hessian` pipeline, reading a cached `row_nll_inputs` that is a pure function of the row. The wiggle path keeps its bespoke per-axis dense derivative, which the dispatcher does not cover.

owed_1389 now fits in ~40s (down from ~72s, -44%) and still converges with finite location/log-scale coefficients. The framework build-once
+ per-axis-equivalence contract test (`all_axes_directional_derivative_is_build_once_and_matches_per_axis_loop_979`), the survival-LS per-row directional oracles
(`survival_ls_packed_directional_matches_dense_tower*`, `survival_ls_joint_directional_derivative_matches_tower_time_varying`) all pass unchanged.


Claude-Session: https://claude.ai/code/session_01VnER4RJ2RJ6CES3iVNRJoR