### PR TITLE
[fleet-infra-test] docs: make README's six survival likelihood modes match the code

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ marginal-slope variant for calibrated risk scores, and a latent-cloglog
 form), Poisson, negative-binomial, Gamma, Beta, Tweedie, multinomial-logit,
 conditional transformation-normal, Royston-Parmar, and parametric /
 semi-parametric survival in six likelihood modes (transformation, Weibull,
-location-scale, marginal-slope, and latent-Gaussian frailty). Firth /
+location-scale, marginal-slope, and latent-Gaussian frailty in `latent`
+and `latent-binary` forms). Firth /
 Jeffreys bias reduction handles separation in binomial fits.
 
 Supported term types in formulas: parametric terms, univariate smooths


### PR DESCRIPTION
## What changed

In `README.md` (Scope section), the text says survival is supported in
**six likelihood modes** but the parenthetical only listed **five** names:
`transformation, Weibull, location-scale, marginal-slope, and latent-Gaussian frailty`.

The fix names both forms of the latent-Gaussian frailty mode so the
enumeration adds up to six:

> ...latent-Gaussian frailty in `latent` and `latent-binary` forms.

## Why it's correct

The `SurvivalLikelihoodMode` enum in
`crates/gam-models/src/survival/construction.rs` has exactly six variants —
`Transformation`, `Weibull`, `LocationScale`, `MarginalSlope`, `Latent`,
`LatentBinary` — and `parse_survival_likelihood_mode` accepts
`transformation|weibull|location-scale|marginal-slope|latent|latent-binary`.
The README already documents the two latent forms (`latent`, `latent-binary`)
further down in the Survival models section; this just makes the Scope summary
consistent with both the code and the rest of the README.

Docs-only change to a single Markdown file; no source, tests, or build affected.

---

_This is an automated infrastructure-validation PR from an autonomous-agent fleet._