### PR TITLE
[agent] reopen #332: Gaussian near-constant response guard

### DIFF
--- a/crates/gam-spec/src/lib.rs
+++ b/crates/gam-spec/src/lib.rs
@@ -719,7 +719,47 @@ impl ResponseFamily {
                     kind,
                 })
             }
-            Self::Gaussian => Ok(()),
+            Self::Gaussian => {
+                // A Gaussian fit's marginal REML log-likelihood carries a
+                // `−n/2·log σ²` term; for an effectively-constant response the
+                // ML scale `σ → 0` drives it to `+∞`, so the outer objective
+                // rejects every seed with "reml_score must be finite, got inf"
+                // (#332). Reject pre-fit when the two-pass, mean-centred sample
+                // sd is at or below `GAUSSIAN_MIN_SAMPLE_SD`. Fewer than two
+                // observations carries no estimable scale degeneracy (the
+                // sample-size gate handles too-small data), and any non-finite
+                // value is left to the dedicated finiteness checks rather than
+                // poisoning the sd, so it is skipped here.
+                let mut count = 0usize;
+                let mut mean = 0.0f64;
+                for &yi in y.iter() {
+                    if !yi.is_finite() {
+                        return Ok(());
+                    }
+                    count += 1;
+                    mean += yi;
+                }
+                if count < 2 {
+                    return Ok(());
+                }
+                mean /= count as f64;
+                let mut sumsq = 0.0f64;
+                for &yi in y.iter() {
+                    let d = yi - mean;
+                    sumsq += d * d;
+                }
+                let sample_sd = (sumsq / (count as f64 - 1.0)).sqrt();
+                if sample_sd <= GAUSSIAN_MIN_SAMPLE_SD {
+                    return Err(ResponseDegeneracy {
+                        family_label: self.response_support_label(),
+                        kind: ResponseDegeneracyKind::GaussianNearConstant {
+                            sample_sd,
+                            min_sd: GAUSSIAN_MIN_SAMPLE_SD,
+                        },
+                    });
+                }
+                Ok(())
+            }
             Self::Poisson
             | Self::Tweedie { .. }
             | Self::NegativeBinomial { .. }
@@ -856,6 +896,19 @@ impl std::error::Error for ResponseSupportViolation {}
 /// three layers agree on exactly which responses are admissible.
 pub const BINOMIAL_BINARY_TOL: f64 = 1.0e-12;
 
+/// Minimum admissible sample standard deviation for a `Gaussian` response.
+///
+/// A response whose two-pass, mean-centred sample sd is at or below this
+/// threshold is *effectively constant* in `f64` arithmetic: the marginal REML
+/// log-likelihood carries a `−n/2·log σ²` term that diverges to `+∞` as the
+/// fitted scale `σ → 0`, so the outer objective rejects every seed with
+/// `reml_score must be finite, got inf` (#332). The bound is chosen well below
+/// any well-conditioned scientific signal (genuine data has sd many orders of
+/// magnitude larger) yet above the f64 round-off floor, so it never trips a
+/// real fit while catching responses that carry no signal (e.g. a column read
+/// in the wrong scale, or a constant accidentally fed as the response).
+pub const GAUSSIAN_MIN_SAMPLE_SD: f64 = 1.0e-10;
+
 /// Round tolerance for recognising an integer-valued (count) response.
 ///
 /// `infer_from_response` classifies a numeric response as a Poisson count when
@@ -876,6 +929,18 @@ pub enum ResponseDegeneracyKind {
     BinomialAllZeros,
     /// Bernoulli / Binomial response with every observed value equal to 1.
     BinomialAllOnes,
+    /// Gaussian response that is effectively constant in `f64` arithmetic
+    /// (sample standard deviation at or below [`GAUSSIAN_MIN_SAMPLE_SD`]). The
+    /// marginal REML log-likelihood `−n/2·log σ²` diverges to `+∞` as the
+    /// fitted scale `σ → 0`, so every outer evaluation rejects with a
+    /// non-finite score. Carries the observed `sample_sd` and the `min_sd`
+    /// threshold so the message can quote both verbatim (#332).
+    GaussianNearConstant {
+        /// The two-pass, mean-centred sample standard deviation of the response.
+        sample_sd: f64,
+        /// The rejection threshold ([`GAUSSIAN_MIN_SAMPLE_SD`]).
+        min_sd: f64,
+    },
 }
 
 /// Degenerate-response detail produced by
@@ -912,6 +977,15 @@ impl ResponseDegeneracy {
                  is not finite. Fix: ensure the response contains at least one 0 and \
                  at least one 1 (e.g. drop the offending subgroup, or refit on a pooled \
                  sample that includes both classes).",
+                family = self.family_label,
+                name = response_name,
+            ),
+            ResponseDegeneracyKind::GaussianNearConstant { sample_sd, min_sd } => format!(
+                "{family} response '{name}' is effectively constant (sample sd ~ {sample_sd:.3e} \
+                 <= {min_sd:.0e}); the marginal REML log-likelihood −n/2·log σ² diverges to \
+                 +∞ as σ → 0. Fix: check the response column units (is it being read in the \
+                 right scale?), centre/rescale the response, or drop the column if it carries \
+                 no signal.",
                 family = self.family_label,
                 name = response_name,
             ),
