### PR TITLE
[agent] reopen #1595: thread survival extrapolation policy into dense FFI kernels

### DIFF
--- a/crates/gam-pyffi/src/io/survival_surface_io.rs
+++ b/crates/gam-pyffi/src/io/survival_surface_io.rs
@@ -285,6 +285,7 @@ fn clip_survival_surface_value(mut value: f64, clip_lo: Option<f64>, clip_hi: Op
 }
 
 #[pyfunction]
+#[pyo3(signature = (grid, surface, times, kind, clip_lo, clip_hi, people_chunk, time_grid_chunk, left_value = None, right_value = None))]
 pub(crate) fn survival_chunk_iter_collect<'py>(
     py: Python<'py>,
     grid: PyReadonlyArray1<'py, f64>,
@@ -295,23 +296,27 @@ pub(crate) fn survival_chunk_iter_collect<'py>(
     clip_hi: Option<f64>,
     people_chunk: usize,
     time_grid_chunk: usize,
+    left_value: Option<f64>,
+    right_value: Option<f64>,
 ) -> PyResult<Py<PyArray2<f64>>> {
-    // Mirror the asymptotic-extrapolation policy in
-    // `gamfit._survival._SURVIVAL_EXTRAPOLATION`: survival surfaces are
-    // continued to S(t<=0)=1 and S(t->inf)=0 outside the modeled grid, and
-    // cumulative hazard mirrors that via H(t<=0)=0. Hazards and standard
-    // errors have no canonical asymptote, so they keep nearest-endpoint
-    // behavior (signaled by `None`/`None`).
-    let (kind_left_value, kind_right_value): (Option<f64>, Option<f64>) = match kind {
-        "survival" => (Some(1.0), Some(0.0)),
-        "cumulative_hazard" => (Some(0.0), None),
-        "hazard" | "survival_se" => (None, None),
+    // The asymptotic-extrapolation policy is owned by
+    // `gamfit._survival._SURVIVAL_EXTRAPOLATION` and threaded in as
+    // `left_value`/`right_value` — Python is the single source of truth so this
+    // dense path cannot drift from the in-process `_interpolate_rows` path (the
+    // #1595 bug: a stale hardcoded `S(t->inf)=0` here re-broke S(t)=exp(-H(t))
+    // past the grid for large queries while cumulative hazard flat-clamped).
+    // `None` on either side means nearest-endpoint (flat-clamp) extrapolation.
+    let (kind_left_value, kind_right_value) = (left_value, right_value);
+    // `kind` is still validated so an unknown surface name is a hard error
+    // rather than a silent flat-clamp.
+    match kind {
+        "survival" | "cumulative_hazard" | "hazard" | "survival_se" => {}
         other => {
             return Err(py_value_error(format!(
                 "unknown survival surface kind '{other}'"
             )));
         }
-    };
+    }
     if people_chunk == 0 {
         return Err(py_value_error("people_chunk must be positive".to_string()));
     }
@@ -382,6 +387,7 @@ pub(crate) fn survival_chunk_iter_collect<'py>(
 }
 
 #[pyfunction]
