### PR TITLE
[agent] reopen #1515: count-family degenerate-response guard (WIP)

### DIFF
--- a/.agent/batch-notes.md
+++ b/.agent/batch-notes.md
@@ -49,3 +49,10 @@ addressed instances, not the pattern, so it keeps regressing.
 - Move the two `cfg(test)` multinomial oracle methods into the existing
   `#[cfg(test)] mod tests` impl block (the sanctioned location).
 - Then sweep the rest of the range for genuinely-improperly-closed bugs.
+
+## #1515 — count-family degenerate-response guard (reopen)
+
+Reopened: gamfit.fit accepts an all-zero Poisson/NB response (saturated η̂=log(0)=−∞)
+while the binomial path and the CLI reject the analogous all-zero/all-one case.
+Fix: extend ResponseFamily::validate_response_degeneracy (gam-spec, the shared
+core guard both fit entry points already call) to reject all-zero count responses.


### PR DESCRIPTION
Reopening #1515. The predict-crash symptom was fixed (robust posterior-mean fallback), but the issue's explicitly-stated parity goal remains live: `gamfit.fit` ACCEPTS an all-zero Poisson/NB response (fits a degenerate flat-likelihood model) while the binomial path AND the `gam` CLI cleanly reject the analogous all-zero/all-one boundary. README: 'share one engine'; SPEC: Python/Rust/CLI parity.

Root-cause fix incoming: extend `ResponseFamily::validate_response_degeneracy` in `crates/gam-spec` (the shared core guard that both `materialize/standard.rs` and `location_scale.rs` already call) to reject an all-zero count response — mathematically the same saturated-boundary pathology (η̂=log 0=−∞) the binomial all-zeros arm already rejects. Will NOT replicate the CLI's over-eager universal-constant guard: a constant *nonzero* count or constant Gaussian fits a valid intercept-only model.

WIP placeholder; implementation + regression tests to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)