### PR TITLE
[agent] #1607: families test cluster (WIP)

### DIFF
--- a/.agent-notes/issue-1607.md
+++ b/.agent-notes/issue-1607.md
@@ -1,12 +1,33 @@
-# Issue #1607 — 10 pre-existing gam-models test failures
+# Issue #1607 — pre-existing gam-models test failures
 
-## Plan
-Prior fleet runs fixed 4 of the original 10. Remaining (per discussion):
-- Cluster 2: binomial_location_scale_batched_gradient_matches_finite_difference (rel 5.5%, envelope logdet-trace Fisher-scoring)
-- Cluster 3: binomial_location_scale_exact_newton_spatial_joint_hyper_returns_fullhessian (indefinite outer joint Hessian)
-- Cluster 3-wiggle: binomial_location_scalewiggle_..._returns_fullhessian (inner active-set on threshold block)
-- Cluster 4-binomial: binomial_location_scale_engine_matches_reference_flow (inner active-set)
-- Cluster 4-gaussian: gaussian_location_scale_engine_matches_reference_flow (σ-floor s·b vs b semantics)
-- Cluster 5: profiled_theta_hvp_outer_hessian_matches_fd_of_gradient_psi_and_mixed (2nd-order LAML β-response)
+## GROUND TRUTH on current main (2026-06-30, branch agent/issue-1607/families-test-cluster)
+`cargo test -p gam-models --lib` of the 10 originally-named tests:
 
-## Step 0: ground-truth re-measure on current main, then attack.
+GREEN now (fixed by prior fleet runs):
+- flex_primary_hessian_matches_central_fd_of_gradient (Cluster 1)
+- arbiter_flex_hessian_h00_fd_step_scaling (Cluster 1)
+- binomial_location_scale_termswith_matern_spatial_blocks_fit_finitely (Cluster 3)
+- rigid_standard_normal_tower_path_matches_hand_chain_witness (Cluster 5)
+
+STILL FAILING (5):
+1. **binomial_location_scale_batched_gradient_matches_finite_difference** (Cluster 2)
+   `batched=-4.8858e-1 fd=-4.6178e-1 rel=5.49e-2`. Root cause per discussion:
+   envelope logdet-trace Fisher-scoring inconsistency (expected-info logdet deriv).
+2. **binomial_location_scale_exact_newton_spatial_joint_hyper_returns_fullhessian** (Cluster 3-spatial)
+   "should return a full [rho,psi] hessian" — materialize_dense returns None.
+3. **binomial_location_scalewiggle_exact_newton_spatial_joint_hyper_returns_fullhessian** (Cluster 3-wiggle)
+   "coupled exact-joint inner solve exited the joint Newton path before convergence".
+4. **gaussian_location_scale_engine_matches_reference_flow** (Cluster 4-gaussian)
+   block 1 coef 0: engine -2.46979 vs reference -2.46534. σ-floor s·b vs b (response_scale standardization).
+5. **binomial_location_scale_engine_matches_reference_flow** (Cluster 4-binomial)
+   **FLAKY** — passed 1/3 runs. Tiny divergences (rel ~7e-4, ~4e-4) on no-wiggle AND wiggle blocks.
+   => nondeterminism / convergence-path difference. Binomial does NOT standardize, so this is
+   a different root cause than gaussian.
+
+Note: profiled_theta_hvp_outer_hessian_matches_fd... (Cluster 5) lives in tests/ integration, NOT gam-models lib.
+
+## Attack plan (tractable first)
+- (A) Cluster 4-binomial FLAKY: determinism bug — engine vs reference take different iteration paths. Investigate.
+- (B) Cluster 4-gaussian: principled σ-floor decision — make reference & engine consistent.
+- (C) Cluster 2: envelope logdet-trace term (risky, prior regressions).
+- (D) Cluster 3: deep architectural.

