### PR TITLE
[agent] fix RED main: redundant #[cfg(test)] on test-mod fn (build P0)

### DIFF
--- a/crates/gam-sae/src/manifold/tests.rs
+++ b/crates/gam-sae/src/manifold/tests.rs
@@ -2142,7 +2142,6 @@ pub(crate) fn separation_barrier_is_collapse_prevention_not_bandaid_1522() {
 /// chosen squared alignment `c² = cos²θ` (`dec0 = e0`, `dec1 = (cosθ, sinθ, 0)`),
 /// co-firing under softmax so the separation barrier's coactivation `q_01 > 0`.
 /// The shared regression fixture for the collinearity-gate guards below.
-#[cfg(test)]
 fn aligned_two_atom_term_with_c2(c2: f64) -> SaeManifoldTerm {
     let coords0 = array![[0.05], [0.20], [0.55], [0.80], [0.35], [0.65]];
     let coords1 = array![[0.15], [0.30], [0.65], [0.90], [0.45], [0.10]];


### PR DESCRIPTION
## P0: origin/main does not build

The latest #1625 commit `a5f099e21` ('gate the separation barrier to near-collapse') added the regression fixture `aligned_two_atom_term_with_c2` to `crates/gam-sae/src/manifold/tests.rs:2145` annotated with a redundant `#[cfg(test)]` attribute.

That file is already gated as `#[cfg(test)] mod tests;` in `crates/gam-sae/src/manifold/mod.rs`, so the inner attribute is dead — and the `build.rs` ban-scanner explicitly forbids `#[cfg(test)]` on `src/` items ("it is not a dead_code-lint escape hatch, regardless of visibility"). The scanner aborts the build:

```
error — #[cfg(test)] on src/ item ...
  crates/gam-sae/src/manifold/tests.rs:2145: [fn aligned_two_atom_term_with_c2(...)] #[cfg(test)]
```

This blocks every agent's `./build.sh` on `main`.

## Fix
Remove the redundant attribute; the fn is already test-only via its enclosing `#[cfg(test)] mod tests`.

## Verification
`./build.sh` → `BUILD OK`. No behavior change; pure attribute removal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)