### PR TITLE
[agent] #1607: wiggle separation bound + batched gradient (WIP)

### DIFF
--- a/.agent-notes/issue-1607.md
+++ b/.agent-notes/issue-1607.md
@@ -31,3 +31,6 @@ Note: profiled_theta_hvp_outer_hessian_matches_fd... (Cluster 5) lives in tests/
 - (B) Cluster 4-gaussian: principled σ-floor decision — make reference & engine consistent.
 - (C) Cluster 2: envelope logdet-trace term (risky, prior regressions).
 - (D) Cluster 3: deep architectural.
+
+## Issue #1607 cont. (wiggle separation + batched gradient)
+Branch off main after #1658 merged. Spatial fullhessian fix already landed.

--- a/crates/gam-custom-family/src/inner_blockwise_fit.rs
+++ b/crates/gam-custom-family/src/inner_blockwise_fit.rs
@@ -617,6 +617,36 @@ pub(crate) fn inner_blockwise_fit<F: CustomFamily + Clone + Send + Sync + 'stati
         const LINEAR_RATE_PROJECTION_CAP: usize = 100;
         let mut residual_rate_history: std::collections::VecDeque<f64> =
             std::collections::VecDeque::with_capacity(LINEAR_RATE_WINDOW + 1);
+        // Trailing window of the Φ-augmented merit objective, parallel to
+        // `residual_rate_history`, for the merit-descent veto on the two
+        // residual-trend stall guards (gam#1607 binomial location-scale-WIGGLE).
+        //
+        // Both residual-trend guards below (flat-residual no-improve, and the
+        // slow-geometric-rate projection) use the trend of the KKT *residual*
+        // as a proxy for "can this solve still reach tol in a practical
+        // budget". On the wiggle family that proxy is unsound: the model
+        // carries an exact additive gauge null (the threshold βₜ and the
+        // wiggle-intercept `βwᵀB(q₀)` both shift q = q₀ + Bᵀβw), and as the
+        // dynamic basis `B(q₀)` re-anchors during PIRLS the KKT residual is
+        // genuinely NON-monotone — it humps up (0.2→0.4) for ~150 cycles
+        // before descending to tol — even though the merit objective the line
+        // search actually minimizes descends monotonically the whole way and
+        // the solve DOES converge (measured: cycle 638, β bounded ≈1.9). A
+        // residual-trend guard then reads the transient rise as "diverging /
+        // can't reach tol" and bails ~cycle 40, handing the outer optimizer a
+        // false non-convergence (the #1607 wiggle fullhessian failure).
+        //
+        // The merit is the real Lyapunov function: a descending merit IS
+        // progress, regardless of the residual's transient shape. So veto a
+        // residual-trend stall exit while the merit is still descending
+        // robustly over the SAME trailing window. This preserves termination —
+        // the merit is bounded below and monotone-nonincreasing under the
+        // line search, so it cannot keep clearing a fixed relative-descent bar
+        // forever; once it genuinely flattens (the true #979 survival stall:
+        // ~1e-5 steps ⇒ merit flat to f64) the veto lifts and the guard fires
+        // exactly as before.
+        let mut merit_window: std::collections::VecDeque<f64> =
+            std::collections::VecDeque::with_capacity(LINEAR_RATE_WINDOW + 1);
         // Fully-rejected stall guard. The residual-stall guard below
         // (post-grad-reload) only fires on cycles that produced an accepted
         // step, because every termination check it gates lives after the
@@ -4880,6 +4910,45 @@ pub(crate) fn inner_blockwise_fit<F: CustomFamily + Clone + Send + Sync + 'stati
                 }
                 residual_rate_history.push_back(residual);
             }
