### PR TITLE
[agent] #1689: pspline/thinplate Gaussian fit perf (WIP)

### DIFF
--- a/.agent/issue-1689.md
+++ b/.agent/issue-1689.md
@@ -1,0 +1,19 @@
+# Issue #1689 — PERF: ordinary P-spline s(x) and thin-plate s(x,z) Gaussian fits 2-10x slower than mgcv
+
+## Problem
+- 1-D P-spline `s(x)` n=400: gamfit 2.3-3.7x slower than mgcv at equal accuracy
+- 2-D thin-plate `s(x,z)` n=1200: gamfit ~8.8-24.5x slower than mgcv
+- Same predictive RMSE — the extra time buys nothing.
+- Also: very heavy stderr logging by default (thousands of [OUTER ...]/[GAM ALO] lines).
+
+## Plan
+1. Reproduce the benchmark numbers locally.
+2. Profile where the time goes (outer REML loop iterations, inner fits, basis construction, prediction).
+3. Fix root-cause hot spots without weakening accuracy or violating SPEC.md.
+4. Address default logging verbosity (verbosity flag / quieter default).
+5. Add regression/perf tests.
+
+## Status
+- [ ] Reproduce
+- [ ] Profile
+- [ ] Fix

--- a/crates/gam-solve/src/inference/alo.rs
+++ b/crates/gam-solve/src/inference/alo.rs
@@ -664,7 +664,14 @@ fn log_leverage_diagnostics(leverage: &Array1<f64>, phi: f64) {
     let a_p99 = percentile_from_sorted(&finite_leverage, LEVERAGE_PERCENTILES[2]);
     let a_max = finite_leverage.last().copied().unwrap_or(0.0);
 
-    log::warn!(
+    // Routine per-ALO leverage summary: a diagnostic snapshot, not an
+    // anomaly. Emitted at `info!` so it is visible under `GAM_LOG=info` but
+    // silent at the default `Warn` level (genuine anomalies — invalid / very
+    // high leverage — are logged at `warn!` above and stay visible). This
+    // line fires once per ALO computation, which recurs across the outer
+    // smoothing loop, so at `warn!` it was a dominant source of stderr noise
+    // on perfectly healthy fits (#1689).
+    log::info!(
         "[GAM ALO] leverage: n={}, mean={:.3e}, median={:.3e}, p95={:.3e}, p99={:.3e}, max={:.3e}",
         n,
         a_mean,
@@ -673,7 +680,7 @@ fn log_leverage_diagnostics(leverage: &Array1<f64>, phi: f64) {
         a_p99,
         a_max
     );
-    log::warn!(
+    log::info!(
         "[GAM ALO] high-leverage: a>0.90: {:.2}%, a>0.95: {:.2}%, a>0.99: {:.2}%, dispersion phi={:.3e}",
         100.0 * (threshold_counts[0] as f64) / n as f64,
         100.0 * (threshold_counts[1] as f64) / n as f64,

--- a/crates/gam-solve/src/progress_log.rs
+++ b/crates/gam-solve/src/progress_log.rs
@@ -114,13 +114,126 @@ fn human_elapsed(elapsed: Duration) -> String {
     }
 }
 
+/// Default verbosity when the user has set no environment override.
+///
+/// A single ordinary fit (e.g. a 400-row `s(x)` P-spline) emits thousands of
+/// per-iteration `[OUTER ...]` / `[GAM ALO]` `info!`/`warn!` records. Writing
+/// them to stderr under a write-lock is not free — when stderr is a terminal
+/// or a pipe it is *measurable* fit overhead (#1689), and for the common case
+/// (a library call from Python that just wants the model back) the stream is
+/// pure noise. So the out-of-the-box level is `Warn`: genuine problems still
+/// surface, but the routine progress chatter is silent unless explicitly
+/// requested. Power users opt back in with `GAM_LOG=info` (or `=debug` /
+/// `=trace`), and `RUST_LOG` is honored as a fallback for ecosystem muscle
+/// memory.
+const DEFAULT_LOG_LEVEL: LevelFilter = LevelFilter::Warn;
+
+/// Resolve the active log level from the environment, falling back to
+/// [`DEFAULT_LOG_LEVEL`]. `GAM_LOG` takes precedence over `RUST_LOG`; both
+/// accept the standard `off|error|warn|info|debug|trace` spellings (case
+/// insensitive). An unset or unrecognized value yields the default, so a typo
+/// never silently turns logging fully off or on.
+fn resolve_log_level() -> LevelFilter {
+    let gam_log = std::env::var("GAM_LOG").ok();
+    let rust_log = std::env::var("RUST_LOG").ok();
+    log_level_from_overrides(gam_log.as_deref(), rust_log.as_deref())
+}
+
+/// Parse one verbosity spelling into a [`LevelFilter`]. Case-insensitive,
+/// surrounding whitespace ignored. Returns `None` for anything unrecognized so
+/// the caller can fall through to the next source rather than guessing.
+fn parse_log_level(value: &str) -> Option<LevelFilter> {
+    match value.trim().to_ascii_lowercase().as_str() {
+        "off" | "none" | "silent" => Some(LevelFilter::Off),
+        "error" => Some(LevelFilter::Error),
+        "warn" | "warning" => Some(LevelFilter::Warn),
+        "info" => Some(LevelFilter::Info),
+        "debug" => Some(LevelFilter::Debug),
+        "trace" | "all" => Some(LevelFilter::Trace),
+        _ => None,
+    }
+}
+
+/// Pure resolution of the active level from the two override sources, so the
+/// precedence rules are unit-testable without mutating process-global env
+/// state (which races under the test harness's thread parallelism). `GAM_LOG`
+/// wins over `RUST_LOG`; an unset or unrecognized value falls through to the
+/// next source, and finally to [`DEFAULT_LOG_LEVEL`].
+fn log_level_from_overrides(gam_log: Option<&str>, rust_log: Option<&str>) -> LevelFilter {
+    gam_log
+        .and_then(parse_log_level)
+        .or_else(|| rust_log.and_then(parse_log_level))
+        .unwrap_or(DEFAULT_LOG_LEVEL)
+}
+
 pub fn init_logging() {
     LOG_START.get_or_init(Instant::now);
+    let level = resolve_log_level();
     if log::set_logger(&LOGGER).is_ok() {
-        log::set_max_level(LevelFilter::Info);
+        log::set_max_level(level);
     }
     // Log the GPU backend inventory once at startup so the "are GPUs being
     // used?" answer is visible at the top of the log, before any solver
     // dispatch site lazily checks for device support.
     gam_gpu::log_backend_inventory_once();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_level_is_warn_when_no_overrides() {
+        assert_eq!(log_level_from_overrides(None, None), LevelFilter::Warn);
+        assert_eq!(DEFAULT_LOG_LEVEL, LevelFilter::Warn);
+    }
+
+    #[test]
+    fn gam_log_takes_precedence_over_rust_log() {
+        assert_eq!(
+            log_level_from_overrides(Some("info"), Some("trace")),
+            LevelFilter::Info
+        );
+        assert_eq!(
+            log_level_from_overrides(Some("off"), Some("debug")),
+            LevelFilter::Off
+        );
+    }
+
+    #[test]
+    fn rust_log_used_when_gam_log_absent_or_unrecognized() {
+        assert_eq!(
+            log_level_from_overrides(None, Some("debug")),
+            LevelFilter::Debug
+        );
+        // GAM_LOG present but garbage → fall through to RUST_LOG.
+        assert_eq!(
+            log_level_from_overrides(Some("loud"), Some("trace")),
+            LevelFilter::Trace
+        );
+    }
+
+    #[test]
+    fn unrecognized_values_fall_back_to_default_not_off() {
+        // A typo must never silently disable logging or crank it to trace.
+        assert_eq!(
+            log_level_from_overrides(Some("verbose"), None),
+            DEFAULT_LOG_LEVEL
+        );
+        assert_eq!(
+            log_level_from_overrides(Some("yes"), Some("loud")),
+            DEFAULT_LOG_LEVEL
+        );
+    }
+
+    #[test]
+    fn parsing_is_case_and_whitespace_insensitive() {
+        assert_eq!(parse_log_level("  INFO "), Some(LevelFilter::Info));
+        assert_eq!(parse_log_level("Warn"), Some(LevelFilter::Warn));
+        assert_eq!(parse_log_level("TRACE"), Some(LevelFilter::Trace));
+        assert_eq!(parse_log_level("off"), Some(LevelFilter::Off));
+        assert_eq!(parse_log_level("warning"), Some(LevelFilter::Warn));
+        assert_eq!(parse_log_level("silent"), Some(LevelFilter::Off));
+        assert_eq!(parse_log_level(""), None);
+    }
 }


### PR DESCRIPTION
Closes #1689.

## Autonomous WIP
This is an autonomous WIP PR that will be force-improved commit-by-commit. The first commit is a placeholder scaffold.

## Problem
On ordinary Gaussian smooths:
- 1-D P-spline `s(x)` (n=400): gamfit ~2.3–3.7x slower than mgcv at equal predictive accuracy.
- 2-D thin-plate `s(x,z)` (n=1200): gamfit ~8.8–24.5x slower than mgcv.

Same RMSE — the extra time buys nothing. Also: very heavy default stderr logging.

## Plan
1. Reproduce locally.
2. Profile the outer REML loop, inner fits, basis construction, and prediction.
3. Fix root-cause hot spots without weakening accuracy or violating SPEC.md.
4. Quiet the default logging / add a verbosity flag.
5. Add regression/perf guards.

Running summary will be kept up to date here.