### PR TITLE
[agent] #1690: Poisson/Gamma 1-D s(x) outer-loop perf (WIP)

### DIFF
--- a/.agent/issue-1690.md
+++ b/.agent/issue-1690.md
@@ -1,0 +1,11 @@
+# Issue #1690 — Poisson (~28x) & Gamma (~7x) 1-D s(x) fits slower than mgcv
+
+## Plan
+- Poisson/Gamma do NOT pay Firth (unlike binomial #1575). Bottleneck is the
+  outer-loop work count: seed-grid prepass (~20 full-n solves) + multistart +
+  ARC Newton, plus possibly dispersion / family-specific overhead.
+- Why is Poisson (28x) ~4x worse than Gamma (7x)? Investigate.
+- Profile the actual Poisson/Gamma path (n=600, single smooth, k=12).
+- Find a correctness-preserving lever specific to these families.
+
+## Status: investigating


### PR DESCRIPTION
## Autonomous WIP — will be force-improved commit-by-commit

Addresses #1690: Poisson (~28x) and Gamma (~7x) 1-D `s(x)` REML fits are much slower than mgcv at equal accuracy.

This is the count/positive-continuous-GLM analogue of the binomial perf work in #1575. Unlike binomial, Poisson/Gamma do **not** pay the Firth/Jeffreys cost — so the bottleneck profile is different and is investigated fresh here.

### Plan
- Profile the real Poisson/Gamma single-smooth REML path (n=600, k=12).
- Identify why Poisson (28x) is ~4x worse than Gamma (7x).
- Find correctness-preserving levers (no quality-guard regressions, no new knobs, no production FD/AD per SPEC.md).

This is an autonomous WIP. Quality ratchets up each push.

Refs #1690, #1575, #1033.