+            // Trailing window of the Φ-augmented merit, kept in lockstep with
+            // `residual_rate_history` so its front is the merit exactly
+            // LINEAR_RATE_WINDOW cycles back. Powers the merit-descent veto on
+            // the two residual-trend stall guards below (gam#1607 wiggle).
+            if lastobjective.is_finite() {
+                if merit_window.len() > LINEAR_RATE_WINDOW {
+                    merit_window.pop_front();
+                }
+                merit_window.push_back(lastobjective);
+            }
+            // Is the merit still descending robustly across the trailing
+            // window? A residual-trend stall verdict is premature while it is:
+            // the line search is making real progress on the actual objective,
+            // and the KKT residual's transient non-monotonicity (the wiggle
+            // gauge-null re-anchoring, gam#1607) is not evidence of being
+            // stuck. "Robustly" = the merit dropped by more than the
+            // accumulated objective tolerance over the window — i.e. by more
+            // than the convergence machinery would call flat — so a merit that
+            // has genuinely plateaued (the #979 survival stall, ~1e-5 steps ⇒
+            // merit flat to f64) does NOT clear the bar and the guard fires as
+            // before. The per-cycle `objective_tol` (relative, scale-aware) is
+            // the natural unit; require the window drop to exceed
+            // LINEAR_RATE_WINDOW × objective_tol so a window of merely
+            // tolerance-scale dithering counts as flat.
+            let merit_still_descending_over_window = || -> bool {
+                if merit_window.len() <= LINEAR_RATE_WINDOW {
+                    // Not enough history yet to judge a window-scale trend;
+                    // don't veto on partial information (the guards have their
+                    // own RESIDUAL_STALL_MIN_CYCLES floor anyway).
+                    return false;
+                }
+                let oldest = *merit_window.front().unwrap();
+                let newest = *merit_window.back().unwrap();
+                if !oldest.is_finite() || !newest.is_finite() {
+                    return false;
+                }
+                let drop = oldest - newest;
+                drop > (LINEAR_RATE_WINDOW as f64) * objective_tol
+            };
             if cycle + 1 >= RESIDUAL_STALL_MIN_CYCLES
                 && cycles_since_residual_improved >= RESIDUAL_STALL_NO_IMPROVE_CYCLES
                 && tr_clamped_during_stall
@@ -5139,6 +5208,7 @@ pub(crate) fn inner_blockwise_fit<F: CustomFamily + Clone + Send + Sync + 'stati
                 && residual > residual_tol
                 && cycle + 1 >= RESIDUAL_STALL_MIN_CYCLES
                 && cycles_since_residual_improved >= RESIDUAL_STALL_NO_IMPROVE_CYCLES
