### PR TITLE
[agent] #1082: fix last quality-suite timeout — competing-risks CIF 439s→122s

### DIFF
--- a/.agent/issue-1082.md
+++ b/.agent/issue-1082.md
@@ -1,0 +1,15 @@
+# Issue #1082 — quality tests exceed 360s budget
+
+## Current state (run 28399514029, 2026-06-29)
+Of the original ~17 timeouts, prior fleet work resolved all but ONE:
+- **TIMEOUT**: `survival::quality_competing_risks_truth_recovery::joint_competing_risks_transformation_recovers_true_cause_specific_cifs` (360s)
+
+## Near-budget risks (PASS but slow — flake risk)
+- pymc_hmc_binomial_penalized_vs_unpenalized (192s)
+- fit_quality_stress::hifreq_tensor_k10 (185s)
+- pymc_nuts_binomial_logit (126s)
+- synthetic_multinomial_deviance_identity (83s, REF_ERROR)
+
+## Plan
+1. Root-cause the competing-risks CIF timeout (profile the hot loop). Magic-by-default: make the loop converge / cut redundant work, NO budget bumps, NO accuracy loss.
+2. Harden the near-budget PASS tests if the slowness is gam-side.

--- a/crates/gam-solve/src/reml/continuation.rs
+++ b/crates/gam-solve/src/reml/continuation.rs
@@ -529,10 +529,33 @@ pub(crate) fn run_path(
                 // rather than expanding into an even more oversmoothed
                 // regime where the alias persists.
                 InnerFailure::IdentifiabilityFailure { .. } => PathOutcome::Propagate(failure),
-                // RankDeficientHPen at ρ₀ → definitely expand. Other
-                // failures at the most oversmoothed point are also
-                // unusual (we're in the strongly-convex regime);
-                // treat as "expand ρ₀ and retry" rather than give up.
+                // Generic, untagged inner non-convergence at ρ₀ (e.g. a
+                // linear-constrained Newton active-set that stays feasible but
+                // cannot certify KKT because the penalty gradient λ₀·Sβ at the
+                // most-oversmoothed start swamps the inequality multipliers).
+                // This is a *monotone-in-λ₀ conditioning* failure: every ρ₀
+                // expansion DOUBLES the oversmoothing offset and makes the
+                // penalty-vs-constraint imbalance strictly worse, so the
+                // catch-all "expand and retry" below would re-run the same
+                // ~p·m·4-iteration active-set thrash at each of
+                // OVERSMOOTH_RETRY_MAX escalating offsets before failing anyway
+                // (#1082: ~290s of pure waste on the K=2 competing-risks fit,
+                // where two of four λ pin at the box bound). The mid-walk
+                // classifier already routes `InnerFailure::Other` to
+                // `Propagate` for exactly this reason; do the same at ρ₀ so the
+                // pre-warm gives up after ONE start instead of four. Propagate
+                // is non-structural here (`ContinuationFailure::is_structural`
+                // inspects the underlying `Other`), so the caller still falls
+                // through to the cold seed eval — identical outcome, a quarter
+                // of the cost.
+                InnerFailure::Other(_) => PathOutcome::Propagate(failure),
+                // RankDeficientHPen at ρ₀ → definitely expand (more penalty
+                // curvature fills the block's polynomial null space, the one
+                // failure mode oversmoothing genuinely repairs). Budget /
+                // trust-region / phantom-multiplier refusals at the most
+                // oversmoothed point are unusual (we're nominally in the
+                // strongly-convex regime); treat those as "expand ρ₀ and retry"
+                // rather than give up.
                 _ => PathOutcome::ExpandRhoZero(failure),
             });
         }
@@ -1032,6 +1055,63 @@ mod tests {
             outcome.err(),
         );
         assert!(obj.rho_history.len() >= 3);
