### PR TITLE
[agent] #1688: matern/GP smooths fit 12-55x slower than mgcv (WIP)

### DIFF
--- a/.agent/issue-1688.md
+++ b/.agent/issue-1688.md
@@ -1,0 +1,24 @@
+# Issue #1688 — matern()/GP smooths 12-55x slower than mgcv s(.,bs="gp")
+
+## Problem
+`matern()` / GP smooths fit 12-55x slower than equivalent mgcv GP smooth at
+identical predictive accuracy. Pure speed regression. Also: a firehose of stderr
+logging (~84 lines/obs) by default.
+
+## Plan
+1. Reproduce the perf gap with a Rust-side benchmark / criterion or CLI timing.
+2. Profile the matern/GP fit path to find the hot spot (outer REML loop iterations,
+   per-iteration linear algebra, basis construction, etc).
+3. Identify root cause — likely:
+   - excessive outer-loop iterations
+   - dense O(n^3) operations that should exploit structure
+   - default logging cost
+4. Fix root cause; verify accuracy unchanged and speed materially improved.
+5. Kill the default stderr firehose (gate behind verbosity).
+
+## Status
+- [ ] reproduce
+- [ ] profile
+- [ ] root cause
+- [ ] fix
+- [ ] verify


### PR DESCRIPTION
## Issue
Closes #1688.

`matern()` / GP smooths fit **12-55x slower** than the equivalent `mgcv`
`s(..., bs="gp")` smooth at **identical predictive accuracy**. Pure speed
regression. The issue also notes a stderr logging firehose (~84 lines/obs)
that is on by default.

## Status: autonomous WIP
This PR is opened immediately and will be force-improved commit-by-commit. The
first commit is a placeholder plan note.

## Plan
1. Reproduce the perf gap from the Rust side (CLI / bench timing).
2. Profile the matern/GP fit path; locate the hot spot.
3. Fix the true root cause (likely outer-loop iteration count and/or per-iter
   dense linear algebra not exploiting structure).
4. Gate the default stderr firehose behind a verbosity flag.
5. Verify accuracy unchanged, speed materially improved, no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)