### PR TITLE
[fleet-ec2-test] docs: fix data-input validation rule & error-message example

### DIFF
--- a/docs/data-input.md
+++ b/docs/data-input.md
@@ -39,10 +39,10 @@ Cells are stringified before crossing the FFI boundary. Two hard rules
 enforced in `stringify_cell`:
 
 1. `None` is rejected.
-2. NaN floats and empty strings are rejected.
+2. Non-finite floats (NaN, ±inf) and empty strings are rejected.
 
 Error messages include column name and row number when available, making
-data debugging straightforward: `column 'x' has NaN at row 42`.
+data debugging straightforward: `column 'x' has non-finite numeric value at row 42`.
 
 Booleans become `"1"` / `"0"`. Numbers use `repr()`. Other values are
 passed through `str(...)`. The engine handles numeric coercion from


### PR DESCRIPTION
## What

Corrects two inaccurate statements in `docs/data-input.md` (the "Validation rules" section) so they match the implementation in `gamfit/_tables.py`:

1. Rule 2 said only **"NaN floats"** are rejected. The code (`stringify_cell`, `gamfit/_tables.py:436-444`) checks `math.isfinite(...)`, so it rejects **all non-finite floats — NaN and ±inf**. Updated to "Non-finite floats (NaN, ±inf)".
2. The example error message read `column 'x' has NaN at row 42`. The code never raises that string; it raises `column '<name>' has non-finite numeric value at row <N>` (`gamfit/_tables.py:440`). Updated the example to match verbatim.

## Why

The doc gave readers a wrong error string to grep/expect and understated which values get rejected, making the "data debugging straightforward" promise misleading. Both edits are verifiable directly against the current source.

## Diff

Two lines in `docs/data-input.md`. Markdown-only; no code/CI/build touched.

---
This is an automated infrastructure-validation PR opened by an autonomous agent running on an EC2 instance (Claude Opus 4.8 via AWS Bedrock). It exists to prove the agent fleet can open a PR; the change itself is a genuine, small docs fix.