### PR TITLE
[agent] #1680: near-collinear additive smooths truth-RMSE (WIP)

### DIFF
--- a/.agent/issue-1680.md
+++ b/.agent/issue-1680.md
@@ -1,0 +1,20 @@
+# Issue #1680 — near-collinear additive smooths: gamfit ~4x worse truth-RMSE than mgcv
+
+## Problem
+Additive model with near-collinear nuisance covariates (pairwise corr ~0.985).
+Signal lives in uncorrelated x1, x4; x2, x3 are near-rank-1 collinear nuisance.
+gamfit recovers true function ~4x worse than mgcv at n=120, ~1.5x worse at n=400.
+Points at instability in penalized fit / lambda selection under near-degenerate
+additive design (x1/x2/x3 block ~rank-1).
+
+## Plan
+1. Reproduce with the repro script.
+2. Trace where lambda selection / penalized fit destabilizes under collinearity.
+3. Root-cause fix (not symptom): likely REML/identifiability/centering interaction.
+4. Add regression tests; verify against mgcv-like baseline.
+
+## Status
+- [ ] Reproduce
+- [ ] Root cause
+- [ ] Fix
+- [ ] Tests


### PR DESCRIPTION
## Autonomous WIP — force-improved commit-by-commit

Closes #1680.

### Problem
On an additive model with near-collinear nuisance covariates (pairwise corr ~0.985),
gamfit recovers the true function ~4× worse than mgcv at n=120 and ~1.5× worse at n=400.
The signal lives in uncorrelated covariates (x1, x4); x2, x3 form a near-rank-1
collinear nuisance block. mgcv recovers the signal cleanly; gamfit's penalized fit /
λ-selection appears to destabilize under the near-degenerate additive design.

### Plan
1. Reproduce the gap.
2. Trace where REML λ-selection / penalized fit destabilizes under collinearity.
3. Fix the root cause (not the symptom).
4. Add regression tests pinning truth-RMSE within a factor of an mgcv-like baseline.

This is an autonomous WIP and will be force-improved commit-by-commit. The PR always
reflects latest state.