### PR TITLE
[agent] reopen #932: unblock HEAD build — jet-cutover left 8 ban violations (WIP)

### DIFF
--- a/.agent/batch-notes.md
+++ b/.agent/batch-notes.md
@@ -1,0 +1,29 @@
+# Batch 778–957 triage — agent gam-closed-778-957
+
+## CRITICAL FINDING (anchor issue #932)
+HEAD does NOT build. `build.rs` ban-scanner aborts every cargo/maturin invocation
+with 8 violations across 4 rules — all debris from the in-flight #932 jet-cutover
+that was landed half-finished and the issue closed "completed":
+
+- 2× `#[allow(clippy::too_many_arguments)]`  flex_jet.rs:4795,4879
+- 3× `#[ignore]` timing microbenches          gradient_paths.rs:2609,
+                                               cell_moment_assembly.rs:4774,
+                                               row_jet_program.rs:1480
+- 1× `#[test]` without assertions             gradient_paths.rs:2608 (same bench)
+- 2× `#[cfg(test)]` on src/ item              multinomial_reml.rs:935,1061
+
+This blocks ALL verification for every agent on every box. Fixing first.
+
+## Plan
+1. Unblock the build (proper fixes, not lint-silencing): delete pure-timing
+   microbenches (covered by non-ignored correctness siblings), bundle test-helper
+   args into a struct, move cfg(test) methods into the test mod's impl block.
+2. Address #932 residual: one live production hand-derivative path remains
+   (row_primary_hessian.rs compute_row_analytic_flex_from_parts_into).
+3. Continue triage: #855 (tolerance-mask), #850 (warm-start freeze), #901 (disabled FD gate).
+
+## Other improperly-closed candidates from parallel triage
+- #855 SAS observed-Jacobian: closed via test-tolerance loosening only, no prod change.
+- #850 SAE inner_max_iter=0 freeze: bug reproduces on HEAD (call-path clobbers seed).
+- #901 non-Gaussian REML pseudo-logdet FD gate commented out of build.
+- #778 explicit "not implemented / defer" marked COMPLETED.

--- a/crates/gam-models/src/bms/cell_moment_assembly.rs
+++ b/crates/gam-models/src/bms/cell_moment_assembly.rs
@@ -4764,87 +4764,10 @@ mod empirical_flex_jet_oracle_tests {
         }
     }
 
-    /// #932 timing baseline (investigation only, ignored by default): measures
-    /// ns/row of the hand path `compute_row_analytic_flex_from_parts_into`
-    /// (need_hessian=true) versus the naive per-op-alloc `Jet2` single-source
-    /// `empirical_flex_row_nll_jet2` on the SAME representative flex fixture, so
-    /// the #932 "jet must be measurably faster" constraint can be quantified.
-    /// Run with: `cargo test -p gam-models --release flex_handpath_vs_jet2_timing_932 -- --ignored --nocapture`.
-    #[test]
-    #[ignore]
-    fn flex_handpath_vs_jet2_timing_932() {
-        use std::time::Instant;
-        let fx = make_fixture(false); // link-dev block
-        let r = fx.primary.total;
-        let q0 = 0.2_f64;
-        let b0 = 0.35_f64;
-        let mut p0 = vec![0.0; r];
-        p0[fx.primary.q] = q0;
-        p0[fx.primary.logslope] = b0;
-        let dev_range = fx.primary.w.clone().unwrap();
-        for (k, i) in dev_range.clone().enumerate() {
-            p0[i] = fx.beta_dev[k];
-        }
-        let scale = fx.family.probit_frailty_scale();
-        let beta: Array1<f64> = Array1::from_iter(dev_range.clone().map(|i| p0[i]));
-        let marginal = bernoulli_marginal_link_map(
-            &InverseLink::Standard(gam_problem::StandardLink::Probit),
-            q0,
-        )
-        .expect("link map");
-        let intercept = witness_intercept(&fx, marginal.mu, b0, &beta, scale);
-        let mut m_a = 0.0;
-        for (node, weight) in fx.grid.pairs() {
-            m_a += weight * witness_normal_pdf(witness_eta(&fx, intercept, b0, &beta, node, scale));
-        }
-        let row_ctx = BernoulliMarginalSlopeRowExactContext {
-            intercept,
-            m_a,
-            intercept_fast_path: false,
-            degree9_cells: None,
-        };
-
-        let iters = 100_000usize;
-
-        // --- Hand path (value + gradient + Hessian). ---
-        let mut scratch =
-            crate::bms::hessian_paths::BernoulliMarginalSlopeFlexRowScratch::new(r);
-        let mut acc = 0.0_f64;
-        for _ in 0..1000 {
-            acc += fx
-                .family
-                .compute_row_analytic_flex_from_parts_into(
-                    0, &fx.primary, q0, b0, None, Some(&beta), &row_ctx, None, None, true,
-                    &mut scratch,
-                )
-                .expect("hand path");
-        }
-        let t0 = Instant::now();
-        for _ in 0..iters {
-            acc += fx
-                .family
-                .compute_row_analytic_flex_from_parts_into(
-                    0, &fx.primary, q0, b0, None, Some(&beta), &row_ctx, None, None, true,
-                    &mut scratch,
-                )
-                .expect("hand path");
-        }
-        let hand_ns = t0.elapsed().as_nanos() as f64 / iters as f64;
-
-        // --- Naive Jet2 single-source path (value + gradient + Hessian). ---
-        let mut acc2 = 0.0_f64;
-        for _ in 0..1000 {
-            acc2 += empirical_flex_row_nll_jet2(&fx, &p0).v;
-        }
-        let t1 = Instant::now();
-        for _ in 0..iters {
-            acc2 += empirical_flex_row_nll_jet2(&fx, &p0).v;
-        }
-        let jet_ns = t1.elapsed().as_nanos() as f64 / iters as f64;
-
-        eprintln!(
-            "#932 flex timing  r={r}  iters={iters}\n  hand_path  = {hand_ns:.1} ns/row\n  jet2_naive = {jet_ns:.1} ns/row\n  ratio jet2/hand = {:.2}x  (acc={acc:.3}, acc2={acc2:.3})",
-            jet_ns / hand_ns
-        );
-    }
+    // NOTE: the #932 hand-vs-jet2 timing baseline (`flex_handpath_vs_jet2_timing_932`)
+    // was removed — `#[ignore]`d timing benches are banned by `build.rs`. The
+    // *correctness* of `empirical_flex_row_nll_jet2` against the production hand
+    // path `compute_row_analytic_flex_from_parts_into` is already pinned by the
+    // non-ignored `empirical_flex_row_nll_jet2_matches_hand_path_932` above.
+    // Throughput quantification belongs in `bench/`, not in a `#[test]`.
 }

--- a/crates/gam-models/src/bms/gradient_paths.rs
+++ b/crates/gam-models/src/bms/gradient_paths.rs
@@ -2601,86 +2601,11 @@ mod jet_tower_oracle_tests {
         }
     }
 
