### PR TITLE
[agent][gpu] NVRTC FMA-contraction breaks GPU↔CPU parity (fmad default on) (WIP)

### DIFF
--- a/.agent/gpu-fmad-parity.md
+++ b/.agent/gpu-fmad-parity.md
@@ -1,0 +1,48 @@
+# GPU FMA-contraction parity bug (`--fmad=true` default)
+
+## Box
+- GPU device 5 (CUDA_VISIBLE_DEVICES=5), Tesla V100-SXM2-32GB, compute capability 7.0.
+
+## Symptom (reproduced on THIS box)
+`gam-models gpu_kernels::survival_rowjet::tests::device_matches_cpu_when_available`
+FAILS on the V100:
+
+```
+survival device vs CPU row-jet max abs diff 0.0000000508973... (5.09e-8) > 1e-9
+```
+
+The GPU genuinely engages (310 MiB on device 5, 9.6s kernel). It is NOT a silent
+CPU fallback — the kernel compiles, runs, and returns numbers that are *close but
+not parity-tight*. The docstring claims "device == CPU to 4.7e-12 (A100, full f64,
+no fast-math)". On the V100 the claim is false by ~4 orders of magnitude.
+
+## Root cause
+NVRTC's default is `--fmad=true`: it contracts `a*b + c` into a single fused
+multiply-add (one rounding) wherever it can. The CPU oracle computes `a*b` then
+`+ c` as two separately-rounded f64 ops. For a shallow kernel the gap is ~1 ULP;
+for the survival row-jet — a deep seeded-jet tower with many `mul`/`add`/`compose`
+steps feeding the Hessian and contracted third/fourth channels — the per-op FMA
+divergence accumulates to ~5e-8.
+
+`cudarc::nvrtc::CompileOptions::default()` leaves `fmad: None`, which means NVRTC
+applies its own default (`--fmad=true`). The shared `nvrtc_compile_options()` in
+`crates/gam-gpu/src/device_cache.rs` pins `arch` but never sets `fmad`, so EVERY
+kernel — even those that route through `compile_ptx_arch` / `PtxModuleCache` —
+gets FMA contraction on. And `survival_rowjet` compiles via the *bare*
+`cudarc::nvrtc::compile_ptx` (zero options): FMA-on AND no arch pin.
+
+"No `--use_fast_math`" (what the docstrings promise) is NOT the same as "no FMA
+contraction". use_fast_math is off; fmad is silently on.
+
+## Fix
+1. `nvrtc_compile_options()` sets `fmad: Some(false)` so every kernel compiled
+   through the shared options is FMA-free and bit-comparable to the separately-
+   rounded CPU oracle. This is the parity-correct default for a library whose
+   contract is "GPU == CPU".
+2. Route `survival_rowjet` (and any other bare `compile_ptx` parity-sensitive
+   kernels) through the shared arch+fmad options instead of bare `compile_ptx`.
+
+## Verification
+- Re-run `device_matches_cpu_when_available` on device 5 → must pass ≤1e-9.
+- Watch nvidia-smi to confirm the GPU still engages (no silent fallback).
+- Full `./build.sh` green; CPU-only tests unaffected.