+                && !merit_still_descending_over_window()
             {
                 log::warn!(
                     "[PIRLS/joint-Newton convergence] cycle {:>3} | flat-residual stall early-exit (gam#1040): residual={:.3e} (tol={:.3e}) best_seen={:.3e} stalled {} cycles with steps inside the trust region (tr_clamped={}) and no acceptance certificate satisfied; the residual is neither trending toward KKT nor stationary on the identifiable subspace, so returning unconverged with finite β instead of grinding to inner_max_cycles={}.",
@@ -5180,6 +5250,7 @@ pub(crate) fn inner_blockwise_fit<F: CustomFamily + Clone + Send + Sync + 'stati
                 && residual > residual_tol
                 && cycle + 1 >= RESIDUAL_STALL_MIN_CYCLES
                 && residual_rate_history.len() > LINEAR_RATE_WINDOW
+                && !merit_still_descending_over_window()
             {
                 let oldest = *residual_rate_history.front().unwrap();
                 // Single source of truth for the slow-geometric-rate projection

--- a/crates/gam-problem/src/lib.rs
+++ b/crates/gam-problem/src/lib.rs
@@ -995,6 +995,18 @@ pub struct HyperCoordPair {
     pub ld_s: f64,
 }
 
+/// Shared-ownership callback computing a second-order fixed-β
+/// [`HyperCoordPair`] for a coordinate pair `(i, j)`.
+///
+/// `Arc` (not `Box`) so the same callback can be cloned into a derived
+/// `InnerSolution` — notably the tangent-projected solution built under active
+/// inequality constraints, which must carry the very same pair callbacks
+/// through to `ValueGradientHessian` outer-Hessian assembly. The pair objects
+/// are p-space; every consumer contracts them through the (possibly
+/// tangent-wrapped) Hessian operator, which applies the `ZᵀMZ` / `Z H_T⁻¹ Zᵀ`
+/// projection internally, so a clone-through is mathematically exact.
+pub type HyperCoordPairFn = Arc<dyn Fn(usize, usize) -> HyperCoordPair + Send + Sync>;
+
 impl HyperCoordPair {
     pub fn zero() -> Self {
         Self {
@@ -1046,6 +1058,16 @@ impl DriftDerivResult {
 
 pub type FixedDriftDerivFn =
     Box<dyn Fn(usize, &Array1<f64>) -> Option<DriftDerivResult> + Send + Sync>;
+
+/// Shared-ownership form of [`FixedDriftDerivFn`] used for `InnerSolution`
+/// storage, so the same `M_i[u] = D_β B_i[u]` callback can be cloned into a
+/// derived (tangent-projected) solution. Construction sites still hand back a
+/// `Box` ([`FixedDriftDerivFn`]); storage re-tags it via `Arc::from` (free).
+/// The drift `M` is a p-space matrix that every consumer contracts through the
+/// (tangent-wrapped) Hessian operator's `trace_logdet_*`, so the clone-through
+/// is exact under projection.
+pub type SharedFixedDriftDerivFn =
+    Arc<dyn Fn(usize, &Array1<f64>) -> Option<DriftDerivResult> + Send + Sync>;
 
 pub struct ContractedPsiSecondOrder {
     pub objective: Array1<f64>,

--- a/crates/gam-solve/src/progress_log.rs
+++ b/crates/gam-solve/src/progress_log.rs
@@ -123,20 +123,26 @@ fn human_elapsed(elapsed: Duration) -> String {
 /// (a library call from Python that just wants the model back) the stream is
 /// pure noise. So the out-of-the-box level is `Warn`: genuine problems still
 /// surface, but the routine progress chatter is silent unless explicitly
-/// requested. Power users opt back in with `GAM_LOG=info` (or `=debug` /
-/// `=trace`), and `RUST_LOG` is honored as a fallback for ecosystem muscle
-/// memory.
+/// requested. Power users opt back in by calling [`set_log_level`] (e.g.
+/// `set_log_level("info")`) or [`log::set_max_level`] directly — verbosity is
+/// set through an explicit API, not a process-global env var (`std::env::var`
+/// is banned crate-wide; see [`resolve_log_level`]).
 const DEFAULT_LOG_LEVEL: LevelFilter = LevelFilter::Warn;
 
-/// Resolve the active log level from the environment, falling back to
-/// [`DEFAULT_LOG_LEVEL`]. `GAM_LOG` takes precedence over `RUST_LOG`; both
-/// accept the standard `off|error|warn|info|debug|trace` spellings (case
-/// insensitive). An unset or unrecognized value yields the default, so a typo
-/// never silently turns logging fully off or on.
+/// Resolve the active log level.
+///
+/// Reading verbosity from the environment (`GAM_LOG` / `RUST_LOG`) is NOT
+/// permitted: `std::env::var` is banned crate-wide (build.rs substring scanner,
+/// `feedback_no_env_vars` policy), because process-global env reads are a hidden
+/// input that makes a library call's behavior depend on ambient state the caller
+/// never passed. An override path landed transiently in #1696 and broke the
+/// build; the supported way to change verbosity is the explicit
+/// [`set_log_level`] entry point (or [`log::set_max_level`] directly), not an
+/// env var. The out-of-the-box level stays [`DEFAULT_LOG_LEVEL`] (`Warn`): a
+/// plain library call from Python gets quiet logs and pays no per-record stderr
+/// cost (#1689), while genuine problems still surface.
 fn resolve_log_level() -> LevelFilter {
-    let gam_log = std::env::var("GAM_LOG").ok();
-    let rust_log = std::env::var("RUST_LOG").ok();
-    log_level_from_overrides(gam_log.as_deref(), rust_log.as_deref())
+    DEFAULT_LOG_LEVEL
 }
 
 /// Parse one verbosity spelling into a [`LevelFilter`]. Case-insensitive,
@@ -154,16 +160,29 @@ fn parse_log_level(value: &str) -> Option<LevelFilter> {
     }
 }
 
-/// Pure resolution of the active level from the two override sources, so the
-/// precedence rules are unit-testable without mutating process-global env
-/// state (which races under the test harness's thread parallelism). `GAM_LOG`
-/// wins over `RUST_LOG`; an unset or unrecognized value falls through to the
-/// next source, and finally to [`DEFAULT_LOG_LEVEL`].
-fn log_level_from_overrides(gam_log: Option<&str>, rust_log: Option<&str>) -> LevelFilter {
-    gam_log
+/// Pure resolution of the active level from up to two explicitly-supplied
+/// override spellings, with the primary source winning over the fallback and an
+/// unset/unrecognized value falling through to [`DEFAULT_LOG_LEVEL`]. Kept pure
+/// (no env, no globals) so the precedence rules are unit-testable and so the
+/// public [`set_log_level`] entry point can hand it caller-provided strings.
+fn log_level_from_overrides(primary: Option<&str>, fallback: Option<&str>) -> LevelFilter {
+    primary
         .and_then(parse_log_level)
-        .or_else(|| rust_log.and_then(parse_log_level))
+        .or_else(|| fallback.and_then(parse_log_level))
         .unwrap_or(DEFAULT_LOG_LEVEL)
+}
+
+/// Explicitly set the active log verbosity from a level spelling
+/// (`off|error|warn|info|debug|trace`, case-insensitive). This is the supported
+/// way to raise verbosity above the default — callers pass the level they want
+/// rather than relying on a process-global env var (`std::env::var` is banned
+/// crate-wide; see [`resolve_log_level`]). Returns the [`LevelFilter`] actually
+/// installed (the default when `spelling` is unrecognized, so a typo never
+/// silently disables logging). A no-op-safe wrapper over [`log::set_max_level`].
+pub fn set_log_level(spelling: &str) -> LevelFilter {
+    let level = log_level_from_overrides(Some(spelling), None);
+    log::set_max_level(level);
+    level
 }
 
 pub fn init_logging() {
@@ -189,7 +208,7 @@ mod tests {
     }
 
     #[test]
-    fn gam_log_takes_precedence_over_rust_log() {
+    fn primary_override_takes_precedence_over_fallback() {
         assert_eq!(
             log_level_from_overrides(Some("info"), Some("trace")),
             LevelFilter::Info
@@ -201,16 +220,29 @@ mod tests {
     }
 
     #[test]
-    fn rust_log_used_when_gam_log_absent_or_unrecognized() {
+    fn fallback_used_when_primary_absent_or_unrecognized() {
         assert_eq!(
             log_level_from_overrides(None, Some("debug")),
             LevelFilter::Debug
         );
-        // GAM_LOG present but garbage → fall through to RUST_LOG.
+        // Primary present but garbage → fall through to the fallback.
         assert_eq!(
             log_level_from_overrides(Some("loud"), Some("trace")),
             LevelFilter::Trace
         );
+    }
+
+    #[test]
+    fn set_log_level_installs_explicit_level_and_defaults_on_typo() {
+        // Explicit spelling installs that level and reports it back.
+        assert_eq!(set_log_level("debug"), LevelFilter::Debug);
+        assert_eq!(log::max_level(), LevelFilter::Debug);
+        // A typo never silently disables logging — it falls back to the default.
+        assert_eq!(set_log_level("verbose"), DEFAULT_LOG_LEVEL);
+        assert_eq!(log::max_level(), DEFAULT_LOG_LEVEL);
+        // Restore a quiet default so this process-global write cannot perturb
+        // sibling tests that observe the level.
+        log::set_max_level(DEFAULT_LOG_LEVEL);
     }
 
     #[test]

--- a/crates/gam-solve/src/reml/reml_outer_engine.rs
+++ b/crates/gam-solve/src/reml/reml_outer_engine.rs
@@ -150,8 +150,8 @@ pub(crate) use gam_linalg::matrix::{
 use crate::model_types::{ActiveLinearConstraintBlock, KktResidualSubspace, ProjectedKktResidual};
 pub use gam_problem::{
     ContractedPsiSecondOrderFn, DenseMatrixHyperOperator, DriftDerivResult, EvalMode,
-    FixedDriftDerivFn, HyperCoord, HyperCoordDrift, HyperCoordPair, HyperOperator,
-    ProjectedFactorCache, ProjectedFactorKey, PseudoLogdetMode,
+    FixedDriftDerivFn, HyperCoord, HyperCoordDrift, HyperCoordPair, HyperCoordPairFn, HyperOperator,
+    ProjectedFactorCache, ProjectedFactorKey, PseudoLogdetMode, SharedFixedDriftDerivFn,
 };
 
 // ─────────────────────────────────────────────────────────────────────────

--- a/crates/gam-solve/src/reml/reml_outer_engine/inner_solution.rs
+++ b/crates/gam-solve/src/reml/reml_outer_engine/inner_solution.rs
@@ -190,14 +190,22 @@ pub struct InnerSolution<'dp> {
     /// of external coordinates (or external × ρ cross pairs).
     /// Arguments: (ext_index_i, ext_index_j) → HyperCoordPair.
     /// When None, the outer Hessian is not computed for extended coordinates.
-    pub ext_coord_pair_fn: Option<Box<dyn Fn(usize, usize) -> HyperCoordPair + Send + Sync>>,
+    ///
+    /// `Arc`-backed ([`HyperCoordPairFn`]) so a derived solution — notably the
+    /// tangent-projected solution built under active inequality constraints —
+    /// can clone the same callback through to `ValueGradientHessian` assembly.
+    pub ext_coord_pair_fn: Option<HyperCoordPairFn>,
 
     /// Callback for ρ × ext cross pairs: (rho_index, ext_index) → HyperCoordPair.
-    pub rho_ext_pair_fn: Option<Box<dyn Fn(usize, usize) -> HyperCoordPair + Send + Sync>>,
+    pub rho_ext_pair_fn: Option<HyperCoordPairFn>,
 
     /// M_i[u] = D_β B_i[u] callback for extended coordinates.
     /// Arguments: (ext_index, direction) → correction matrix.
-    pub fixed_drift_deriv: Option<FixedDriftDerivFn>,
+    ///
+    /// `Arc`-backed ([`SharedFixedDriftDerivFn`]) so the tangent-projected
+    /// solution can clone it through — the drift `M` is a p-space matrix the
+    /// wrapper projects via `ZᵀMZ` in `trace_logdet_*`.
+    pub fixed_drift_deriv: Option<SharedFixedDriftDerivFn>,
 
     /// Direction-contracted second-order ψ hook for the profiled θ-HVP (#740).
     /// When present, the outer-Hessian operator builder skips the `K²` per-pair
@@ -263,9 +271,9 @@ pub struct InnerSolutionBuilder<'dp> {
     pub(crate) nullspace_dim_override: Option<f64>,
     // Extended hyperparameter coordinates
     pub(crate) ext_coords: Vec<HyperCoord>,
-    pub(crate) ext_coord_pair_fn: Option<Box<dyn Fn(usize, usize) -> HyperCoordPair + Send + Sync>>,
-    pub(crate) rho_ext_pair_fn: Option<Box<dyn Fn(usize, usize) -> HyperCoordPair + Send + Sync>>,
-    pub(crate) fixed_drift_deriv: Option<FixedDriftDerivFn>,
+    pub(crate) ext_coord_pair_fn: Option<HyperCoordPairFn>,
+    pub(crate) rho_ext_pair_fn: Option<HyperCoordPairFn>,
+    pub(crate) fixed_drift_deriv: Option<SharedFixedDriftDerivFn>,
     pub(crate) contracted_psi_second_order: Option<ContractedPsiSecondOrderFn>,
     pub(crate) barrier_config: Option<BarrierConfig>,
     pub(crate) kkt_residual: Option<ProjectedKktResidual>,
@@ -371,7 +379,10 @@ impl<'dp> InnerSolutionBuilder<'dp> {
         mut self,
         f: Box<dyn Fn(usize, usize) -> HyperCoordPair + Send + Sync>,
     ) -> Self {
-        self.ext_coord_pair_fn = Some(f);
+        // `Arc::from(Box<dyn …>)` is a zero-cost re-tag of the existing
+        // allocation; storing it as `Arc` lets the projected solution clone
+        // the callback through.
+        self.ext_coord_pair_fn = Some(HyperCoordPairFn::from(f));
         self
     }
 
@@ -379,12 +390,14 @@ impl<'dp> InnerSolutionBuilder<'dp> {
         mut self,
         f: Box<dyn Fn(usize, usize) -> HyperCoordPair + Send + Sync>,
     ) -> Self {
-        self.rho_ext_pair_fn = Some(f);
+        self.rho_ext_pair_fn = Some(HyperCoordPairFn::from(f));
         self
     }
 
     pub fn fixed_drift_deriv(mut self, f: FixedDriftDerivFn) -> Self {
-        self.fixed_drift_deriv = Some(f);
+        // `Arc::from(Box<dyn …>)` re-tags the existing allocation for shared
+        // ownership so the projected solution can clone the callback through.
+        self.fixed_drift_deriv = Some(SharedFixedDriftDerivFn::from(f));
         self
     }
 

--- a/crates/gam-solve/src/reml/reml_outer_engine/outer_derivatives/traces.rs
+++ b/crates/gam-solve/src/reml/reml_outer_engine/outer_derivatives/traces.rs
@@ -240,7 +240,7 @@ pub(crate) fn compute_drift_deriv_traces(
     ext_j: Option<usize>,
     beta_i: &Array1<f64>,
     beta_j: &Array1<f64>,
-    fixed_drift_deriv: Option<&FixedDriftDerivFn>,
+    fixed_drift_deriv: Option<&SharedFixedDriftDerivFn>,
     subspace: Option<&PenaltySubspaceTrace>,
 ) -> f64 {
     let trace_via = |result: DriftDerivResult| -> f64 {

--- a/crates/gam-solve/src/reml/reml_outer_engine/outer_entry_helpers.rs
+++ b/crates/gam-solve/src/reml/reml_outer_engine/outer_entry_helpers.rs
@@ -1023,25 +1023,30 @@ pub(crate) fn try_tangent_projected_evaluate(
     // `BorrowedDerivProvider` uses for the deriv-provider corrections.
     //
     // The pair callbacks (`ext_coord_pair_fn`, `rho_ext_pair_fn`) return
-    // `HyperCoordPair` objects with p-space `b_mat` / `b_operator`.
-    // `ValueAndGradient` mode does not contract those pair objects (they
-    // only enter outer-Hessian assembly), so they are dropped (set to
-    // `None`) in the projected inner solution — gradient evaluations are
-    // unaffected. `ValueGradientHessian` mode would actually consume the
-    // pair callbacks; the tangent hessian wrapper cannot re-project
-    // their p-space second-drift outputs a posteriori, so refuse that
-    // combination upfront when callbacks are present.
-    if mode == EvalMode::ValueGradientHessian
-        && !solution.ext_coords.is_empty()
-        && (solution.ext_coord_pair_fn.is_some() || solution.rho_ext_pair_fn.is_some())
-    {
-        return Err(
-            "active constraints + ext_coords + mode=ValueGradientHessian not yet supported; \
-             fall back to ValueAndGradient. The ext-coord pair callbacks return p-space \
-             second-drift objects that the tangent hessian wrapper does not re-project."
-                .to_string(),
-        );
-    }
+    // `HyperCoordPair` objects with p-space `b_mat` / `b_operator` / `g`.
+    // `ValueGradientHessian` consumes them in outer-Hessian assembly, but
+    // every consumer contracts them THROUGH the (now tangent-wrapped)
+    // Hessian operator: `b_mat` / `b_operator` enter via
+    // `hop.trace_logdet_gradient` / `hop.trace_logdet_operator`, and the
+    // pair `g` is dotted against the mode-response vectors `coord.v =
+    // hop.solve(rhs)`. The `TangentProjectedHessianOperator` wrapper applies
+    // `Zᵀ·Z` inside exactly those `trace_*` / `solve` methods, so a
+    // clone-through of the pair callbacks is the EXACT second-order analog of
+    // the single-coordinate ext drift / `g` already passed through above for
+    // `ValueAndGradient`. Cloning is cheap and ownership-safe because the
+    // callbacks are now `Arc`-backed ([`HyperCoordPairFn`]).
+    //
+    // The only combination that is still NOT contracted through the wrapper
+    // is the direction-contracted ψψ hook (`contracted_psi_second_order`): it
+    // returns pre-traced `base_h2` scalars that bypass the operator, so it
+    // would need its drifts re-projected at source rather than a posteriori.
+    // That hook is mutually exclusive with the per-pair `ext_coord_pair_fn`
+    // assembly (operator.rs #740), and the active-constraint families that
+    // reach this path use the per-pair callbacks, so we drop the hook (set to
+    // `None`, as the `ValueAndGradient` path already did) and keep the per-pair
+    // callbacks, which the wrapper projects exactly.
+    let projected_ext_coord_pair_fn = solution.ext_coord_pair_fn.clone();
+    let projected_rho_ext_pair_fn = solution.rho_ext_pair_fn.clone();
     let projected = InnerSolution {
         log_likelihood: solution.log_likelihood,
         penalty_quadratic: solution.penalty_quadratic,
@@ -1065,13 +1070,25 @@ pub(crate) fn try_tangent_projected_evaluate(
         // ext_coord g/drift pass-through: projection is applied by the
         // tangent hessian wrapper's trace and solve methods.
         ext_coords: solution.ext_coords.clone(),
-        ext_coord_pair_fn: None,
-        rho_ext_pair_fn: None,
-        // Second-order pair callbacks are dropped on the projected path (same
-        // reason as the ext-coord/rho pair fns: the tangent hessian wrapper
-        // cannot re-project their p-space second-drift outputs).
+        // Pair callbacks pass through (cloned `Arc`s): the tangent hessian
+        // wrapper projects every p-space object they return via `ZᵀMZ` /
+        // `Z H_T⁻¹ Zᵀ` in its `trace_*` / `solve` methods, so this is the exact
+        // second-order analog of the per-coord `g`/`drift` pass-through above.
+        ext_coord_pair_fn: projected_ext_coord_pair_fn,
+        rho_ext_pair_fn: projected_rho_ext_pair_fn,
+        // The direction-contracted ψψ hook returns pre-traced scalars that
+        // bypass the wrapper (it cannot re-project them a posteriori), and it
+        // is mutually exclusive with the per-pair `ext_coord_pair_fn` assembly
+        // (#740). Drop it; the per-pair callbacks above carry the exact ψψ
+        // block under projection.
         contracted_psi_second_order: None,
-        fixed_drift_deriv: None,
+        // The `M_i[u] = D_β B_i[u]` drift is a p-space matrix the wrapper
+        // projects via `ZᵀMZ` in `trace_logdet_*`, and its `β_i`/`β_j`
+        // arguments are mode responses already in range(Z) (`hop.solve`
+        // outputs). Clone it through so the constraint-active families whose
+        // basis depends on β (`b_depends_on_beta`, e.g. the wiggle block) keep
+        // their genuine `m_terms` second-order contribution.
+        fixed_drift_deriv: solution.fixed_drift_deriv.clone(),
         barrier_config: solution.barrier_config.clone(),
         kkt_residual: projected_kkt,
         // Prevents recursion via `try_tangent_projected_evaluate`.

--- a/crates/gam-solve/src/reml/reml_outer_engine/tests.rs
+++ b/crates/gam-solve/src/reml/reml_outer_engine/tests.rs
@@ -2043,14 +2043,14 @@ pub(crate) fn operator_hessian_matches_dense_with_operator_drifts_and_extended_g
             tk_eta_fixed: None,
             tk_x_fixed: None,
         }],
-        ext_coord_pair_fn: Some(Box::new(|_, _| HyperCoordPair {
+        ext_coord_pair_fn: Some(Arc::new(|_, _| HyperCoordPair {
             a: 0.09,
             g: array![0.16, -0.12],
             b_mat: array![[0.08, 0.03], [0.03, -0.04]],
             b_operator: None,
             ld_s: -0.05,
         })),
-        rho_ext_pair_fn: Some(Box::new(|_, _| HyperCoordPair {
+        rho_ext_pair_fn: Some(Arc::new(|_, _| HyperCoordPair {
             a: -0.14,
             g: array![-0.18, 0.22],
             b_mat: array![[0.05, -0.02], [-0.02, 0.07]],
@@ -2205,14 +2205,14 @@ pub(crate) fn operator_hessian_with_contracted_psi_hook_matches_per_pair_dense()
                 tk_eta_fixed: None,
                 tk_x_fixed: None,
             }],
-            ext_coord_pair_fn: Some(Box::new(move |_, _| HyperCoordPair {
+            ext_coord_pair_fn: Some(Arc::new(move |_, _| HyperCoordPair {
                 a: psi_pair_a,
                 g: array![0.16, -0.12],
                 b_mat: pair_b_for_dense.clone(),
                 b_operator: None,
                 ld_s: psi_pair_ld_s,
             })),
-            rho_ext_pair_fn: Some(Box::new(|_, _| HyperCoordPair {
+            rho_ext_pair_fn: Some(Arc::new(|_, _| HyperCoordPair {
                 a: -0.14,
                 g: array![-0.18, 0.22],
                 b_mat: array![[0.05, -0.02], [-0.02, 0.07]],
@@ -2344,7 +2344,7 @@ pub(crate) fn operator_hessian_with_contracted_psi_hook_matches_per_pair_dense()
     // term2-only: zero the ψψ second drift (pair.b_mat) → removes base_h2 ψψ.
     let dense_no_base = {
         let mut sol = build_solution(false);
-        sol.ext_coord_pair_fn = Some(Box::new(move |_, _| HyperCoordPair {
+        sol.ext_coord_pair_fn = Some(Arc::new(move |_, _| HyperCoordPair {
             a: psi_pair_a,
             g: array![0.16, -0.12],
             b_mat: Array2::zeros((2, 2)),
@@ -2424,7 +2424,7 @@ pub(crate) fn operator_hessian_with_contracted_psi_hook_matches_per_pair_dense()
     let dense_without_psi_score_hvp = {
         let mut sol = build_solution(false);
         let pair_b_for_zero_score = psi_pair_b.clone();
-        sol.ext_coord_pair_fn = Some(Box::new(move |_, _| HyperCoordPair {
+        sol.ext_coord_pair_fn = Some(Arc::new(move |_, _| HyperCoordPair {
             a: psi_pair_a,
             g: Array1::zeros(2),
             b_mat: pair_b_for_zero_score.clone(),
@@ -2791,14 +2791,14 @@ pub(crate) fn projected_operator_hessian_matches_dense_subspace_trace() {
             tk_eta_fixed: None,
             tk_x_fixed: None,
         }],
-        ext_coord_pair_fn: Some(Box::new(|_, _| HyperCoordPair {
+        ext_coord_pair_fn: Some(Arc::new(|_, _| HyperCoordPair {
             a: 0.09,
             g: array![0.16, -0.12],
             b_mat: array![[0.08, 0.03], [0.03, -0.04]],
             b_operator: None,
             ld_s: -0.05,
         })),
-        rho_ext_pair_fn: Some(Box::new(|_, _| HyperCoordPair {
+        rho_ext_pair_fn: Some(Arc::new(|_, _| HyperCoordPair {
             a: -0.14,
             g: array![-0.18, 0.22],
             b_mat: array![[0.05, -0.02], [-0.02, 0.07]],


### PR DESCRIPTION
Follow-up to #1658 (merged: spatial fullhessian PSD-gate fix landed on main).

Remaining #1607 failures on current main (3):
1. \`binomial_location_scalewiggle_exact_newton_spatial_joint_hyper_returns_fullhessian\` — coupled exact-joint inner solve exits joint Newton before convergence (quasi-complete separation; wiggle family has Firth deliberately disabled per gam#932 + HardPseudo).
2. \`gaussian_location_scale_engine_matches_reference_flow\` — now fails inside its **wiggle** sub-fit with the SAME separation error (σ-floor parity already fixed; wiggle is now the blocker).
3. \`binomial_location_scale_batched_gradient_matches_finite_difference\` — envelope logdet-trace Fisher-scoring inconsistency (rel ~5.5%).

Plan: find a principled bound for the separating direction in the constrained-QP inner solve that does NOT re-enable the destabilizing full-span Firth wall.

🤖 Generated with [Claude Code](https://claude.com/claude-code)