-    /// Perf certificate (#932): the shipped jet value/grad/Hessian kernel vs the
-    /// original HAND path. `#[ignore]` (timing is environment-dependent, not a
-    /// CI gate) — run with
-    /// `cargo test -p gam-models --release bench_rigid_vgh_jet_vs_hand -- --ignored --nocapture`.
-    #[test]
-    #[ignore = "timing benchmark; run manually with --ignored --nocapture"]
-    fn bench_rigid_vgh_jet_vs_hand() {
-        use std::hint::black_box;
-        use std::time::Instant;
-        let eta = [0.3_f64, -0.7, 0.05, 0.9, -1.2, 2.1, -2.4];
-        let g = [0.2_f64, -0.5, 0.35, -0.15, 0.6, 0.45, -0.55];
-        let z = [0.4_f64, -1.1, 0.0, 0.7, -0.3, 1.6, -1.4];
-        let y = [1.0_f64, 0.0, 0.0, 1.0, 1.0, 0.0, 1.0];
-        let w = [1.0_f64, 0.8, 1.3, 0.9, 1.1, 0.7, 1.4];
-        let probit_scale = 1.0_f64;
-        let n = eta.len();
-        // Precompute the marginal link maps once (both paths receive them in
-        // production), so the loop measures only the kernel itself.
-        let maps: Vec<BernoulliMarginalLinkMap> = (0..n)
-            .map(|r| {
-                bernoulli_marginal_link_map(
-                    &InverseLink::Standard(gam_problem::StandardLink::Probit),
-                    eta[r],
-                )
-                .expect("link map")
-            })
-            .collect();
-
-        let reps: usize = 3_000_000;
-        // Warm both paths.
-        let mut acc = 0.0_f64;
-        for r in 0..n {
-            let (v, gr, h) = hand_rigid_vgh(maps[r], g[r], z[r], y[r], w[r], probit_scale);
-            acc += v + gr[0] + h[0][0];
-            let (v, gr, h) =
-                rigid_standard_normal_row_kernel(maps[r], g[r], z[r], y[r], w[r], probit_scale)
-                    .unwrap();
-            acc += v + gr[0] + h[0][0];
-        }
-        black_box(acc);
-
-        let mut best_hand = f64::INFINITY;
-        let mut best_jet = f64::INFINITY;
-        for _trial in 0..5 {
-            let t0 = Instant::now();
-            let mut a = 0.0_f64;
-            for _ in 0..reps {
-                for r in 0..n {
-                    let (v, gr, h) =
-                        hand_rigid_vgh(maps[r], g[r], z[r], y[r], w[r], probit_scale);
-                    a += v + gr[0] + gr[1] + h[0][0] + h[0][1] + h[1][1];
-                }
-            }
-            black_box(a);
-            best_hand = best_hand.min(t0.elapsed().as_secs_f64());
-
-            let t1 = Instant::now();
-            let mut b = 0.0_f64;
-            for _ in 0..reps {
-                for r in 0..n {
-                    let (v, gr, h) = rigid_standard_normal_row_kernel(
-                        maps[r], g[r], z[r], y[r], w[r], probit_scale,
-                    )
-                    .unwrap();
-                    b += v + gr[0] + gr[1] + h[0][0] + h[0][1] + h[1][1];
-                }
-            }
-            black_box(b);
-            best_jet = best_jet.min(t1.elapsed().as_secs_f64());
-        }
-        let rows = (reps * n) as f64;
-        let hand_ns = best_hand / rows * 1e9;
-        let jet_ns = best_jet / rows * 1e9;
-        eprintln!(
-            "RIGID v/g/H K=2: hand={hand_ns:.2} ns/row  jet={jet_ns:.2} ns/row  \
-             jet/hand={:.3}x ({} rows)",
-            jet_ns / hand_ns,
-            rows as u64
-        );
-    }
+    // NOTE: the hand-vs-jet timing microbench (`bench_rigid_vgh_jet_vs_hand`)
+    // was removed — `#[ignore]`d timing benches are banned by `build.rs`, and
+    // the kernel's *correctness* against the hand chain is already pinned by the
+    // non-ignored `rigid_bernoulli_row_kernel_matches_hand_chain_witness` above.
+    // Timing belongs in `bench/`, not in a `#[test]`.
 }
 
 #[cfg(test)]

--- a/crates/gam-models/src/multinomial_reml.rs
+++ b/crates/gam-models/src/multinomial_reml.rs
@@ -918,288 +918,6 @@ impl MultinomialFamily {
         Ok(out)
     }
 