+#[pyo3(signature = (path, grid, surface, times, id_column, row_ids, people_chunk, time_grid_chunk, left_value = None, right_value = None))]
 pub(crate) fn write_survival_csv(
     py: Python<'_>,
     path: &str,
@@ -392,6 +398,8 @@ pub(crate) fn write_survival_csv(
     row_ids: Option<Vec<String>>,
     people_chunk: usize,
     time_grid_chunk: usize,
+    left_value: Option<f64>,
+    right_value: Option<f64>,
 ) -> PyResult<String> {
     if people_chunk == 0 {
         return Err(py_value_error("people_chunk must be positive".to_string()));
@@ -463,6 +471,12 @@ pub(crate) fn write_survival_csv(
                 let time_stop = (time_start + time_grid_chunk).min(times_values.len());
                 for row_idx in row_start..row_stop {
                     for query_value in &times_values[time_start..time_stop] {
+                        // Extrapolation policy threaded from
+                        // `gamfit._survival._SURVIVAL_EXTRAPOLATION` (single
+                        // source of truth): S(t<=0)=1 below the grid, and
+                        // flat-clamp to S(t_max) above it (`right_value` is
+                        // `None`), so the CSV agrees with `survival_at()` and
+                        // preserves S(t)=exp(-H(t)) past the grid (#1595).
                         let survival = survival_csv_interpolate(
                             &surface_values,
                             n_cols,
@@ -470,8 +484,8 @@ pub(crate) fn write_survival_csv(
                             &sorted_indices,
                             row_idx,
                             *query_value,
-                            Some(1.0),
-                            Some(0.0),
+                            left_value,
+                            right_value,
                         )
                         .clamp(0.0, 1.0);
                         match (id_column.as_ref(), row_ids.as_ref()) {

--- a/gamfit/_survival.py
+++ b/gamfit/_survival.py
@@ -273,6 +273,11 @@ class SurvivalPrediction:
         left_value, right_value = _extrapolation_for(kind)
         if self._should_auto_chunk_dense(surface.shape[0], times_arr.size):
             clip_lo, clip_hi = clip
+            # Thread the asymptotic-extrapolation policy through so the dense
+            # path uses the SAME S(t<=0)/S(t->inf) law as the in-process
+            # `_interpolate_rows` branch below (#1595): a previously-hardcoded
+            # `S(t->inf)=0` in the Rust chunk kernel re-broke S(t)=exp(-H(t))
+            # past the grid for large queries.
             return rust_module().survival_chunk_iter_collect(
                 grid,
                 surface,
@@ -282,6 +287,8 @@ class SurvivalPrediction:
                 clip_hi,
                 DEFAULT_SURVIVAL_PEOPLE_CHUNK,
                 DEFAULT_SURVIVAL_TIME_GRID_CHUNK,
+                left_value,
+                right_value,
             )
         return _interpolate_rows(
             grid,
@@ -503,6 +510,10 @@ class SurvivalPrediction:
         grid, surface = self._ffi_surface("survival")
         if grid is not None and surface is not None:
             include_ids = self.id_column is not None and self.row_ids is not None
+            # Same extrapolation law as the in-memory survival path (#1595):
+            # S(t<=0)=1, S(t->inf) flat-held at the last fitted value, never
+            # forced to 0. The Rust CSV writer used to hardcode (1.0, 0.0).
+            left_value, right_value = _extrapolation_for("survival")
             return str(
                 rust_module().write_survival_csv(
                     str(path),
@@ -513,6 +524,8 @@ class SurvivalPrediction:
                     list(self.row_ids) if include_ids else None,
                     people_chunk,
                     time_grid_chunk,
+                    left_value,
+                    right_value,
                 )
             )
 

--- a/tests/test_bug_hunt_survival_at_inconsistent_with_cumulative_hazard_beyond_support_test.py
+++ b/tests/test_bug_hunt_survival_at_inconsistent_with_cumulative_hazard_beyond_support_test.py
@@ -31,6 +31,7 @@ import numpy as np
 import pandas as pd
 
 import gamfit
+from gamfit._survival import DENSE_SURVIVAL_AUTO_CHUNK_CELLS
 
 
 def _make_dataset() -> pd.DataFrame:
@@ -109,4 +110,80 @@ def test_survival_at_consistent_with_cumulative_hazard_beyond_support(
     assert abs(survival[1] - survival[2]) < 1e-4, (
         f"[{likelihood}] survival jumps at the grid edge: "
         f"S(t_max)={survival[1]:.6f} -> S(t_max+eps)={survival[2]:.6f}"
+    )
+
+
+def test_survival_at_consistent_beyond_support_on_dense_chunk_path() -> None:
+    """Same identity, but forced through the dense auto-chunk FFI kernel.
+
+    ``cumulative_hazard_at`` / ``survival_at`` interpolate through one of two
+    code paths chosen purely by query size: the in-process ``_interpolate_rows``
+    helper for small queries, and the chunked Rust kernel
+    ``survival_chunk_iter_collect`` once ``n_rows * n_times`` crosses
+    ``DENSE_SURVIVAL_AUTO_CHUNK_CELLS`` (1M cells). The original #1595 fix only
+    corrected the Python extrapolation policy and the small-query path; the
+    dense kernel kept a *hardcoded* ``S(t->inf)=0`` while cumulative hazard
+    flat-clamped, so the very same ``S(t)=exp(-H(t))`` identity silently broke
+    again for large queries -- and no regression test crossed the threshold to
+    catch it. This test deliberately sizes the query past the threshold so the
+    dense kernel is exercised.
+    """
+    df = _make_dataset()
+    model = gamfit.fit(df, "Surv(entry, exit, event) ~ age", survival_likelihood="weibull")
+
+    # Pick a row count and time count whose product clears the 1M-cell dense
+    # auto-chunk threshold so the chunked Rust kernel (not _interpolate_rows) is
+    # the path under test. ~3000 people x ~350 times = ~1.05M cells.
+    n_people = 3000
+    rng = np.random.default_rng(7)
+    predict_df = pd.DataFrame(
+        {
+            "entry": np.zeros(n_people),
+            "exit": np.full(n_people, 5.0),
+            "event": np.ones(n_people, dtype=int),
+            "age": rng.uniform(40.0, 75.0, n_people),
+        }
+    )
+    pred = model.predict(predict_df)
+
+    t_max = float(np.asarray(pred.times).max())
+    assert t_max > 12.0, f"unexpectedly small fitted grid: t_max={t_max}"
+
+    # Straddle below / at / just past / well past t_max, then pad with in-grid
+    # query times so the total cell count crosses the dense threshold.
+    straddle = np.array([0.5 * t_max, t_max, t_max + 1e-3, t_max + 5.0, t_max + 20.0])
+    n_times = (DENSE_SURVIVAL_AUTO_CHUNK_CELLS // n_people) + 50
+    n_pad = max(0, n_times - straddle.size)
+    pad = np.linspace(1e-3, t_max - 1e-3, n_pad)
+    ts = np.concatenate([straddle, pad])
+
+    assert n_people * ts.size > DENSE_SURVIVAL_AUTO_CHUNK_CELLS, (
+        "test misconfigured: query does not cross the dense auto-chunk threshold "
+        f"({n_people} x {ts.size} = {n_people * ts.size} <= "
+        f"{DENSE_SURVIVAL_AUTO_CHUNK_CELLS})"
+    )
+
+    survival = np.asarray(pred.survival_at(ts))
+    cum_haz = np.asarray(pred.cumulative_hazard_at(ts))
+    survival_from_haz = np.exp(-cum_haz)
+
+    # Identity over the WHOLE dense surface (every person, every time).
+    max_gap = float(np.max(np.abs(survival - survival_from_haz)))
+    assert max_gap < 1e-4, (
+        f"dense chunk path violates S(t)=exp(-H(t)): max gap = {max_gap:.6f}"
+    )
+
+    # Focus the asymptote assertions on the straddle columns (indices 0..4).
+    past_grid = straddle > t_max
+    s_straddle = survival[:, : straddle.size]
+    h_straddle = cum_haz[:, : straddle.size]
+    assert np.all(np.isfinite(h_straddle[:, past_grid])), (
+        "dense path: cumulative hazard went non-finite past the grid"
+    )
+    assert np.all(s_straddle[:, past_grid] > 1e-6), (
+        "dense path: survival collapsed to ~0 past the grid while H stayed finite"
+    )
+    # No jump at the grid edge: S(t_max) ~= S(t_max + eps) for every row.
+    assert np.max(np.abs(s_straddle[:, 1] - s_straddle[:, 2])) < 1e-4, (
+        "dense path: survival jumps at the grid edge"
     )


### PR DESCRIPTION
## Why #1595 was improperly closed

The original fix (`ee5994c`) only corrected **half** the code paths:

- ✅ Python `_SURVIVAL_EXTRAPOLATION` policy table (`survival: (1.0, None)`, `cumulative_hazard: (0.0, None)`)
- ✅ small-query `_interpolate_rows` FFI path
- ❌ the **two dense Rust FFI kernels** in `crates/gam-pyffi/src/io/survival_surface_io.rs` (`survival_chunk_iter_collect`, `write_survival_csv`) kept a **hardcoded** policy:
  ```rust
  match kind {
      "survival" => (Some(1.0), Some(0.0)),  // forces S(t->inf) = 0
      "cumulative_hazard" => (Some(0.0), None),
      ...
  }
  ```

So past the fitted grid the chunked path forced `S(t→∞)=0` while `cumulative_hazard` flat-clamped to a finite `H(t_max)` — giving `exp(-H) > 0` but `S = 0`, a gross violation of `S(t) = exp(-H(t))` and a spurious jump discontinuity at the grid edge.

**Why it slipped through review:** the dense kernels are only taken when `n_rows × n_times > DENSE_SURVIVAL_AUTO_CHUNK_CELLS` (1,000,000). The #1595 regression test queries 400 rows × 5 times = 2000 cells, so it never crossed the threshold and the stale kernel was never exercised.

Reproduced directly: under the old hardcoded `right_value=0.0`, the dense path yields a **0.67** absolute `|S − exp(−H)|` gap.

## Fix — make Python the single source of truth

- `survival_chunk_iter_collect` and `write_survival_csv` now accept `left_value: Option<f64>` / `right_value: Option<f64>` (with `#[pyo3(signature = ...)]` defaults) instead of re-deriving the policy in Rust. `kind` is still validated so an unknown surface name remains a hard error. The CSV writer uses the survival policy `(1.0, None)`.
- `gamfit/_survival.py` threads `_extrapolation_for(kind)` into both dense call sites (`_ffi_surface_at` chunk branch and `write_survival_at_csv`), matching the in-process path exactly.
- New dense-path regression test crosses the auto-chunk threshold (~3000 people × ~350 times > 1M cells) and asserts the identity over the whole surface, finite `H` + strictly-positive `S` past the grid, and no edge jump. Verified **discriminating**: passes with the fix, fails (gap 0.67) under the simulated old policy.

## Verification

- `./build.sh` — green (Rust workspace)
- `./build.sh maturin` — extension rebuilt
- `pytest tests/test_bug_hunt_survival_at_inconsistent_with_cumulative_hazard_beyond_support_test.py` — 4 passed (3 existing likelihoods + new dense-path test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)