--- a/crates/gam-gpu/src/device_cache.rs
+++ b/crates/gam-gpu/src/device_cache.rs
@@ -141,6 +141,21 @@ mod linux {
     fn nvrtc_compile_options() -> CompileOptions {
         let mut opts = CompileOptions::default();
         opts.include_paths = nvrtc_include_paths();
+        // GPU↔CPU PARITY: disable FMA contraction. NVRTC's default is
+        // `--fmad=true`, which fuses `a*b + c` into a single fused multiply-add
+        // (ONE rounding). The CPU oracle computes `a*b` then `+ c` as two
+        // SEPARATELY-rounded f64 ops. For shallow kernels the gap is ~1 ULP;
+        // for deep derivative towers (the survival/SAE seeded jets, whose
+        // Hessian + contracted third/fourth channels chain dozens of mul/add
+        // steps) the per-op FMA divergence accumulates to ~5e-8 — enough to
+        // blow a 1e-9 parity gate on a real device (measured on a V100,
+        // compute 7.0: survival_rowjet device-vs-CPU max abs diff 5.09e-8).
+        // `--use_fast_math` was already off, but that does NOT imply fmad off
+        // (use_fast_math only ADDS fmad=true; the converse default is still
+        // on). Pinning fmad=false makes every shared-options kernel
+        // bit-comparable to the separately-rounded CPU path. `Option::None`
+        // would defer to NVRTC's `true` default, so we set it explicitly.
+        opts.fmad = Some(false);
         // #1551: pin the NVRTC virtual arch to the selected device's compute
         // capability. Without it NVRTC defaults below sm_60, where the
         // `atomicAdd(double*, double)` overload is absent — so kernels using

--- a/crates/gam-models/src/gpu_kernels/survival_rowjet.rs
+++ b/crates/gam-models/src/gpu_kernels/survival_rowjet.rs
@@ -265,7 +265,14 @@ mod device {
                 return Ok(m.clone());
             }
         }
-        let ptx = cudarc::nvrtc::compile_ptx(SURVIVAL_ROWJET_SOURCE)
+        // Compile through the shared arch+fmad options (NOT bare `compile_ptx`,
+        // which leaves NVRTC at `--fmad=true` and no `--gpu-architecture` pin).
+        // FMA contraction must be off so the deep seeded-jet tower is
+        // bit-comparable to the separately-rounded CPU oracle — bare
+        // `compile_ptx` made this kernel miss the 1e-9 parity gate by ~5e-8 on
+        // a V100. The arch pin keeps the kernel keyed to the device's real
+        // compute capability rather than NVRTC's default.
+        let ptx = gam_gpu::device_cache::compile_ptx_arch(SURVIVAL_ROWJET_SOURCE)
             .gpu_ctx_with(|err| format!("survival_rowjet NVRTC compile: {err}"))?;
         let m = b
             .ctx


### PR DESCRIPTION
## Problem (reproduced on a V100, compute 7.0)

`gam-models gpu_kernels::survival_rowjet::tests::device_matches_cpu_when_available` **FAILS** on this box's real GPU:

```
survival device vs CPU row-jet max abs diff 5.09e-8 > 1e-9
```

The GPU genuinely engages (310 MiB on the device, ~9.6s kernel) — this is **not** a silent CPU fallback. The kernel compiles and runs but returns numbers that miss the 1e-9 parity gate by ~4 orders of magnitude. The kernel docstring claims "device == CPU to 4.7e-12 (A100, full f64, no fast-math)".

## Root cause

NVRTC defaults to `--fmad=true`: it contracts `a*b + c` into a single fused multiply-add (one rounding). The CPU oracle computes `a*b` then `+ c` as two separately-rounded f64 ops. For the deep survival seeded-jet tower (Hessian + contracted third/fourth channels), the per-op FMA divergence accumulates to ~5e-8.

`cudarc::nvrtc::CompileOptions::default()` leaves `fmad: None` → NVRTC's own default (`true`) applies. The shared `nvrtc_compile_options()` pins `arch` but never sets `fmad`. And `survival_rowjet` compiles via the **bare** `compile_ptx` (zero options): FMA-on AND no arch pin.

"No `--use_fast_math`" ≠ "no FMA contraction". use_fast_math is off; fmad is silently on.

## Fix (in progress)
1. `nvrtc_compile_options()` sets `fmad: Some(false)` — every shared-options kernel becomes bit-comparable to the separately-rounded CPU oracle.
2. Route `survival_rowjet` (and other parity-sensitive bare-`compile_ptx` kernels) through the shared arch+fmad options.

## Verification
- [ ] `device_matches_cpu_when_available` passes ≤1e-9 on device 5
- [ ] nvidia-smi confirms the GPU still engages
- [ ] `./build.sh` green; CPU path unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)