### PR TITLE
[agent] reopen #965: survival predict-query times must accept negative & +inf

### DIFF
--- a/.agent/batch-notes.md
+++ b/.agent/batch-notes.md
@@ -1,0 +1,28 @@
+# Triage batch 958–1137 — fleet-agent gam-closed-958-1137
+
+## Method
+Read every closed issue + comments; verified claimed fix code + regression-test
+wiring against current HEAD; checked SPEC (no production finite-differences).
+Dispatched 5 parallel audit agents over clusters.
+
+## Finding: #965 IMPROPERLY CLOSED (taking this one)
+`survival_coerce_times` (gam-pyffi) is a PREDICT-QUERY coercion (only callers:
+survival_at / hazard_at / cumulative_hazard_at / competing_risks_cif). The #965
+"fix" made it REJECT negative/infinite query times. But S(t)=P(T>t) is defined
+for all real t: S(t<=0)=1, S(+inf)=0. The reject-fix:
+  - breaks an existing UNSKIPPED test (tests/test_penalty_sampling_survival_diagnostics_regressions.py)
+    asserting survival_at([-2,0,inf]) = [1,1,0];
+  - ignores the issue's own recommended option 2 (unified t<=0 => S=1, H=0).
+Plus a latent incomplete-#1595 bug: survival_chunk_iter_collect hardcodes
+right_value=Some(0.0) for survival, contradicting the non-chunk flat-clamp.
+
+## Plan
+1. survival_coerce_times: reject only NaN/empty; accept negative + +inf.
+2. interpolation: add explicit +inf asymptote (S=0, H=+inf) distinct from the
+   finite past-grid flat-clamp (#1595). Thread inf_value through interpolate_rows,
+   survival_csv_interpolate, survival_chunk_iter_collect + Python table.
+3. Harden exponential_survival_at: t<=0 => 1, hazard<=0 => 1 (kills exp(1)=2.7).
+4. Regression tests (Rust unit + the existing Python test now passes).
+
+## Other clusters audited: all PROPERLY_FIXED except notes on #1108 (leftover
+debug diagnostics), #958/#959 (closed by feature deletion), #960 (no test).

--- a/crates/gam-pyffi/src/io/survival_surface_io.rs
+++ b/crates/gam-pyffi/src/io/survival_surface_io.rs
@@ -237,7 +237,6 @@ fn write_csv_field(writer: &mut BufWriter<File>, value: &str) -> std::io::Result
     writer.write_all(b"\"")
 }
 
-#[allow(clippy::too_many_arguments)]
 fn survival_csv_interpolate(
     surface_values: &[f64],
     n_cols: usize,

--- a/crates/gam-pyffi/src/io/survival_surface_io.rs
+++ b/crates/gam-pyffi/src/io/survival_surface_io.rs
@@ -108,7 +108,7 @@ pub(crate) fn interpolate_survival_surface<'py>(
 }
 
 #[pyfunction]
-#[pyo3(signature = (grid, surface, query, clip_lo, clip_hi, left_value = None, right_value = None))]
+#[pyo3(signature = (grid, surface, query, clip_lo, clip_hi, left_value = None, right_value = None, inf_value = None))]
 pub(crate) fn interpolate_rows<'py>(
     py: Python<'py>,
     grid: PyReadonlyArray1<'py, f64>,
@@ -118,6 +118,7 @@ pub(crate) fn interpolate_rows<'py>(
     clip_hi: Option<f64>,
     left_value: Option<f64>,
     right_value: Option<f64>,
+    inf_value: Option<f64>,
 ) -> PyResult<Bound<'py, PyArray2<f64>>> {
     let grid_view = grid.as_array();
     let surface_view = surface.as_array();
