### PR TITLE
[agent] #1628: verify #932 logdet build fix at HEAD + fmt the relocated oracle

### DIFF
--- a/crates/gam-sae/src/manifold/construction_row_jet_logdet_channels.rs
+++ b/crates/gam-sae/src/manifold/construction_row_jet_logdet_channels.rs
@@ -652,39 +652,44 @@ mod batch4_oracle_tests {
         /// `refill_jet_window` now builds the hand `row_jets_for_logdet` per row (the
         /// jet was a 25–57× regression). Retained as the live cross-check of the hand
         /// path (`batch4_jet_lanes_match_scalar_hand_row_jets`).
-    pub(crate) fn row_jets_for_logdet_batch4(
-        &self,
-        rho: &SaeManifoldRho,
-        rows: [usize; 4],
-        cache: &ArrowFactorCache,
-        second_jets: &[Array4<f64>],
-        border: &[SaeBorderChannel],
-    ) -> Result<Option<[SaeRowJets; 4]>, String> {
-        let p = self.output_dim();
-        let k_atoms = self.k_atoms();
-        let mut progs: Vec<crate::row_jet_program::SaeReconstructionRowProgram> =
-            Vec::with_capacity(4);
-        let mut vars_each: Vec<Vec<SaeLocalRowVar>> = Vec::with_capacity(4);
-        let mut sqrt_w = [1.0_f64; 4];
-        for (i, &row) in rows.iter().enumerate() {
-            let vars = self.row_vars_for_cache_row(row, cache)?;
-            let mut a = Array1::<f64>::zeros(k_atoms);
-            self.assignment.try_assignments_row_for_rho_into(
-                row,
-                rho,
-                a.as_slice_mut().expect("contiguous assignment scratch"),
-            )?;
-            let prog =
-                self.reconstruction_row_program_for_logdet(rho, row, &vars, a.view(), second_jets)?;
-            sqrt_w[i] = self
-                .row_loss_weights
-                .as_deref()
-                .map_or(1.0, |w| w[row].sqrt());
-            vars_each.push(vars);
-            progs.push(prog);
-        }
-        let refs = [&progs[0], &progs[1], &progs[2], &progs[3]];
-        macro_rules! dispatch {
+        pub(crate) fn row_jets_for_logdet_batch4(
+            &self,
+            rho: &SaeManifoldRho,
+            rows: [usize; 4],
+            cache: &ArrowFactorCache,
+            second_jets: &[Array4<f64>],
+            border: &[SaeBorderChannel],
+        ) -> Result<Option<[SaeRowJets; 4]>, String> {
+            let p = self.output_dim();
+            let k_atoms = self.k_atoms();
+            let mut progs: Vec<crate::row_jet_program::SaeReconstructionRowProgram> =
+                Vec::with_capacity(4);
+            let mut vars_each: Vec<Vec<SaeLocalRowVar>> = Vec::with_capacity(4);
+            let mut sqrt_w = [1.0_f64; 4];
+            for (i, &row) in rows.iter().enumerate() {
+                let vars = self.row_vars_for_cache_row(row, cache)?;
+                let mut a = Array1::<f64>::zeros(k_atoms);
+                self.assignment.try_assignments_row_for_rho_into(
+                    row,
+                    rho,
+                    a.as_slice_mut().expect("contiguous assignment scratch"),
+                )?;
+                let prog = self.reconstruction_row_program_for_logdet(
+                    rho,
+                    row,
+                    &vars,
+                    a.view(),
+                    second_jets,
+                )?;
+                sqrt_w[i] = self
+                    .row_loss_weights
+                    .as_deref()
+                    .map_or(1.0, |w| w[row].sqrt());
+                vars_each.push(vars);
+                progs.push(prog);
+            }
+            let refs = [&progs[0], &progs[1], &progs[2], &progs[3]];
+            macro_rules! dispatch {
             ($($k:literal),* $(,)?) => {
                 match progs[0].n_primaries {
                     $( $k => Self::batch4_assemble::<$k>(refs, &vars_each, &sqrt_w, border, p), )*
@@ -692,76 +697,78 @@ mod batch4_oracle_tests {
                 }
             };
         }
-        dispatch!(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16)
-    }
-
-    /// Assemble the four lanes of a SIMD batch into per-row [`SaeRowJets`],
-    /// applying the identical `√w` / `output_c` scaling the scalar fills use.
-    /// Returns `None` if the rows are not batchable (the batch primitives
-    /// decline). Test-only oracle helper for `row_jets_for_logdet_batch4`.
-    fn batch4_assemble<const K: usize>(
-        rows: [&crate::row_jet_program::SaeReconstructionRowProgram; 4],
-        vars_each: &[Vec<SaeLocalRowVar>],
-        sqrt_w: &[f64; 4],
-        border: &[SaeBorderChannel],
-        p: usize,
-    ) -> Result<Option<[SaeRowJets; 4]>, String> {
-        use crate::row_jet_program::SaeReconstructionRowProgram;
-        let recon = match SaeReconstructionRowProgram::reconstruction_all_columns_batch4::<K>(rows) {
-            Some(r) => r,
-            None => return Ok(None),
-        };
-        let chans: Vec<(usize, usize)> = border.iter().map(|c| (c.atom, c.basis_col)).collect();
-        let bjets = match SaeReconstructionRowProgram::beta_border_order1_batch4::<K>(rows, &chans) {
-            Some(b) => b,
-            None => return Ok(None),
-        };
-        let mut outs: Vec<SaeRowJets> = Vec::with_capacity(4);
-        for lane in 0..4 {
-            let sqrt = sqrt_w[lane];
-            let mut first = vec![vec![0.0_f64; p]; K];
-            let mut second = vec![vec![vec![0.0_f64; p]; K]; K];
-            for (out_col, tower) in recon[lane].iter().enumerate() {
-                let g = tower.g();
-                let h = tower.h();
-                for a in 0..K {
-                    first[a][out_col] = sqrt * g[a];
-                    for b in 0..K {
-                        second[a][b][out_col] = sqrt * h[a][b];
-                    }
-                }
-            }
-            let mut beta = vec![vec![0.0_f64; p]; border.len()];
-            let mut beta_deriv = vec![vec![vec![0.0_f64; p]; border.len()]; K];
-            let mut beta_l_deriv = vec![vec![vec![0.0_f64; p]; border.len()]; K];
-            for (beta_pos, channel) in border.iter().enumerate() {
-                let s = &bjets[lane][beta_pos];
-                let s_v = s.value();
-                let s_g = s.g();
-                for out_col in 0..p {
-                    let out_c = channel.output[out_col];
-                    beta[beta_pos][out_col] = sqrt * s_v * out_c;
-                    for a in 0..K {
-                        let mixed = sqrt * s_g[a] * out_c;
-                        beta_deriv[a][beta_pos][out_col] = mixed;
-                        beta_l_deriv[a][beta_pos][out_col] = mixed;
-                    }
-                }
-            }
-            outs.push(SaeRowJets {
-                vars: vars_each[lane].clone(),
-                first,
-                second,
-                beta,
-                beta_deriv,
-                beta_l_deriv,
-            });
+            dispatch!(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16)
         }
-        let arr: [SaeRowJets; 4] = outs
-            .try_into()
-            .map_err(|_| "batch4_assemble produced wrong lane count".to_string())?;
-        Ok(Some(arr))
-    }
+
+        /// Assemble the four lanes of a SIMD batch into per-row [`SaeRowJets`],
+        /// applying the identical `√w` / `output_c` scaling the scalar fills use.
+        /// Returns `None` if the rows are not batchable (the batch primitives
+        /// decline). Test-only oracle helper for `row_jets_for_logdet_batch4`.
+        fn batch4_assemble<const K: usize>(
+            rows: [&crate::row_jet_program::SaeReconstructionRowProgram; 4],
+            vars_each: &[Vec<SaeLocalRowVar>],
+            sqrt_w: &[f64; 4],
+            border: &[SaeBorderChannel],
+            p: usize,
+        ) -> Result<Option<[SaeRowJets; 4]>, String> {
+            use crate::row_jet_program::SaeReconstructionRowProgram;
+            let recon =
+                match SaeReconstructionRowProgram::reconstruction_all_columns_batch4::<K>(rows) {
+                    Some(r) => r,
+                    None => return Ok(None),
+                };
+            let chans: Vec<(usize, usize)> = border.iter().map(|c| (c.atom, c.basis_col)).collect();
+            let bjets =
+                match SaeReconstructionRowProgram::beta_border_order1_batch4::<K>(rows, &chans) {
+                    Some(b) => b,
+                    None => return Ok(None),
+                };
+            let mut outs: Vec<SaeRowJets> = Vec::with_capacity(4);
+            for lane in 0..4 {
+                let sqrt = sqrt_w[lane];
+                let mut first = vec![vec![0.0_f64; p]; K];
+                let mut second = vec![vec![vec![0.0_f64; p]; K]; K];
+                for (out_col, tower) in recon[lane].iter().enumerate() {
+                    let g = tower.g();
+                    let h = tower.h();
+                    for a in 0..K {
+                        first[a][out_col] = sqrt * g[a];
+                        for b in 0..K {
+                            second[a][b][out_col] = sqrt * h[a][b];
+                        }
+                    }
+                }
+                let mut beta = vec![vec![0.0_f64; p]; border.len()];
+                let mut beta_deriv = vec![vec![vec![0.0_f64; p]; border.len()]; K];
+                let mut beta_l_deriv = vec![vec![vec![0.0_f64; p]; border.len()]; K];
+                for (beta_pos, channel) in border.iter().enumerate() {
+                    let s = &bjets[lane][beta_pos];
+                    let s_v = s.value();
+                    let s_g = s.g();
+                    for out_col in 0..p {
+                        let out_c = channel.output[out_col];
+                        beta[beta_pos][out_col] = sqrt * s_v * out_c;
+                        for a in 0..K {
+                            let mixed = sqrt * s_g[a] * out_c;
+                            beta_deriv[a][beta_pos][out_col] = mixed;
+                            beta_l_deriv[a][beta_pos][out_col] = mixed;
+                        }
+                    }
+                }
+                outs.push(SaeRowJets {
+                    vars: vars_each[lane].clone(),
+                    first,
+                    second,
+                    beta,
+                    beta_deriv,
+                    beta_l_deriv,
+                });
+            }
+            let arr: [SaeRowJets; 4] = outs
+                .try_into()
+                .map_err(|_| "batch4_assemble produced wrong lane count".to_string())?;
+            Ok(Some(arr))
+        }
     }
 }
 


### PR DESCRIPTION
Autonomous WIP for #1628 — verified complete.

## Context
#1628 (CLOSED) reported 5 `build.rs` ban-scanner violations across 4 rules from the #932 SAE logdet-channels revert (700e6c5a2), all in `crates/gam-sae/src/manifold/construction_row_jet_logdet_channels.rs`. The build break was **real** at the issue's authoring checkout but was already resolved on `main` (`b31609097` + `7abe8850d`) before this agent started: the demoted jet oracle was relocated into `#[cfg(test)] mod batch4_oracle_tests`, and the `#[allow(too_many_arguments)]`, the `_n` param, and the two bare `#[cfg(test)]` gates were removed.

This PR does **not** re-fix the (already-fixed) build break. It (a) rigorously re-verifies the resolution at HEAD and (b) fixes a real formatting defect the #932 relocation left behind.

## Verification at HEAD (all green)
- `./build.sh` with `build.rs` **force-touched** (forces the ban-scanner to re-run, the exact path the issue says aborts) → ban-scanner passes, `BUILD OK`.
- The committed regression guard `bug_hunt_sae_logdet_channels_revert_ban_violations_break_build` → **3/3 pass**.
- The whole build-break ban family run together → **8/8 pass** (incl. the tree-wide `source_tree_has_no_lint_silencing_allow_or_expect_attributes`, the multinomial-reml #1587 guard, and the build.rs human-author guard).
- The #932 oracle cross-check `batch4_jet_lanes_match_scalar_hand_row_jets` → **PASS**: the demoted 4-row SIMD jet reproduces the reinstated hand `row_jets_for_logdet` to ≤1e-9 on every channel. The oracle is genuinely exercised — not orphaned dead code — so the "keep jet as oracle" rationale of the revert holds.

## Fix in this PR
The #932 relocation of the oracle `impl` into the new `mod batch4_oracle_tests` left the moved block **under-indented** (4-space bodies sitting inside a nested `mod`→`impl` that needs 8). On `main`, this file is rustfmt-clean **except exactly the 2 hunks of that relocated block** — i.e. it was authored to be fmt-conformant and the revert is the sole drift. `build.rs`/CI don't run `fmt`, so it rode onto `main` next to the (now-fixed) ban violations.

Applied `rustfmt` (edition/style 2024, per `rustfmt.toml`) to the one file: pure re-indentation plus a couple of benign width-driven reflows, **no semantic change**. The oracle cross-check still passes post-fmt and the file is now fully rustfmt-clean.

Refs #1628.

🤖 Generated with [Claude Code](https://claude.com/claude-code)