+    }
+
+    #[test]
+    pub(crate) fn untagged_inner_failure_at_rho_zero_does_not_expand_offset() {
+        // #1082: a generic, untagged inner non-convergence at ρ₀ (here the
+        // verbatim "linear-constrained Newton active-set failed to converge"
+        // string the K=2 competing-risks fit emits — it carries NO
+        // `diagnosis:` tag, so `classify_inner_error` lands on
+        // `InnerFailure::Other`) must give up after ONE oversmoothed start.
+        // It must NOT cycle through OVERSMOOTH_RETRY_MAX ρ₀ expansions: every
+        // expansion doubles the oversmoothing offset and re-runs the same
+        // expensive active-set thrash at a strictly worse penalty/constraint
+        // imbalance (~290s wasted on the real fit). The failure is
+        // non-structural, so the seed-loop caller still falls through to the
+        // cold seed eval.
+        let target = rho(&[0.0]);
+        let upper = rho(&[10.0]);
+        // Fail at EVERY ρ₀ the schedule could try. Pre-fix this objective would
+        // be re-entered OVERSMOOTH_RETRY_MAX+1 times (offset 3.47→6.93→13.86→
+        // 27.7), so 4 distinct ρ₀ evals would be recorded; post-fix exactly 1.
+        let responses: Vec<ScriptedResponse> = (0..8)
+            .map(|_| {
+                ScriptedResponse::Fail(
+                    "custom-family invalid input in custom-family string boundary: \
+                     Parameter constraint violation: linear-constrained Newton active-set \
+                     failed to converge; max(Aβ-b violation)=8.853e-18 at row 137; \
+                     KKT[primal=8.853e-18, dual=9.297e2, comp=1.290e-14, stat=2.046e4, \
+                     active=3/900]",
+                )
+            })
+            .collect();
+        let mut obj = ScriptedObjective::new(1, responses);
+        let err = prime_outer_seed_with_budget(&mut obj, &target, &upper, PATH_BUDGET)
+            .expect_err("untagged ρ₀ failure must surface, not loop");
+        // Propagate (not PathStuck): the eval0 router now treats `Other` the
+        // same way the mid-walk `classify_action` already does.
+        assert!(
+            matches!(
+                err,
+                ContinuationFailure::StructuralPropagate(InnerFailure::Other(_))
+            ),
+            "expected StructuralPropagate(Other), got {err:?}",
+        );
+        // is_structural() stays FALSE for `Other`, so the caller falls through
+        // to the cold seed eval rather than disqualifying the seed.
+        assert!(
+            !err.is_structural(),
+            "an untagged active-set non-convergence is a warm-start property, \
+             not a structural seed defect; the cold eval must still judge it",
+        );
+        // The crux: exactly ONE ρ₀ inner eval, not OVERSMOOTH_RETRY_MAX+1.
+        assert_eq!(
+            obj.rho_history.len(),
+            1,
+            "must give up after a single oversmoothed start; doubling ρ₀ only \
+             worsens the penalty/constraint imbalance",
+        );
     }
 
     #[test]


### PR DESCRIPTION
## #1082 — last quality-suite wall-clock timeout RESOLVED

Closes #1082.

Of the original ~17 timed-out quality tests, prior fleet work resolved all but one. This PR fixes the last: the joint competing-risks CIF truth-recovery test, which fit cold in **439s** (> the 360s per-test budget).

### Root cause

The K=2 competing-risks transformation fit drives the per-seed **continuation pre-warm**. Its first inner solve at the heavily-oversmoothed start ρ₀ fails with an *untagged* `"linear-constrained Newton active-set failed to converge"`: at λ₀ — with two of four λ already pinned at the box bound exp(10) ≈ 22026 — the penalty gradient λ₀·Sβ swamps the ~900 monotonicity-constraint multipliers, so the active-set stays feasible (primal ≈ 9e-18) but cannot certify KKT and thrashes its full `(p+m+8)·4 ≈ 3744`-iteration cap.

That message carries no `diagnosis:` tag, so it classifies as `InnerFailure::Other`. At `run_path`'s `eval0` the catch-all routed `Other → ExpandRhoZero`, which **doubled the oversmoothing offset** (3.47 → 6.93 → 13.86 → 27.7) and re-ran the same doomed solve at each of `OVERSMOOTH_RETRY_MAX + 1` starts — every expansion making the penalty-vs-constraint imbalance strictly worse. ~290s of pure waste, then it failed and fell back to the cold seed eval anyway (the pre-warm is, by contract, a warm-start optimization, never a feasibility gate).

The tell: the mid-walk classifier (`classify_action`) already routes `InnerFailure::Other → Propagate`. Only `eval0` was inconsistent.

### Fix

One file (`crates/gam-solve/src/reml/continuation.rs`): route untagged `InnerFailure::Other` at `eval0` to `Propagate`, matching the mid-walk classifier. The pre-warm gives up after **one** oversmoothed start instead of four. The failure stays non-structural (`is_structural` inspects the underlying `Other`), so the seed-loop caller still falls through to the cold seed eval — identical downstream outcome, a quarter of the cost. `RankDeficientHPen` still expands ρ₀ (more curvature genuinely fills a polynomial null space).

### Magic-by-default

No budget bump, no accuracy loss, no weakened bound. The fit converges to the **bit-identical** optimum (`status=Converged | iterations=7 | objective=5.651983e2`, matching pre-fix). Only the doomed ρ₀-expansion thrash is removed.

### Verification (cold, after `rm -rf /tmp/gam/warm`)

- `nextest --cargo-profile release-dev -p gam quality_competing_risks_truth_recovery`: **118.9s, 1 passed** (was 439s). All RMSE / structural-identity / covariate-direction bounds hold unchanged.
- New regression test `untagged_inner_failure_at_rho_zero_does_not_expand_offset`: asserts exactly ONE ρ₀ inner eval (not `OVERSMOOTH_RETRY_MAX + 1`) and non-structural propagation. All 17 continuation tests pass.

### Pre-existing failures flagged (NOT introduced here)

Two `gam-solve` unit tests fail deterministically on `main` HEAD (156fe0a5f) too — separate subsystems, not in the reference-quality CI this issue concerns. Reported to the coordination board for their owners:
- `seeding::objective_grid_can_seed_adjacent_pair_oversmoothing_corner` (null-space seed-corner refinement; #1548/#1266/#1033)
- `structure_search::birth_certifies_and_null_fusion_stays_contested` (#984 e-BH FDR certificate; #1521 carve)

🤖 Generated with [Claude Code](https://claude.com/claude-code)