### PR TITLE
[agent] #979: margslope large-scale convergence (WIP)

### DIFF
--- a/.agent/issue-979.md
+++ b/.agent/issue-979.md
@@ -1,0 +1,20 @@
+# Issue #979 — marginal-slope (binary + survival) slowdown / hang
+
+## Status snapshot (2026-06-29)
+- 225+ comment omnibus. Original symptoms (binary slowdown, survival uncatchable
+  hang) reportedly RESOLVED + regression-tested on main.
+- Owner's last word: Large-scale CI "still failing on all three" — the three
+  centers=24 marginal-slope methods (binary rigid, binary linkwiggle, survival).
+- Recent large_scale runs: 50-min job-cap TIMEOUTS on the n=60000/centers=24
+  fits (true #979 residual), PLUS a build break (ban-scanner violations in a
+  #932 SAE file) blocking the latest scheduled runs from reaching benchmark.
+
+## Plan
+1. Establish local build/test ground truth on main HEAD.
+2. Profile the large-scale margslope path (examples/large_scale_margslope_*).
+3. Attack the genuine residual: inner joint-Newton grind on the ill-posed
+   marginal<->logslope coupling at large centers; survival reparam parity.
+4. Make the centers=24 fits complete fast + converge honestly (no fake
+   converged=true, no wall-clock-as-correctness).
+
+This is an autonomous WIP, force-improved commit-by-commit.

--- a/crates/gam-custom-family/src/assembly.rs
+++ b/crates/gam-custom-family/src/assembly.rs
@@ -1736,6 +1736,10 @@ pub(crate) fn outerobjectiveefs<F: CustomFamily + Clone + Send + Sync + 'static>
             total,
             options,
             inner.joint_workspace.clone(),
+            // The EFS evaluator always assembles the first-order (gradient)
+            // fixed-point terms; the third-derivative directional cache is the
+            // one it consumes (gam#979).
+            EvalMode::ValueAndGradient,
         )? {
             let JointHessianBundle {
                 source: h_joint_unpen,

--- a/crates/gam-custom-family/src/joint_newton.rs
+++ b/crates/gam-custom-family/src/joint_newton.rs
@@ -508,6 +508,7 @@ pub(crate) fn build_joint_hessian_closures<'a, F: CustomFamily + Clone + Send + 
     total: usize,
     options: &BlockwiseFitOptions,
     preferred_workspace: Option<Arc<dyn ExactNewtonJointHessianWorkspace>>,
+    eval_mode: EvalMode,
 ) -> Result<Option<JointHessianBundle<'a>>, String> {
     // Path 1: exact Newton joint Hessian (preferred).
     let beta_flat = flatten_state_betas(block_states, specs);
@@ -531,8 +532,12 @@ pub(crate) fn build_joint_hessian_closures<'a, F: CustomFamily + Clone + Send + 
     // `par_iter` enjoys full thread-pool parallelism. PIRLS-side workspace
     // construction skips this priming because PIRLS never invokes
     // `directional_derivative_operator`.
+    //
+    // gam#979: pass `eval_mode` so a value-only probe primes nothing and a
+    // first-order eval primes only the gradient's third-derivative cache —
+    // the dominant per-eval O(n) jet pass at biobank scale.
     if let Some(workspace) = hessian_workspace.as_ref() {
-        workspace.warm_up_outer_caches()?;
+        workspace.warm_up_outer_caches_for_mode(eval_mode)?;
     }
     if let Some(curvature) = family.exact_newton_outer_curvature(block_states)? {
         let h_joint_unpen = JointHessianSource::Dense(symmetrized_square_matrix(

--- a/crates/gam-custom-family/src/psi_hyper.rs
+++ b/crates/gam-custom-family/src/psi_hyper.rs
@@ -1328,9 +1328,10 @@ pub(crate) fn evaluate_custom_family_hyper_internal_shared<
             )?,
         };
         // Outer-eval entry: prime per-row jet caches before the ext-coord
-        // par_iter — see `warm_up_outer_caches` doc.
+        // par_iter — see `warm_up_outer_caches_for_mode` doc. gam#979: only the
+        // caches this `eval_mode` consumes are primed.
         if let Some(workspace) = hessian_workspace.as_ref() {
-            workspace.warm_up_outer_caches()?;
+            workspace.warm_up_outer_caches_for_mode(eval_mode)?;
         }
         let (
             h_joint_unpen,
@@ -1869,6 +1870,11 @@ pub(crate) fn evaluate_custom_family_hyper_internal_shared<
                     total,
                     options,
                     inner.joint_workspace.clone(),
+                    // The bundle's directional closures feed only the
+                    // `EvalMode::ValueOnly` `joint_outer_evaluate` below — the
+                    // gradient is supplied by the family's batched terms — so
+                    // no directional jet cache needs priming (gam#979).
+                    EvalMode::ValueOnly,
                 )?
             {
                 let mut gradient = Array1::<f64>::zeros(expected);
@@ -1976,6 +1982,11 @@ pub(crate) fn evaluate_custom_family_hyper_internal_shared<
         total,
         options,
         inner.joint_workspace.clone(),
+        // gam#979: this bundle drives the unified evaluator at the caller's
+        // requested `eval_mode`, so prime exactly the directional caches that
+        // mode consumes (none for value-only line-search / seed-screen probes,
+        // third-only for the first-order gradient, both for the outer Hessian).
+        eval_mode,
     )? {
         let JointHessianBundle {
             source: h_joint_unpen,
@@ -2605,9 +2616,11 @@ pub(crate) fn evaluate_custom_family_joint_hyper_efs_internal_shared<
         options,
     )?;
     // Outer-eval entry: prime per-row jet caches before the ext-coord
-    // par_iter — see `warm_up_outer_caches` doc.
+    // par_iter — see `warm_up_outer_caches_for_mode` doc. The EFS evaluator
+    // always assembles the first-order fixed-point gradient terms, so it
+    // consumes the third-derivative directional cache (gam#979).
     if let Some(workspace) = hessian_workspace.as_ref() {
-        workspace.warm_up_outer_caches()?;
+        workspace.warm_up_outer_caches_for_mode(EvalMode::ValueAndGradient)?;
     }
     let (
         h_joint_unpen,

--- a/crates/gam-model-api/src/families/custom_family/family_trait.rs
+++ b/crates/gam-model-api/src/families/custom_family/family_trait.rs
@@ -802,7 +802,11 @@ pub trait CustomFamily {
         );
         assert_rho_matches_specs(rho, specs, "batched outer gradient terms");
         assert_valid_options(options, "batched outer gradient terms");
-        validate_hessian_workspace_ready(&hessian_workspace, "batched outer gradient terms")?;
+        validate_hessian_workspace_ready(
+            &hessian_workspace,
+            "batched outer gradient terms",
+            gam_problem::EvalMode::ValueAndGradient,
+        )?;
         Ok(None)
     }
 
@@ -831,7 +835,11 @@ pub trait CustomFamily {
             "batched outer Hessian terms",
         );
         assert_rho_matches_specs(rho, specs, "batched outer Hessian terms");
-        validate_hessian_workspace_ready(&hessian_workspace, "batched outer Hessian terms")?;
+        validate_hessian_workspace_ready(
+            &hessian_workspace,
+            "batched outer Hessian terms",
+            gam_problem::EvalMode::ValueGradientHessian,
+        )?;
         Ok(self
             .outer_hyper_hessian_operator(specs)
             .map(|operator| BatchedOuterHessianTerms {

--- a/crates/gam-model-api/src/families/custom_family/options.rs
+++ b/crates/gam-model-api/src/families/custom_family/options.rs
@@ -136,10 +136,11 @@ pub(crate) fn assert_rho_matches_specs(
 pub(crate) fn validate_hessian_workspace_ready(
     hessian_workspace: &Option<Arc<dyn ExactNewtonJointHessianWorkspace>>,
     context: &str,
+    eval_mode: gam_problem::EvalMode,
 ) -> Result<(), String> {
     if let Some(workspace) = hessian_workspace.as_ref() {
         workspace
-            .warm_up_outer_caches()
+            .warm_up_outer_caches_for_mode(eval_mode)
             .map_err(|err| format!("{context}: failed to warm Hessian workspace caches: {err}"))?;
     }
     Ok(())

--- a/crates/gam-model-api/src/families/custom_family/psi_design.rs
+++ b/crates/gam-model-api/src/families/custom_family/psi_design.rs
@@ -5,7 +5,7 @@
 //! and the exact-Newton joint-ψ term carriers + workspace traits.
 
 use crate::families::custom_family::family_trait::ExactNewtonJointGradientEvaluation;
-use gam_problem::{CustomFamilyError, DenseMatrixHyperOperator, HyperOperator};
+use gam_problem::{CustomFamilyError, DenseMatrixHyperOperator, EvalMode, HyperOperator};
 use ndarray::{Array1, Array2};
 use std::sync::Arc;
 
@@ -38,6 +38,42 @@ pub trait ExactNewtonJointHessianWorkspace: Send + Sync {
     /// Deliberately not called from PIRLS-side workspaces (which never
     /// invoke `directional_derivative_operator` and would pay the prime
     /// cost without ever consuming the cache).
+    ///
+    /// `eval_mode` bounds *which* caches are worth priming for the eval that
+    /// is about to run (gam#979 — large-scale margslope line-search /
+    /// seed-screen cost):
+    ///   * [`EvalMode::ValueOnly`] consumes **no** directional cache — the
+    ///     objective is read straight off the converged inner mode — so a
+    ///     value-only probe (line search, seed screen, continuation pre-warm)
+    ///     should prime nothing.
+    ///   * [`EvalMode::ValueAndGradient`] consumes only the **first** (third-
+    ///     derivative) directional cache, which feeds the REML/LAML gradient's
+    ///     `coord_corrections` IFT-drift trace.
+    ///   * [`EvalMode::ValueGradientHessian`] additionally consumes the
+    ///     **second** (fourth-derivative) directional cache used by the outer
+    ///     Hessian's second-directional pass.
+    /// Priming a cache the mode never reads is pure wasted O(n) work, so under-
+    /// priming is always safe: every cache is a lazy `get_or_compute`, so a
+    /// later consumer (if any) still builds it on demand — just without the
+    /// top-level-rayon fan-out this hook would have given it.
+    fn warm_up_outer_caches_for_mode(&self, eval_mode: EvalMode) -> Result<(), String> {
+        // Legacy default: prime everything (matches the historic
+        // `warm_up_outer_caches` contract) for any workspace that has not
+        // opted into mode-aware priming. Every mode falls through to the same
+        // mode-blind prime; mode-aware workspaces override this method to skip
+        // caches the requested mode never reads.
+        match eval_mode {
+            EvalMode::ValueOnly
+            | EvalMode::ValueAndGradient
+            | EvalMode::ValueGradientHessian => self.warm_up_outer_caches(),
+        }
+    }
+
+    /// Mode-blind warm-up retained for back-compat: primes every directional
+    /// cache the workspace keeps. Production call sites should prefer
+    /// [`Self::warm_up_outer_caches_for_mode`] so value-only probes skip the
+    /// prime entirely. Default impl is a no-op for workspaces with no per-row
+    /// jet cache.
     fn warm_up_outer_caches(&self) -> Result<(), String> {
         Ok(())
     }

--- a/crates/gam-models/src/bms/mod.rs
+++ b/crates/gam-models/src/bms/mod.rs
@@ -1,6 +1,6 @@
 use crate::custom_family::{
     BatchedOuterGradientTerms, BlockEffectiveJacobian, BlockWorkingSet, BlockwiseFitOptions,
-    CustomFamily, CustomFamilyWarmStart, ExactNewtonJointGradientEvaluation,
+    CustomFamily, CustomFamilyWarmStart, EvalMode, ExactNewtonJointGradientEvaluation,
     ExactNewtonJointHessianWorkspace, ExactNewtonJointPsiSecondOrderTerms,
     ExactNewtonJointPsiTerms, ExactNewtonJointPsiWorkspace, FamilyEvaluation,
     FamilyLinearizationState, ParameterBlockSpec, ParameterBlockState, PenaltyMatrix,

--- a/crates/gam-models/src/bms/row_kernel.rs
+++ b/crates/gam-models/src/bms/row_kernel.rs
@@ -402,17 +402,53 @@ impl RowKernel<2> for BernoulliRigidRowKernel {
     /// before any outer `par_iter` enters; subsequent
     /// `row_third_contracted` calls inside the parallel ext-idx sweep then
     /// hit a populated cache and skip straight to a 2×2 contraction.
-    fn warm_up_directional_caches(&self) -> Result<(), String> {
-        // Touch both caches so their parallel builds run here, not later
-        // (nested inside the outer ext-idx par_iter where the lock-holder
-        // thread would have to do each row pass alone).
-        let third_cache_len = self.third_full_cache().len();
-        let fourth_cache_len = self.fourth_full_cache().len();
-        crate::row_kernel::validate_row_kernel_cache_lengths(
-            "bernoulli rigid warm-up",
-            self.family.y.len(),
-            &[("third", third_cache_len), ("fourth", fourth_cache_len)],
-        )
+    fn warm_up_directional_caches(&self, eval_mode: EvalMode) -> Result<(), String> {
+        // gam#979: prime only the caches the eval about to run will consume.
+        //
+        //   * `ValueOnly`            → neither cache (the objective is read off
+        //                              the converged inner mode; no directional
+        //                              contraction is taken). Seed screening,
+        //                              line-search cost probes, and continuation
+        //                              pre-warm are all value-only — at biobank
+        //                              scale each was paying two full `O(n)` jet
+        //                              passes (third + fourth) for tensors it
+        //                              never reads.
+        //   * `ValueAndGradient`     → third-derivative cache only. The REML/LAML
+        //                              gradient's `coord_corrections` IFT-drift
+        //                              trace is a *first* directional derivative
+        //                              (`row_third_contracted`); the BFGS
+        //                              first-order bridge never asks for the
+        //                              outer Hessian, so the fourth cache stays
+        //                              cold for the whole fit.
+        //   * `ValueGradientHessian` → both caches; the outer Hessian's second-
+        //                              directional pass reads `row_fourth_contracted`.
+        //
+        // Under-priming is safe: both caches are lazy `get_or_compute`, so a
+        // later consumer still builds on demand — it just loses this hook's
+        // top-level-rayon fan-out.
+        match eval_mode {
+            EvalMode::ValueOnly => Ok(()),
+            EvalMode::ValueAndGradient => {
+                let third_cache_len = self.third_full_cache().len();
+                crate::row_kernel::validate_row_kernel_cache_lengths(
+                    "bernoulli rigid warm-up",
+                    self.family.y.len(),
+                    &[("third", third_cache_len)],
+                )
+            }
+            EvalMode::ValueGradientHessian => {
+                // Touch both caches so their parallel builds run here, not later
+                // (nested inside the outer ext-idx par_iter where the lock-holder
+                // thread would have to do each row pass alone).
+                let third_cache_len = self.third_full_cache().len();
+                let fourth_cache_len = self.fourth_full_cache().len();
+                crate::row_kernel::validate_row_kernel_cache_lengths(
+                    "bernoulli rigid warm-up",
+                    self.family.y.len(),
+                    &[("third", third_cache_len), ("fourth", fourth_cache_len)],
+                )
+            }
+        }
     }
 
     fn row_fourth_contracted(

--- a/crates/gam-models/src/row_kernel.rs
+++ b/crates/gam-models/src/row_kernel.rs
@@ -24,7 +24,7 @@ use crate::custom_family::{
 use gam_linalg::faer_ndarray::fast_ab;
 use gam_linalg::matrix::DesignMatrix;
 use crate::util::loop_progress::LoopProgress;
-use gam_problem::{HyperOperator, ProjectedFactorCache, ProjectedFactorKey};
+use gam_problem::{EvalMode, HyperOperator, ProjectedFactorCache, ProjectedFactorKey};
 use ndarray::{Array1, Array2, ArrayView2, s};
 use rayon::prelude::*;
 use std::sync::Arc;
@@ -271,8 +271,21 @@ pub trait RowKernel<const K: usize>: Send + Sync {
     /// cache builder's own `par_iter` collapses to a single worker — the
     /// other seven threads are parked on the cache `OnceLock`. Default impl
     /// is a no-op for kernels with no per-row jet cache to prime.
-    fn warm_up_directional_caches(&self) -> Result<(), String> {
-        Ok(())
+    ///
+    /// `eval_mode` bounds which caches are worth priming (gam#979): a
+    /// [`EvalMode::ValueOnly`] eval reads neither directional cache, a
+    /// [`EvalMode::ValueAndGradient`] eval reads only the third-derivative
+    /// (`row_third_contracted`) cache, and only [`EvalMode::ValueGradientHessian`]
+    /// reads the fourth-derivative (`row_fourth_contracted`) cache. Priming a
+    /// cache the mode never touches is wasted O(n) work; under-priming is safe
+    /// because each cache is a lazy `get_or_compute`.
+    fn warm_up_directional_caches(&self, eval_mode: EvalMode) -> Result<(), String> {
+        // Default: no per-row jet cache to prime, for any mode.
+        match eval_mode {
+            EvalMode::ValueOnly
+            | EvalMode::ValueAndGradient
+            | EvalMode::ValueGradientHessian => Ok(()),
+        }
     }
 
     /// Optional batched all-rows `(nll, grad, hess)` fast path for the full-data
@@ -1039,7 +1052,8 @@ pub fn row_kernel_directional_derivative_generic<const K: usize>(
 ) -> Result<Array2<f64>, String> {
     let n = kern.n_rows();
     let p = kern.n_coefficients();
-    kern.warm_up_directional_caches()?;
+    // First directional derivative consumes only the third-derivative cache.
+    kern.warm_up_directional_caches(EvalMode::ValueAndGradient)?;
     rows.par_try_reduce_fold(
         n,
         || Array2::<f64>::zeros((p, p)),
@@ -1114,7 +1128,9 @@ pub fn row_kernel_second_directional_derivative<const K: usize>(
 ) -> Result<Array2<f64>, String> {
     let n = kern.n_rows();
     let p = kern.n_coefficients();
-    kern.warm_up_directional_caches()?;
+    // Second directional derivative consumes the fourth-derivative cache (and
+    // its third-derivative prerequisite): full outer-Hessian priming.
+    kern.warm_up_directional_caches(EvalMode::ValueGradientHessian)?;
     rows.par_try_reduce_fold(
         n,
         || Array2::<f64>::zeros((p, p)),
@@ -1927,14 +1943,29 @@ impl<const K: usize, T: RowKernel<K>> RowKernelHessianWorkspace<K, T> {
 impl<const K: usize, T: RowKernel<K> + 'static> ExactNewtonJointHessianWorkspace
     for RowKernelHessianWorkspace<K, T>
 {
-    fn warm_up_outer_caches(&self) -> Result<(), String> {
+    fn warm_up_outer_caches_for_mode(&self, eval_mode: EvalMode) -> Result<(), String> {
         // Forward to the kernel: any per-row third/fourth-contracted jet
         // cache it keeps gets primed here, at the top-level rayon site
         // where the outer-eval `compute_dh`/`compute_d2h` closures are
         // wired up. Called exactly once per outer iter, far outside the
         // ext-coord `par_iter`, so the cache build's `par_iter` enjoys
         // full 8-core parallelism instead of a single lock-holder worker.
-        self.kern.warm_up_directional_caches()
+        //
+        // gam#979: forward `eval_mode` so a value-only probe (line search,
+        // seed screen, continuation pre-warm) primes nothing, and a
+        // first-order (`ValueAndGradient`) eval primes only the third-
+        // derivative cache its `coord_corrections` trace consumes — skipping
+        // the fourth-derivative outer-Hessian cache that only `ValueGradientHessian`
+        // reads. At biobank scale this is the dominant per-eval `O(n)` jet pass.
+        self.kern.warm_up_directional_caches(eval_mode)
+    }
+
+    fn warm_up_outer_caches(&self) -> Result<(), String> {
+        // Mode-blind back-compat entry: prime every directional cache the
+        // kernel keeps (legacy contract). Mode-aware callers route through
+        // `warm_up_outer_caches_for_mode` instead.
+        self.kern
+            .warm_up_directional_caches(EvalMode::ValueGradientHessian)
     }
 
     fn joint_log_likelihood_evaluation(&self) -> Result<Option<f64>, String> {


### PR DESCRIPTION
Autonomous WIP for #979 (marginal-slope binary + survival slowdown / hang). Force-improved commit-by-commit; nothing here is final until marked so.

## Context
The original reported symptoms (binary slowdown, survival uncatchable hang) are resolved + regression-tested on `main`. The owner's most recent word is that **Large-scale CI still fails on all three** centers=24 marginal-slope methods. This PR targets the genuine residual.

## Two failures seen in recent `large_scale.yml` runs
1. **Build break (adjacent, not #979):** latest scheduled runs die in `bootstrap-runtime` on ban-scanner violations in `crates/gam-sae/src/manifold/construction_row_jet_logdet_channels.rs` (a #932 file). This blocks the benchmark from running at all.
2. **#979 residual:** the runs that DO build hit the 50-min job cap on the n=60000/centers=24 margslope fits — the inner joint-Newton grind on the ill-posed marginal↔logslope coupling.

## Plan / running summary
- [x] Establish local build/test ground truth
- [ ] Profile large-scale margslope path
- [ ] Fix the genuine convergence residual (honest, no wall-clock-as-correctness)
- [ ] Unblock the SAE build break if unowned

🤖 Generated with [Claude Code](https://claude.com/claude-code)
