### PR TITLE
[agent][gpu] fix fused arrow-Schur B/Y block-stride OOB (p_max≠r_template) (WIP)

### DIFF
--- a/.agent/gpu-arrowschur-bstride-fix.md
+++ b/.agent/gpu-arrowschur-bstride-fix.md
@@ -1,0 +1,48 @@
+# [agent][gpu] Fused arrow-Schur B/Y block-stride bug (P_MAX·P_MAX vs P_MAX·R_TEMPLATE)
+
+GPU device: 6 (Tesla V100-SXM2-32GB, CC 7.0, `compute_70`). CUDA_VISIBLE_DEVICES=6.
+
+## The bug (real GPU correctness defect, found 2026-06-30)
+
+The fused arrow-Schur Newton kernel
+(`crates/gam-solve/src/gpu_kernels/arrow_schur.rs`,
+`crates/gam-solve/src/gpu_kernels/arrow_schur_nvrtc.rs`) packs three per-row
+strided blocks:
+
+| block | semantic | allocated block stride | documented |
+|-------|----------|-------------------------|------------|
+| `d_stack` | `D_i = H_tt` | `P_MAX · P_MAX` | ✅ |
+| `b_stack` | `B_i = H_tβ`  | `P_MAX · R_TEMPLATE` | ✅ |
+| `y_out`   | `Y_i = L⁻¹B_i`| `P_MAX · R_TEMPLATE` | ✅ |
+
+But the host PACKER (`pack_fused_host`, line ~2985) and the DEVICE kernel
+(`arrow_schur_forward_pgroup`, lines ~219 load and ~276 store) index `b_stack` /
+`y_out` with the **D-block stride** `((i*P_MAX + c) * P_MAX + r)` — copy-pasted
+from the D block — instead of the B/Y stride `((i*P_MAX + c) * P_MAX + r)` …
+wait, the per-element layout inside a block is `col*P_MAX + row` which is the
+SAME for B and Y (P_MAX rows). The defect is the **per-ROW (per-i) block
+stride**: B's block i must start at `i * P_MAX * R_TEMPLATE`, but the code uses
+`i * P_MAX * P_MAX` (via `(i*P_MAX + col)*P_MAX`). When `p_max > r_template` the
+column index `col ∈ 0..r_runtime` combined with the wrong i-multiplier walks
+past the end of the smaller B/Y buffer.
+
+### Trigger
+`p_max != r_template`. `p_max = d.next_power_of_two().min(32)`,
+`r_template = ceil_to_template_r(k)`. Equal only by coincidence. The V100
+validation test `arrow_schur_gpu_multi_size_groups_match_reference`
+(`d ∈ {10,16,30}`, `k=5` → `r_template=5`, `p_max ∈ {16,16,32}`) panics:
+`index out of bounds: the len is 1280 but the index is 2048` at
+arrow_schur.rs:2987 (host packer). On-device the kernel does the same OOB
+read/write (silent UB / wrong result / illegal access).
+
+## Plan
+1. [ ] Fix host packer B-block i-stride: base must use `P_MAX·R_TEMPLATE` per i.
+2. [ ] Fix device kernel `b_stack` load index (line ~219).
+3. [ ] Fix device kernel `y_out` store index (line ~276) — must match the
+       readback which already uses `i*P_MAX*R_TEMPLATE + c*P_MAX + r`.
+4. [ ] Verify host readback (line ~3681 etc.) already correct → it's the oracle.
+5. [ ] Run V100 validation suite → all green, GPU engaged (nvidia-smi mem/util).
+6. [ ] CPU↔GPU parity at d≠r sizes; document tolerance.
+
+## Verification log
+- (pending)

--- a/crates/gam-solve/src/gpu_kernels/arrow_schur.rs
+++ b/crates/gam-solve/src/gpu_kernels/arrow_schur.rs
@@ -2980,9 +2980,15 @@ extern "C" __global__ void arrow_sae_frame_diag_sub(
                     d_buf[base + r] = value;
                 }
             }