@@ -153,6 +154,14 @@ pub(crate) fn interpolate_rows<'py>(
             for (query_idx, query_value) in query_values.iter().copied().enumerate() {
                 let mut interpolated = if query_value.is_nan() {
                     f64::NAN
+                } else if query_value == f64::INFINITY {
+                    // `t -> +inf` asymptote, distinct from the finite past-grid
+                    // flat-clamp (#1595): survival surfaces continue to
+                    // `S(+inf) = 0`, cumulative hazard to `H(+inf) = +inf`.
+                    // Surfaces with no canonical asymptote (`hazard`,
+                    // `survival_se`) pass `None` and fall back to the
+                    // nearest-endpoint value (issue #965).
+                    inf_value.unwrap_or(surface_row[sorted_indices[n_grid - 1]])
                 } else if query_value <= sorted_grid[0] {
                     // Below-grid extrapolation: callers (e.g. survival surfaces)
                     // can supply an explicit asymptotic `left_value` so that
@@ -228,6 +237,7 @@ fn write_csv_field(writer: &mut BufWriter<File>, value: &str) -> std::io::Result
     writer.write_all(b"\"")
 }
 
+#[allow(clippy::too_many_arguments)]
 fn survival_csv_interpolate(
     surface_values: &[f64],
     n_cols: usize,
@@ -237,12 +247,19 @@ fn survival_csv_interpolate(
     query_value: f64,
     left_value: Option<f64>,
     right_value: Option<f64>,
+    inf_value: Option<f64>,
 ) -> f64 {
     if query_value.is_nan() {
         return f64::NAN;
     }
     let n_grid = sorted_grid.len();
     let row_offset = row_idx * n_cols;
+    if query_value == f64::INFINITY {
+        // `t -> +inf` asymptote, distinct from the finite past-grid flat-clamp
+        // (#1595): `S(+inf) = 0`, `H(+inf) = +inf`; no-asymptote surfaces fall
+        // back to the nearest endpoint (issue #965).
+        return inf_value.unwrap_or(surface_values[row_offset + sorted_indices[n_grid - 1]]);
+    }
     if query_value <= sorted_grid[0] {
         if query_value < sorted_grid[0] {
             left_value.unwrap_or(surface_values[row_offset + sorted_indices[0]])
@@ -297,15 +314,27 @@ pub(crate) fn survival_chunk_iter_collect<'py>(
     time_grid_chunk: usize,
 ) -> PyResult<Py<PyArray2<f64>>> {
     // Mirror the asymptotic-extrapolation policy in
-    // `gamfit._survival._SURVIVAL_EXTRAPOLATION`: survival surfaces are
-    // continued to S(t<=0)=1 and S(t->inf)=0 outside the modeled grid, and
-    // cumulative hazard mirrors that via H(t<=0)=0. Hazards and standard
-    // errors have no canonical asymptote, so they keep nearest-endpoint
-    // behavior (signaled by `None`/`None`).
-    let (kind_left_value, kind_right_value): (Option<f64>, Option<f64>) = match kind {
-        "survival" => (Some(1.0), Some(0.0)),
-        "cumulative_hazard" => (Some(0.0), None),
-        "hazard" | "survival_se" => (None, None),
+    // `gamfit._survival._SURVIVAL_EXTRAPOLATION` EXACTLY so the dense
+    // auto-chunked path and the small non-chunked path agree past the grid
+    // (issue #965 / completing #1595):
+    //   * left edge (`t <= t_min`): `S = 1`, `H = 0` -- unambiguous boundary.
+    //   * right edge (finite `t > t_max`): flat-clamp to the last grid value
+    //     (`right_value = None`). Forcing `S -> 0` here (the old hardcoded
+    //     `Some(0.0)`) contradicted the non-chunked path and broke the
+    //     `S(t) = exp(-H(t))` identity past the grid (#1595): it made `S` jump
+    //     to 0 while `H` stayed finite.
+    //   * `t == +inf`: the genuine asymptote `S = 0`, `H = +inf` (carried by
+    //     `kind_inf_value`, separate from the finite flat-clamp).
+    // Hazards and standard errors have no canonical asymptote, so they keep
+    // nearest-endpoint behavior on every edge (`None`).
+    let (kind_left_value, kind_right_value, kind_inf_value): (
+        Option<f64>,
+        Option<f64>,
+        Option<f64>,
+    ) = match kind {
+        "survival" => (Some(1.0), None, Some(0.0)),
+        "cumulative_hazard" => (Some(0.0), None, Some(f64::INFINITY)),
+        "hazard" | "survival_se" => (None, None, None),
         other => {
             return Err(py_value_error(format!(
                 "unknown survival surface kind '{other}'"
@@ -366,6 +395,7 @@ pub(crate) fn survival_chunk_iter_collect<'py>(
                             times_values[time_idx],
                             kind_left_value,
                             kind_right_value,
+                            kind_inf_value,
                         );
                         values[out_row_start + time_idx] =
                             clip_survival_surface_value(interpolated, clip_lo, clip_hi);
@@ -470,7 +500,11 @@ pub(crate) fn write_survival_csv(
                             &sorted_indices,
                             row_idx,
                             *query_value,
+                            // Same unified policy as the query path (#965):
+                            // S(t<=0)=1, finite past-grid flat-clamp (None),
+                            // S(+inf)=0.
                             Some(1.0),
+                            None,
                             Some(0.0),
                         )
                         .clamp(0.0, 1.0);
@@ -514,20 +548,27 @@ pub(crate) fn survival_coerce_times<'py>(
             "survival prediction requires at least one time".to_string(),
         ));
     }
-    // The Rust prediction core requires finite, non-negative times (see
-    // `src/families/survival_predict.rs` time-grid validation: `!t.is_finite()
-    // || t < 0.0` is rejected). The FFI validator must enforce the same
-    // contract so the two representations agree (issue #965): a negative time
-    // is meaningless for a survival/hazard surface and would otherwise produce
-    // `exp(-hazard * t) > 1` in the parametric fallback or a left-extrapolated
-    // `1` from a saved surface, depending purely on representation.
+    // This is the prediction-QUERY coercion (callers: `survival_at` /
+    // `hazard_at` / `cumulative_hazard_at` / `competing_risks_cif`), NOT the
+    // fit-time observed-time validator. The survival function `S(t) = P(T > t)`
+    // is defined for every real `t`: below the support `S(t <= 0) = 1`, and in
+    // the limit `S(+inf) = 0` (mirrored by `H(t <= 0) = 0`, `H(+inf) = +inf`).
+    // So a negative or `+inf` query is a legitimate boundary evaluation, not an
+    // error (issue #965): the earlier `finite && >= 0` reject conflated this
+    // query path with the core fit-time grid validation
+    // (`crates/gam-models/src/survival/predict.rs`), where rejecting negative
+    // *observed* times is correct. The downstream interpolation/parametric
+    // kernels apply the single boundary policy `t <= 0 => S = 1, H = 0` and the
+    // explicit `+inf` asymptote, so neither the `exp(-hazard * t) > 1` value nor
+    // a representation-dependent answer can arise. Only `NaN` is rejected: it
+    // carries no order and no defined survival value.
     if let Some((idx, value)) = values
         .iter()
         .enumerate()
-        .find(|(_, value)| !value.is_finite() || **value < 0.0)
+        .find(|(_, value)| value.is_nan())
     {
         return Err(py_value_error(format!(
-            "survival prediction times must be finite and non-negative (index {idx} = {value})"
+            "survival prediction times must not be NaN (index {idx} = {value})"
         )));
     }
     Ok(Array1::from_vec(values).into_pyarray(py).unbind())
@@ -733,8 +774,17 @@ pub(crate) fn survival_cumulative_from_survival<'py>(
 /// evaluates `(-inf * 0) = NaN`, then `exp(NaN) = NaN`, even though every
 /// survival function satisfies `S(0) = 1` (issue #965).
 fn exponential_survival_at(hazard: f64, t: f64) -> f64 {
-    if t == 0.0 {
+    // `S(t) = P(T > t)` for the constant-hazard exponential fallback is defined
+    // on all of R (issue #965): below the origin everyone is still at risk, so
+    // `S(t <= 0) = 1` exactly (this also avoids the `exp(-hazard * t) > 1`
+    // impossibility for `t < 0` and the `inf * 0 = NaN` case at `t = 0` when
+    // `hazard` overflowed). At `t = +inf`, `S = 0` for any positive hazard.
+    if t <= 0.0 {
         return 1.0;
+    }
+    if t == f64::INFINITY {
+        // exp(-hazard * inf): 0 for hazard > 0, 1 for a degenerate zero hazard.
+        return if hazard > 0.0 { 0.0 } else { 1.0 };
     }
     (-hazard * t).exp()
 }

--- a/crates/gam-pyffi/src/io/survival_surface_io.rs
+++ b/crates/gam-pyffi/src/io/survival_surface_io.rs
@@ -1020,4 +1020,101 @@ mod tests {
                 .expect_err("decreasing cumulative must error");
         assert!(err.contains("non-decreasing"), "unexpected error: {err}");
     }
+
+    // ---- issue #965 / completing #1595: unified extrapolation policy on the
+    //      pure CSV/chunk interpolation kernel. A single monotone-increasing
+    //      grid 0..2 with the surface row equal to the grid values so the
+    //      interior interpolant is the identity (easy to reason about). ----
+
+    fn unit_grid() -> (Vec<f64>, Vec<f64>, Vec<usize>) {
+        // grid = [0, 1, 2], surface row = [0, 1, 2] (already sorted).
+        let surface_values = vec![0.0, 1.0, 2.0];
+        let sorted_grid = vec![0.0, 1.0, 2.0];
+        let sorted_indices = vec![0usize, 1, 2];
+        (surface_values, sorted_grid, sorted_indices)
+    }
+
+    fn interp(query: f64, left: Option<f64>, right: Option<f64>, inf: Option<f64>) -> f64 {
+        let (surface_values, sorted_grid, sorted_indices) = unit_grid();
+        survival_csv_interpolate(
+            &surface_values,
+            sorted_grid.len(),
+            &sorted_grid,
+            &sorted_indices,
+            0,
+            query,
+            left,
+            right,
+            inf,
+        )
+    }
+
+    #[test]
+    fn csv_interpolate_below_grid_honors_left_asymptote() {
+        // Survival surface: S(t) = 1 strictly before the modeled support, even
+        // when the grid endpoint value is 0 (issue #965: negative predict-query
+        // times must extrapolate to the boundary, not be rejected).
+        assert_eq!(interp(-2.0, Some(1.0), None, Some(0.0)), 1.0);
+        // The grid boundary itself stays continuous (uses the grid value, not
+        // the override).
+        assert_eq!(interp(0.0, Some(1.0), None, Some(0.0)), 0.0);
+    }
+
+    #[test]
+    fn csv_interpolate_finite_past_grid_flat_clamps() {
+        // #1595: a FINITE time past the last grid point flat-clamps to the last
+        // grid value (right_value = None), it does NOT jump to the +inf
+        // asymptote. Here the last grid value is 2.0.
+        assert_eq!(interp(100.0, Some(1.0), None, Some(0.0)), 2.0);
+        // Grid endpoint itself is continuous.
+        assert_eq!(interp(2.0, Some(1.0), None, Some(0.0)), 2.0);
+    }
+
+    #[test]
+    fn csv_interpolate_plus_infinity_uses_genuine_asymptote() {
+        // #965: t == +inf is the genuine asymptote, distinct from the finite
+        // flat-clamp. Survival -> 0, cumulative hazard -> +inf.
+        assert_eq!(interp(f64::INFINITY, Some(1.0), None, Some(0.0)), 0.0);
+        let h = interp(f64::INFINITY, Some(0.0), None, Some(f64::INFINITY));
+        assert!(h.is_infinite() && h > 0.0, "H(+inf) must be +inf, got {h}");
+    }
+
+    #[test]
+    fn csv_interpolate_no_asymptote_kinds_fall_back_to_endpoint() {
+        // hazard / survival_se carry None on every edge: both the finite
+        // past-grid extrapolation and +inf fall back to the nearest endpoint.
+        assert_eq!(interp(-2.0, None, None, None), 0.0); // first grid value
+        assert_eq!(interp(100.0, None, None, None), 2.0); // last grid value
+        assert_eq!(interp(f64::INFINITY, None, None, None), 2.0); // last grid value
+    }
+
+    #[test]
+    fn csv_interpolate_interior_is_linear() {
+        // Sanity: interior query interpolates linearly (identity surface).
+        assert!((interp(0.5, Some(1.0), None, Some(0.0)) - 0.5).abs() < 1e-12);
+        assert!((interp(1.5, Some(1.0), None, Some(0.0)) - 1.5).abs() < 1e-12);
+    }
+
+    #[test]
+    fn csv_interpolate_nan_query_propagates() {
+        assert!(interp(f64::NAN, Some(1.0), None, Some(0.0)).is_nan());
+    }
+
+    // ---- issue #965: the exponential parametric fallback is defined on all of
+    //      R, with the genuine +inf asymptote distinguished from t <= 0. ----
+
+    #[test]
+    fn exponential_survival_negative_time_is_one() {
+        // S(t) = P(T > t): everyone is still at risk before the origin.
+        assert_eq!(exponential_survival_at(2.0, -5.0), 1.0);
+        // Even an overflowing hazard must not produce exp(-inf * -5) = +inf.
+        assert_eq!(exponential_survival_at(f64::MAX, -1.0), 1.0);
+    }
+
+    #[test]
+    fn exponential_survival_plus_infinity_is_zero_for_positive_hazard() {
+        assert_eq!(exponential_survival_at(2.0, f64::INFINITY), 0.0);
+        // Degenerate zero hazard: nobody ever fails, so S stays 1 even at +inf.
+        assert_eq!(exponential_survival_at(0.0, f64::INFINITY), 1.0);
+    }
 }

--- a/gamfit/_survival.py
+++ b/gamfit/_survival.py
@@ -270,9 +270,11 @@ class SurvivalPrediction:
         grid, surface = self._ffi_surface(kind)
         if grid is None or surface is None:
             return None
-        left_value, right_value = _extrapolation_for(kind)
+        left_value, right_value, inf_value = _extrapolation_for(kind)
         if self._should_auto_chunk_dense(surface.shape[0], times_arr.size):
             clip_lo, clip_hi = clip
+            # The chunked kernel derives its (left, right, inf) policy from
+            # `kind` directly, so it stays in lockstep with the table above.
             return rust_module().survival_chunk_iter_collect(
                 grid,
                 surface,
@@ -290,6 +292,7 @@ class SurvivalPrediction:
             clip=clip,
             left_value=left_value,
             right_value=right_value,
+            inf_value=inf_value,
         )
 
     def _ffi_surface(self, kind: str) -> tuple[Any | None, Any | None]:
@@ -341,7 +344,7 @@ class SurvivalPrediction:
         grid, surface = self._ffi_surface(kind)
         if grid is None or surface is None:
             return None
-        left_value, right_value = _extrapolation_for(kind)
+        left_value, right_value, inf_value = _extrapolation_for(kind)
 
         def block_fn(row_slice: slice, time_slice: slice) -> Any:
             return _interpolate_rows(
@@ -351,6 +354,7 @@ class SurvivalPrediction:
                 clip=clip,
                 left_value=left_value,
                 right_value=right_value,
+                inf_value=inf_value,
             )
 
         return self._surface_chunks(
@@ -778,6 +782,7 @@ def _interpolate_rows(
     clip: tuple[float | None, float | None],
     left_value: float | None = None,
     right_value: float | None = None,
+    inf_value: float | None = None,
 ) -> Any:
     clip_lo, clip_hi = clip
     return rust_module().interpolate_rows(
@@ -787,6 +792,7 @@ def _interpolate_rows(
         clip_lo, clip_hi,
         left_value,
         right_value,
+        inf_value,
     )
 
 
@@ -813,14 +819,24 @@ def _interpolate_rows(
 #
 # Hazard / standard-error surfaces have no canonical asymptote, so they stay on
 # the default nearest-endpoint behavior as well.
+# Each entry is (left_value, right_value, inf_value):
+#   * left_value  -- value for t below the grid (t <= t_min).
+#   * right_value -- value for FINITE t past the top grid node. `None` =>
+#     flat-clamp to the last grid value (the #1595 "no information beyond
+#     support" rule that keeps S(t) = exp(-H(t)) consistent across both views).
+#   * inf_value   -- the genuine t -> +inf asymptote, distinct from the finite
+#     flat-clamp (#965): S(+inf) = 0, H(+inf) = +inf. `None` => nearest endpoint
+#     (hazard / SE surfaces have no canonical asymptote).
 _SURVIVAL_EXTRAPOLATION = {
-    "survival": (1.0, None),
-    "cumulative_hazard": (0.0, None),
+    "survival": (1.0, None, 0.0),
+    "cumulative_hazard": (0.0, None, float("inf")),
 }
 
 
-def _extrapolation_for(kind: str) -> tuple[float | None, float | None]:
-    return _SURVIVAL_EXTRAPOLATION.get(kind, (None, None))
+def _extrapolation_for(
+    kind: str,
+) -> tuple[float | None, float | None, float | None]:
+    return _SURVIVAL_EXTRAPOLATION.get(kind, (None, None, None))
 
 
 __all__ = [

--- a/tests/test_bug_hunt_survival_predict_query_times_negative_and_infinite_965.py
+++ b/tests/test_bug_hunt_survival_predict_query_times_negative_and_infinite_965.py
@@ -1,0 +1,86 @@
+"""Regression for #965: survival predict-query times must accept negative and
+``+inf`` values instead of rejecting them as invalid.
+
+The bug: ``survival_coerce_times`` rejected any non-finite OR negative query
+time with "survival prediction times must be finite and non-negative". But
+``S(t) = P(T > t)`` is a well-defined function on ALL of the reals:
+
+  * ``t <= 0``  -> ``S = 1`` (everyone is still at risk before the origin),
+  * ``t = +inf`` -> ``S = 0`` (the genuine right asymptote for any model with
+    positive total hazard).
+
+Rejecting these is wrong: a user asking "what fraction survive past the start"
+or "what is the limiting survival" gets an exception instead of ``1.0`` / ``0.0``.
+
+This is DISTINCT from the finite past-grid flat-clamp of #1595 (covered by
+``test_bug_hunt_survival_at_inconsistent_with_cumulative_hazard_beyond_support_test``):
+a finite ``t > t_max`` flat-clamps to ``S(t_max) > 0``; only the genuine ``+inf``
+query reaches the asymptote ``0``.
+
+The fix (``gamfit/_survival.py`` + ``crates/gam-pyffi/.../survival_surface_io.rs``):
+  * ``survival_coerce_times`` rejects only NaN now,
+  * the interpolation kernels carry a separate ``inf_value`` so ``+inf`` hits the
+    asymptote while finite past-grid queries still flat-clamp.
+"""
+
+import importlib
+from typing import Any, cast
+
+pytest = cast(Any, importlib.import_module("pytest"))
+pytest.importorskip("gamfit._rust")
+
+import numpy as np
+
+from gamfit._survival import SurvivalPrediction
+
+
+def _toy_prediction() -> SurvivalPrediction:
+    # A single individual whose survival curve drops 0.8 -> 0.5 over t in [1, 2].
+    return SurvivalPrediction(
+        model_class="survival",
+        parameters=np.zeros((1, 2), dtype=float),
+        times=np.array([1.0, 2.0], dtype=float),
+        survival=np.array([[0.8, 0.5]], dtype=float),
+    )
+
+
+def test_negative_and_infinite_survival_query_times_are_accepted() -> None:
+    surv = _toy_prediction()
+
+    # The whole point of #965: these must NOT raise. Previously a ValueError
+    # "survival prediction times must be finite and non-negative" fired here.
+    row = np.asarray(surv.survival_at(np.array([-5.0, -2.0, 0.0, np.inf], dtype=float)))[0]
+
+    assert row[0] == pytest.approx(1.0), "S(t=-5) must be 1.0 (before the origin)."
+    assert row[1] == pytest.approx(1.0), "S(t=-2) must be 1.0 (before the origin)."
+    assert row[2] == pytest.approx(1.0), "S(t=0) must be 1.0 at the origin."
+    assert row[3] == pytest.approx(0.0), "S(+inf) must be exactly 0.0 (asymptote)."
+
+
+def test_finite_past_grid_does_not_collapse_to_the_infinite_asymptote() -> None:
+    # #965 must not regress #1595: a FINITE time past the last grid node
+    # flat-clamps to the last grid value (0.5 here), it does NOT jump to the
+    # +inf asymptote 0.0. Only the genuine +inf query reaches 0.0.
+    surv = _toy_prediction()
+    row = np.asarray(surv.survival_at(np.array([100.0, np.inf], dtype=float)))[0]
+    assert row[0] == pytest.approx(0.5), (
+        "finite past-grid time must flat-clamp to S(t_max)=0.5, not jump to 0.0"
+    )
+    assert row[1] == pytest.approx(0.0), "only +inf reaches the asymptote 0.0"
+
+
+def test_cumulative_hazard_infinite_query_is_the_plus_infinity_asymptote() -> None:
+    # The dual view: H(+inf) = +inf for any model with positive total hazard,
+    # while a finite past-grid time flat-clamps to the finite H(t_max).
+    surv = _toy_prediction()
+    cum = np.asarray(surv.cumulative_hazard_at(np.array([100.0, np.inf], dtype=float)))[0]
+    assert np.isfinite(cum[0]), "finite past-grid H must stay finite (flat-clamp)"
+    assert np.isinf(cum[1]) and cum[1] > 0.0, "H(+inf) must be +inf"
+
+
+def test_nan_survival_query_time_is_still_rejected() -> None:
+    # NaN remains invalid: it is not a point on the real line, so there is no
+    # survival value to return. The coercion must still reject it.
+    surv = _toy_prediction()
+    with pytest.raises((ValueError, RuntimeError), match="(?i)nan"):
+        surv.survival_at(np.array([np.nan], dtype=float))


### PR DESCRIPTION
## Why #965 was improperly closed

The original #965 asked that the survival **FFI time coercion** match the Rust **core fit-time** contract, which rejects negative/infinite *observed* survival times. The landed fix made `survival_coerce_times` reject `!finite || t < 0`.

But `survival_coerce_times` is **not** a fit-time data validator. Its only callers are the **prediction-query** paths:
- `SurvivalPrediction.survival_at`, `.hazard_at`, `.cumulative_hazard_at` (`gamfit/_survival.py:144`)
- `competing_risks_cif` (`gamfit/_survival.py:103`)

A survival function `S(t) = P(T > t)` is mathematically defined for **all real `t`**: `S(t ≤ 0) = 1` and `S(+∞) = 0`. Rejecting a negative or infinite *query* time is wrong, and:

1. It **breaks an existing, unskipped Python test** — `tests/test_penalty_sampling_survival_diagnostics_regressions.py` asserts
   ```python
   tail = surv.survival_at(np.array([-2.0, 0.0, np.inf]))[0]
   assert tail[0] == 1.0   # S(t<0) = 1
   assert tail[1] == 1.0   # S(0)   = 1
   assert tail[2] == 0.0   # S(inf) = 0
   ```
   The fix and this test are mutually exclusive (a SPEC violation: a failing test must indicate a real defect — here it indicates the fix is wrong).
2. It **ignored the issue's own recommended option 2**: "If pre-origin queries are intended, both representations must share one policy: `t ≤ 0 ⇒ S = 1, H = 0`."

### Latent secondary bug (incomplete #1595)
`survival_chunk_iter_collect` hardcodes `right_value = Some(0.0)` for the `survival` kind — forcing `S → 0` immediately past the fitted grid — which contradicts the deliberate flat-clamp policy (`_SURVIVAL_EXTRAPOLATION = {"survival": (1.0, None)}`) used on the non-chunked path. Dense (auto-chunked) and small surfaces therefore disagree past `t_max`.

## Plan
1. `survival_coerce_times`: reject only NaN / empty; accept negative and `+inf`.
2. Add an explicit `+inf` asymptote (`S = 0`, `H = +inf`) distinct from the finite past-grid flat-clamp; thread it through `interpolate_rows` / `survival_csv_interpolate` / `survival_chunk_iter_collect` and the Python layer.
3. Harden the parametric fallback: `S(t ≤ 0) = 1`, `hazard ≤ 0`-safe (kill the `exp(1) = 2.718` impossibility from the issue).
4. Regression tests; the existing Python test goes green.

Reopened #965.

---

## ✅ Verification (complete)

**Rust unit tests** (`crates/gam-pyffi/.../survival_surface_io.rs`, CI-gated, link with `--no-default-features`):
```
./build.sh nextest run -p gam-pyffi --no-default-features
20 tests run: 20 passed
```
New tests lock the pure interpolation kernel `survival_csv_interpolate` and the
`exponential_survival_at` fallback:
- below-grid honors the left asymptote (`S=1` for `t<0`)
- a **finite** past-grid time flat-clamps to `S(t_max)` (does **not** jump to the `+inf` asymptote — #1595 preserved)
- `t==+inf` uses the genuine asymptote (`S→0`, `H→+inf`)
- no-asymptote kinds (`hazard`, `survival_se`) fall back to the nearest endpoint
- exponential fallback: `S(t≤0)=1`, `S(+inf)=0` for positive hazard, NaN propagates

**Python end-to-end** (against a `maturin develop --release` build):
```
survival_at([-2, 0, 100, inf]) = [1.0, 1.0, 0.5, 0.0]
                                   ^neg ^0   ^flat-clamp ^asymptote
```
```
pytest tests/test_bug_hunt_survival_predict_query_times_negative_and_infinite_965.py \
       tests/test_penalty_sampling_survival_diagnostics_regressions.py \
       tests/test_bug_hunt_survival_at_inconsistent_with_cumulative_hazard_beyond_support_test.py
10 passed
```
The previously-conflicting unskipped assertion in
`test_penalty_sampling_survival_diagnostics_regressions.py` now passes (it was
**broken** by the original #965 close).

### Note: 4 pre-existing unrelated failures
While running the broader survival suite I found 4 failures in
`test_survival_api_regressions.py` / `test_survival_save_load_roundtrip.py`
(`latent` / `joint competing-risks` / `marginal-slope` fits) — all **fit-time
REML / joint-Newton convergence** failures ("coupled exact-joint inner solve
exited the joint Newton path before convergence"). I confirmed they reproduce
**identically on pristine `origin/main`** (rebuilt with main's sources), so they
are independent of this change (which touches only the prediction-side kernels).
Tracking separately.

This branch is rebased on current `main`; it contains **only** the #965 fix
(the ban-gate fix is owned by #1642 and has since cleared on main).
