### PR TITLE
[agent][gpu] arrow-Schur NVRTC arch-pin + fail-loud (WIP)

### DIFF
--- a/.agent/gpu-arrowschur-nvrtc.md
+++ b/.agent/gpu-arrowschur-nvrtc.md
@@ -1,0 +1,27 @@
+# [agent][gpu] arrow-Schur NVRTC PCG device kernel — arch-pin + fail-loud
+
+GPU box: 8× Tesla V100 SXM2 32GB (sm_70), CUDA 13.2, driver 595.71.05.
+Device pinned: CUDA_VISIBLE_DEVICES=4.
+
+## Focus
+crates/gam-solve/src/gpu_kernels/arrow_schur{,_nvrtc}.rs — the fused Layer D+E
+NVRTC arrow-Schur Newton kernel + the device PCG. Ensure:
+1. NVRTC compiles for THIS arch (sm_70) — not the NVRTC default (<sm_60).
+2. The device path actually RUNS on the GPU (not silent CPU/degrade).
+3. CPU↔GPU parity vs the dense reference oracle.
+4. NVRTC-decline FAILS LOUD.
+
+## Findings (in progress)
+- `fused_module_for` (arrow_schur.rs:1889) compiles via BARE `cudarc::nvrtc::compile_ptx`,
+  NOT the arch-pinned `compile_ptx_arch` / `PtxModuleCache`. device_cache.rs:129-139
+  explicitly warns bare compile_ptx defaults NVRTC below sm_60.
+- Dispatch (arrow_schur.rs:157-171) treats a fused NVRTC compile failure
+  (SchurFactorFailed) as "fall through to unfused" — silently degrades the fused path.
+
+## Plan
+- Route the fused module compile through the arch-pinned options.
+- Audit fail-loud semantics on NVRTC decline.
+- CPU-verifiable parity tests now; real device parity once driver is up.
+
+## Blocker
+nvidia kernel module not loaded at start (cuInit->100 NO_DEVICE); polling for recovery.


### PR DESCRIPTION
## Focus
The arrow-Schur NVRTC PCG device kernel (`crates/gam-solve/src/gpu_kernels/arrow_schur{,_nvrtc}.rs`). Ensure the fused Layer D+E Newton kernel **compiles for this device's arch via NVRTC**, **runs on the GPU** (not silent CPU), **matches the CPU oracle**, and **fails loud** when NVRTC declines.

Box: 8× Tesla V100 SXM2 (sm_70), CUDA 13.2.

## Findings under investigation
- `cuda::fused_module_for` (arrow_schur.rs:1889) compiles via **bare `cudarc::nvrtc::compile_ptx`** — NOT the arch-pinned path. `device_cache.rs:129-139` explicitly documents that the bare entry point defaults NVRTC below `sm_60`, so any kernel relying on the device's real CC (or double atomics) silently fails to compile and degrades to CPU. This is the #1551-class root cause for the fused kernel.
- The fused-path dispatch (arrow_schur.rs:157-171) treats `SchurFactorFailed` from an NVRTC compile failure as "fall through to unfused" — masking a real compile error.

## Plan
1. Route the fused module compile through arch-pinned NVRTC options (sm_70 on this box).
2. Make NVRTC-decline fail loud where it should, not silently degrade.
3. CPU↔GPU parity vs the dense reference oracle; prove on the real V100.

## Status
WIP. Box's nvidia kernel module was not loaded at session start (`cuInit→100`); polling for recovery while doing CPU-verifiable work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)