### PR TITLE
[agent] #1610: derive SAE barrier strength from REML evidence (WIP)

### DIFF
--- a/.agent/issue-1610.md
+++ b/.agent/issue-1610.md
@@ -1,0 +1,22 @@
+# Issue #1610 — Manifold SAE magic-constant penalty strengths
+
+## State at start (HEAD on main)
+- `SAE_SEPARATION_BARRIER_STRENGTH = 10.0` is ALREADY DELETED (commit d3f63d62e).
+  Replaced by data-derived `μ_C = K / reachable_rank` in
+  `penalties.rs::separation_barrier_strength`.
+- Decoder-repulsion strength derived as `RATIO · μ_C` (8381579).
+- Collapse bar uses reachable geometric rank (339fe75).
+- Norm-floor scale-invariant (fc20443d2).
+
+## Remaining substantive ask (issue ask #1)
+Owner: "It doesn't matter if they are scale relative. They are unprincipled and
+arbitrary." `K/rank` is still a hand-chosen formula, NOT REML/evidence-derived.
+Ask #1 explicitly: derive collapse-prevention strength from the EVIDENCE/REML
+objective.
+
+## Plan
+1. Understand the SAE evidence/REML machinery (rho.rs, outer_objective.rs).
+2. Make the barrier strength genuinely evidence-derived (or prove K/rank IS the
+   evidence-optimal value).
+3. Audit remaining SAE_* constants for principled replacement.
+4. Crate-level tests; flag GPU/OLMo validation gaps honestly.

--- a/crates/gam-sae/src/manifold/tests_olmo.rs
+++ b/crates/gam-sae/src/manifold/tests_olmo.rs
@@ -75,8 +75,7 @@ pub(crate) fn real_data_torus_seed_term(
 /// real fixture.
 #[test]
 pub(crate) fn olmo_real_curvature_anchor_is_positive_definite() {
-    let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
-        .join("tests/data/olmo_mixedlayer_pca64_768.npy");
+    let path = olmo_fixture_path("olmo_mixedlayer_pca64_768.npy");
     let z = read_npy_f32_2d(&path);
     assert_eq!(z.dim(), (768, 64), "real OLMo fixture shape");
     // Small REAL slice (K=2 d=2 torus, 160 rows) so the per-row curvature-anchor
@@ -207,8 +206,7 @@ pub(crate) fn olmo_real_curvature_anchor_is_positive_definite() {
 ///     threshold (a genuinely degenerate fit is always caught).
 #[test]
 pub(crate) fn olmo_real_outer_fit_does_not_pin_at_collapse_sentinel() {
-    let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
-        .join("tests/data/olmo_mixedlayer_pca64_768.npy");
+    let path = olmo_fixture_path("olmo_mixedlayer_pca64_768.npy");
     let z = read_npy_f32_2d(&path);
     assert_eq!(z.dim(), (768, 64), "real OLMo fixture shape");
     // This is a fast, SOLVE-FREE check of the arrival-floor logic on genuine
@@ -393,6 +391,26 @@ pub(crate) fn olmo_real_outer_fit_does_not_pin_at_collapse_sentinel() {
 
     // Guard the sentinel constant the fix exists to avoid pinning the loop at.
     assert_eq!(SAE_FIT_DATA_COLLAPSE_COST, 1.0e12);
+}
+
+/// Resolve a committed OLMo activation fixture (`tests/data/<name>`) regardless
+/// of where the test binary's `CARGO_MANIFEST_DIR` lands. The fixtures live at
+/// the WORKSPACE-ROOT `tests/data/`, but `CARGO_MANIFEST_DIR` for this crate is
+/// `crates/gam-sae`, so the crate-relative `tests/data/` does not exist —
+/// every fixture must be reached via the `../../tests/data/` workspace-root
+/// fallback. Some sites historically hard-coded only the crate-relative path
+/// (no fallback), so those tests panicked with a missing-file error on EVERY
+/// fresh checkout — a silent XFAIL the SPEC forbids. Route all fixture loads
+/// through this single resolver so the path can never desync again: it prefers
+/// the crate-relative location (if a tree ever stages fixtures there) and falls
+/// back to the workspace root.
+pub(crate) fn olmo_fixture_path(name: &str) -> std::path::PathBuf {
+    let mani = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
+    let crate_rel = mani.join("tests/data").join(name);
+    if crate_rel.exists() {
+        return crate_rel;
+    }
+    mani.join("../../tests/data").join(name)
 }
 
 /// Read a 2-D float32 (`<f4`) C-contiguous `.npy` into an `Array2<f64>`.
@@ -588,11 +606,7 @@ pub(crate) fn fit_data_collapse_bar_is_data_derived_not_absolute_floor_1522() {
 /// the real OLMo l18 slice (256-chart torus) so multi-chart routing is exercised.
 #[test]
 pub(crate) fn fast_encode_matches_per_row_warm_start() {
-    let mani = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
-    let mut path = mani.join("tests/data/olmo_l18_pca64_635.npy");
-    if !path.exists() {
-        path = mani.join("../../tests/data/olmo_l18_pca64_635.npy");
-    }
+    let path = olmo_fixture_path("olmo_l18_pca64_635.npy");
     let z = read_npy_f32_2d(&path);
     let n = z.nrows();
     let k = 1usize;
@@ -669,11 +683,7 @@ pub(crate) fn fast_encode_matches_per_row_warm_start() {
 /// OLMo l18 slice so multi-chart routing + real curvature are exercised.
 #[test]
 pub(crate) fn fast_reconstruct_matches_per_row_decode() {
-    let mani = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
-    let mut path = mani.join("tests/data/olmo_l18_pca64_635.npy");
-    if !path.exists() {
-        path = mani.join("../../tests/data/olmo_l18_pca64_635.npy");
-    }
+    let path = olmo_fixture_path("olmo_l18_pca64_635.npy");
     let z = read_npy_f32_2d(&path);
     let n = z.nrows();
     let p = z.ncols();
@@ -867,11 +877,7 @@ fn fast_forward_is_accuracy_parity_with_certified() {
 /// correlated neighbour rows across train↔test — see the structure_harvest
 /// estimation/eval split rationale). Returns (z_train, z_test).
 pub(crate) fn olmo_l18_oos_split() -> (Array2<f64>, Array2<f64>) {
-    let mani = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
-    let mut path = mani.join("tests/data/olmo_l18_pca64_635.npy");
-    if !path.exists() {
-        path = mani.join("../../tests/data/olmo_l18_pca64_635.npy");
-    }
+    let path = olmo_fixture_path("olmo_l18_pca64_635.npy");
     let z = read_npy_f32_2d(&path);
     let n = z.nrows();
     let n_tr = (n * 6) / 10;


### PR DESCRIPTION
Autonomous WIP for #1610. Will be force-improved commit-by-commit.

## Context
`SAE_SEPARATION_BARRIER_STRENGTH = 10.0` was **already deleted** on main (d3f63d62e), replaced by data-derived `μ_C = K / reachable_rank`. The literal "delete the constant" ask is satisfied.

## Remaining substantive ask (issue ask #1)
The owner explicitly rejected scale-relative-but-arbitrary fixes: *"It doesn't matter if they are scale relative. They are unprincipled and arbitrary."* `K/rank` is still a hand-chosen formula, not derived from the REML/evidence objective. This PR targets making the barrier strength genuinely **evidence/REML-derived**, and audits the remaining `SAE_*` constants.

This is an autonomous WIP — diff ratchets up each push.