### PR TITLE
[agent][gpu] #1551 device-resident SAE solver engagement + #1209 honest fail-loud routing

### DIFF
--- a/.agent/gpu-1551-engage.md
+++ b/.agent/gpu-1551-engage.md
@@ -60,6 +60,30 @@ GPU engagement proven via nvidia-smi dmon (312MB fb resident, SM util spikes 2-8
 
 ## Next: dense reduced-β path, #1209 honest routing, run full gpu suite.
 
+## END-TO-END PRODUCTION ENGAGEMENT TEST — GREEN on V100
+`sae_direct_inner_solve_engages_device_and_matches_cpu_1551` PASSES on Tesla V100:
+- Drives the PUBLIC production entry `solve_arrow_newton_step_artifacts` with a
+  device-equipped SAE system (n=512, k=64) that clears the offload gate.
+- HARD ASSERTS `used_device_arrow == true` on a CUDA host (fail-loud #1551 contract:
+  a silent CPU fallback FAILS the test). Engagement re-confirmed via nvidia-smi dmon
+  (312MB fb resident during the run).
+- Δβ/Δt parity vs `solve_arrow_newton_step_dense_reference` within 1e-7.
+
+Two fixture defects fixed to get a SOUND parity gate (NOT loosened):
+1. Reduced Schur not PD — device non-framed H_ββ comes from `data.sparse_g_blocks`
+   (G⊗I_p), NOT `sys.hbb`; fixture left them empty so H_ββ≈ρ·I and the n=512-row
+   Schur subtraction went indefinite (device CORRECTLY failed loud). Installed a
+   dominant-diagonal H_ββ as 1×1 SparseGBlocks AND mirrored it in sys.hbb.
+2. Parity oracle decoupled — the dense reference reads `row.htbeta` directly; the
+   fixture shipped coupling ONLY as a matrix-free operator (row.htbeta all-zeros),
+   so the reference solved a DECOUPLED system. Materialized the operator into each
+   row.htbeta (exact unit-column probe), htbeta_dense_supplement OFF so the
+   matrix-free apply is unchanged. All three paths now encode one H_tβ.
+
+Full `gpu_kernels::arrow_schur` suite (17 tests) GREEN; `arrow_schur::tests` 57 pass
+(the only failure is the pre-existing 2x2 brittleness below — proven identical on
+clean merge-base e128441cd, owned by PR #1650 which already edits that test file).
+
 ## Pre-existing CPU failure (NOT mine, out of GPU scope)
 `arrow_schur::tests::arrow_schur_matches_dense_reference_2x2` FAILS on main @ e128441cd,
 deterministically, single-threaded. It `assert_eq!`s delta_beta (non-streaming) vs

--- a/.agent/gpu-1551-engage.md
+++ b/.agent/gpu-1551-engage.md
@@ -24,3 +24,19 @@ Agent: `gpu-1551-engage` on Tesla V100-SXM2-32GB (sm_70), CUDA 12.4, device 0.
 
 ## Log
 - (start) branch + PR opened; verifying GPU + reading kernels.
+
+## CRITICAL FINDING (on V100, build green)
+Ran `framed_sae_device_pcg_matches_cpu_when_cuda_admits` on the live V100:
+```
+max_rel=5.45e-3 | ‖S_cpu·device−rhs‖=3.63e-12 (CPU's own =1.02e-1)
+device PCG stop=Converged iters=74 final_rel_resid=9.65e-13
+```
+=> The framed DEVICE matvec is now CORRECT (satisfies the CPU operator to 3.6e-12).
+   The historic "different operator, resid 18.5" bug is RESOLVED on current main.
+   The test FAILS because its CPU REFERENCE (dense Cholesky on the assembled S) is
+   itself inaccurate (resid 0.10) — the 400-row reduced-Schur fixture makes S
+   ill-conditioned, so dense Cholesky loses precision while PCG (self-correcting)
+   reaches 1e-12. Device is MORE accurate than the test's own oracle.
+
+## Next: rigorously confirm conditioning is the cause; fix the parity oracle to be
+## a sound CPU comparison (CPU-PCG with same matvec, or well-conditioned fixture).

--- a/.agent/gpu-1551-engage.md
+++ b/.agent/gpu-1551-engage.md
@@ -1,0 +1,26 @@
+# #1551 — device-resident SAE solver engagement (+ #1209 honest routing)
+
+Agent: `gpu-1551-engage` on Tesla V100-SXM2-32GB (sm_70), CUDA 12.4, device 0.
+
+## State of the issue (from comments)
+- NVRTC arch-pin (`--gpu-architecture` from device CC) landed → SAE PCG kernels now
+  COMPILE on real GPUs (root cause of historic 0% GPU).
+- Direct-mode device routing (`try_device_arrow_direct_sae_pcg`) landed → production
+  SAE inner solve routes to device.
+- `#1209` honest-routing diagnostics landed (`injected_host_procedural_matvec`).
+- OPEN BLOCKER: the **framed** SAE device PCG (`G⊗W_ij`) computes a WRONG operator on
+  hardware. CPU dense reduced-β PCG parity PASSES; framed FAILS (max_rel≈0.91,
+  ‖S_cpu·x_dev−rhs‖≈18.5 vs CPU's 0.10). Structural marshalling/launch bug.
+
+## My GPU is live
+`cuInit=0 count=1` (peer's `cuInit→100` was transient). V100 sm_70 has double atomicAdd.
+
+## Plan
+1. Build via `./build.sh`; run the stage-isolating triage seam + the two parity tests
+   ON the V100. Confirm which kernel stage diverges (per-component S·e_j diff).
+2. Fix the framed-matvec structural bug; prove device==CPU ≤1e-9.
+3. Keep CPU path bit-identical; fail loud on device decline.
+4. Promote the recorded on-GPU assertion to a live `#[test]`.
+
+## Log
+- (start) branch + PR opened; verifying GPU + reading kernels.

--- a/.agent/gpu-1551-engage.md
+++ b/.agent/gpu-1551-engage.md
@@ -40,3 +40,22 @@ device PCG stop=Converged iters=74 final_rel_resid=9.65e-13
 
 ## Next: rigorously confirm conditioning is the cause; fix the parity oracle to be
 ## a sound CPU comparison (CPU-PCG with same matvec, or well-conditioned fixture).
+
+## RESOLVED on V100 — framed SAE device PCG now GREEN
+All three framed device tests PASS on Tesla V100 sm_70:
+- framed_sae_device_matvec_matches_cpu_oracle_when_cuda_admits (NEW, conditioning-free) ✅
+- framed_sae_device_pcg_matches_cpu_when_cuda_admits (was FAILING; fixed gate) ✅
+- framed_sae_device_matvec_stage_diff_tiny_1551 ✅
+
+Root cause of the historic "framed kernel 91% wrong / resid 18.5":
+- The CURRENT kernel computes the correct operator (matvec parity ≤1e-9, conditioning-free).
+- The OLD test asserted solution-VECTOR equality vs a dense-Cholesky reference. On the
+  fixture's near-singular S, κ(S) amplifies O(ε) residual diffs to O(κ·ε) vector diffs.
+  The dense ref itself only reached ‖S·x−rhs‖≈0.1 while device PCG reached ~1e-12 — the
+  device was MORE accurate, not wrong.
+Fix: gate on OPERATOR RESIDUAL (device δβ must solve the CPU-oracle system to PCG tol)
+  + an independent CPU pcg_core solve of the same operator/preconditioner. Both converge.
+
+GPU engagement proven via nvidia-smi dmon (312MB fb resident, SM util spikes 2-8%).
+
+## Next: dense reduced-β path, #1209 honest routing, run full gpu suite.

--- a/.agent/gpu-1551-engage.md
+++ b/.agent/gpu-1551-engage.md
@@ -59,3 +59,11 @@ Fix: gate on OPERATOR RESIDUAL (device δβ must solve the CPU-oracle system to 
 GPU engagement proven via nvidia-smi dmon (312MB fb resident, SM util spikes 2-8%).
 
 ## Next: dense reduced-β path, #1209 honest routing, run full gpu suite.
+
+## Pre-existing CPU failure (NOT mine, out of GPU scope)
+`arrow_schur::tests::arrow_schur_matches_dense_reference_2x2` FAILS on main @ e128441cd,
+deterministically, single-threaded. It `assert_eq!`s delta_beta (non-streaming) vs
+delta_beta_stream (streaming chunk_size=1) — they differ in the LAST ULP (~4e-16 rel),
+a brittle exact-equality assertion over two summation orderings. File is
+crates/gam-solve/src/arrow_schur/tests.rs (I never touched it). Noted on PR; belongs to
+a CPU-path owner, not this GPU PR.

--- a/.agent/gpu-1551-engage.md
+++ b/.agent/gpu-1551-engage.md
@@ -84,6 +84,24 @@ Full `gpu_kernels::arrow_schur` suite (17 tests) GREEN; `arrow_schur::tests` 57 
 (the only failure is the pre-existing 2x2 brittleness below — proven identical on
 clean merge-base e128441cd, owned by PR #1650 which already edits that test file).
 
+## #1209 fail-loud + honest-routing hardening (beyond the original blocker)
+1. InexactPCG device seam (newton_step.rs:1715) silently swallowed ALL
+   `solve_sae_matrix_free_pcg` errors via a bare `if let Ok` → CPU fallback with
+   used_device_arrow=false. This is the K>2000 regime `automatic` routes to (where
+   the device matters MOST). Fixed: classify exactly like the Direct seam
+   (RidgeBumpRequired/SchurFactorFailed surface as ArrowSchurError; only Unavailable
+   falls through). Test `sae_inexact_pcg_inner_solve_engages_device_and_matches_cpu_1551`.
+2. Contradictory diagnostics: `solve_arrow_newton_step_core` unconditionally stamped
+   `injected_host_procedural_matvec=true` after injecting a host matvec — but the
+   re-entry can take the device-resident SAE PCG branch (used_device_arrow=true)
+   without consuming the host closure → BOTH flags set (mutually exclusive per #1209).
+   Fixed: only stamp host-procedural when !used_device_arrow. Test
+   `device_arrow_and_host_procedural_matvec_flags_are_mutually_exclusive_1209` (with a
+   non-vacuity guard proving the device-served InexactPCG path is reached on CUDA).
+
+Final suite: `arrow_schur` (incl gpu_kernels) 70 pass / 1 fail; the only failure is
+the pre-existing 2x2 brittleness below. All four new tests GREEN on V100.
+
 ## Pre-existing CPU failure (NOT mine, out of GPU scope)
 `arrow_schur::tests::arrow_schur_matches_dense_reference_2x2` FAILS on main @ e128441cd,
 deterministically, single-threaded. It `assert_eq!`s delta_beta (non-streaming) vs

--- a/crates/gam-solve/src/arrow_schur/newton_step.rs
+++ b/crates/gam-solve/src/arrow_schur/newton_step.rs
@@ -219,7 +219,19 @@ pub fn solve_arrow_newton_step_core(
                 // must NOT claim device execution here — flag it as a host procedural
                 // matvec instead. `used_device_arrow` stays reserved for the genuinely
                 // device-executed Direct and device-resident PCG paths.
-                diagnostics.injected_host_procedural_matvec = true;
+                //
+                // BUT the re-entered solve may itself have taken the genuinely
+                // device-resident SAE PCG branch (`device_sae_pcg` present + the
+                // offload gate cleared) and returned `used_device_arrow == true`
+                // WITHOUT ever consuming the injected host matvec — in that case the
+                // host closure did not run, so stamping the host-procedural flag
+                // would emit a contradictory diagnostic (#1209 treats the two as
+                // mutually exclusive: one says "matvec ran on the host", the other
+                // "the solve ran on the device"). Only claim the host procedural
+                // matvec when the device-resident path did NOT serve this step.
+                if !diagnostics.used_device_arrow {
+                    diagnostics.injected_host_procedural_matvec = true;
+                }
                 (step.delta_t, step.delta_beta, diagnostics)
             },
         );

--- a/crates/gam-solve/src/arrow_schur/newton_step.rs
+++ b/crates/gam-solve/src/arrow_schur/newton_step.rs
@@ -1722,33 +1722,75 @@ pub(crate) fn solve_arrow_newton_step_artifacts(
                         .pcg
                         .relative_tolerance
                         .max(options.trust_region.steihaug_relative_tolerance);
-                    if let Ok((delta, mut diag)) =
-                        crate::gpu_kernels::arrow_schur::solve_sae_matrix_free_pcg(
-                            sys,
-                            device_data.as_ref(),
-                            ridge_t,
-                            ridge_beta,
-                            &rhs_beta,
-                            max_iterations,
-                            relative_tolerance,
-                        )
-                    {
-                        diag.used_device_arrow = true;
-                        return Ok(ArrowNewtonStepArtifacts {
-                            delta_t: back_substitute_delta_t(
-                                sys,
-                                &htt_factors,
-                                delta.view(),
-                                &backend,
-                            ),
-                            delta_beta: delta,
-                            htt_factors,
-                            schur_factor: None,
-                            pcg_diagnostics: diag,
-                            gauge_deflated_directions,
-                            deflated_row_directions,
-                            deflation_row_spectra,
-                        });
+                    // #1209/#1551 fail-loud routing — classify the device result
+                    // EXACTLY as the Direct seam (`try_device_arrow_direct_sae_pcg`)
+                    // does, never with a bare `if let Ok` that swallows hard faults.
+                    // A `SchurFactorFailed` / `RidgeBumpRequired` here is a REAL
+                    // numerical signal the LM escalation must respond to (bump the
+                    // ridge and retry); silently falling through to the CPU
+                    // `steihaug_pcg_auto` on those would (a) hide a device kernel
+                    // fault behind a CPU result flagged `used_device_arrow=false`
+                    // (the #1551 0%-GPU regression the issue is about — this is the
+                    // large-K InexactPCG regime where the device matters MOST), and
+                    // (b) continue on a possibly-wrong step instead of escalating.
+                    // Only a genuine "device declined" (`Unavailable` /
+                    // `GpuRequiresDenseSystem` / transient) falls through to CPU.
+                    match crate::gpu_kernels::arrow_schur::solve_sae_matrix_free_pcg(
+                        sys,
+                        device_data.as_ref(),
+                        ridge_t,
+                        ridge_beta,
+                        &rhs_beta,
+                        max_iterations,
+                        relative_tolerance,
+                    ) {
+                        Ok((delta, mut diag)) => {
+                            diag.used_device_arrow = true;
+                            return Ok(ArrowNewtonStepArtifacts {
+                                delta_t: back_substitute_delta_t(
+                                    sys,
+                                    &htt_factors,
+                                    delta.view(),
+                                    &backend,
+                                ),
+                                delta_beta: delta,
+                                htt_factors,
+                                schur_factor: None,
+                                pcg_diagnostics: diag,
+                                gauge_deflated_directions,
+                                deflated_row_directions,
+                                deflation_row_spectra,
+                            });
+                        }
+                        // Non-PD per-row block → surface the matching CPU error so
+                        // the LM loop bumps `ridge_t` and retries (NOT a silent CPU
+                        // step on stale curvature).
+                        Err(
+                            crate::gpu_kernels::arrow_schur::ArrowSchurGpuFailure::RidgeBumpRequired {
+                                row,
+                                bump,
+                            },
+                        ) => {
+                            return Err(ArrowSchurError::PerRowFactorFailed {
+                                row,
+                                reason: format!(
+                                    "device SAE matrix-free PCG per-row block non-PD; \
+                                     suggested ridge bump {bump:e}"
+                                ),
+                            });
+                        }
+                        // Non-PD reduced Schur → surface so LM escalation responds.
+                        Err(
+                            crate::gpu_kernels::arrow_schur::ArrowSchurGpuFailure::SchurFactorFailed {
+                                reason,
+                            },
+                        ) => {
+                            return Err(ArrowSchurError::SchurFactorFailed { reason });
+                        }
+                        // Unavailable / framed-mismatch / transient ⇒ the device
+                        // genuinely declined; fall through to the CPU PCG path
+                        // transparently (`used_device_arrow` stays false — honest).
+                        Err(_) => {}
                     }
                 }
             }

--- a/crates/gam-solve/src/arrow_schur/tests.rs
+++ b/crates/gam-solve/src/arrow_schur/tests.rs
@@ -3310,6 +3310,79 @@ pub(crate) fn sae_direct_inner_solve_engages_device_and_matches_cpu_1551() {
     let m_active = 4usize;
     let (mut sys, _a_phi, _jac) = sae_structured_system(n, q, p, n_atoms, m_active);
 
+    // The device non-framed `H_ββ` is assembled from `data.sparse_g_blocks` (as
+    // `G ⊗ I_p`), NOT from `sys.hbb` (which only the dense reference reads). For a
+    // sound parity fixture the two MUST encode the same matrix. In
+    // `sae_structured_system` each atom owns `p` consecutive β slots (μ-space
+    // index = atom, so `m_i = 1`), so a dominant diagonal `H_ββ` is one 1×1
+    // `SparseGBlock` per atom. Make it strongly diagonally dominant so the reduced
+    // Schur `S = (H_ββ + ρI) − Σ_i H_βt^(i)(H_tt^(i)+ρI)⁻¹ H_tβ^(i)` stays PD once
+    // the n=512-row subtraction accumulates (otherwise the device correctly fails
+    // loud on a non-positive Schur Jacobi diagonal — that fail-loud IS the #1551
+    // contract, just not what this parity fixture is exercising).
+    let hbb_diag = (n as f64) + 1000.0;
+    let mut sparse_g_blocks = Vec::with_capacity(n_atoms);
+    let mut new_hbb = Array2::<f64>::zeros((sys.k, sys.k));
+    for atom in 0..n_atoms {
+        sparse_g_blocks.push(SparseGBlock {
+            row_off: atom,
+            col_off: atom,
+            data: ndarray::array![[hbb_diag]],
+        });
+        // `G ⊗ I_p`: the 1×1 μ-block at (atom, atom) puts `hbb_diag` on the
+        // diagonal of all p channels of this atom's β slots.
+        for c in 0..p {
+            new_hbb[[atom * p + c, atom * p + c]] = hbb_diag;
+        }
+    }
+    sys.hbb = new_hbb;
+    // Reinstall the device payload carrying the matching sparse-G data Hessian.
+    {
+        let device = sys
+            .device_sae_pcg
+            .as_ref()
+            .expect("fixture installs device data");
+        let new_device = DeviceSaePcgData {
+            p: device.p,
+            beta_dim: device.beta_dim,
+            a_phi: std::sync::Arc::clone(&device.a_phi),
+            local_jac: std::sync::Arc::clone(&device.local_jac),
+            smooth_blocks: device.smooth_blocks.clone(),
+            sparse_g_blocks,
+            frame: None,
+        };
+        sys.set_device_sae_pcg_data(new_device);
+    }
+
+    // PARITY-ORACLE CONSISTENCY: `solve_arrow_newton_step_dense_reference` reads
+    // the cross-block `H_tβ` from `row.htbeta` DIRECTLY — it does not invoke the
+    // installed `htbeta_matvec` operator. But `sae_structured_system` ships the
+    // coupling ONLY as that matrix-free operator (`row.htbeta` is all-zeros), so
+    // an unmaterialized fixture makes the dense reference solve a DECOUPLED system
+    // (H_tβ ≡ 0) while the device solves the true coupled one — the parity gap is
+    // then the omitted coupling term, not a kernel/conditioning artifact. Materialize
+    // the operator into each `row.htbeta` (exact for a linear operator: probe with
+    // unit columns). With `htbeta_dense_supplement == false` the production apply
+    // (`sys_htbeta_apply_row`) still uses the operator ONLY, so the device/CPU
+    // matrix-free path is unchanged; the dense reference now reads the identical
+    // operator. All three paths (device PCG, CPU reduced, dense reference) then
+    // encode one and the same `H_tβ`.
+    assert!(
+        !sys.htbeta_dense_supplement,
+        "fixture must keep dense-supplement OFF so the matrix-free apply uses the \
+         operator only (row.htbeta is the dense ECHO for the reference, not a second \
+         additive slab)"
+    );
+    let materialized: Vec<Array2<f64>> = (0..sys.rows.len())
+        .map(|i| {
+            sys_htbeta_materialize_row(&sys, i, &sys.rows[i])
+                .expect("materialize row H_tβ from installed operator")
+        })
+        .collect();
+    for (i, mat) in materialized.into_iter().enumerate() {
+        sys.rows[i].htbeta = mat;
+    }
+
     // The fixture ships zero gradients (trivial zero step); install deterministic
     // nonzero g_t / g_β so the solved Δ is a real, discriminating vector.
     for (i, row) in sys.rows.iter_mut().enumerate() {

--- a/crates/gam-solve/src/arrow_schur/tests.rs
+++ b/crates/gam-solve/src/arrow_schur/tests.rs
@@ -3567,6 +3567,65 @@ pub(crate) fn sae_inexact_pcg_inner_solve_engages_device_and_matches_cpu_1551() 
     );
 }
 
+/// #1209 MUTUAL EXCLUSION — `used_device_arrow` (the matvec/solve genuinely ran
+/// on the device) and `injected_host_procedural_matvec` (a host Rust/Rayon
+/// reduced-Schur matvec closure was injected and ran on the CPU) describe
+/// MUTUALLY EXCLUSIVE execution facts: a single solve cannot have run its matvec
+/// both on the device and on the host. The production core entry
+/// `solve_arrow_newton_step_core` injects a host procedural matvec via
+/// `maybe_inject_gpu_schur_matvec` for an admitted InexactPCG SAE system — but
+/// the re-entered solve may itself take the genuinely device-resident SAE PCG
+/// branch (`device_sae_pcg` present) and never consume that injected closure. A
+/// naive unconditional stamp would then report BOTH flags (a contradiction, and
+/// an `injected_host_procedural_matvec` that is simply wrong — the matvec ran on
+/// the device). This pins that the two flags are never simultaneously set,
+/// driven through the public production path on a CUDA host.
+#[test]
+pub(crate) fn device_arrow_and_host_procedural_matvec_flags_are_mutually_exclusive_1209() {
+    let (sys, _n, _q) = well_posed_device_sae_system_1551();
+    let ridge_t = 1e-7;
+    let ridge_beta = 1e-6;
+
+    // Exercise the explicit InexactPCG entry (the one that injects a host
+    // procedural matvec via `maybe_inject_gpu_schur_matvec`) and the Direct entry
+    // through the public core.
+    let on_cuda = gam_gpu::device_runtime::GpuRuntime::global().is_some();
+    let mut inexact_used_device = false;
+    for options in [
+        ArrowSolveOptions::inexact_pcg(),
+        ArrowSolveOptions::direct(),
+    ] {
+        let mode = options.mode;
+        let (_dt, _db, diag) = solve_arrow_newton_step_core(&sys, ridge_t, ridge_beta, &options)
+            .expect("core solve");
+        assert!(
+            !(diag.used_device_arrow && diag.injected_host_procedural_matvec),
+            "#1209: used_device_arrow and injected_host_procedural_matvec are mutually \
+             exclusive execution facts but BOTH were set (mode={mode:?}) — a single solve \
+             cannot run its reduced-Schur matvec on the device AND as a host procedural \
+             closure"
+        );
+        if mode == ArrowSolverMode::InexactPCG && diag.used_device_arrow {
+            inexact_used_device = true;
+        }
+    }
+
+    // NON-VACUITY: on a CUDA host the InexactPCG path is EXACTLY the regression
+    // scenario — `maybe_inject_gpu_schur_matvec` injects a host matvec AND the
+    // re-entered solve takes the device-resident SAE PCG branch. If the device
+    // branch never engaged the mutual-exclusion assertion would pass trivially,
+    // so confirm the contradictory pre-condition (device-served InexactPCG) was
+    // actually reached. (The injection itself fires whenever the offload gate
+    // clears, which the well-posed fixture is built to do.)
+    if on_cuda {
+        assert!(
+            inexact_used_device,
+            "#1209: fixture must reach the device-served InexactPCG path on a CUDA host \
+             so the mutual-exclusion check is non-vacuous"
+        );
+    }
+}
+
 /// The CPU-resident SAE reduced-Schur matvec (#1017) must compute the SAME
 /// `S·x` as the generic per-row `apply → solve → transpose` path, up to f64
 /// reassociation. This is the residency correctness gate: a resident matvec

--- a/crates/gam-solve/src/arrow_schur/tests.rs
+++ b/crates/gam-solve/src/arrow_schur/tests.rs
@@ -3289,20 +3289,15 @@ pub(crate) fn sae_structured_system(
     (sys, a_phi, local_jac)
 }
 
-/// #1551 PRODUCTION ENGAGEMENT — end-to-end on a GPU host the SAE Direct inner
-/// solve must run on the DEVICE (`used_device_arrow == true`) and match the CPU
-/// dense reference Newton step. This is the test the issue asked for: it drives
-/// the public production entry `solve_arrow_newton_step_artifacts` with a
-/// device-equipped matrix-free SAE system whose `(n, k, d, cg_iters)` clears the
-/// reduced-Schur offload gate, so on a CUDA box `try_device_arrow_direct_sae_pcg`
-/// engages. On a non-CUDA host it skips cleanly (the seam declines → bit-identical
-/// CPU path); on a CUDA host it FAILS LOUD if the device path does not engage.
-#[test]
-pub(crate) fn sae_direct_inner_solve_engages_device_and_matches_cpu_1551() {
-    // Shape: k = n_atoms·p = 8·8 = 64 ≥ DEVICE_LOOP_MIN_P (32); the work
-    // predicate n·(2·d·k + d²)·cg_iters clears MATVEC_OFFLOAD_FLOPS_MIN by orders
-    // of magnitude (cg_iters defaults to 200). Modest n keeps the CPU reference
-    // and dense parity check cheap.
+/// Build a WELL-POSED device-equipped SAE system for the end-to-end engagement
+/// parity tests: PD reduced Schur, matching device/dense `H_ββ`, materialized
+/// cross-block `H_tβ`, and deterministic nonzero gradients. Shared by the Direct
+/// and InexactPCG engagement tests so both exercise the identical operator.
+///
+/// Shape `k = n_atoms·p = 64 ≥ DEVICE_LOOP_MIN_P (32)`; the work predicate
+/// `n·(2·d·k + d²)·cg_iters` clears `MATVEC_OFFLOAD_FLOPS_MIN` by orders of
+/// magnitude. Modest `n` keeps the CPU reference + dense parity check cheap.
+pub(crate) fn well_posed_device_sae_system_1551() -> (ArrowSchurSystem, usize, usize) {
     let n = 512usize;
     let q = 4usize; // per-row latent depth d
     let p = 8usize;
@@ -3393,6 +3388,20 @@ pub(crate) fn sae_direct_inner_solve_engages_device_and_matches_cpu_1551() {
     for a in 0..sys.k {
         sys.gb[a] = 0.05 * ((a as f64 + 1.0) * 0.021).cos() - 0.02;
     }
+    (sys, n, q)
+}
+
+/// #1551 PRODUCTION ENGAGEMENT — end-to-end on a GPU host the SAE Direct inner
+/// solve must run on the DEVICE (`used_device_arrow == true`) and match the CPU
+/// dense reference Newton step. This is the test the issue asked for: it drives
+/// the public production entry `solve_arrow_newton_step_artifacts` with a
+/// device-equipped matrix-free SAE system whose `(n, k, d, cg_iters)` clears the
+/// reduced-Schur offload gate, so on a CUDA box `try_device_arrow_direct_sae_pcg`
+/// engages. On a non-CUDA host it skips cleanly (the seam declines → bit-identical
+/// CPU path); on a CUDA host it FAILS LOUD if the device path does not engage.
+#[test]
+pub(crate) fn sae_direct_inner_solve_engages_device_and_matches_cpu_1551() {
+    let (sys, n, q) = well_posed_device_sae_system_1551();
 
     let policy = gam_gpu::policy::GpuDispatchPolicy::default();
     assert!(
@@ -3461,6 +3470,100 @@ pub(crate) fn sae_direct_inner_solve_engages_device_and_matches_cpu_1551() {
     assert!(
         max_dt_rel <= 1e-7,
         "#1551 SAE Direct Δt parity vs dense reference: max_rel={max_dt_rel:e} (>1e-7)"
+    );
+}
+
+/// #1551/#1209 PRODUCTION ENGAGEMENT (InexactPCG mode) — the LARGE-K regime
+/// (`K > DIRECT_SOLVE_MAX_K`) that `ArrowSolverMode::automatic` routes to
+/// `InexactPCG`, which is where the device matters MOST. The InexactPCG branch
+/// of `solve_arrow_newton_step_core` runs the device matrix-free SAE PCG when the
+/// trust radius is unbounded (the SAE inner-solve default). This pins TWO
+/// contracts the Direct test cannot:
+///   1. ENGAGEMENT (`used_device_arrow == true` on a CUDA host) for the InexactPCG
+///      seam specifically — a separate code path from the Direct seam.
+///   2. FAIL-LOUD routing (#1209): the branch must NOT swallow a device kernel
+///      fault and silently continue on the CPU with `used_device_arrow == false`.
+///      A genuine `Unavailable` decline still falls through transparently.
+/// Parity vs the dense reference holds on every host (CPU oracle == device).
+#[test]
+pub(crate) fn sae_inexact_pcg_inner_solve_engages_device_and_matches_cpu_1551() {
+    let (sys, n, q) = well_posed_device_sae_system_1551();
+
+    let policy = gam_gpu::policy::GpuDispatchPolicy::default();
+    assert!(
+        policy.reduced_schur_matvec_should_offload(n, sys.k, q, DEFAULT_PCG_MAX_ITERATIONS),
+        "fixture must clear the reduced-Schur offload gate so the device path is eligible"
+    );
+
+    // `inexact_pcg()` defaults to an unbounded trust radius (f64::INFINITY), so the
+    // device matrix-free SAE PCG branch of `solve_arrow_newton_step_core` is the
+    // one exercised here (NOT the Direct seam).
+    let options = ArrowSolveOptions::inexact_pcg();
+    assert_eq!(
+        options.trust_region.radius,
+        f64::INFINITY,
+        "InexactPCG default must keep the unbounded trust radius that authorizes the \
+         device matrix-free SAE PCG branch"
+    );
+    let ridge_t = 1e-7;
+    let ridge_beta = 1e-6;
+
+    let artifacts = solve_arrow_newton_step_artifacts(&sys, ridge_t, ridge_beta, &options)
+        .expect("SAE InexactPCG artifacts solve");
+
+    if gam_gpu::device_runtime::GpuRuntime::global().is_none() {
+        assert!(
+            !artifacts.pcg_diagnostics.used_device_arrow,
+            "no CUDA device present, yet the InexactPCG step was flagged device-served"
+        );
+    } else {
+        // CUDA present + the fixture clears the gate ⇒ the InexactPCG inner solve
+        // MUST run on the device. After the #1209/#1551 fail-loud routing fix, a
+        // device kernel fault would surface as an Err (caught by `.expect` above);
+        // a genuine decline would fall through to CPU. Either way a silent
+        // device→CPU fallback under a healthy device is the failure we forbid.
+        assert!(
+            artifacts.pcg_diagnostics.used_device_arrow,
+            "#1551: CUDA device present and the offload gate cleared, but the SAE \
+             InexactPCG inner solve did NOT engage the device \
+             (used_device_arrow=false) — the device path silently fell back to CPU"
+        );
+    }
+
+    // Parity (holds on every host): the produced Newton step must match the dense
+    // joint-system reference, exactly as in the Direct test (same well-posed system).
+    let reference = crate::gpu_kernels::arrow_schur::solve_arrow_newton_step_dense_reference(
+        &sys, ridge_t, ridge_beta,
+    )
+    .expect("dense reference solve");
+    let db_scale = reference
+        .delta_beta
+        .iter()
+        .fold(0.0_f64, |m, &v| m.max(v.abs()))
+        .max(1.0);
+    let mut max_db_rel = 0.0_f64;
+    for a in 0..sys.k {
+        max_db_rel =
+            max_db_rel.max((artifacts.delta_beta[a] - reference.delta_beta[a]).abs() / db_scale);
+    }
+    assert!(
+        max_db_rel <= 1e-7,
+        "#1551 SAE InexactPCG Δβ parity vs dense reference: max_rel={max_db_rel:e} (>1e-7) \
+         (device-served={})",
+        artifacts.pcg_diagnostics.used_device_arrow
+    );
+    let dt_scale = reference
+        .delta_t
+        .iter()
+        .fold(0.0_f64, |m, &v| m.max(v.abs()))
+        .max(1.0);
+    let mut max_dt_rel = 0.0_f64;
+    for i in 0..artifacts.delta_t.len() {
+        max_dt_rel = max_dt_rel.max((artifacts.delta_t[i] - reference.delta_t[i]).abs() / dt_scale);
+    }
+    assert!(
+        max_dt_rel <= 1e-7,
+        "#1551 SAE InexactPCG Δt parity vs dense reference: max_rel={max_dt_rel:e} (>1e-7)"
     );
 }
 

--- a/crates/gam-solve/src/arrow_schur/tests.rs
+++ b/crates/gam-solve/src/arrow_schur/tests.rs
@@ -3289,6 +3289,108 @@ pub(crate) fn sae_structured_system(
     (sys, a_phi, local_jac)
 }
 
+/// #1551 PRODUCTION ENGAGEMENT — end-to-end on a GPU host the SAE Direct inner
+/// solve must run on the DEVICE (`used_device_arrow == true`) and match the CPU
+/// dense reference Newton step. This is the test the issue asked for: it drives
+/// the public production entry `solve_arrow_newton_step_artifacts` with a
+/// device-equipped matrix-free SAE system whose `(n, k, d, cg_iters)` clears the
+/// reduced-Schur offload gate, so on a CUDA box `try_device_arrow_direct_sae_pcg`
+/// engages. On a non-CUDA host it skips cleanly (the seam declines → bit-identical
+/// CPU path); on a CUDA host it FAILS LOUD if the device path does not engage.
+#[test]
+pub(crate) fn sae_direct_inner_solve_engages_device_and_matches_cpu_1551() {
+    // Shape: k = n_atoms·p = 8·8 = 64 ≥ DEVICE_LOOP_MIN_P (32); the work
+    // predicate n·(2·d·k + d²)·cg_iters clears MATVEC_OFFLOAD_FLOPS_MIN by orders
+    // of magnitude (cg_iters defaults to 200). Modest n keeps the CPU reference
+    // and dense parity check cheap.
+    let n = 512usize;
+    let q = 4usize; // per-row latent depth d
+    let p = 8usize;
+    let n_atoms = 8usize;
+    let m_active = 4usize;
+    let (mut sys, _a_phi, _jac) = sae_structured_system(n, q, p, n_atoms, m_active);
+
+    // The fixture ships zero gradients (trivial zero step); install deterministic
+    // nonzero g_t / g_β so the solved Δ is a real, discriminating vector.
+    for (i, row) in sys.rows.iter_mut().enumerate() {
+        for r in 0..q {
+            row.gt[r] = 0.1 * (((i + 1) * (r + 2)) as f64 * 0.013).sin();
+        }
+    }
+    for a in 0..sys.k {
+        sys.gb[a] = 0.05 * ((a as f64 + 1.0) * 0.021).cos() - 0.02;
+    }
+
+    let policy = gam_gpu::policy::GpuDispatchPolicy::default();
+    assert!(
+        policy.reduced_schur_matvec_should_offload(n, sys.k, q, DEFAULT_PCG_MAX_ITERATIONS),
+        "fixture must clear the reduced-Schur offload gate so the device path is eligible"
+    );
+
+    let options = ArrowSolveOptions::direct();
+    let ridge_t = 1e-7;
+    let ridge_beta = 1e-6;
+
+    let artifacts = solve_arrow_newton_step_artifacts(&sys, ridge_t, ridge_beta, &options)
+        .expect("SAE Direct artifacts solve");
+
+    if gam_gpu::device_runtime::GpuRuntime::global().is_none() {
+        // No CUDA device: the seam must have declined and run the CPU path. The
+        // step must NOT be flagged device-served. (Parity below still holds.)
+        assert!(
+            !artifacts.pcg_diagnostics.used_device_arrow,
+            "no CUDA device present, yet the step was flagged device-served"
+        );
+    } else {
+        // CUDA present + the fixture clears the gate ⇒ the production SAE Direct
+        // inner solve MUST have run on the device. A silent CPU fallback here is
+        // exactly the #1551 failure (0% GPU); fail loud.
+        assert!(
+            artifacts.pcg_diagnostics.used_device_arrow,
+            "#1551: CUDA device present and the offload gate cleared, but the SAE \
+             Direct inner solve did NOT engage the device (used_device_arrow=false) \
+             — the device path silently fell back to CPU"
+        );
+    }
+
+    // Parity (holds on every host): the produced Newton step must match the dense
+    // joint-system reference. On a GPU host this is the device==CPU parity gate;
+    // on a CPU host it pins the matrix-free reduced solve to the dense oracle.
+    let reference =
+        crate::gpu_kernels::arrow_schur::solve_arrow_newton_step_dense_reference(
+            &sys, ridge_t, ridge_beta,
+        )
+        .expect("dense reference solve");
+    let db_scale = reference
+        .delta_beta
+        .iter()
+        .fold(0.0_f64, |m, &v| m.max(v.abs()))
+        .max(1.0);
+    let mut max_db_rel = 0.0_f64;
+    for a in 0..sys.k {
+        max_db_rel = max_db_rel.max((artifacts.delta_beta[a] - reference.delta_beta[a]).abs() / db_scale);
+    }
+    assert!(
+        max_db_rel <= 1e-7,
+        "#1551 SAE Direct Δβ parity vs dense reference: max_rel={max_db_rel:e} (>1e-7) \
+         (device-served={})",
+        artifacts.pcg_diagnostics.used_device_arrow
+    );
+    let dt_scale = reference
+        .delta_t
+        .iter()
+        .fold(0.0_f64, |m, &v| m.max(v.abs()))
+        .max(1.0);
+    let mut max_dt_rel = 0.0_f64;
+    for i in 0..artifacts.delta_t.len() {
+        max_dt_rel = max_dt_rel.max((artifacts.delta_t[i] - reference.delta_t[i]).abs() / dt_scale);
+    }
+    assert!(
+        max_dt_rel <= 1e-7,
+        "#1551 SAE Direct Δt parity vs dense reference: max_rel={max_dt_rel:e} (>1e-7)"
+    );
+}
+
 /// The CPU-resident SAE reduced-Schur matvec (#1017) must compute the SAME
 /// `S·x` as the generic per-row `apply → solve → transpose` path, up to f64
 /// reassociation. This is the residency correctness gate: a resident matvec

--- a/crates/gam-solve/src/gpu_kernels/arrow_schur.rs
+++ b/crates/gam-solve/src/gpu_kernels/arrow_schur.rs
@@ -5793,61 +5793,177 @@ mod tests {
                 }
             };
 
-        // CPU dense reduced-system solve of the SAME framed system: form S via
-        // the CPU oracle matvec on the identity, then solve S·δβ = rhs.
-        let mut s_dense = Array2::<f64>::zeros((border_dim, border_dim));
-        for col in 0..border_dim {
-            let mut e = vec![0.0_f64; border_dim];
-            e[col] = 1.0;
-            let mut sc = vec![0.0_f64; border_dim];
-            sae_framed_schur_matvec_cpu(&sys, &data, ridge_t, ridge_beta, &e, &mut sc)
-                .expect("cpu matvec");
-            for r in 0..border_dim {
-                s_dense[[r, col]] = sc[r];
-            }
-        }
-        let factor = cholesky_factor_in_place(s_dense.view(), CholeskyGuard::NonnegativePivot)
-            .expect("S PD");
-        let cpu = cholesky_solve_vector(factor.view(), rhs.view());
-
-        let scale = cpu.iter().fold(0.0_f64, |m, v| m.max(v.abs())).max(1.0);
-        let mut max_rel = 0.0_f64;
-        for a in 0..border_dim {
-            max_rel = max_rel.max((device[a] - cpu[a]).abs() / scale);
-        }
-        // #1551 divergence triage (max_rel=0.91 once the device actually engages):
-        // disambiguate matvec-bug vs PCG-non-convergence vs operator-mismatch.
-        // Residual of the DEVICE solution against the CPU operator S_cpu: if the
-        // device solved the SAME operator and converged, ‖S_cpu·device − rhs‖ ≈ 0;
-        // a large residual means the device matvec is a DIFFERENT operator (kernel
-        // bug), whereas a small residual with large max_rel would indicate a
-        // (near-)singular S where both solves are valid. Also surface what the
-        // device PCG thought it did (stopping reason / iters / final residual).
-        let mut s_dev_resid = 0.0_f64;
-        {
-            let sx = s_dense.dot(&device);
+        // #1551 PARITY GATE — operator-residual, NOT solution-vector equality.
+        //
+        // The honest GPU↔CPU contract for an iterative solve of `S·δβ = rhs` is
+        // that the device solution SOLVES the system DEFINED BY THE CPU ORACLE to
+        // PCG tolerance — i.e. `‖S_cpu·δβ_device − rhs‖ / ‖rhs‖ ≤ tol`, where
+        // `S_cpu` is applied with the bit-for-bit CPU oracle matvec the device
+        // kernel mirrors (`sae_framed_schur_matvec_cpu`). This is the correct,
+        // conditioning-robust gate: a near-singular assembled `S` has a large
+        // condition number `κ(S)`, which amplifies an O(ε) residual difference
+        // into an O(κ·ε) *solution-vector* difference, so comparing δβ vectors
+        // would spuriously fail even when both operators are bit-identical and
+        // both solves converged. (Historically this test compared δβ against a
+        // dense-Cholesky reference and "failed" with max_rel≈0.9 because the
+        // dense solve itself only reached ‖S·x−rhs‖≈0.1 on this fixture's
+        // ill-conditioned S while the device PCG reached ~1e-12 — the device was
+        // MORE accurate than the reference, not wrong. The kernel correctness is
+        // pinned conditioning-free by `framed_sae_device_matvec_matches_cpu_oracle_*`.)
+        let rhs_norm = rhs.iter().map(|v| v * v).sum::<f64>().sqrt();
+        let oracle_resid = |x: &Array1<f64>| -> f64 {
+            let mut sx = vec![0.0_f64; border_dim];
+            sae_framed_schur_matvec_cpu(
+                &sys,
+                &data,
+                ridge_t,
+                ridge_beta,
+                x.as_slice().unwrap(),
+                &mut sx,
+            )
+            .expect("cpu oracle matvec");
+            let mut acc = 0.0_f64;
             for a in 0..border_dim {
-                s_dev_resid = s_dev_resid.max((sx[a] - rhs[a]).abs());
+                let e = sx[a] - rhs[a];
+                acc += e * e;
             }
-        }
-        let s_cpu_resid = {
-            let sc = s_dense.dot(&cpu);
-            let mut m = 0.0_f64;
-            for a in 0..border_dim {
-                m = m.max((sc[a] - rhs[a]).abs());
-            }
-            m
+            acc.sqrt()
         };
+        let s_dev_resid = oracle_resid(&device);
+        let dev_rel_resid = s_dev_resid / rhs_norm.max(1e-300);
+
+        // Independent CPU iterative solve of the SAME operator with the SAME
+        // Jacobi preconditioner the device builds, via the shared `pcg_core`. If
+        // the device kernel computed a different operator, the two converged
+        // residuals could not BOTH be tiny.
+        let precond = {
+            let d = sae_frame_penalty_diag_host_for_test(&data, ridge_beta);
+            // The reduced-Schur diagonal subtraction (device `arrow_sae_frame_diag_sub`)
+            // mirrored on the host for the Jacobi preconditioner.
+            let mut diag = d;
+            for (i, row) in sys.rows.iter().enumerate() {
+                let slab = &data.frame.as_ref().unwrap().row_htbeta[i];
+                let qi = sys.row_dims[i];
+                if slab.is_empty() || qi == 0 || slab.len() != qi * border_dim {
+                    continue;
+                }
+                let mut block = row.htt.clone();
+                for dd in 0..qi {
+                    block[[dd, dd]] += ridge_t;
+                }
+                let factor = cholesky_factor_in_place(block.view(), CholeskyGuard::NonnegativePivot)
+                    .expect("row htt PD");
+                // ainv = (H_tt+ρI)⁻¹ column by column.
+                let mut ainv = Array2::<f64>::zeros((qi, qi));
+                for col in 0..qi {
+                    let mut e = Array1::<f64>::zeros(qi);
+                    e[col] = 1.0;
+                    let s = cholesky_solve_vector(factor.view(), e.view());
+                    for r in 0..qi {
+                        ainv[[r, col]] = s[r];
+                    }
+                }
+                for a in 0..border_dim {
+                    let mut quad = 0.0_f64;
+                    for c in 0..qi {
+                        let hc = slab[c * border_dim + a];
+                        for dd in 0..qi {
+                            quad += hc * ainv[[c, dd]] * slab[dd * border_dim + a];
+                        }
+                    }
+                    diag[a] -= quad;
+                }
+            }
+            Array1::from_vec(diag)
+        };
+        let mut cpu = Array1::<f64>::zeros(border_dim);
+        let cpu_result = {
+            let mut apply = |v: &Array1<f64>, out: &mut Array1<f64>| {
+                let mut tmp = vec![0.0_f64; border_dim];
+                sae_framed_schur_matvec_cpu(
+                    &sys,
+                    &data,
+                    ridge_t,
+                    ridge_beta,
+                    v.as_slice().unwrap(),
+                    &mut tmp,
+                )
+                .expect("cpu oracle matvec");
+                out.assign(&Array1::from_vec(tmp));
+            };
+            gam_linalg::pcg::pcg_core(
+                &mut apply,
+                &rhs.view(),
+                &precond.view(),
+                1e-12,
+                800,
+                32,
+                false,
+                gam_linalg::pcg::DotReduction::Serial,
+                &mut cpu.view_mut(),
+            )
+        };
+        let s_cpu_resid = oracle_resid(&cpu);
+        let cpu_rel_resid = s_cpu_resid / rhs_norm.max(1e-300);
+
+        // GATE 1: the device solution solves the CPU-oracle system to PCG-grade
+        // accuracy (proves device kernel == CPU operator AND device PCG converged).
         assert!(
-            max_rel <= 1e-7,
-            "[#1551 framed-triage] max_rel={max_rel:e} | device-vs-CPU-operator residual \
-             ‖S_cpu·device−rhs‖={s_dev_resid:e} (CPU's own ={s_cpu_resid:e}) | device PCG \
-             stop={:?} iters={} final_rel_resid={:e} — large operator-residual ⇒ device matvec \
-             is a different operator (kernel bug); small ⇒ PCG/precond or singular-S issue",
+            dev_rel_resid <= 1e-7,
+            "[#1551] device δβ does not solve the CPU-oracle system: \
+             ‖S_cpu·device−rhs‖/‖rhs‖={dev_rel_resid:e} (>1e-7) | abs={s_dev_resid:e} | \
+             device PCG stop={:?} iters={} final_rel_resid={:e} — a large operator residual \
+             means the device matvec is a DIFFERENT operator (kernel bug)",
             diag.stopping_reason,
             diag.iterations,
             diag.final_relative_residual,
         );
+        // GATE 2: the independent CPU iterative solve of the same operator with the
+        // same preconditioner also converges — both paths agree on the operator.
+        assert!(
+            cpu_rel_resid <= 1e-6,
+            "[#1551] CPU pcg_core failed to solve the oracle system: \
+             ‖S_cpu·cpu−rhs‖/‖rhs‖={cpu_rel_resid:e} (stop={:?}, iters={}) — fixture/oracle issue",
+            cpu_result.stop,
+            cpu_result.iterations,
+        );
+    }
+
+    /// Host mirror of the device `sae_frame_penalty_diag_host` for the framed
+    /// Jacobi preconditioner (penalty diagonal only; the reduced-Schur diagonal
+    /// subtraction is applied by the caller). Test-only.
+    fn sae_frame_penalty_diag_host_for_test(
+        data: &DeviceSaePcgData,
+        ridge_beta: f64,
+    ) -> Vec<f64> {
+        let frame = data.frame.as_ref().expect("frame");
+        let mut diag = vec![ridge_beta; data.beta_dim];
+        for (blk, &r) in data.smooth_blocks.iter().zip(frame.smooth_ranks.iter()) {
+            let m = blk.factor_a.nrows();
+            for ia in 0..m {
+                let coeff = blk.factor_a[[ia, ia]];
+                let base = blk.global_offset + ia * r;
+                for ib in 0..r {
+                    diag[base + ib] += coeff;
+                }
+            }
+        }
+        for blk in &frame.frame_blocks {
+            if blk.atom_i != blk.atom_j {
+                continue;
+            }
+            let r = frame.ranks[blk.atom_i];
+            let off = frame.border_offsets[blk.atom_i];
+            let (mi, mj) = blk.g.dim();
+            for li in 0..mi.min(mj) {
+                let gii = blk.g[[li, li]];
+                let base = off + li * r;
+                for a in 0..r {
+                    diag[base + a] += gii * blk.w[[a, a]];
+                }
+            }
+        }
+        diag
     }
 
     /// #1551 DEFINITIVE kernel-correctness proof: the framed reduced-Schur matvec

--- a/crates/gam-solve/src/gpu_kernels/arrow_schur.rs
+++ b/crates/gam-solve/src/gpu_kernels/arrow_schur.rs
@@ -732,6 +732,39 @@ pub fn solve_sae_matrix_free_pcg(
     }
 }
 
+/// #1551 kernel-isolating parity probe: run the framed reduced-Schur matvec
+/// `out = S·x` exactly once on the device and return it (no PCG, no offload-floor
+/// gate). The test suite diffs this element-wise against the CPU oracle
+/// [`sae_framed_schur_matvec_cpu`] to prove the GPU kernel computes the SAME
+/// operator — a check that is independent of solver conditioning (unlike a
+/// solved-`δβ` comparison, which can diverge purely because dense Cholesky and
+/// iterative PCG resolve an ill-conditioned `S` to different accuracies). On a
+/// non-CUDA host this returns `Unavailable` so the caller skips cleanly.
+#[doc(hidden)]
+pub fn framed_schur_matvec_once_on_device(
+    sys: &ArrowSchurSystem,
+    data: &DeviceSaePcgData,
+    ridge_t: f64,
+    ridge_beta: f64,
+    x: &Array1<f64>,
+) -> Result<Array1<f64>, ArrowSchurGpuFailure> {
+    if sys.k != data.beta_dim || x.len() != data.beta_dim || data.p == 0 {
+        return Err(ArrowSchurGpuFailure::Unavailable);
+    }
+    if data.frame.is_none() {
+        return Err(ArrowSchurGpuFailure::Unavailable);
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        let _ = (ridge_t, ridge_beta);
+        Err(ArrowSchurGpuFailure::Unavailable)
+    }
+    #[cfg(target_os = "linux")]
+    {
+        cuda::framed_schur_matvec_once_on_device(sys, data, ridge_t, ridge_beta, x)
+    }
+}
+
 /// Reference dense back-end used by tests and as the fallback when the
 /// GPU declines. Kept here (not in `arrow_schur_gpu.rs`) so the validation
 /// suite has one canonical baseline.
@@ -4129,6 +4162,62 @@ extern "C" __global__ void arrow_sae_frame_diag_sub(
             .map_err(|_| ArrowSchurGpuFailure::Unavailable)
     }
 
+    /// #1551 kernel-isolating seam: evaluate the framed reduced-Schur matvec
+    /// `out = S·x` EXACTLY ONCE on the device (no PCG, no offload-floor gate) and
+    /// return `out`. This is the parity probe the test harness diffs against the
+    /// CPU oracle [`super::sae_framed_schur_matvec_cpu`] element-by-element, so a
+    /// kernel/marshalling defect is exposed directly — independent of how the
+    /// iterative solver behaves on an ill-conditioned assembled `S` (where dense
+    /// Cholesky and PCG legitimately disagree at the solution level). Declines
+    /// (`Unavailable`) only when CUDA is genuinely absent so the test skips
+    /// cleanly off-device; it deliberately does NOT consult the offload policy so
+    /// even a tiny verifiable fixture runs on the GPU.
+    pub(super) fn framed_schur_matvec_once_on_device(
+        sys: &ArrowSchurSystem,
+        data: &DeviceSaePcgData,
+        ridge_t: f64,
+        ridge_beta: f64,
+        x: &Array1<f64>,
+    ) -> Result<Array1<f64>, ArrowSchurGpuFailure> {
+        let k = x.len();
+        if k == 0 || data.beta_dim != k || sys.k != k {
+            return Err(ArrowSchurGpuFailure::Unavailable);
+        }
+        let frame = data
+            .frame
+            .as_ref()
+            .ok_or(ArrowSchurGpuFailure::Unavailable)?;
+        // No offload-policy filter here: the seam exists to validate the kernel on
+        // ANY device, including the smallest hand-checkable fixture.
+        let runtime = gam_gpu::device_runtime::GpuRuntime::global()
+            .ok_or(ArrowSchurGpuFailure::Unavailable)?;
+        let ctx = gam_gpu::device_runtime::cuda_context_for(runtime.selected_device().ordinal)
+            .ok_or(ArrowSchurGpuFailure::Unavailable)?;
+        let stream = ctx
+            .new_stream()
+            .map_err(|_| ArrowSchurGpuFailure::Unavailable)?;
+        let vector_module = pcg_vector_module(&ctx)?;
+        let mut buffers = flatten_device_sae_frame_data(sys, data, frame, ridge_t, &stream)?;
+        let x_dev = stream
+            .clone_htod(x.as_slice().ok_or(ArrowSchurGpuFailure::Unavailable)?)
+            .map_err(|_| ArrowSchurGpuFailure::Unavailable)?;
+        let mut out_dev = stream
+            .alloc_zeros::<f64>(k)
+            .map_err(|_| ArrowSchurGpuFailure::Unavailable)?;
+        launch_sae_frame_matvec(
+            &stream,
+            vector_module,
+            &mut buffers,
+            &x_dev,
+            &mut out_dev,
+            ridge_beta,
+        )?;
+        let out = stream
+            .clone_dtoh(&out_dev)
+            .map_err(|_| ArrowSchurGpuFailure::Unavailable)?;
+        Ok(Array1::from_vec(out))
+    }
+
     pub(super) fn solve_sae_matrix_free_pcg_framed(
         sys: &ArrowSchurSystem,
         data: &DeviceSaePcgData,
@@ -5759,5 +5848,234 @@ mod tests {
             diag.iterations,
             diag.final_relative_residual,
         );
+    }
+
+    /// #1551 DEFINITIVE kernel-correctness proof: the framed reduced-Schur matvec
+    /// `out = S·x` must agree with the CPU oracle [`sae_framed_schur_matvec_cpu`]
+    /// element-wise, for several independent `x`, to ≤ 1e-9. This is the parity
+    /// gate that actually localizes a kernel/marshalling defect — unlike a
+    /// solved-`δβ` comparison, it does NOT route through a linear solve, so it is
+    /// independent of the conditioning of the assembled `S` (a near-singular `S`
+    /// can make a dense-Cholesky vector and an iterative-PCG vector disagree at
+    /// the *solution* level even when both operators are bit-correct; the
+    /// operator itself must still match here). Fails loud if CUDA is present but
+    /// the device matvec declines; skips cleanly only when no device exists.
+    #[test]
+    fn framed_sae_device_matvec_matches_cpu_oracle_when_cuda_admits() {
+        use crate::arrow_schur::{
+            DeviceSaeFrameData, DeviceSaePcgData, DeviceSaeSmoothBlock, FactoredFrameGBlock,
+        };
+
+        // Hand-checkable frame fixture: a mix of framed (r<p) and identity-ride
+        // (r==p) atoms, a few off-diagonal cross blocks, dense per-row H_tβ.
+        let p = 6usize;
+        let n_atoms = 8usize;
+        let ranks: Vec<usize> = (0..n_atoms)
+            .map(|k| if k % 2 == 0 { 3usize } else { p })
+            .collect();
+        let basis_sizes: Vec<usize> = (0..n_atoms).map(|_| 3usize).collect();
+        let mut border_offsets = Vec::with_capacity(n_atoms);
+        let mut acc = 0usize;
+        for k in 0..n_atoms {
+            border_offsets.push(acc);
+            acc += basis_sizes[k] * ranks[k];
+        }
+        let border_dim = acc;
+
+        let mut state = 0x1551_0017_1026_0922u64;
+        let mut sample = || -> f64 {
+            state = state
+                .wrapping_mul(6364136223846793005)
+                .wrapping_add(1442695040888963407);
+            ((state >> 33) as f64) / ((1u64 << 31) as f64) - 1.0
+        };
+        let mut frames: Vec<Array2<f64>> = Vec::new();
+        for k in 0..n_atoms {
+            let r = ranks[k];
+            let mut u = Array2::<f64>::zeros((p, r));
+            for i in 0..p {
+                for j in 0..r {
+                    u[[i, j]] = if r == p && i == j {
+                        1.0
+                    } else if r == p {
+                        0.0
+                    } else {
+                        sample()
+                    };
+                }
+            }
+            frames.push(u);
+        }
+        let w_of = |i: usize, j: usize| {
+            let (ui, uj) = (&frames[i], &frames[j]);
+            let (ri, rj) = (ranks[i], ranks[j]);
+            let mut w = Array2::<f64>::zeros((ri, rj));
+            for a in 0..ri {
+                for b in 0..rj {
+                    let mut s = 0.0;
+                    for c in 0..p {
+                        s += ui[[c, a]] * uj[[c, b]];
+                    }
+                    w[[a, b]] = s;
+                }
+            }
+            w
+        };
+        let mut pairs: Vec<(usize, usize)> = (0..n_atoms).map(|k| (k, k)).collect();
+        for &(i, j) in &[(0usize, 1usize), (2, 4), (3, 6)] {
+            pairs.push((i, j));
+            pairs.push((j, i));
+        }
+        let mut frame_blocks = Vec::new();
+        for &(i, j) in &pairs {
+            let (mi, mj) = (basis_sizes[i], basis_sizes[j]);
+            let mut g = Array2::<f64>::zeros((mi, mj));
+            for r in 0..mi {
+                for c in 0..mj {
+                    g[[r, c]] = 0.25 * sample();
+                }
+            }
+            if i == j {
+                for r in 0..mi.min(mj) {
+                    g[[r, r]] += mi as f64 + 2.0;
+                }
+            }
+            frame_blocks.push(FactoredFrameGBlock {
+                atom_i: i,
+                atom_j: j,
+                g,
+                w: w_of(i, j),
+            });
+        }
+        let mut smooth_blocks = Vec::new();
+        let mut smooth_ranks = Vec::new();
+        for k in 0..n_atoms {
+            let m = basis_sizes[k];
+            let mut a = Array2::<f64>::zeros((m, m));
+            for r in 0..m {
+                for c in 0..m {
+                    a[[r, c]] = 0.2 * sample();
+                }
+            }
+            let mut s = a.t().dot(&a);
+            for r in 0..m {
+                s[[r, r]] += 1.0;
+            }
+            smooth_blocks.push(DeviceSaeSmoothBlock {
+                global_offset: border_offsets[k],
+                factor_a: s,
+            });
+            smooth_ranks.push(ranks[k]);
+        }
+        // Modest row count: this seam bypasses the offload floor, so we keep the
+        // fixture small and the per-row reduced-Schur term well-scaled — the
+        // matvec parity does not depend on the assembled-S conditioning at all.
+        let n = 32usize;
+        let q = 4usize;
+        let mut sys = ArrowSchurSystem::new(n, q, border_dim);
+        let mut row_htbeta = Vec::new();
+        for i in 0..n {
+            let mut a = Array2::<f64>::zeros((q, q));
+            for r in 0..q {
+                for c in 0..q {
+                    a[[r, c]] = sample();
+                }
+            }
+            let mut htt = a.t().dot(&a);
+            for r in 0..q {
+                htt[[r, r]] += q as f64 + 1.0;
+            }
+            sys.rows[i].htt = htt;
+            let mut slab = vec![0.0_f64; q * border_dim];
+            for c in 0..q {
+                for col in 0..border_dim {
+                    let v = 0.3 * sample();
+                    slab[c * border_dim + col] = v;
+                    sys.rows[i].htbeta[[c, col]] = v;
+                }
+            }
+            row_htbeta.push(slab);
+        }
+        let ridge_t = 1e-7;
+        let ridge_beta = 1e-6;
+        let data = DeviceSaePcgData {
+            p,
+            beta_dim: border_dim,
+            a_phi: std::sync::Arc::from(Vec::new().into_boxed_slice()),
+            local_jac: std::sync::Arc::from(Vec::new().into_boxed_slice()),
+            smooth_blocks,
+            sparse_g_blocks: Vec::new(),
+            frame: Some(DeviceSaeFrameData {
+                ranks: ranks.clone(),
+                basis_sizes: basis_sizes.clone(),
+                border_offsets: border_offsets.clone(),
+                frame_blocks,
+                smooth_ranks,
+                row_htbeta,
+            }),
+        };
+
+        // Several independent probe vectors x, including unit axes and dense
+        // random — a marshalling stride/offset bug shows up as a per-component
+        // mismatch on at least one.
+        let mut probes: Vec<Array1<f64>> = Vec::new();
+        probes.push(Array1::from_shape_fn(border_dim, |a| {
+            ((a as f64 + 1.0) * 0.37).sin()
+        }));
+        probes.push(Array1::from_shape_fn(border_dim, |_| sample()));
+        for axis in [0usize, border_dim / 3, border_dim - 1] {
+            let mut e = Array1::<f64>::zeros(border_dim);
+            e[axis] = 1.0;
+            probes.push(e);
+        }
+
+        let mut any_ran = false;
+        let mut worst = 0.0_f64;
+        for (pi, x) in probes.iter().enumerate() {
+            let device = match super::framed_schur_matvec_once_on_device(
+                &sys, &data, ridge_t, ridge_beta, x,
+            ) {
+                Ok(out) => out,
+                Err(failure) => {
+                    // Fail loud: a present CUDA device that declines this seam
+                    // (which deliberately ignores the offload floor) means the
+                    // framed matvec kernel does not run on GPU.
+                    assert!(
+                        gam_gpu::device_runtime::GpuRuntime::global().is_none(),
+                        "#1551: CUDA device present but the framed device matvec \
+                         declined/faulted (probe {pi}, tag: {failure:?}) — the kernel \
+                         does not run on GPU"
+                    );
+                    return;
+                }
+            };
+            any_ran = true;
+            let mut cpu = vec![0.0_f64; border_dim];
+            sae_framed_schur_matvec_cpu(&sys, &data, ridge_t, ridge_beta, x.as_slice().unwrap(), &mut cpu)
+                .expect("cpu oracle matvec");
+            let scale = cpu.iter().fold(0.0_f64, |m, v| m.max(v.abs())).max(1.0);
+            for a in 0..border_dim {
+                let rel = (device[a] - cpu[a]).abs() / scale;
+                worst = worst.max(rel);
+                assert!(
+                    rel <= 1e-9,
+                    "[#1551 matvec-parity] probe {pi} component {a}: device={:e} cpu={:e} \
+                     rel={rel:e} (>1e-9) — framed S·x kernel diverges from the CPU oracle",
+                    device[a],
+                    cpu[a],
+                );
+            }
+        }
+        if any_ran {
+            // Positive on-device confirmation: the framed matvec ran on the GPU
+            // and matched the CPU oracle across every probe. (1e-9 is far above
+            // the ~1e-13 fp64 GEMV round-off; a structural marshalling bug would
+            // be O(1).)
+            assert!(
+                gam_gpu::device_runtime::GpuRuntime::global().is_some(),
+                "#1551: matvec ran but no GPU runtime — unexpected"
+            );
+            assert!(worst <= 1e-9, "framed matvec parity worst rel = {worst:e}");
+        }
     }
 }


### PR DESCRIPTION
## Focus
Own **#1551** (the device-resident SAE solver never engages → real SAE fits run the inner arrow-Schur on CPU, GPU 0%) and the related **#1209** (`used_device_arrow=true` while the matvec actually runs as host CPU code — false GPU routing).

Box: Tesla V100-SXM2-32GB (sm_70), CUDA 12.4, device 0. All claims below were run on this live GPU.

## What this PR establishes

### 1. The framed SAE device PCG kernel is ALREADY arithmetically correct on hardware (corrected diagnosis)
The issue's open blocker stated the framed (`G⊗W_ij`) device PCG "computes a WRONG operator" (max_rel≈0.91, ‖S_cpu·x_dev−rhs‖≈18.5). **Run on the V100, this is not true of current `main`:** the device matvec satisfies the CPU oracle operator to **3.6e-12** and the device PCG converges to **~1e-12**.

The historic "91% wrong / resid 18.5" was a **test artifact**, not a kernel bug: the old test asserted solution-**vector** equality against a dense-Cholesky reference. On the fixture's ill-conditioned reduced Schur `S`, `κ(S)` amplifies an O(ε) operator-residual difference into an O(κ·ε) solution-vector difference — and the dense reference *itself* only reached ‖S·x−rhs‖≈0.1 while the device PCG reached ~1e-12. **The device was more accurate than the test's own oracle.**

Fix: replace the conditioning-fragile gate with a **conditioning-robust** one:
- **GATE 1 (operator residual):** `‖S_cpu·δβ_device − rhs‖/‖rhs‖ ≤ 1e-7`, applying `S` with the bit-for-bit CPU oracle matvec the kernel mirrors.
- **GATE 2 (independent CPU solve):** an independent `gam_linalg::pcg::pcg_core` solve of the same operator + Jacobi preconditioner also converges.
- **NEW conditioning-free test** `framed_sae_device_matvec_matches_cpu_oracle_when_cuda_admits`: pins the device matvec == CPU oracle to ≤1e-9 directly (no solve, no κ).

### 2. End-to-end PRODUCTION engagement, proven + fail-loud (#1551 core contract)
New `sae_direct_inner_solve_engages_device_and_matches_cpu_1551` drives the **public production entry** `solve_arrow_newton_step_artifacts` with a device-equipped SAE system that clears the offload gate. On a CUDA host it **fails loud** if `used_device_arrow != true` (a silent CPU fallback = the #1551 failure), and pins Δβ/Δt parity vs the dense CPU reference to **1e-7**. GPU engagement re-confirmed via `nvidia-smi dmon` (312 MB framebuffer resident during the run).

Two fixture defects fixed to make the parity gate *sound* (not loosened):
- **PD reduced Schur:** the device non-framed `H_ββ` is assembled from `data.sparse_g_blocks` (`G⊗I_p`), NOT `sys.hbb`; the fixture left them empty so `H_ββ≈ρ·I` and the n=512-row Schur subtraction went indefinite (device *correctly* failed loud). Installed a dominant-diagonal `H_ββ` mirrored in both representations.
- **Consistent oracle:** the dense reference reads `row.htbeta` directly while the fixture shipped coupling only as a matrix-free operator (so the reference was solving a *decoupled* system). Materialized the operator into `row.htbeta` (exact unit-column probe; `htbeta_dense_supplement` stays OFF so the matrix-free apply is unchanged).

### 3. #1209/#1551 fail-loud routing in the InexactPCG seam (the large-K regime)
`ArrowSolverMode::automatic` routes **K > 2000** (where the device matters most) to **InexactPCG**. That branch took the device result via a bare `if let Ok(...)`, **silently swallowing every error** — including hard kernel faults — and falling through to CPU with `used_device_arrow=false`. Fixed to classify the device result **exactly** as the Direct seam: `RidgeBumpRequired`/`SchurFactorFailed` surface as the matching `ArrowSchurError` (LM escalation responds); only `Unavailable`/decline falls through honestly. New `sae_inexact_pcg_inner_solve_engages_device_and_matches_cpu_1551` pins engagement + parity for this seam.

### 4. #1209 contradictory diagnostics fixed (`used_device_arrow` ⊥ `injected_host_procedural_matvec`)
`solve_arrow_newton_step_core` injects a HOST procedural reduced-Schur matvec for an admitted InexactPCG SAE system, then unconditionally stamped `injected_host_procedural_matvec = true`. But the re-entered solve can itself take the genuinely device-resident SAE PCG branch (`used_device_arrow = true`) **without ever consuming** the injected host closure — yielding a contradiction (both flags set, which #1209 treats as mutually exclusive) and a host-procedural flag that is simply wrong (the matvec ran on the device). Fixed to stamp the host flag only when `!used_device_arrow`. New `device_arrow_and_host_procedural_matvec_flags_are_mutually_exclusive_1209` pins it through the public core, with a non-vacuity guard proving the device-served InexactPCG path (the exact regression scenario) is actually reached on a CUDA host.

## Verification on V100 (sm_70)
- `gpu_kernels::arrow_schur` suite: **17/17 green**.
- `arrow_schur` (incl. `gpu_kernels`): **70/71 green** — the lone failure is the pre-existing 2x2 brittleness below. All FOUR new tests green (Direct engagement, InexactPCG engagement, #1209 mutual-exclusion, conditioning-free framed matvec parity).
- GPU engagement re-confirmed live via `nvidia-smi dmon` (312 MB fb resident during a solve).
- Downstream `gam-sae` builds + lib tests pass against the patched `gam-solve`.
- Both CPU and GPU paths kept fully working; CPU remains the parity oracle. No test weakened.
- Build via `./build.sh`.

## Out of scope (pre-existing, NOT introduced here)
`arrow_schur::tests::arrow_schur_matches_dense_reference_2x2` fails deterministically on the **clean merge-base `e128441cd`** too (verified in an isolated worktree): it `assert_eq!`s two float summation orderings (non-streaming vs streaming chunk_size=1) that differ in the last ~3 ULPs (~4e-16 rel). It is a CPU-path bit-exactness brittleness untouched by this PR and already in the edit scope of PR #1650.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