--- a/.agent-notes/issue-1607.md
+++ b/.agent-notes/issue-1607.md
@@ -1,0 +1,12 @@
+# Issue #1607 — 10 pre-existing gam-models test failures
+
+## Plan
+Prior fleet runs fixed 4 of the original 10. Remaining (per discussion):
+- Cluster 2: binomial_location_scale_batched_gradient_matches_finite_difference (rel 5.5%, envelope logdet-trace Fisher-scoring)
+- Cluster 3: binomial_location_scale_exact_newton_spatial_joint_hyper_returns_fullhessian (indefinite outer joint Hessian)
+- Cluster 3-wiggle: binomial_location_scalewiggle_..._returns_fullhessian (inner active-set on threshold block)
+- Cluster 4-binomial: binomial_location_scale_engine_matches_reference_flow (inner active-set)
+- Cluster 4-gaussian: gaussian_location_scale_engine_matches_reference_flow (σ-floor s·b vs b semantics)
+- Cluster 5: profiled_theta_hvp_outer_hessian_matches_fd_of_gradient_psi_and_mixed (2nd-order LAML β-response)
+
+## Step 0: ground-truth re-measure on current main, then attack.

--- a/crates/gam-custom-family/src/assembly.rs
+++ b/crates/gam-custom-family/src/assembly.rs
@@ -864,11 +864,43 @@ pub(crate) fn joint_outer_evaluate(
         && include_logdet_h
         && include_logdet_s
         && pseudo_logdet_mode == PseudoLogdetMode::Smooth;
+    // TRUST-REGION GATE on the second-order completion (gam#979, gam#1607). The
+    // completion is the true-Hessian remainder of the Φ-augmented inner objective
+    // and refines the bounded, PSD divided-difference `H_Φ` into the exact mode-
+    // response curvature — but ONLY inside the second-order expansion's trust
+    // region. In the near-separable regime the remainder `−½ tr(K·D_ab)` explodes
+    // negative, cancels `H_Φ`, and leaves `H_Φ + completion` strongly indefinite
+    // (measured: `H_Φ` spectrum `8e-9 … 1e10`; `H_Φ + completion` spectrum
+    // `−3.3e9 … 9e-3`). As the mode-response operator `M = H + S_λ + H_Φ + comp`,
+    // that indefinite curvature is not a legitimate Hessian: the smooth pseudo-
+    // logdet regularizes its large negative eigenvalue to a near-zero pivot, so the
+    // IFT solve `v_k = −M⁻¹ Ṡ_k β̂` amplifies by `~1/ε²` and the outer gradient
+    // explodes, after which the envelope tripwire suppresses the Hessian entirely
+    // (`HessianResult::Unavailable`). When the completed curvature is NOT PSD we
+    // keep the bounded PSD `H_Φ` — which is exactly the curvature the criterion's
+    // value (`½log|H+S_λ+H_Φ|`) and trace kernel already use, so the operator and
+    // the criterion agree. The decision is all-or-nothing per evaluation:
+    // PSD-projecting the indefinite sum would collapse the `O(1e10)` curvature
+    // scale to the surviving positive dregs and re-singularize the operator.
     let robust_jeffreys_hphi_for_operator: Option<Array2<f64>> = match (
         robust_jeffreys_hphi.as_ref(),
-        robust_jeffreys_completion.filter(|_| completion_in_operator),
+        robust_jeffreys_completion
+            .as_ref()
+            .filter(|_| completion_in_operator),
     ) {
-        (Some(hphi), Some(completion)) => Some(hphi + &completion),
+        (Some(hphi), Some(completion))
+            if custom_family_jeffreys_completion_preserves_psd(hphi, completion) =>
+        {
+            Some(hphi + completion)
+        }
+        (Some(hphi), Some(_)) => {
+            // Completion left its trust region; fall back to the bounded PSD base.
+            log::debug!(
+                "[OUTER jeffreys] second-order completion would make the mode-response \
+                 operator indefinite; keeping the divided-difference H_Φ"
+            );
+            Some(hphi.clone())
+        }
         (Some(hphi), None) => Some(hphi.clone()),
         (None, _) => None,
     };

--- a/crates/gam-custom-family/src/inner_blockwise_fit.rs
+++ b/crates/gam-custom-family/src/inner_blockwise_fit.rs
@@ -1754,7 +1754,23 @@ pub(crate) fn inner_blockwise_fit<F: CustomFamily + Clone + Send + Sync + 'stati
                                     family, &states, specs, h_info, z_joint, false,
                                 )?
                             {
-                                lhs_true += &completion;
+                                // TRUST-REGION GATE (gam#1607): fold the completion
+                                // only when `H_Φ + completion` stays PSD. In the
+                                // near-separable regime the `−½ tr(K·D_ab)` remainder
+                                // explodes negative and cancels `H_Φ`, leaving the
+                                // augmented inner Hessian strongly indefinite. The
+                                // trust-region spectral solve below would reflect those
+                                // negative modes, but that turns the quadratic endgame
+                                // back into a reflected-descent crawl that plateaus
+                                // above the certificate tolerance ("inner solve exited
+                                // before convergence"). Keeping the bounded PSD `H_Φ`
+                                // model preserves the linear-but-monotone endgame the
+                                // divided-difference solve already certifies.
+                                if custom_family_jeffreys_completion_preserves_psd(
+                                    hphi, &completion,
+                                ) {
+                                    lhs_true += &completion;
+                                }
                             }
                         }
                         // Single metric-whitened eigendecomposition drives BOTH the

