### PR TITLE
[agent] #1641: fix IBP theta-adjoint logdet channel vs dense FD (WIP)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3866,3 +3866,5 @@ publish paths.
   including Duchon/Matern basis coverage, sparse-native REML paths, probit
   location-scale warm starts, model-consistency fixes, and the first Rust CI
   workflow.
+
+<!-- agent #1641: investigating logdet_theta_adjoint IBP theta-adjoint vs dense FD; WIP -->


### PR DESCRIPTION
## Autonomous WIP — force-improved commit-by-commit

Closes #1641.

Tracking the now-runnable dense-FD oracle `sae_logdet_theta_adjoint_matches_dense_fd_ibp_map`, which fails its analytic-vs-FD assertion (logit channel ~4x over tol; coord channel ~10x off). Isolated to `logdet_theta_adjoint`'s IBP theta-adjoint cross-row empirical-M_k channel, routed through `refill_jet_window` / `row_jets_for_logdet` (the #932-revert jet path).

### Plan
1. Reproduce + characterize the failure.
2. Read `logdet_theta_adjoint` + the IBP `row_jets_for_logdet` path.
3. Derive the correct analytic; locate the discrepancy term-by-term vs FD.
4. Fix the root cause in production code (no test weakening, no XFAIL/ignore).
5. Verify green + sibling oracles + surrounding suite.

This is an autonomous WIP; the diff ratchets up each push.