@@ -2544,9 +2618,76 @@ mod tests {
     }
 
     #[test]
-    fn gaussian_degeneracy_always_ok() {
+    fn gaussian_degeneracy_exactly_constant_errors() {
+        // An exactly-constant response has sample sd 0 ⇒ the marginal
+        // `−n/2·log σ²` diverges; the guard must reject it pre-fit (#332).
         let y = arr1(&[1.0_f64, 1.0, 1.0]);
-        assert!(ResponseFamily::Gaussian.validate_response_degeneracy(y.view()).is_ok());
+        let err = ResponseFamily::Gaussian
+            .validate_response_degeneracy(y.view())
+            .expect_err("exactly-constant Gaussian response must be rejected");
+        assert!(matches!(
+            err.kind,
+            ResponseDegeneracyKind::GaussianNearConstant { .. }
+        ));
+    }
+
+    #[test]
+    fn gaussian_degeneracy_near_constant_reproducer_errors() {
+        // The issue reproducer: a response with sd ~ 1e-13, well below the
+        // `1e-10` floor, so the REML score blows up to +inf without the guard.
+        let y = arr1(&[
+            5.0_f64,
+            5.0 + 1.0e-13,
+            5.0 - 1.0e-13,
+            5.0 + 2.0e-13,
+            5.0 - 2.0e-13,
+        ]);
+        let err = ResponseFamily::Gaussian
+            .validate_response_degeneracy(y.view())
+            .expect_err("near-constant Gaussian response must be rejected");
+        match err.kind {
+            ResponseDegeneracyKind::GaussianNearConstant { sample_sd, min_sd } => {
+                assert!(
+                    sample_sd <= min_sd,
+                    "guard must fire only when sample_sd ({sample_sd:.3e}) <= min_sd ({min_sd:.0e})"
+                );
+                assert_eq!(min_sd, GAUSSIAN_MIN_SAMPLE_SD);
+                // The message quotes both numbers verbatim.
+                let msg = err.message_for("y");
+                assert!(msg.contains("effectively constant"), "msg = {msg}");
+            }
+            other => panic!("expected GaussianNearConstant, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn gaussian_degeneracy_well_conditioned_ok() {
+        // A genuinely varying response (sd ~ O(1)) is never tripped.
+        let y = arr1(&[-2.0_f64, 0.5, 1.7, 3.0, -1.1, 2.2]);
+        assert!(ResponseFamily::Gaussian
+            .validate_response_degeneracy(y.view())
+            .is_ok());
+    }
+
+    #[test]
+    fn gaussian_degeneracy_small_signal_above_floor_ok() {
+        // sd ~ 1e-6 is small but far above the 1e-10 floor: a legitimately
+        // small-but-real signal (e.g. a finely-resolved measurement) must fit,
+        // so the guard must not over-reject.
+        let y = arr1(&[1.0_f64, 1.0 + 1.0e-6, 1.0 - 1.0e-6, 1.0 + 2.0e-6]);
+        assert!(ResponseFamily::Gaussian
+            .validate_response_degeneracy(y.view())
+            .is_ok());
+    }
+
+    #[test]
+    fn gaussian_degeneracy_single_observation_ok() {
+        // Fewer than two observations carries no estimable scale degeneracy;
+        // the sample-size gate handles too-small data separately.
+        let y = arr1(&[42.0_f64]);
+        assert!(ResponseFamily::Gaussian
+            .validate_response_degeneracy(y.view())
+            .is_ok());
     }
 
     // -----------------------------------------------------------------------

--- a/tests/test_gaussian_near_constant_response_rejected_issue_332.py
+++ b/tests/test_gaussian_near_constant_response_rejected_issue_332.py
@@ -1,0 +1,79 @@
+"""#332 contract: a near-constant Gaussian response is rejected pre-fit with a
+clear, actionable error — not an opaque ``reml_score must be finite, got inf``.
+
+A Gaussian fit's marginal REML log-likelihood carries a ``-n/2 * log sigma^2``
+term that diverges to ``+inf`` as the maximum-likelihood scale ``sigma -> 0``.
+For an effectively-constant response (the issue's reproducer:
+``y = rng.normal(scale=1e-13, size=200)``) every outer seed is therefore
+rejected and the fit aborts with ``reml_score must be finite, got inf``, which
+gives the user no hint that the real problem is a signal-free response column.
+
+The fix adds a family-owned degeneracy guard
+(``ResponseFamily::validate_response_degeneracy`` Gaussian arm,
+``crates/gam-spec/src/lib.rs``): it computes the two-pass mean-centred sample
+standard deviation and refuses ``sd <= GAUSSIAN_MIN_SAMPLE_SD = 1e-10`` *before*
+the marginal diverges, with a message that names the observed sd, the threshold,
+and concrete remedies (check units, centre/rescale, or drop the column).
+
+This test pins both directions: the near-constant reproducer raises a clean
+``gamfit.GamError`` (no panic, no inf-crash message), and a well-conditioned
+response with the same shape fits successfully (no over-rejection).
+"""
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+import gamfit
+
+
+def test_near_constant_gaussian_response_rejected_cleanly() -> None:
+    # The issue reproducer: a response that is constant up to f64 noise.
+    rng = np.random.default_rng(0)
+    n = 200
+    data = {
+        "x": np.linspace(0.0, 1.0, n),
+        "y": rng.normal(scale=1e-13, size=n),
+    }
+
+    with pytest.raises(gamfit.GamError) as excinfo:
+        gamfit.fit(data, "y ~ s(x)", family="gaussian")
+
+    msg = str(excinfo.value)
+    # The actionable degeneracy message, NOT the opaque internal crash.
+    assert "effectively constant" in msg, msg
+    assert "reml_score must be finite" not in msg, (
+        "near-constant Gaussian response should be rejected by the pre-fit "
+        f"degeneracy guard, not crash deep in the REML loop: {msg!r}"
+    )
+
+
+def test_well_conditioned_gaussian_response_still_fits() -> None:
+    # Same shape, but a genuine O(1) signal: the guard must not over-reject.
+    rng = np.random.default_rng(0)
+    n = 200
+    x = np.linspace(0.0, 1.0, n)
+    data = {"x": x, "y": np.sin(2.0 * np.pi * x) + rng.normal(scale=0.1, size=n)}
+
+    model = gamfit.fit(data, "y ~ s(x)", family="gaussian")
+    out = model.predict(data)
+    mean = out if isinstance(out, np.ndarray) else out["mean"]
+    mean = np.asarray(mean, dtype=float).ravel()
+    assert mean.shape[0] == n
+    assert np.all(np.isfinite(mean))
+
+
+def test_small_but_real_gaussian_signal_not_over_rejected() -> None:
+    # sd ~ 1e-6 is small but far above the 1e-10 floor: a legitimately
+    # finely-resolved measurement must fit, not be rejected as degenerate.
+    rng = np.random.default_rng(1)
+    n = 200
+    x = np.linspace(0.0, 1.0, n)
+    data = {"x": x, "y": 1.0 + 1e-6 * (x + rng.normal(scale=0.1, size=n))}
+
+    # Must not raise: this is a valid (if tiny-variance) signal.
+    model = gamfit.fit(data, "y ~ s(x)", family="gaussian")
+    out = model.predict(data)
+    mean = out if isinstance(out, np.ndarray) else out["mean"]
+    mean = np.asarray(mean, dtype=float).ravel()
+    assert np.all(np.isfinite(mean))


### PR DESCRIPTION
## Reopened #332 — improperly closed

The closing comment claimed a family-owned `GaussianNearConstant` degeneracy guard (two-pass mean-centred sample sd, threshold `GAUSSIAN_MIN_SAMPLE_SD = 1e-10`) was added to `ResponseFamily::validate_response_degeneracy`. **It was never implemented.**

- `crates/gam-spec/src/lib.rs:722` (pre-fix): the Gaussian arm was `Self::Gaussian => Ok(())` (unconditional).
- No `GaussianNearConstant` variant, no `GAUSSIAN_MIN_SAMPLE_SD` constant anywhere in the tree.
- `gaussian_degeneracy_always_ok` was a unit test that **codified the absence** of the guard.

Net effect: the issue's reproducer (`y = rng.normal(scale=1e-13, size=200)`) still crashed with `reml_score must be finite, got inf` because the marginal REML `-n/2·log σ²` diverges to +∞ as σ→0.

## Fix
Implemented the family-owned guard exactly as the closing comment described:
- `ResponseDegeneracyKind::GaussianNearConstant { sample_sd, min_sd }` with a message quoting both numbers verbatim (mirrors the `BinomialAll{Zeros,Ones}` pattern).
- `GAUSSIAN_MIN_SAMPLE_SD = 1e-10` — well below any well-conditioned signal, above the f64 round-off floor.
- Gaussian arm: two-pass mean-centred sample sd; reject when `sd <= floor`; skip <2 observations (no estimable scale) and non-finite values (left to the dedicated finiteness checks). Surfaces through the existing `materialize_standard` call site (no new wiring).

## Tests — all green
**Rust** (`./build.sh nextest run -p gam-spec` → 71/71 pass): replaced the absence-codifying `gaussian_degeneracy_always_ok` with 5 real tests — exactly-constant ⇒ rejected, the `1e-13` reproducer ⇒ rejected (asserts variant + message), well-conditioned ⇒ accepted, small-but-real `1e-6` ⇒ accepted, single observation ⇒ accepted.

**Python e2e** (`maturin develop --release` + pytest → 3/3 pass): the reproducer now raises `gamfit.GamError` containing "effectively constant" (NOT the opaque `reml_score must be finite`); well-conditioned and small-but-real signals still fit.