-            // B_i in P_MAX×R_TEMPLATE strided block.
+            // B_i in P_MAX×R_TEMPLATE strided block. The per-row (per-i) block
+            // stride is `p_max · r_template` (matching the `b_buf` allocation
+            // above and the kernel's `b_stack`/`y_out` layout), NOT
+            // `p_max · p_max`: using the D-block multiplier here overflows the
+            // buffer whenever `p_max > r_template` (e.g. d=30→p_max=32,
+            // k=5→r_template=5). The within-block element offset stays
+            // column-major `col·p_max + r` (P_MAX rows per column).
             for col in 0..k {
-                let base = (i * p_max + col) * p_max;
+                let base = (i * r_template + col) * p_max;
                 for r in 0..d {
                     b_buf[base + r] = row.htbeta[[r, col]];
                 }

--- a/crates/gam-solve/src/gpu_kernels/arrow_schur_nvrtc.rs
+++ b/crates/gam-solve/src/gpu_kernels/arrow_schur_nvrtc.rs
@@ -214,9 +214,12 @@ void arrow_schur_forward_pgroup(
         }
         // ---- Load g_i into u (will be overwritten by L^{-1} g). ----
         u[tid] = g_stack[(size_t) i * P_MAX + tid];
-        // ---- Load B_i into Y (will be overwritten by L^{-1} B). ----
+        // ---- Load B_i into Y (will be overwritten by L^{-1} B). The B block
+        //      stride is P_MAX·R_TEMPLATE per row block i (see signature), so
+        //      the per-i multiplier is R_TEMPLATE, NOT P_MAX (using P_MAX walks
+        //      off the smaller b_stack whenever P_MAX > R_TEMPLATE). ----
         for (int c = 0; c < r_runtime; ++c) {
-            Y[tid][c] = b_stack[((size_t) i * P_MAX + c) * P_MAX + tid];
+            Y[tid][c] = b_stack[((size_t) i * R_TEMPLATE + c) * P_MAX + tid];
         }
     }
     __syncthreads();
@@ -272,8 +275,11 @@ void arrow_schur_forward_pgroup(
             l_out[((size_t) i * P_MAX + c) * P_MAX + tid] = L[tid][c];
         }
         u_out[(size_t) i * P_MAX + tid] = u[tid];
+        // y_out has block stride P_MAX·R_TEMPLATE per row block i (the host
+        // readback reads it at `i·P_MAX·R_TEMPLATE + c·P_MAX + r`), so the
+        // per-i multiplier is R_TEMPLATE, not P_MAX.
         for (int c = 0; c < r_runtime; ++c) {
-            y_out[((size_t) i * P_MAX + c) * P_MAX + tid] = Y[tid][c];
+            y_out[((size_t) i * R_TEMPLATE + c) * P_MAX + tid] = Y[tid][c];
         }
     }
 
@@ -331,8 +337,10 @@ void arrow_schur_back_sub_pgroup(
             L[tid][c] = l_stack[((size_t) i * P_MAX + c) * P_MAX + tid];
         }
         double acc = u_stack[(size_t) i * P_MAX + tid];
+        // y_stack block stride is P_MAX·R_TEMPLATE per row block i (written by
+        // the forward kernel); per-i multiplier is R_TEMPLATE, not P_MAX.
         for (int c = 0; c < r_runtime; ++c) {
-            acc += y_stack[((size_t) i * P_MAX + c) * P_MAX + tid] * delta_beta[c];
+            acc += y_stack[((size_t) i * R_TEMPLATE + c) * P_MAX + tid] * delta_beta[c];
         }
         w[tid] = acc;
     }


### PR DESCRIPTION
## Real GPU correctness bug

The fused arrow-Schur Newton kernel (`crates/gam-solve/src/gpu_kernels/arrow_schur.rs` + `arrow_schur_nvrtc.rs`) allocates and documents the `B = H_tβ` block and its `Y = L⁻¹B` output with per-row block stride `P_MAX·R_TEMPLATE`, and the host **readback** uses that stride — but the host **packer** (`pack_fused_host`) and the **device kernel** (`arrow_schur_forward_pgroup`, load + store) index them with the **D-block** stride `P_MAX·P_MAX`.

Whenever `p_max ≠ r_template` (the common case — e.g. `d=30 → p_max=32`, `k=5 → r_template=5`) the host packer panics with `index out of bounds` and the on-device kernel reads/writes out of bounds (UB / wrong result).

### Repro (this V100, device 6)
`arrow_schur_gpu_multi_size_groups_match_reference` FAILs:
`index out of bounds: the len is 1280 but the index is 2048` at `arrow_schur.rs:2987`.

## Plan
- Fix the host packer B-block per-row stride.
- Fix the device-kernel `b_stack` load and `y_out` store indices to the B/Y stride.
- Prove CPU↔GPU parity at `d≠r` sizes on this V100; keep CPU oracle path intact.

Found and owned by autonomous GPU agent gpu-free-2. Does not overlap the 1551/1017/1026/415/closed-triage peer claims.

🤖 Generated with [Claude Code](https://claude.com/claude-code)