-    /// Assemble `D_beta H[d_j]` for an arbitrary batch of coefficient
-    /// directions in one shared softmax/probability pass.
-    ///
-    /// This is the outer-LAML mode-response counterpart to
-    /// [`Self::assemble_all_axis_directional_derivatives`]: the directions are
-    /// not canonical axes, but the row probabilities and design outer products
-    /// are identical for every `d_j` at a frozen beta. Sharing that row sweep is
-    /// the #1082 penguin lever; the old path rebuilt the softmax jet and dense
-    /// Gram once per outer coordinate.
-    ///
-    /// #932 cutover: this dense block assembly is no longer on the production
-    /// outer-Hessian path (the matrix-free `MultinomialDirectionalHyperOperator`
-    /// replaced it). It is retained, `cfg(test)`-only, as the reference the
-    /// ≤1e-10 parity oracle contracts the matrix-free operator against.
-    #[cfg(test)]
-    fn assemble_directional_derivatives_from_probs(
-        &self,
-        probs_full: ArrayView2<'_, f64>,
-        directions: &[Array1<f64>],
-    ) -> Result<Vec<Array2<f64>>, String> {
-        use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
-
-        let n_dirs = directions.len();
-        if n_dirs == 0 {
-            return Ok(Vec::new());
-        }
-        let n = self.weights.len();
-        let p = self.design.ncols();
-        let m = self.active_classes();
-        let dim = m * p;
-        for (idx, direction) in directions.iter().enumerate() {
-            if direction.len() != dim {
-                return Err(format!(
-                    "MultinomialFamily batched direction {idx} length {} != (K-1)·P = {dim}",
-                    direction.len()
-                ));
-            }
-        }
-        let design = self.design.view();
-        // #1082: parallelise over the DIRECTION batch instead of rows, dropping
-        // the `n_dirs·dim·dim` per-worker accumulator + `reduce` (see the note on
-        // `assemble_all_axis_directional_derivatives`). Each direction owns one
-        // `dim·dim` block and scans all rows independently; the per-row
-        // arithmetic is unchanged (only the row-summation order differs, admitted
-        // to 1e-10 by the batched-vs-per-direction parity test).
-        let out: Vec<Array2<f64>> = directions
-            .par_iter()
-            .map(|direction| {
-                let mut mat = vec![0.0_f64; dim * dim];
-                let mut d_eta = vec![0.0_f64; m];
-                let mut dp = vec![0.0_f64; m];
-                for row in 0..n {
-                    let w = self.weights[row];
-                    if w == 0.0 {
-                        continue;
-                    }
-                    let mut s = 0.0_f64;
-                    for a in 0..m {
-                        let base = a * p;
-                        let mut eta_dir = 0.0_f64;
-                        for i in 0..p {
-                            eta_dir += design[[row, i]] * direction[base + i];
-                        }
-                        d_eta[a] = eta_dir;
-                        s += probs_full[[row, a]] * eta_dir;
-                    }
-                    for a in 0..m {
-                        dp[a] = probs_full[[row, a]] * (d_eta[a] - s);
-                    }
-
-                    for a in 0..m {
-                        let pa = probs_full[[row, a]];
-                        let row_a = a * p;
-                        let jaa = w * (dp[a] - 2.0 * dp[a] * pa);
-                        if jaa != 0.0 {
-                            for i in 0..p {
-                                let xi = design[[row, i]];
-                                if xi == 0.0 {
-                                    continue;
-                                }
-                                let scaled = jaa * xi;
-                                let out_row = (row_a + i) * dim;
-                                for j in 0..p {
-                                    mat[out_row + row_a + j] += scaled * design[[row, j]];
-                                }
-                            }
-                        }
-                        for b in (a + 1)..m {
-                            let pb = probs_full[[row, b]];
-                            let jab = w * (-(dp[a] * pb + pa * dp[b]));
-                            if jab == 0.0 {
-                                continue;
-                            }
-                            let row_b = b * p;
-                            for i in 0..p {
-                                let xi = design[[row, i]];
-                                if xi == 0.0 {
-                                    continue;
-                                }
-                                let scaled = jab * xi;
-                                let out_a = (row_a + i) * dim;
-                                let out_b = (row_b + i) * dim;
-                                for j in 0..p {
-                                    let xj = design[[row, j]];
-                                    let value = scaled * xj;
-                                    mat[out_a + row_b + j] += value;
-                                    mat[out_b + row_a + j] += value;
-                                }
-                            }
-                        }
-                    }
-                }
-                let mut mat = Array2::<f64>::from_shape_vec((dim, dim), mat)
-                    .expect("batched direction derivative buffer is dim·dim");
-                for i in 0..dim {
-                    for j in (i + 1)..dim {
-                        let avg = 0.5 * (mat[[i, j]] + mat[[j, i]]);
-                        mat[[i, j]] = avg;
-                        mat[[j, i]] = avg;
-                    }
-                }
-                mat
-            })
-            .collect();
-        Ok(out)
-    }
-
-    /// Assemble `D²_beta H[u_j, v_j]` for an arbitrary batch of coefficient
-    /// direction pairs in one shared probability/design row sweep.
-    ///
-    /// The exact outer Hessian asks for one correction per ρ-pair, where both
-    /// directions are mode responses rather than canonical axes. The old
-    /// workspace default delegated each pair to
-    /// [`Self::second_directional_fisher_jet`] plus `dense_block_xtwx`, rebuilding
-    /// the same softmax probabilities and design Gram scatter for every pair.
-    /// This fused path keeps the singular formula but amortizes the row walk
-    /// across the whole `K(K+1)/2` pair batch (#1082).
-    ///
-    /// #932 cutover: `cfg(test)`-only, retained as the parity oracle's dense
-    /// reference (see `assemble_directional_derivatives_from_probs`).
-    #[cfg(test)]
-    fn assemble_second_directional_derivatives_from_probs(
-        &self,
-        probs_full: ArrayView2<'_, f64>,
-        pairs: &[(Array1<f64>, Array1<f64>)],
-    ) -> Result<Vec<Array2<f64>>, String> {
-        use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
-
-        let n_pairs = pairs.len();
-        if n_pairs == 0 {
-            return Ok(Vec::new());
-        }
-        let n = self.weights.len();
-        let p = self.design.ncols();
-        let m = self.active_classes();
-        let dim = m * p;
-        for (idx, (u, v)) in pairs.iter().enumerate() {
-            if u.len() != dim || v.len() != dim {
-                return Err(format!(
-                    "MultinomialFamily batched second-directional pair {idx} lengths {} and {} != (K-1)·P = {dim}",
-                    u.len(),
-                    v.len()
-                ));
-            }
-        }
-
-        let design = self.design.view();
-        // #1082: parallelise over the PAIR batch instead of rows, dropping the
-        // `n_pairs·dim·dim` per-worker accumulator + `reduce` (this is the exact
-        // outer Hessian's `K(K+1)/2` pair walk; see the note on
-        // `assemble_all_axis_directional_derivatives`). Each pair owns one
-        // `dim·dim` block and scans all rows independently; the per-row
-        // arithmetic is unchanged (only the row-summation order differs, admitted
-        // to 1e-10 by the workspace-batched-vs-per-pair parity test).
-        let out: Vec<Array2<f64>> = pairs
-            .par_iter()
-            .map(|(u, v)| {
-                let mut mat = vec![0.0_f64; dim * dim];
-                let mut d_eta_u = vec![0.0_f64; m];
-                let mut d_eta_v = vec![0.0_f64; m];
-                let mut dp_u = vec![0.0_f64; m];
-                let mut dp_v = vec![0.0_f64; m];
-                let mut ddp = vec![0.0_f64; m];
-                for row in 0..n {
-                    let w = self.weights[row];
-                    if w == 0.0 {
-                        continue;
-                    }
-                    let mut s_u = 0.0_f64;
-                    let mut s_v = 0.0_f64;
-                    for a in 0..m {
-                        let base = a * p;
-                        let mut eta_u = 0.0_f64;
-                        let mut eta_v = 0.0_f64;
-                        for i in 0..p {
-                            let x = design[[row, i]];
-                            eta_u += x * u[base + i];
-                            eta_v += x * v[base + i];
-                        }
-                        d_eta_u[a] = eta_u;
-                        d_eta_v[a] = eta_v;
-                        s_u += probs_full[[row, a]] * eta_u;
-                        s_v += probs_full[[row, a]] * eta_v;
-                    }
-
-                    for a in 0..m {
-                        let pa = probs_full[[row, a]];
-                        dp_u[a] = pa * (d_eta_u[a] - s_u);
-                        dp_v[a] = pa * (d_eta_v[a] - s_v);
-                    }
-
-                    let mut ds_u_dv = 0.0_f64;
-                    for a in 0..m {
-                        ds_u_dv += dp_v[a] * d_eta_u[a];
-                    }
-                    for a in 0..m {
-                        let pa = probs_full[[row, a]];
-                        ddp[a] = dp_v[a] * (d_eta_u[a] - s_u) - pa * ds_u_dv;
-                    }
-
-                    for a in 0..m {
-                        let pa = probs_full[[row, a]];
-                        let row_a = a * p;
-                        let jaa = w * (ddp[a] - 2.0 * ddp[a] * pa - 2.0 * dp_u[a] * dp_v[a]);
-                        if jaa != 0.0 {
-                            for i in 0..p {
-                                let xi = design[[row, i]];
-                                if xi == 0.0 {
-                                    continue;
-                                }
-                                let scaled = jaa * xi;
-                                let out_row = (row_a + i) * dim;
-                                for j in 0..p {
-                                    mat[out_row + row_a + j] += scaled * design[[row, j]];
-                                }
-                            }
-                        }
-
-                        for b in (a + 1)..m {
-                            let pb = probs_full[[row, b]];
-                            let jab = -w
-                                * (ddp[a] * pb
-                                    + dp_u[a] * dp_v[b]
-                                    + dp_v[a] * dp_u[b]
-                                    + pa * ddp[b]);
-                            if jab == 0.0 {
-                                continue;
-                            }
-                            let row_b = b * p;
-                            for i in 0..p {
-                                let xi = design[[row, i]];
-                                if xi == 0.0 {
-                                    continue;
-                                }
-                                let scaled = jab * xi;
-                                let out_a = (row_a + i) * dim;
-                                let out_b = (row_b + i) * dim;
-                                for j in 0..p {
-                                    let xj = design[[row, j]];
-                                    let value = scaled * xj;
-                                    mat[out_a + row_b + j] += value;
-                                    mat[out_b + row_a + j] += value;
-                                }
-                            }
-                        }
-                    }
-                }
-                let mut mat = Array2::<f64>::from_shape_vec((dim, dim), mat)
-                    .expect("batched second-directional buffer is dim·dim");
-                for i in 0..dim {
-                    for j in (i + 1)..dim {
-                        let avg = 0.5 * (mat[[i, j]] + mat[[j, i]]);
-                        mat[[i, j]] = avg;
-                        mat[[j, i]] = avg;
-                    }
-                }
-                mat
-            })
-            .collect();
-        Ok(out)
-    }
-
     /// Per-row `M×M` first-directional Fisher jet `Ĵ[row]` from frozen row
     /// probabilities (issue #932 matrix-free port).
     ///