--- a/crates/gam-custom-family/src/jeffreys.rs
+++ b/crates/gam-custom-family/src/jeffreys.rs
@@ -292,6 +292,86 @@ pub(crate) const JEFFREYS_CONDITIONING_GATE_ABSOLUTE_CLEAR: f64 = 16.0;
 
 pub(crate) const JEFFREYS_CONDITIONING_GATE_RELATIVE_CLEAR: f64 = 1e-6;
 
+/// Trust-region tolerance for folding the second-order completion into the
+/// mode-response operator. The completion is the true-Hessian remainder of the
+/// Φ-augmented inner objective and is accurate ONLY where the second-order
+/// expansion is valid. The divided-difference base `H_Φ` is bounded and PSD; the
+/// completed curvature `H_Φ + completion` must remain PSD (a legitimate Hessian
+/// of the convex Firth-augmented penalty over the under-identified span) for the
+/// expansion to be trusted. We tolerate negative excursions only up to this
+/// fraction of `H_Φ`'s own curvature scale — benign float rounding, never the
+/// `O(λ_max)` sign-flip the near-separable cancellation produces (measured:
+/// `H_Φ` spectrum `8e-9 … 1e10` but `H_Φ + completion` spectrum `−3.3e9 … 9e-3`,
+/// a 33%-of-`λ_max` negative excursion AND a collapse of the curvature scale).
+pub(crate) const JEFFREYS_COMPLETION_PSD_REL_TOL: f64 = 1e-8;
+
+/// Decide whether the second-order completion may be folded into the
+/// mode-response operator without destroying its positive semidefiniteness.
+///
+/// `H_Φ` (PSD, bounded) is the divided-difference curvature the value/logdet/trace
+/// path uses; `completion` refines it into the TRUE Hessian of the Φ-augmented
+/// inner objective, but only inside the second-order expansion's trust region. In
+/// the near-degenerate regime the completion's `−½ tr(K·D_ab)` remainder explodes
+/// negative and cancels `H_Φ`, leaving `H_Φ + completion` strongly indefinite. As
+/// the mode-response operator `M = H + S_λ + H_Φ + completion`, that indefinite
+/// curvature is not a legitimate Hessian: under the smooth pseudo-logdet
+/// regularization a large negative eigenvalue regularizes to a near-zero pivot, so
+/// the IFT solve `v_k = −M⁻¹ Ṡ_k β̂` amplifies by `~1/ε²` and the outer gradient
+/// explodes (then the envelope tripwire suppresses the Hessian → `Unavailable`).
+///
+/// Returns `true` only when the completed curvature `H_Φ + completion` stays
+/// positive semidefinite to within [`JEFFREYS_COMPLETION_PSD_REL_TOL`] of `H_Φ`'s
+/// own eigenvalue scale — i.e. the completion is a small correction, not a
+/// sign-flipping cancellation. When `false`, the caller keeps the bounded PSD
+/// `H_Φ`, which is exactly the curvature the criterion's value and traces use, so
+/// the operator and the criterion agree. PSD-PROJECTING the indefinite sum is the
+/// wrong fix: it collapses the `O(1e10)` curvature scale to the surviving positive
+/// dregs (`9e-3`), re-singularizing the operator. The trust decision is therefore
+/// all-or-nothing per evaluation.
+pub(crate) fn custom_family_jeffreys_completion_preserves_psd(
+    hphi: &Array2<f64>,
+    completion: &Array2<f64>,
+) -> bool {
+    if hphi.dim() != completion.dim() {
+        return false;
+    }
+    let p = hphi.nrows();
+    if p == 0 {
+        return true;
+    }
+    // Symmetrize both before any spectral query: the divided-difference assembly
+    // and the contracted-trace completion are each symmetric up to rounding, and
+    // `eigh` reads only one triangle, so a tiny asymmetry must not leak in.
+    let sym = |m: &Array2<f64>| -> Array2<f64> {
+        let mut out = Array2::<f64>::zeros((p, p));
+        for i in 0..p {
+            for j in 0..p {
+                out[[i, j]] = 0.5 * (m[[i, j]] + m[[j, i]]);
+            }
+        }
+        out
+    };
+    let hphi_sym = sym(hphi);
+    let combined = sym(&(hphi + completion));
+    let Ok((hphi_evals, _)) = hphi_sym.eigh(Side::Lower) else {
+        // Cannot certify PSD ⇒ refuse the completion (keep the bounded base).
+        return false;
+    };
+    let Ok((combined_evals, _)) = combined.eigh(Side::Lower) else {
+        return false;
+    };
+    let hphi_lambda_max = hphi_evals.iter().copied().fold(0.0_f64, f64::max);
+    if !hphi_lambda_max.is_finite() || hphi_lambda_max <= 0.0 {
+        // Degenerate / zero base curvature: any completion is untrustworthy here.
+        return false;
+    }
+    let combined_lambda_min = combined_evals.iter().copied().fold(f64::INFINITY, f64::min);
+    if !combined_lambda_min.is_finite() {
+        return false;
+    }
+    combined_lambda_min >= -JEFFREYS_COMPLETION_PSD_REL_TOL * hphi_lambda_max
+}
+
 #[inline]
 pub(crate) fn custom_family_jeffreys_cap(floor: f64) -> f64 {
     JEFFREYS_CONDITIONING_GATE_ABSOLUTE_CLEAR.max(floor)

--- a/crates/gam-models/src/fit_orchestration/fit.rs
+++ b/crates/gam-models/src/fit_orchestration/fit.rs
@@ -666,7 +666,7 @@ impl LocationScaleWorkflowAdapter for BinomialLocationScaleWorkflow {
 /// location-scale path, so the standardized fit is identical whether the
 /// request arrives from the library (`fit_from_formula` →
 /// `materialize_location_scale`), the FFI marshaller, or the CLI.
-fn gaussian_response_sample_std(v: ArrayView1<'_, f64>) -> f64 {
+pub(crate) fn gaussian_response_sample_std(v: ArrayView1<'_, f64>) -> f64 {
     if v.is_empty() {
         return 0.0;
     }
@@ -711,7 +711,7 @@ fn gaussian_response_sample_std(v: ArrayView1<'_, f64>) -> f64 {
 /// observe raw-unit coefficients with **no** additional per-call rescaling,
 /// which is what keeps the σ-floor scale-relative (κ ≈ 1) without leaving the
 /// reconstruction half-applied in any one path.
-fn rescale_gaussian_location_scale_to_raw(
+pub(crate) fn rescale_gaussian_location_scale_to_raw(
     result: &mut GaussianLocationScaleFitResult,
     response_scale: f64,
 ) {

--- a/crates/gam-models/src/fit_orchestration/materialize/tests.rs
+++ b/crates/gam-models/src/fit_orchestration/materialize/tests.rs
@@ -1593,6 +1593,95 @@ fn assert_beta_link_wiggle_match(
     }
 }
 
+/// Standardize a Gaussian location-scale spec by the same response factor the
+/// engine applies internally (`fit_gaussian_location_scale_model`): fit on
+/// `y / s` and `mean_offset / s` so the fixed log-σ soft floor is scale-relative
+/// (#884). Returns the factor `s` used (1.0 ⇒ no standardization needed).
+///
+/// This lets the reference flow exercise the *identical* model contract as the
+/// engine — both standardize, fit the longhand pilot/refit terms, then rescale
+/// back to raw units — so the engine-vs-reference equivalence stays an honest
+/// orchestration check rather than comparing two different σ-floor models.
+fn standardize_gaussian_spec_like_engine(spec: &mut GaussianLocationScaleTermSpec) -> f64 {
+    let s = gaussian_response_sample_std(spec.y.view()).max(1e-6);
+    if s != 1.0 {
+        spec.y.mapv_inplace(|v| v / s);
+        spec.mean_offset.mapv_inplace(|v| v / s);
+    }
+    s
+}
+
+/// Reference Gaussian no-wiggle fit through the longhand terms path, wrapped in
+/// the same standardize→fit→rescale envelope the engine wrapper applies.
+fn reference_gaussian_no_wiggle(
+    data: ArrayView2<'_, f64>,
+    mut spec: GaussianLocationScaleTermSpec,
+    options: &BlockwiseFitOptions,
+    kappa_options: &SpatialLengthScaleOptimizationOptions,
+) -> GaussianLocationScaleFitResult {
+    let s = standardize_gaussian_spec_like_engine(&mut spec);
+    let fit = fit_gaussian_location_scale_terms(data, spec, options, kappa_options)
+        .expect("reference gaussian no-wiggle terms fit");
+    let mut result = GaussianLocationScaleFitResult {
+        fit,
+        wiggle_knots: None,
+        wiggle_degree: None,
+        beta_link_wiggle: None,
+        response_scale: 1.0,
+    };
+    rescale_gaussian_location_scale_to_raw(&mut result, s);
+    result
+}
+
+/// Reference Gaussian wiggle fit (pilot → basis selection → refit → assemble)
+/// through the longhand terms path, under the engine's standardization envelope.
+fn reference_gaussian_wiggle(
+    data: ArrayView2<'_, f64>,
+    mut spec: GaussianLocationScaleTermSpec,
+    wiggle_cfg: &LinkWiggleConfig,
+    options: &BlockwiseFitOptions,
+    kappa_options: &SpatialLengthScaleOptimizationOptions,
+) -> GaussianLocationScaleFitResult {
+    let s = standardize_gaussian_spec_like_engine(&mut spec);
+    let ref_pilot = fit_gaussian_location_scale_terms(data, spec.clone(), options, kappa_options)
+        .expect("reference gaussian pilot");
+    let ref_basis = select_gaussian_location_scale_link_wiggle_basis_from_pilot(
+        &ref_pilot,
+        &WiggleBlockConfig {
+            degree: wiggle_cfg.degree,
+            num_internal_knots: wiggle_cfg.num_internal_knots,
+            penalty_order: 2,
+            double_penalty: wiggle_cfg.double_penalty,
+        },
+        &wiggle_cfg.penalty_orders,
+    )
+    .expect("reference gaussian wiggle basis selection");
+    let ref_solved = fit_gaussian_location_scale_terms_with_selected_wiggle(
+        data,
+        spec,
+        ref_basis,
+        options,
+        kappa_options,
+    )
+    .expect("reference gaussian wiggle refit");
+
+    let beta_link_wiggle = ref_solved
+        .fit
+        .fit
+        .block_states
+        .get(2)
+        .map(|b| b.beta.to_vec());
+    let mut result = GaussianLocationScaleFitResult {
+        fit: ref_solved.fit,
+        wiggle_knots: Some(ref_solved.wiggle_knots),
+        wiggle_degree: Some(ref_solved.wiggle_degree),
+        beta_link_wiggle,
+        response_scale: 1.0,
+    };
+    rescale_gaussian_location_scale_to_raw(&mut result, s);
+    result
+}
+
 #[test]
 fn gaussian_location_scale_engine_matches_reference_flow() {
     let data = gaussian_location_scale_dataset();
@@ -1624,12 +1713,11 @@ fn gaussian_location_scale_engine_matches_reference_flow() {
     })
     .expect("engine gaussian no-wiggle fit");
     let reference_plain =
-        fit_gaussian_location_scale_terms(req_data, spec.clone(), &options, &kappa_options)
-            .expect("reference gaussian no-wiggle fit");
+        reference_gaussian_no_wiggle(req_data, spec.clone(), &options, &kappa_options);
     assert_block_states_match(
         "gaussian/no-wiggle",
         &engine_plain.fit.fit,
-        &reference_plain.fit,
+        &reference_plain.fit.fit,
     );
     assert!(engine_plain.wiggle_knots.is_none());
     assert!(engine_plain.wiggle_degree.is_none());
@@ -1646,29 +1734,12 @@ fn gaussian_location_scale_engine_matches_reference_flow() {
     })
     .expect("engine gaussian wiggle fit");
 
-    // Reference: the exact pre-unification hand-rolled sequence.
-    let ref_pilot =
-        fit_gaussian_location_scale_terms(req_data, spec.clone(), &options, &kappa_options)
-            .expect("reference gaussian pilot");
-    let ref_basis = select_gaussian_location_scale_link_wiggle_basis_from_pilot(
-        &ref_pilot,
-        &WiggleBlockConfig {
-            degree: wiggle_cfg.degree,
-            num_internal_knots: wiggle_cfg.num_internal_knots,
-            penalty_order: 2,
-            double_penalty: wiggle_cfg.double_penalty,
-        },
-        &wiggle_cfg.penalty_orders,
-    )
-    .expect("reference gaussian wiggle basis selection");
-    let ref_solved = fit_gaussian_location_scale_terms_with_selected_wiggle(
-        req_data,
-        spec.clone(),
-        ref_basis,
-        &options,
-        &kappa_options,
-    )
-    .expect("reference gaussian wiggle refit");
+    // Reference: the exact pre-unification hand-rolled sequence, wrapped in the
+    // same standardize→fit→rescale envelope the engine applies (#884), so the
+    // two paths compare the same σ-floor model rather than diverging on the
+    // raw-vs-scale-relative floor.
+    let ref_solved =
+        reference_gaussian_wiggle(req_data, spec.clone(), &wiggle_cfg, &options, &kappa_options);
 
     assert_block_states_match(
         "gaussian/wiggle",
@@ -1677,23 +1748,23 @@ fn gaussian_location_scale_engine_matches_reference_flow() {
     );
     assert_eq!(
         engine_wiggle.wiggle_degree,
-        Some(ref_solved.wiggle_degree),
+        ref_solved.wiggle_degree,
         "gaussian wiggle degree must match the reference refit"
     );
     let engine_knots = engine_wiggle
         .wiggle_knots
         .as_ref()
         .expect("engine gaussian wiggle knots present");
+    let ref_knots = ref_solved
+        .wiggle_knots
+        .as_ref()
+        .expect("reference gaussian wiggle knots present");
     assert_eq!(
         engine_knots.len(),
-        ref_solved.wiggle_knots.len(),
+        ref_knots.len(),
         "gaussian wiggle knot count must match the reference refit"
     );
-    for (k, (&ek, &rk)) in engine_knots
-        .iter()
-        .zip(ref_solved.wiggle_knots.iter())
-        .enumerate()
-    {
+    for (k, (&ek, &rk)) in engine_knots.iter().zip(ref_knots.iter()).enumerate() {
         assert!(
             (ek - rk).abs() <= 1e-12 * (1.0 + rk.abs()),
             "gaussian wiggle knot {k} diverged: engine {ek:.17e} vs reference {rk:.17e}"
@@ -1701,12 +1772,7 @@ fn gaussian_location_scale_engine_matches_reference_flow() {
     }
     // `beta_link_wiggle` is block 2 of the refit; the engine must extract it
     // exactly as the reference would read it off the same fit.
-    let ref_beta_link_wiggle = ref_solved
-        .fit
-        .fit
-        .block_states
-        .get(2)
-        .map(|b| b.beta.to_vec());
+    let ref_beta_link_wiggle = ref_solved.beta_link_wiggle.clone();
     assert_beta_link_wiggle_match(
         "gaussian",
         &engine_wiggle.beta_link_wiggle,


### PR DESCRIPTION
Autonomous WIP addressing #1607 — the remaining pre-existing `gam-models --lib` test failures.

Prior fleet runs (see issue #1607 discussion) fixed 4 of the original 10. This PR picks up the remaining cluster:
- Cluster 2: `binomial_location_scale_batched_gradient_matches_finite_difference`
- Cluster 3: `binomial_location_scale_exact_newton_spatial_joint_hyper_returns_fullhessian` (+ wiggle variant)
- Cluster 4: `gaussian/binomial_location_scale_engine_matches_reference_flow`
- Cluster 5: `profiled_theta_hvp_outer_hessian_matches_fd_of_gradient_psi_and_mixed`

This is an autonomous WIP that will be force-improved commit-by-commit. The PR body and commits will be updated as root causes are pinned and fixes verified.

Relates to #1607.