@@ -2388,6 +2106,286 @@ mod tests {
         ) -> Result<Vec<Array2<f64>>, String> {
             let probs = self.row_probabilities(eta);
             self.assemble_directional_derivatives_from_probs(probs.view(), directions)
+        }
+
+        /// Assemble `D_beta H[d_j]` for an arbitrary batch of coefficient
+        /// directions in one shared softmax/probability pass.
+        ///
+        /// This is the outer-LAML mode-response counterpart to
+        /// [`Self::assemble_all_axis_directional_derivatives`]: the directions are
+        /// not canonical axes, but the row probabilities and design outer products
+        /// are identical for every `d_j` at a frozen beta. Sharing that row sweep is
+        /// the #1082 penguin lever; the old path rebuilt the softmax jet and dense
+        /// Gram once per outer coordinate.
+        ///
+        /// #932 cutover: this dense block assembly is no longer on the production
+        /// outer-Hessian path (the matrix-free `MultinomialDirectionalHyperOperator`
+        /// replaced it). It lives here in the test module as the reference the
+        /// ≤1e-10 parity oracle contracts the matrix-free operator against.
+        fn assemble_directional_derivatives_from_probs(
+            &self,
+            probs_full: ArrayView2<'_, f64>,
+            directions: &[Array1<f64>],
+        ) -> Result<Vec<Array2<f64>>, String> {
+            use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
+
+            let n_dirs = directions.len();
+            if n_dirs == 0 {
+                return Ok(Vec::new());
+            }
+            let n = self.weights.len();
+            let p = self.design.ncols();
+            let m = self.active_classes();
+            let dim = m * p;
+            for (idx, direction) in directions.iter().enumerate() {
+                if direction.len() != dim {
+                    return Err(format!(
+                        "MultinomialFamily batched direction {idx} length {} != (K-1)·P = {dim}",
+                        direction.len()
+                    ));
+                }
+            }
+            let design = self.design.view();
+            // #1082: parallelise over the DIRECTION batch instead of rows, dropping
+            // the `n_dirs·dim·dim` per-worker accumulator + `reduce` (see the note on
+            // `assemble_all_axis_directional_derivatives`). Each direction owns one
+            // `dim·dim` block and scans all rows independently; the per-row
+            // arithmetic is unchanged (only the row-summation order differs, admitted
+            // to 1e-10 by the batched-vs-per-direction parity test).
+            let out: Vec<Array2<f64>> = directions
+                .par_iter()
+                .map(|direction| {
+                    let mut mat = vec![0.0_f64; dim * dim];
+                    let mut d_eta = vec![0.0_f64; m];
+                    let mut dp = vec![0.0_f64; m];
+                    for row in 0..n {
+                        let w = self.weights[row];
+                        if w == 0.0 {
+                            continue;
+                        }
+                        let mut s = 0.0_f64;
+                        for a in 0..m {
+                            let base = a * p;
+                            let mut eta_dir = 0.0_f64;
+                            for i in 0..p {
+                                eta_dir += design[[row, i]] * direction[base + i];
+                            }
+                            d_eta[a] = eta_dir;
+                            s += probs_full[[row, a]] * eta_dir;
+                        }
+                        for a in 0..m {
+                            dp[a] = probs_full[[row, a]] * (d_eta[a] - s);
+                        }
+
+                        for a in 0..m {
+                            let pa = probs_full[[row, a]];
+                            let row_a = a * p;
+                            let jaa = w * (dp[a] - 2.0 * dp[a] * pa);
+                            if jaa != 0.0 {
+                                for i in 0..p {
+                                    let xi = design[[row, i]];
+                                    if xi == 0.0 {
+                                        continue;
+                                    }
+                                    let scaled = jaa * xi;
+                                    let out_row = (row_a + i) * dim;
+                                    for j in 0..p {
+                                        mat[out_row + row_a + j] += scaled * design[[row, j]];
+                                    }
+                                }
+                            }
+                            for b in (a + 1)..m {
+                                let pb = probs_full[[row, b]];
+                                let jab = w * (-(dp[a] * pb + pa * dp[b]));
+                                if jab == 0.0 {
+                                    continue;
+                                }
+                                let row_b = b * p;
+                                for i in 0..p {
+                                    let xi = design[[row, i]];
+                                    if xi == 0.0 {
+                                        continue;
+                                    }
+                                    let scaled = jab * xi;
+                                    let out_a = (row_a + i) * dim;
+                                    let out_b = (row_b + i) * dim;
+                                    for j in 0..p {
+                                        let xj = design[[row, j]];
+                                        let value = scaled * xj;
+                                        mat[out_a + row_b + j] += value;
+                                        mat[out_b + row_a + j] += value;
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    let mut mat = Array2::<f64>::from_shape_vec((dim, dim), mat)
+                        .expect("batched direction derivative buffer is dim·dim");
+                    for i in 0..dim {
+                        for j in (i + 1)..dim {
+                            let avg = 0.5 * (mat[[i, j]] + mat[[j, i]]);
+                            mat[[i, j]] = avg;
+                            mat[[j, i]] = avg;
+                        }
+                    }
+                    mat
+                })
+                .collect();
+            Ok(out)
+        }
+
+        /// Assemble `D²_beta H[u_j, v_j]` for an arbitrary batch of coefficient
+        /// direction pairs in one shared probability/design row sweep.
+        ///
+        /// The exact outer Hessian asks for one correction per ρ-pair, where both
+        /// directions are mode responses rather than canonical axes. The old
+        /// workspace default delegated each pair to
+        /// [`Self::second_directional_fisher_jet`] plus `dense_block_xtwx`, rebuilding
+        /// the same softmax probabilities and design Gram scatter for every pair.
+        /// This fused path keeps the singular formula but amortizes the row walk
+        /// across the whole `K(K+1)/2` pair batch (#1082).
+        ///
+        /// #932 cutover: test-module reference, the parity oracle's dense
+        /// reference (see `assemble_directional_derivatives_from_probs`).
+        fn assemble_second_directional_derivatives_from_probs(
+            &self,
+            probs_full: ArrayView2<'_, f64>,
+            pairs: &[(Array1<f64>, Array1<f64>)],
+        ) -> Result<Vec<Array2<f64>>, String> {
+            use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
+
+            let n_pairs = pairs.len();
+            if n_pairs == 0 {
+                return Ok(Vec::new());
+            }
+            let n = self.weights.len();
+            let p = self.design.ncols();
+            let m = self.active_classes();
+            let dim = m * p;
+            for (idx, (u, v)) in pairs.iter().enumerate() {
+                if u.len() != dim || v.len() != dim {
+                    return Err(format!(
+                        "MultinomialFamily batched second-directional pair {idx} lengths {} and {} != (K-1)·P = {dim}",
+                        u.len(),
+                        v.len()
+                    ));
+                }
+            }
+
+            let design = self.design.view();
+            // #1082: parallelise over the PAIR batch instead of rows, dropping the
+            // `n_pairs·dim·dim` per-worker accumulator + `reduce` (this is the exact
+            // outer Hessian's `K(K+1)/2` pair walk; see the note on
+            // `assemble_all_axis_directional_derivatives`). Each pair owns one
+            // `dim·dim` block and scans all rows independently; the per-row
+            // arithmetic is unchanged (only the row-summation order differs, admitted
+            // to 1e-10 by the workspace-batched-vs-per-pair parity test).
+            let out: Vec<Array2<f64>> = pairs
+                .par_iter()
+                .map(|(u, v)| {
+                    let mut mat = vec![0.0_f64; dim * dim];
+                    let mut d_eta_u = vec![0.0_f64; m];
+                    let mut d_eta_v = vec![0.0_f64; m];
+                    let mut dp_u = vec![0.0_f64; m];
+                    let mut dp_v = vec![0.0_f64; m];
+                    let mut ddp = vec![0.0_f64; m];
+                    for row in 0..n {
+                        let w = self.weights[row];
+                        if w == 0.0 {
+                            continue;
+                        }
+                        let mut s_u = 0.0_f64;
+                        let mut s_v = 0.0_f64;
+                        for a in 0..m {
+                            let base = a * p;
+                            let mut eta_u = 0.0_f64;
+                            let mut eta_v = 0.0_f64;
+                            for i in 0..p {
+                                let x = design[[row, i]];
+                                eta_u += x * u[base + i];
+                                eta_v += x * v[base + i];
+                            }
+                            d_eta_u[a] = eta_u;
+                            d_eta_v[a] = eta_v;
+                            s_u += probs_full[[row, a]] * eta_u;
+                            s_v += probs_full[[row, a]] * eta_v;
+                        }
+
+                        for a in 0..m {
+                            let pa = probs_full[[row, a]];
+                            dp_u[a] = pa * (d_eta_u[a] - s_u);
+                            dp_v[a] = pa * (d_eta_v[a] - s_v);
+                        }
+
+                        let mut ds_u_dv = 0.0_f64;
+                        for a in 0..m {
+                            ds_u_dv += dp_v[a] * d_eta_u[a];
+                        }
+                        for a in 0..m {
+                            let pa = probs_full[[row, a]];
+                            ddp[a] = dp_v[a] * (d_eta_u[a] - s_u) - pa * ds_u_dv;
+                        }
+
+                        for a in 0..m {
+                            let pa = probs_full[[row, a]];
+                            let row_a = a * p;
+                            let jaa = w * (ddp[a] - 2.0 * ddp[a] * pa - 2.0 * dp_u[a] * dp_v[a]);
+                            if jaa != 0.0 {
+                                for i in 0..p {
+                                    let xi = design[[row, i]];
+                                    if xi == 0.0 {
+                                        continue;
+                                    }
+                                    let scaled = jaa * xi;
+                                    let out_row = (row_a + i) * dim;
+                                    for j in 0..p {
+                                        mat[out_row + row_a + j] += scaled * design[[row, j]];
+                                    }
+                                }
+                            }
+
+                            for b in (a + 1)..m {
+                                let pb = probs_full[[row, b]];
+                                let jab = -w
+                                    * (ddp[a] * pb
+                                        + dp_u[a] * dp_v[b]
+                                        + dp_v[a] * dp_u[b]
+                                        + pa * ddp[b]);
+                                if jab == 0.0 {
+                                    continue;
+                                }
+                                let row_b = b * p;
+                                for i in 0..p {
+                                    let xi = design[[row, i]];
+                                    if xi == 0.0 {
+                                        continue;
+                                    }
+                                    let scaled = jab * xi;
+                                    let out_a = (row_a + i) * dim;
+                                    let out_b = (row_b + i) * dim;
+                                    for j in 0..p {
+                                        let xj = design[[row, j]];
+                                        let value = scaled * xj;
+                                        mat[out_a + row_b + j] += value;
+                                        mat[out_b + row_a + j] += value;
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    let mut mat = Array2::<f64>::from_shape_vec((dim, dim), mat)
+                        .expect("batched second-directional buffer is dim·dim");
+                    for i in 0..dim {
+                        for j in (i + 1)..dim {
+                            let avg = 0.5 * (mat[[i, j]] + mat[[j, i]]);
+                            mat[[i, j]] = avg;
+                            mat[[j, i]] = avg;
+                        }
+                    }
+                    mat
+                })
+                .collect();
+            Ok(out)
         }
     }
 

--- a/crates/gam-models/src/survival/marginal_slope/timepoint_exact/flex_jet.rs
+++ b/crates/gam-models/src/survival/marginal_slope/timepoint_exact/flex_jet.rs
@@ -4765,18 +4765,15 @@ mod fused_jet2_oracle_tests {
 }
 
 #[cfg(test)]
-mod hand_vs_jet_bench_tests {
-    //! #932 SPEED AUDIT: shipped jet value/grad/Hessian (`fused_row_nll_jet2` +
-    //! the `fused_inputs_from_view` input copies the production
-    //! `flex_row_nll_value_grad_hess` pays) vs the ORIGINAL HAND probit-chain +
-    //! quotient-rule assembly it replaced (recovered verbatim from the pre-cutover
-    //! commit `b17785d2a~1`, `flex_sensitivity.rs`). Measures ns/row at
-    //! p∈{6,12,24}, asserts ≤1e-12 channel agreement, and quantifies the
-    //! transcendental fraction (the 2×logΦ + 2×neglog-deriv calls both paths share).
+mod hand_vs_jet_agreement_tests {
+    //! #932 AGREEMENT GATE: the shipped jet value/grad/Hessian (`fused_row_nll_jet2`
+    //! + the `fused_inputs_from_view` input copies the production
+    //! `flex_row_nll_value_grad_hess` pays) reproduces, to ≤1e-12 on every channel,
+    //! the ORIGINAL HAND probit-chain + quotient-rule assembly it replaced
+    //! (recovered verbatim from the pre-cutover commit `b17785d2a~1`,
+    //! `flex_sensitivity.rs`) across p∈{6,12,24}.
     use super::*;
     use ndarray::{Array1, Array2};
-    use std::hint::black_box;
-    use std::time::Instant;
 
     fn xorshift(state: &mut u64) -> f64 {
         let mut x = *state;
@@ -4788,24 +4785,23 @@ mod hand_vs_jet_bench_tests {
         2.0 * u - 1.0
     }
 
-    /// The ORIGINAL HAND value/grad/Hessian assembly (verbatim from
-    /// `b17785d2a~1` `flex_sensitivity.rs`): sparse single-pass grad loop +
-    /// upper-triangle Hessian loop reading the timepoint `*_u`/`*_uv` ndarrays
-    /// directly (NO contiguous copy). Pays its own 2×logΦ + 2×neglog-deriv calls.
-    #[allow(clippy::too_many_arguments)]
-    fn hand_vgh(
+    /// One flex row's timepoint derivative inputs (the `*_u`/`*_uv` first/second
+    /// partials of each link channel, plus the q/qd seed indices). Bundled into a
+    /// struct so the hand/jet witnesses take a single argument instead of 19
+    /// positional ones.
+    struct RowInputs {
         eta0: f64,
-        eta0_u: &Array1<f64>,
-        eta0_uv: &Array2<f64>,
+        eta0_u: Array1<f64>,
+        eta0_uv: Array2<f64>,
         eta1: f64,
-        eta1_u: &Array1<f64>,
-        eta1_uv: &Array2<f64>,
+        eta1_u: Array1<f64>,
+        eta1_uv: Array2<f64>,
         chi1: f64,
-        chi1_u: &Array1<f64>,
-        chi1_uv: &Array2<f64>,
+        chi1_u: Array1<f64>,
+        chi1_uv: Array2<f64>,
         d1: f64,
-        d1_u: &Array1<f64>,
-        d1_uv: &Array2<f64>,
+        d1_u: Array1<f64>,
+        d1_uv: Array2<f64>,
         q1: f64,
         qd1: f64,
         wi: f64,
@@ -4813,7 +4809,20 @@ mod hand_vs_jet_bench_tests {
         q1_idx: usize,
         qd1_idx: usize,
         p: usize,
-    ) -> (f64, Array1<f64>, Array2<f64>) {
+    }
+
+    /// The ORIGINAL HAND value/grad/Hessian assembly (verbatim from
+    /// `b17785d2a~1` `flex_sensitivity.rs`): sparse single-pass grad loop +
+    /// upper-triangle Hessian loop reading the timepoint `*_u`/`*_uv` ndarrays
+    /// directly (NO contiguous copy). Pays its own 2×logΦ + 2×neglog-deriv calls.
+    fn hand_vgh(r: &RowInputs) -> (f64, Array1<f64>, Array2<f64>) {
+        let (eta0, eta1, chi1, d1, q1, qd1, wi, di, q1_idx, qd1_idx, p) = (
+            r.eta0, r.eta1, r.chi1, r.d1, r.q1, r.qd1, r.wi, r.di, r.q1_idx, r.qd1_idx, r.p,
+        );
+        let (eta0_u, eta0_uv) = (&r.eta0_u, &r.eta0_uv);
+        let (eta1_u, eta1_uv) = (&r.eta1_u, &r.eta1_uv);
+        let (chi1_u, chi1_uv) = (&r.chi1_u, &r.chi1_uv);
+        let (d1_u, d1_uv) = (&r.d1_u, &r.d1_uv);
         let (log_surv0, _) = signed_probit_logcdf_and_mills_ratio(-eta0);
         let (log_surv1, _) = signed_probit_logcdf_and_mills_ratio(-eta1);
         let (entry_k1, entry_k2, _, _) =
@@ -4876,28 +4885,14 @@ mod hand_vs_jet_bench_tests {
     /// The SHIPPED JET path: surv stacks + the `fused_inputs_from_view` contiguous
     /// copies + `fused_row_nll_jet2` (the exact body of the `want_hess` branch of
     /// `flex_row_nll_value_grad_hess`).
-    #[allow(clippy::too_many_arguments)]
-    fn jet_vgh(
-        eta0: f64,
-        eta0_u: &Array1<f64>,
-        eta0_uv: &Array2<f64>,
-        eta1: f64,
-        eta1_u: &Array1<f64>,
-        eta1_uv: &Array2<f64>,
-        chi1: f64,
-        chi1_u: &Array1<f64>,
-        chi1_uv: &Array2<f64>,
-        d1: f64,
-        d1_u: &Array1<f64>,
-        d1_uv: &Array2<f64>,
-        q1: f64,
-        qd1: f64,
-        wi: f64,
-        di: f64,
-        q1_idx: usize,
-        qd1_idx: usize,
-        p: usize,
-    ) -> (f64, Array1<f64>, Array2<f64>) {
+    fn jet_vgh(r: &RowInputs) -> (f64, Array1<f64>, Array2<f64>) {
+        let (eta0, eta1, chi1, d1, q1, qd1, wi, di, q1_idx, qd1_idx, p) = (
+            r.eta0, r.eta1, r.chi1, r.d1, r.q1, r.qd1, r.wi, r.di, r.q1_idx, r.qd1_idx, r.p,
+        );
+        let (eta0_u, eta0_uv) = (&r.eta0_u, &r.eta0_uv);
+        let (eta1_u, eta1_uv) = (&r.eta1_u, &r.eta1_uv);
+        let (chi1_u, chi1_uv) = (&r.chi1_u, &r.chi1_uv);
+        let (d1_u, d1_uv) = (&r.d1_u, &r.d1_uv);
         let surv0 = surv_stack(eta0).unwrap();
         let surv1 = surv_stack(eta1).unwrap();
         let (e0g, e0h) = fused_inputs_from_view(eta0_u.view(), eta0_uv.view(), p);
@@ -4932,28 +4927,7 @@ mod hand_vs_jet_bench_tests {
         (value, grad, hess)
     }
 
-    type Row = (
-        f64,
-        Array1<f64>,
-        Array2<f64>,
-        f64,
-        Array1<f64>,
-        Array2<f64>,
-        f64,
-        Array1<f64>,
-        Array2<f64>,
-        f64,
-        Array1<f64>,
-        Array2<f64>,
-        f64,
-        f64,
-        f64,
-        f64,
-        usize,
-        usize,
-    );
-
-    fn make_row(p: usize, st: &mut u64) -> Row {
+    fn make_row(p: usize, st: &mut u64) -> RowInputs {
         // Moderate η so logΦ / Mills are well-conditioned; χ,D strictly positive.
         let eta0 = 0.4 * xorshift(st);
         let eta1 = 0.4 * xorshift(st);
@@ -4983,28 +4957,43 @@ mod hand_vs_jet_bench_tests {
         let chh = mk_h(st);
         let dg = mk_g(st);
         let dh = mk_h(st);
-        (
-            eta0, e0g, e0h, eta1, e1g, e1h, chi1, cg, chh, d1, dg, dh, q1, qd1, wi, di, p - 2,
-            p - 1,
-        )
+        RowInputs {
+            eta0,
+            eta0_u: e0g,
+            eta0_uv: e0h,
+            eta1,
+            eta1_u: e1g,
+            eta1_uv: e1h,
+            chi1,
+            chi1_u: cg,
+            chi1_uv: chh,
+            d1,
+            d1_u: dg,
+            d1_uv: dh,
+            q1,
+            qd1,
+            wi,
+            di,
+            q1_idx: p - 2,
+            qd1_idx: p - 1,
+            p,
+        }
     }
 
+    /// #932 bit-identity gate: the single-source `Jet2` flex row v/g/H
+    /// (`jet_vgh`) reproduces the original HAND assembly (`hand_vgh`) to ≤1e-12
+    /// on value, gradient, and Hessian across p∈{6,12,24} and 256 random rows
+    /// each. (The ns/row throughput comparison this gate used to carry lives in
+    /// `bench/`, not in a `#[test]`.)
     #[test]
-    fn hand_vs_jet_vgh_bitident_and_timing() {
+    fn hand_vs_jet_vgh_bit_identical() {
         for &p in &[6usize, 12, 24] {
             let mut st = 0xA1B2_C3D4_E5F6_0718u64 ^ (p as u64).wrapping_mul(0x9E3779B97F4A7C15);
             let mut max_diff = 0.0f64;
-            let mut rows: Vec<Row> = Vec::new();
             for _ in 0..256 {
                 let r = make_row(p, &mut st);
-                let (h_v, h_g, h_h) = hand_vgh(
-                    r.0, &r.1, &r.2, r.3, &r.4, &r.5, r.6, &r.7, &r.8, r.9, &r.10, &r.11, r.12,
-                    r.13, r.14, r.15, r.16, r.17, p,
-                );
-                let (j_v, j_g, j_h) = jet_vgh(
-                    r.0, &r.1, &r.2, r.3, &r.4, &r.5, r.6, &r.7, &r.8, r.9, &r.10, &r.11, r.12,
-                    r.13, r.14, r.15, r.16, r.17, p,
-                );
+                let (h_v, h_g, h_h) = hand_vgh(&r);
+                let (j_v, j_g, j_h) = jet_vgh(&r);
                 max_diff = max_diff.max((h_v - j_v).abs());
                 for u in 0..p {
                     max_diff = max_diff.max((h_g[u] - j_g[u]).abs());
@@ -5012,74 +5001,10 @@ mod hand_vs_jet_bench_tests {
                         max_diff = max_diff.max((h_h[[u, v]] - j_h[[u, v]]).abs());
                     }
                 }
-                rows.push(r);
             }
             assert!(
                 max_diff <= 1e-12,
                 "hand vs jet channel mismatch p={p}: max_diff={max_diff:.3e}"
-            );
-
-            let iters = 200_000usize / p;
-            let n = rows.len();
-            for r in &rows {
-                let (_, g, h) = hand_vgh(
-                    r.0, &r.1, &r.2, r.3, &r.4, &r.5, r.6, &r.7, &r.8, r.9, &r.10, &r.11, r.12,
-                    r.13, r.14, r.15, r.16, r.17, p,
-                );
-                black_box((g, h));
-                let (_, g, h) = jet_vgh(
-                    r.0, &r.1, &r.2, r.3, &r.4, &r.5, r.6, &r.7, &r.8, r.9, &r.10, &r.11, r.12,
-                    r.13, r.14, r.15, r.16, r.17, p,
-                );
-                black_box((g, h));
-            }
-
-            let t0 = Instant::now();
-            for k in 0..iters {
-                let r = &rows[k % n];
-                let out = hand_vgh(
-                    black_box(r.0), &r.1, &r.2, black_box(r.3), &r.4, &r.5, black_box(r.6), &r.7,
-                    &r.8, black_box(r.9), &r.10, &r.11, black_box(r.12), black_box(r.13),
-                    black_box(r.14), black_box(r.15), r.16, r.17, p,
-                );
-                black_box(out);
-            }
-            let hand_ns = t0.elapsed().as_nanos() as f64 / iters as f64;
-
-            let t1 = Instant::now();
-            for k in 0..iters {
-                let r = &rows[k % n];
-                let out = jet_vgh(
-                    black_box(r.0), &r.1, &r.2, black_box(r.3), &r.4, &r.5, black_box(r.6), &r.7,
-                    &r.8, black_box(r.9), &r.10, &r.11, black_box(r.12), black_box(r.13),
-                    black_box(r.14), black_box(r.15), r.16, r.17, p,
-                );
-                black_box(out);
-            }
-            let jet_ns = t1.elapsed().as_nanos() as f64 / iters as f64;
-
-            let r = &rows[0];
-            let t2 = Instant::now();
-            for _ in 0..iters {
-                let (a, _) = signed_probit_logcdf_and_mills_ratio(black_box(-r.0));
-                let (b, _) = signed_probit_logcdf_and_mills_ratio(black_box(-r.3));
-                let c = signed_probit_neglog_derivatives_up_to_fourth(black_box(-r.0), -r.14)
-                    .unwrap();
-                let d = signed_probit_neglog_derivatives_up_to_fourth(
-                    black_box(-r.3),
-                    r.14 * (1.0 - r.15),
-                )
-                .unwrap();
-                black_box((a, b, c, d));
-            }
-            let trans_ns = t2.elapsed().as_nanos() as f64 / iters as f64;
-
-            eprintln!(
-                "VGH-BENCH p={p:2}: hand={hand_ns:7.1} ns/row  jet={jet_ns:7.1} ns/row  \
-                 ratio_jet/hand={:.2}x  transcendental={trans_ns:6.1} ns ({:.0}% of hand)  \
-                 max_diff={max_diff:.1e}",
-                jet_ns / hand_ns,
-                100.0 * trans_ns / hand_ns,
             );
         }
     }

--- a/crates/gam-sae/src/row_jet_program.rs
+++ b/crates/gam-sae/src/row_jet_program.rs
@@ -1469,53 +1469,28 @@ mod tests {
         }
     }
 
-    /// #932 ns/row microbench: the production packed jet recon
+    /// #932 correctness gate: the production packed jet recon
     /// ([`SaeReconstructionRowProgram::reconstruction_all_columns_packed`], gate +
-    /// basis jets HOISTED out of the column loop, softmax denom/recip SHARED)
-    /// versus the hand path ([`hand_softmax_column`], the old `row_jets_for_logdet`
-    /// closed-form softmax gate Jacobian/Hessian × decoded basis, re-derived per
-    /// output column). Both produce every output column's value/grad/Hessian. This
-    /// is a measurement, not an assertion; run with `--release --nocapture`.
+    /// basis jets HOISTED out of the column loop, softmax denom/recip SHARED) and
+    /// the per-column packed call must each reproduce the hand path
+    /// ([`hand_softmax_column`], the old `row_jets_for_logdet` closed-form softmax
+    /// gate Jacobian/Hessian × decoded basis, re-derived per output column) on
+    /// value/grad/Hessian — the #932 bit-identity bar. (The ns/row timing
+    /// comparison this gate used to precede lives in `bench/`, not in a `#[test]`:
+    /// `#[ignore]`d timing benches are banned by `build.rs`.)
     #[test]
-    #[ignore = "microbench; run with --release --nocapture"]
-    fn bench_recon_jet_vs_hand_ns_per_row() {
+    fn recon_jet_matches_hand_path_value_grad_hess() {
         let out_dim = 16;
         let n_basis = 4;
         let inv_tau = 1.3;
-        let warm = 2_000usize;
-        let iters = 50_000usize;
-
         // K=8: 4 atoms × (1 logit + 1 coord) = 8 primaries.
-        bench_one::<8>(
-            softmax_fixture_k(4, 1, n_basis, out_dim, inv_tau),
-            inv_tau,
-            warm,
-            iters,
-            "K=8 (4 atoms, latent_dim=1)",
-        );
+        check_recon_vs_hand::<8>(softmax_fixture_k(4, 1, n_basis, out_dim, inv_tau), inv_tau);
         // K=16: 8 atoms × (1 logit + 1 coord) = 16 primaries.
-        bench_one::<16>(
-            softmax_fixture_k(8, 1, n_basis, out_dim, inv_tau),
-            inv_tau,
-            warm,
-            iters / 2,
-            "K=16 (8 atoms, latent_dim=1)",
-        );
+        check_recon_vs_hand::<16>(softmax_fixture_k(8, 1, n_basis, out_dim, inv_tau), inv_tau);
     }
 
-    fn bench_one<const K: usize>(
-        prog: SaeReconstructionRowProgram,
-        inv_tau: f64,
-        warm: usize,
-        iters: usize,
-        label: &str,
-    ) {
-        use std::hint::black_box;
-        use std::time::Instant;
+    fn check_recon_vs_hand<const K: usize>(prog: SaeReconstructionRowProgram, inv_tau: f64) {
         let out_dim = prog.out_dim();
-
-        // Correctness gate before timing: the packed jet all-columns path agrees
-        // with the hand path on value/grad/Hessian (the #932 bit-identity bar).
         let cols = prog.reconstruction_all_columns_packed::<K>();
         for c in 0..out_dim {
             let hand = hand_softmax_column(&prog, c, inv_tau);
@@ -1524,57 +1499,24 @@ mod tests {
                 .iter()
                 .flatten()
                 .fold(0.0_f64, |m, x| m.max(x.abs()));
+            // The all-columns (hoisted) path matches hand value + Hessian.
             assert!((cols[c].value() - hand.value).abs() <= 1e-9 * hand.value.abs().max(1.0));
+            // The per-column path matches the all-columns path (same kernel, no hoist).
+            let percol = prog.reconstruction_column_packed::<K>(c);
+            assert!((percol.value() - cols[c].value()).abs() <= 1e-12 * cols[c].value().abs().max(1.0));
             for a in 0..K {
                 for b in 0..K {
                     assert!(
                         (cols[c].h()[a][b] - hand.second[a][b]).abs()
                             <= 1e-8 * h_floor.max(1e-12)
                     );
+                    assert!(
+                        (percol.h()[a][b] - cols[c].h()[a][b]).abs()
+                            <= 1e-12 * h_floor.max(1e-12)
+                    );
                 }
             }
         }
-
-        // Warmup.
-        for _ in 0..warm {
-            black_box(prog.reconstruction_all_columns_packed::<K>());
-            for c in 0..out_dim {
-                black_box(hand_softmax_column(&prog, c, inv_tau));
-            }
-        }
-
-        // Jet: one all-columns packed call per row.
-        let t0 = Instant::now();
-        for _ in 0..iters {
-            black_box(prog.reconstruction_all_columns_packed::<K>());
-        }
-        let jet_ns = t0.elapsed().as_nanos() as f64 / iters as f64;
-
-        // Hand: every output column re-derived (the production hand path).
-        let t1 = Instant::now();
-        for _ in 0..iters {
-            for c in 0..out_dim {
-                black_box(hand_softmax_column(&prog, c, inv_tau));
-            }
-        }
-        let hand_ns = t1.elapsed().as_nanos() as f64 / iters as f64;
-
-        // Jet per-column (no hoist) to isolate the hoist/share win.
-        let t2 = Instant::now();
-        for _ in 0..iters {
-            for c in 0..out_dim {
-                black_box(prog.reconstruction_column_packed::<K>(c));
-            }
-        }
-        let jet_percol_ns = t2.elapsed().as_nanos() as f64 / iters as f64;
-
-        eprintln!(
-            "[#932 bench {label}] out_dim={out_dim}  jet(hoisted)={jet_ns:.1} ns/row  \
-             jet(per-col)={jet_percol_ns:.1} ns/row  hand={hand_ns:.1} ns/row  \
-             jet-vs-hand={:.2}x  hoist={:.2}x",
-            hand_ns / jet_ns,
-            jet_percol_ns / jet_ns
-        );
     }
 
     /// INDEPENDENT scalar witness for the reconstruction column `ẑ_c(δ)` as a


### PR DESCRIPTION
## Why reopen #932

Issue #932 (*Taylor-jet scalar algebra: derive each family's RowKernel tower mechanically*) was closed as **completed**, but the cutover was landed half-finished: it left the workspace **unbuildable at HEAD**. `build.rs`'s ban-scanner aborts *every* `cargo`/`maturin` invocation (`exit 101`) with **8 violations across 4 rules**, all in #932-touched files:

| Rule | Site |
|------|------|
| `#[allow(clippy::too_many_arguments)]` | `flex_jet.rs:4795`, `:4879` |
| `#[ignore]` test | `gradient_paths.rs:2609`, `cell_moment_assembly.rs:4774`, `row_jet_program.rs:1480` |
| `#[test]` without assertions | `gradient_paths.rs:2608` (the same bench) |
| `#[cfg(test)]` on `src/` item | `multinomial_reml.rs:935`, `:1061` |

A cached `target/` hides this on developer boxes; a clean build, the wheel build, and CI all re-run the scanner and fail. This blocks **all** test verification on the project. (Related but distinct from #1614, which cited an already-resolved `kernel.rs` site.)

## Plan (updated continuously)
1. **Unblock the build** with *proper* fixes — never silence the lint:
   - delete pure-timing `#[ignore]` microbenches whose correctness is already covered by non-ignored sibling tests;
   - replace `#[allow(too_many_arguments)]` test helpers by bundling args into a struct;
   - move `#[cfg(test)]`-gated `multinomial_reml` methods into the test module's `impl` block.
2. Address the #932 residual: the last live production hand-derivative path.
3. Add regression coverage.

WIP — commits incoming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)