### PR TITLE
[agent][gpu] deficit-aware Gershgorin ridge bump for arrow-Schur non-PD rows

### DIFF
--- a/.agent/gpu-arrowschur-ridgebump-deficit.md
+++ b/.agent/gpu-arrowschur-ridgebump-deficit.md
@@ -39,5 +39,24 @@ internally. A column-major-slice variant covers the multi-GPU tile path.
 - SAE device PCG host Cholesky ×2                         → ridge_bump_to_make_pd
 - multi-GPU tile batched POTRF (info index)               → ridge_bump_to_make_pd_colmajor
 
-## Verification log
-- (pending build + V100 run)
+## Verification log (Tesla V100-SXM2-32GB, CC 7.0, CUDA_VISIBLE_DEVICES=6)
+- Rebased onto fresh main (after peer fixed the #1696 env::var ban break, c54156bc2).
+- `./build.sh` clean under `warnings = "deny"` (removed now-dead `RowSlot.diag_scale`).
+- `arrow_schur_gpu_ridge_bump_required_on_non_pd_row_recovers_after_bump`: FAIL → PASS.
+  - Root cause of the residual failure after the per-row bump: the deficit-aware
+    bump correctly lifts the `-I` block PAST λ_min=-1, so it factors as a barely-PD
+    `(bump-1)*I ~ 1.5e-5*I` block. Locally κ=1, but `Y_2=L_2^-1 B_2` is amplified
+    ~256×, driving the REDUCED Schur `S_β` strongly indefinite → legitimate
+    `SchurFactorFailed`. The dense CPU reference fails identically at that ridge.
+  - Production `solve_with_lm_escalation_inner` treats BOTH RidgeBumpRequired and
+    SchurFactorFailed as ridge-recoverable; the test's manual loop only handled the
+    former. Fixed the test to mirror production and to assert dense-CPU parity on
+    the failure path at every escalation step.
+- Full V100 suite (minus slow hill_climb): 7/7 PASS — baseline, multi_size,
+  ridge_escalation, log_det, dense_reference, ridge_bump_required, fused_layer_d.
+- GPU engagement: `nvidia-smi dmon -s um -i 6` caught SM 3%, fb 86→312 MB on
+  device 6 during the suite (idle baseline 1 MB) — device path genuinely ran, no
+  silent CPU fallback (every test fail-louds on Unavailable with a runtime present).
+- CPU↔GPU parity: every passing test asserts the device step matches the dense
+  CPU reference to 1e-10; CPU path unchanged.
+- PR: #1711.

--- a/.agent/gpu-arrowschur-ridgebump-deficit.md
+++ b/.agent/gpu-arrowschur-ridgebump-deficit.md
@@ -1,0 +1,43 @@
+# [agent][gpu] Fused/batched arrow-Schur ridge bump never scales with the deficit
+
+GPU device 6 (Tesla V100-SXM2-32GB, CC 7.0, `compute_70`). Builds on merged PR #1691.
+
+## The bug (pre-existing GPU correctness defect — found while verifying #1691)
+
+When a per-row latent block `H_tt + ridge_t·I` is not positive definite, the
+device arrow-Schur paths return `ArrowSchurGpuFailure::RidgeBumpRequired{row,
+bump}` so the outer LM escalation can retry at `ridge_t + bump`. But the
+suggested `bump` was computed as `scale · |pivot| · √ε · 1024`, where `pivot`
+is the cuSOLVER POTRF `info` (or the NVRTC kernel status code) — a **1-based
+pivot ROW INDEX, not the pivot magnitude**. So a block that is indefinite by
+`O(1)` (e.g. `H_tt = -I`, λ_min = −1, needs ridge > 1) yields the same
+`bump ≈ √ε·1024 ≈ 1.5e-5` as a block indefinite by `O(√ε)`. The outer
+escalation (bounded geometric doublings) can never lift a strongly indefinite
+block out of the negative regime → the solve fails to recover.
+
+Surfaced by the V100 validation test
+`arrow_schur_gpu_ridge_bump_required_on_non_pd_row_recovers_after_bump`
+(fails on main too — confirmed by checkout).
+
+## Fix (analytic, no finite differences — SPEC-clean)
+
+New shared helper `ridge_bump_to_make_pd(htt, ridge_t)` sizes the bump from the
+block's own entries via the **Gershgorin circle theorem**:
+`λ_min(A) ≥ g := min_i (A_ii − Σ_{j≠i}|A_ij|)`. Adding `t·I` shifts all
+eigenvalues up by `t`, so `A + (ridge_t + bump)·I` is PD as soon as
+`bump > -(g + ridge_t)`. Return `max(0, -(g+ridge_t)) + margin` where
+`margin = scale·√ε·1024` (the same rounding headroom as before). One retry now
+recovers a strongly indefinite block — matching the CPU oracle
+(`arrow_schur/factorization.rs`), which lifts the per-row ridge "just enough"
+internally. A column-major-slice variant covers the multi-GPU tile path.
+
+## Producer sites updated (all in gpu_kernels/arrow_schur.rs)
+- cuda::solve dense batched POTRF (info index)            → ridge_bump_to_make_pd
+- cuda::solve_resident / Layer-A POTRF (info index)       → ridge_bump_to_make_pd
+- fused forward status (kernel status index) ×2           → ridge_bump_to_make_pd
+- row-procedural host Cholesky                            → ridge_bump_to_make_pd
+- SAE device PCG host Cholesky ×2                         → ridge_bump_to_make_pd
+- multi-GPU tile batched POTRF (info index)               → ridge_bump_to_make_pd_colmajor
+
+## Verification log
+- (pending build + V100 run)

--- a/crates/gam-solve/src/gpu_kernels/arrow_schur.rs
+++ b/crates/gam-solve/src/gpu_kernels/arrow_schur.rs
@@ -16,7 +16,7 @@
 //!
 //! On non-Linux builds the entire module degrades to a CPU-fallback shim.
 
-use ndarray::{Array1, Array2};
+use ndarray::{Array1, Array2, ArrayView2};
 
 use gam_linalg::triangular::{CholeskyGuard, cholesky_factor_in_place, cholesky_solve_vector};
 use crate::arrow_schur::{ArrowSchurSystem, DeviceSaePcgData, PcgDiagnostics};
@@ -54,19 +54,117 @@ pub enum ArrowSchurGpuFailure {
     },
 }
 
-/// Safety-margin multiplier on `√(machine ε)` for the diagonal ridge bump
-/// suggested when a local block fails Cholesky.
+/// Relative rounding margin (multiplier on `diag_scale · √ε`) added on top of
+/// the deficit-clearing shift in [`ridge_bump_to_make_pd`].
 ///
-/// The estimated bump is `diag_scale · |pivot| · √ε · RIDGE_BUMP_EPS_MARGIN`.
-/// A bare `diag_scale · √ε` ridge is the smallest perturbation that makes a
-/// marginally-indefinite block PD in exact arithmetic, but a single retry at
-/// that magnitude is routinely re-rejected by the next POTRF because the
-/// rounding error of forming `D + ridge·I` and re-factoring is itself O(√ε).
-/// The 1024× headroom (≈ 2¹⁰, i.e. ten extra bits below the f64 mantissa's
-/// 52) clears the pivot on the first retry without materially perturbing the
-/// curvature the Newton step sees. Shared by the per-row scalar path and the
-/// batched-tile path so both suggest an identical bump.
+/// The exact shift `-(λ_min)` makes a block PD in exact arithmetic, but a
+/// single retry at precisely that magnitude is routinely re-rejected by the
+/// next POTRF because the rounding error of forming `D + ridge·I` and
+/// re-factoring is itself O(√ε). The 1024× headroom (≈ 2¹⁰, ten extra bits
+/// below the f64 mantissa's 52) clears the pivot on the first retry without
+/// materially perturbing the curvature the Newton step sees. Shared by every
+/// per-row / batched / fused producer so they suggest a consistent bump.
 const RIDGE_BUMP_EPS_MARGIN: f64 = 1024.0;
+
+/// Diagonal ridge bump that is GUARANTEED to make `H_tt + (ridge_t + bump)·I`
+/// positive definite for a *symmetric* per-row block, sized from the block's
+/// own entries rather than from the factorization's pivot index.
+///
+/// # Why the old `scale · |pivot| · √ε · 1024` estimate is wrong
+///
+/// The batched/fused device paths derive the suggested bump from the
+/// factorization "pivot" — but cuSOLVER's `potrf` (and the NVRTC kernel's
+/// status code) report the failing pivot as a **1-based row index**, NOT the
+/// magnitude of the negative pivot. A block that is indefinite by `O(1)`
+/// (e.g. `H_tt = -I`, whose smallest eigenvalue is `-1`) then yields the same
+/// `bump ≈ √ε · 1024 ≈ 1.5e-5` as a block that is indefinite by `O(√ε)`. The
+/// outer LM escalation, which retries at `ridge_t + bump` and grows
+/// geometrically with a bounded step count, can never lift a strongly
+/// indefinite block out of the negative regime, so the solve fails to recover
+/// even though the block is trivially regularizable. (Surfaced by the V100
+/// `ridge_bump_required_on_non_pd_row_recovers_after_bump` validation test.)
+///
+/// # The bound
+///
+/// By the Gershgorin circle theorem every eigenvalue `λ` of the symmetric
+/// matrix `A = H_tt` satisfies, for some row `i`,
+///   `λ ≥ A[i,i] − Σ_{j≠i} |A[i,j]|`,
+/// so `λ_min(A) ≥ min_i ( A[i,i] − Σ_{j≠i} |A[i,j]| ) =: g` (the most negative
+/// Gershgorin left edge). Adding `t·I` shifts every eigenvalue up by `t`, so
+/// `A + t·I` is PD as soon as `t > -g`. We are already sitting at `ridge_t`, so
+/// the ADDITIONAL bump needed is `-(g + ridge_t)` when that is positive. We add
+/// a relative safety margin (`√ε · scale · 1024`, the same headroom the legacy
+/// estimate used) so the re-factored, rounding-perturbed block clears the pivot
+/// on the first retry, and a `max(1)`-scaled floor so a marginally-indefinite
+/// block still gets a strictly positive, non-vanishing bump.
+///
+/// The returned value is the bump to ADD to the current `ridge_t`. It is always
+/// strictly positive (the caller only constructs `RidgeBumpRequired` on an
+/// actual non-PD failure, but the bound is defensive regardless).
+#[must_use]
+fn ridge_bump_to_make_pd(htt: ArrayView2<'_, f64>, ridge_t: f64) -> f64 {
+    let d = htt.nrows();
+    // Diagonal magnitude scale (also the legacy `scale`), and the most-negative
+    // Gershgorin left edge `g = min_i (A_ii − Σ_{j≠i} |A_ij|)`.
+    let mut scale = 1.0_f64;
+    let mut min_gershgorin_edge = f64::INFINITY;
+    for i in 0..d {
+        let diag = htt[[i, i]];
+        scale = scale.max(diag.abs());
+        let mut off_sum = 0.0_f64;
+        for j in 0..d {
+            if j != i {
+                off_sum += htt[[i, j]].abs();
+            }
+        }
+        min_gershgorin_edge = min_gershgorin_edge.min(diag - off_sum);
+    }
+    if !min_gershgorin_edge.is_finite() {
+        // d == 0 (no rows) or non-finite entries: fall back to the scale-only
+        // floor so the caller still gets a strictly positive bump.
+        return scale * f64::EPSILON.sqrt() * RIDGE_BUMP_EPS_MARGIN;
+    }
+    // Additional shift needed so `λ_min(A) + ridge_t + bump > 0`, i.e.
+    // `bump > -(min_gershgorin_edge + ridge_t)`.
+    let deficit = -(min_gershgorin_edge + ridge_t);
+    let margin = scale * f64::EPSILON.sqrt() * RIDGE_BUMP_EPS_MARGIN;
+    // Lift past the deficit (when positive) plus a rounding margin; never below
+    // the scale-relative floor so a marginal block still moves.
+    deficit.max(0.0) + margin
+}
+
+/// [`ridge_bump_to_make_pd`] for a `d × d` symmetric block stored column-major
+/// in a flat slice with the current ridge ALREADY baked into the diagonal
+/// (the device packers emit `D = H_tt + ridge_t·I` this way). Because the shift
+/// is already present, the Gershgorin bound is taken at `ridge_t = 0` and the
+/// returned value is still the ADDITIONAL bump to add on top of the current
+/// ridge. Returns the scale-only floor when `block` is mis-sized.
+#[must_use]
+fn ridge_bump_to_make_pd_colmajor(block: &[f64], d: usize) -> f64 {
+    if d == 0 || block.len() < d * d {
+        return f64::EPSILON.sqrt() * RIDGE_BUMP_EPS_MARGIN;
+    }
+    // Column-major: element (row r, col c) at block[c*d + r]. The matrix is
+    // symmetric, so reading by column gives the same Gershgorin edges as by row.
+    let mut scale = 1.0_f64;
+    let mut min_gershgorin_edge = f64::INFINITY;
+    for i in 0..d {
+        let diag = block[i * d + i];
+        scale = scale.max(diag.abs());
+        let mut off_sum = 0.0_f64;
+        for j in 0..d {
+            if j != i {
+                off_sum += block[j * d + i].abs();
+            }
+        }
+        min_gershgorin_edge = min_gershgorin_edge.min(diag - off_sum);
+    }
+    let margin = scale * f64::EPSILON.sqrt() * RIDGE_BUMP_EPS_MARGIN;
+    if !min_gershgorin_edge.is_finite() {
+        return margin;
+    }
+    (-min_gershgorin_edge).max(0.0) + margin
+}
 
 /// Entry point: attempt the fully device-resident Arrow-Schur Newton solve.
 /// Returns `Err(ArrowSchurGpuFailure::Unavailable)` to indicate "device path
@@ -472,16 +570,12 @@ fn build_row_procedural_matvec(
         }
         let factor = cholesky_factor_in_place(block.view(), CholeskyGuard::NonnegativePivot)
             .ok_or_else(|| {
-                let scale = row
-                    .htt
-                    .diag()
-                    .iter()
-                    .map(|v| v.abs())
-                    .fold(0.0_f64, f64::max)
-                    .max(1.0);
+                // Deficit-aware bump from the block's own entries (Gershgorin),
+                // so the outer LM escalation lifts a strongly-indefinite block
+                // out of the negative regime in one retry.
                 ArrowSchurGpuFailure::RidgeBumpRequired {
                     row: i,
-                    bump: scale * f64::EPSILON.sqrt() * RIDGE_BUMP_EPS_MARGIN,
+                    bump: ridge_bump_to_make_pd(row.htt.view(), ridge_t),
                 }
             })?;
         factors.push(factor);
@@ -961,7 +1055,6 @@ mod cuda {
         d_block: Vec<f64>, // d*d
         b_block: Vec<f64>, // d*k
         g_vec: Vec<f64>,   // d
-        diag_scale: f64,   // |diag(H_tt)| scale for the ridge-bump diagnostic
         // Forward outputs, kept on the host for the back-sub pass.
         l_block: Vec<f64>, // d*d lower factor, column-major
         u_vec: Vec<f64>,   // d   (= L^{-1} g)
@@ -1031,18 +1124,10 @@ mod cuda {
             let mut b_block = Vec::with_capacity(d * k);
             let mut g_vec = Vec::with_capacity(d);
             pack_block(row, ridge_t, d, k, &mut d_block, &mut b_block, &mut g_vec);
-            let diag_scale = row
-                .htt
-                .diag()
-                .iter()
-                .map(|v| v.abs())
-                .fold(0.0_f64, f64::max)
-                .max(1.0);
             slots.push(RowSlot {
                 d_block,
                 b_block,
                 g_vec,
-                diag_scale,
                 l_block: Vec::new(),
                 u_vec: Vec::new(),
                 y_block: Vec::new(),
@@ -1214,15 +1299,16 @@ mod cuda {
         let mut g_dev = stream.clone_htod(&g_host).ok()?;
 
         // Batched POTRF; a non-PD block records its bump and stops the tile.
+        // The bump is deficit-aware (Gershgorin lower bound on λ_min of the
+        // already-ridged `d_block`), NOT derived from the cuSOLVER `info` —
+        // which is a 1-based pivot ROW INDEX, not a pivot magnitude — so a
+        // strongly-indefinite block recovers in one outer-loop retry.
         let info_host = potrf_batched(&solver, &stream, d, m, &mut d_dev).ok()?;
         if let Some(local) = info_host.iter().position(|info| *info != 0) {
-            let pivot = info_host[local];
-            tile[local].bump = Some(
-                tile[local].diag_scale
-                    * (f64::from(pivot).abs()).max(1.0)
-                    * f64::EPSILON.sqrt()
-                    * super::RIDGE_BUMP_EPS_MARGIN,
-            );
+            tile[local].bump = Some(super::ridge_bump_to_make_pd_colmajor(
+                &tile[local].d_block,
+                d,
+            ));
             return Some(());
         }
 
@@ -1345,17 +1431,12 @@ mod cuda {
         // is the single-device leaf the split dispatches per tile.
         let info_host = potrf_batched(&solver, &stream, d, n, &mut d_dev)?;
         if let Some(idx) = info_host.iter().position(|info| *info != 0) {
-            let pivot = info_host[idx];
-            let scale = sys.rows[idx]
-                .htt
-                .diag()
-                .iter()
-                .map(|v| v.abs())
-                .fold(0.0_f64, f64::max)
-                .max(1.0);
+            // `info` is cuSOLVER's 1-based pivot ROW INDEX, not a magnitude;
+            // size the bump from the block's own entries (Gershgorin λ_min
+            // bound) so a strongly-indefinite block recovers in one retry.
             return Err(ArrowSchurGpuFailure::RidgeBumpRequired {
                 row: idx,
-                bump: scale * (pivot.abs() as f64).max(1.0) * f64::EPSILON.sqrt() * 1024.0,
+                bump: super::ridge_bump_to_make_pd(sys.rows[idx].htt.view(), ridge_t),
             });
         }
 
@@ -2598,16 +2679,11 @@ extern "C" __global__ void arrow_sae_frame_diag_sub(
                 gam_linalg::triangular::CholeskyGuard::NonnegativePivot,
             )
             .ok_or_else(|| {
-                let scale = row
-                    .htt
-                    .diag()
-                    .iter()
-                    .map(|v| v.abs())
-                    .fold(0.0_f64, f64::max)
-                    .max(1.0);
+                // Deficit-aware bump (Gershgorin λ_min bound) so a strongly
+                // indefinite per-row block recovers in one outer-loop retry.
                 ArrowSchurGpuFailure::RidgeBumpRequired {
                     row: row_idx,
-                    bump: scale * f64::EPSILON.sqrt() * super::RIDGE_BUMP_EPS_MARGIN,
+                    bump: super::ridge_bump_to_make_pd(row.htt.view(), ridge_t),
                 }
             })?;
             for col in 0..q {
@@ -3087,17 +3163,12 @@ extern "C" __global__ void arrow_sae_frame_diag_sub(
             // POTRF(D) → L_i, kept resident in l_dev.
             let info_host = potrf_batched(&solver, &stream, d, n, &mut l_dev)?;
             if let Some(idx) = info_host.iter().position(|info| *info != 0) {
-                let pivot = info_host[idx];
-                let scale = sys.rows[idx]
-                    .htt
-                    .diag()
-                    .iter()
-                    .map(|v| v.abs())
-                    .fold(0.0_f64, f64::max)
-                    .max(1.0);
+                // cuSOLVER `info` is a 1-based pivot row index; size the bump
+                // from the block (Gershgorin λ_min bound) so a strongly
+                // indefinite block recovers in one retry.
                 return Err(ArrowSchurGpuFailure::RidgeBumpRequired {
                     row: idx,
-                    bump: scale * (pivot.abs() as f64).max(1.0) * f64::EPSILON.sqrt() * 1024.0,
+                    bump: super::ridge_bump_to_make_pd(sys.rows[idx].htt.view(), ridge_t),
                 });
             }
 
@@ -3384,17 +3455,12 @@ extern "C" __global__ void arrow_sae_frame_diag_sub(
             .clone_dtoh(&status_dev)
             .map_err(|_| ArrowSchurGpuFailure::Unavailable)?;
         if let Some(row) = status_host.iter().position(|s| *s != 0) {
-            let pivot = status_host[row];
-            let scale = sys.rows[row]
-                .htt
-                .diag()
-                .iter()
-                .map(|v| v.abs())
-                .fold(0.0_f64, f64::max)
-                .max(1.0);
+            // The NVRTC kernel's status code is a 1-based pivot row index, not
+            // a magnitude; size the bump from the block (Gershgorin λ_min
+            // bound) so a strongly indefinite block recovers in one retry.
             return Err(ArrowSchurGpuFailure::RidgeBumpRequired {
                 row,
-                bump: scale * (pivot.abs() as f64).max(1.0) * f64::EPSILON.sqrt() * 1024.0,
+                bump: super::ridge_bump_to_make_pd(sys.rows[row].htt.view(), ridge_t),
             });
         }
 
@@ -3632,17 +3698,12 @@ extern "C" __global__ void arrow_sae_frame_diag_sub(
             .clone_dtoh(&status_dev)
             .map_err(|_| super::ArrowSchurGpuFailure::Unavailable)?;
         if let Some(row) = status_host.iter().position(|s| *s != 0) {
-            let pivot = status_host[row];
-            let scale = sys.rows[row]
-                .htt
-                .diag()
-                .iter()
-                .map(|v| v.abs())
-                .fold(0.0_f64, f64::max)
-                .max(1.0);
+            // Status code is a 1-based pivot row index, not a magnitude; size
+            // the bump from the block (Gershgorin λ_min bound) so a strongly
+            // indefinite block recovers in one retry.
             return Err(super::ArrowSchurGpuFailure::RidgeBumpRequired {
                 row,
-                bump: scale * (pivot.abs() as f64).max(1.0) * f64::EPSILON.sqrt() * 1024.0,
+                bump: super::ridge_bump_to_make_pd(sys.rows[row].htt.view(), ridge_t),
             });
         }
 
@@ -3872,16 +3933,11 @@ extern "C" __global__ void arrow_sae_frame_diag_sub(
                 gam_linalg::triangular::CholeskyGuard::NonnegativePivot,
             )
             .ok_or_else(|| {
-                let scale = row
-                    .htt
-                    .diag()
-                    .iter()
-                    .map(|v| v.abs())
-                    .fold(0.0_f64, f64::max)
-                    .max(1.0);
+                // Deficit-aware bump (Gershgorin λ_min bound) so a strongly
+                // indefinite per-row block recovers in one outer-loop retry.
                 ArrowSchurGpuFailure::RidgeBumpRequired {
                     row: i,
-                    bump: scale * f64::EPSILON.sqrt() * super::RIDGE_BUMP_EPS_MARGIN,
+                    bump: super::ridge_bump_to_make_pd(row.htt.view(), ridge_t),
                 }
             })?;
             for col in 0..q {

--- a/crates/gam-solve/src/gpu_kernels/arrow_schur.rs
+++ b/crates/gam-solve/src/gpu_kernels/arrow_schur.rs
@@ -5051,6 +5051,102 @@ mod tests {
         sys
     }
 
+    /// The Gershgorin ridge bump must actually make a known-indefinite block PD
+    /// on the first retry — the whole point of #1711. Verified directly by
+    /// re-factoring `H_tt + (ridge_t + bump)·I` with the same Cholesky guard the
+    /// device readback uses, for blocks whose `λ_min` is known in closed form.
+    #[test]
+    fn ridge_bump_makes_known_indefinite_blocks_pd() {
+        // `cholesky_factor_in_place` / `CholeskyGuard` are already in scope via
+        // `super::*` (imported at the top of the module).
+        // A few blocks with a CLOSED-FORM smallest eigenvalue, all at ridge_t=0.
+        // (label, matrix, λ_min) — the bump must clear each one.
+        let neg_identity = Array2::<f64>::from_diag(&Array1::from_elem(8, -1.0)); // λ_min = -1
+        let scaled_neg = Array2::<f64>::from_diag(&Array1::from_elem(4, -250.0)); // λ_min = -250
+        // Symmetric 2×2 [[1, 2], [2, 1]] has eigenvalues 3 and -1 → indefinite.
+        let mut indef2 = Array2::<f64>::zeros((2, 2));
+        indef2[[0, 0]] = 1.0;
+        indef2[[1, 1]] = 1.0;
+        indef2[[0, 1]] = 2.0;
+        indef2[[1, 0]] = 2.0;
+        // A genuinely PD block must get a bump that is the bare rounding margin
+        // only (deficit 0), and must still factor — the helper is defensive.
+        let pd = Array2::<f64>::from_diag(&Array1::from_elem(3, 5.0));
+
+        for (label, block) in [
+            ("-I (λ_min=-1)", neg_identity),
+            ("-250·I (λ_min=-250)", scaled_neg),
+            ("[[1,2],[2,1]] (λ_min=-1)", indef2),
+            ("5·I (PD)", pd),
+        ] {
+            let ridge_t = 0.0;
+            let bump = ridge_bump_to_make_pd(block.view(), ridge_t);
+            assert!(
+                bump > 0.0 && bump.is_finite(),
+                "[{label}] bump must be strictly positive and finite, got {bump:e}"
+            );
+            let d = block.nrows();
+            let mut shifted = block.clone();
+            for i in 0..d {
+                shifted[[i, i]] += ridge_t + bump;
+            }
+            assert!(
+                cholesky_factor_in_place(shifted.view(), CholeskyGuard::NonnegativePivot).is_some(),
+                "[{label}] H_tt + (ridge_t + bump={bump:e})·I must be PD after the \
+                 Gershgorin bump, but the Cholesky still rejected it"
+            );
+        }
+    }
+
+    /// The column-major variant (multi-GPU tile path) must agree with the
+    /// row-major helper for a symmetric block, since Gershgorin edges are
+    /// invariant under reading the symmetric matrix by row vs by column. The
+    /// colmajor variant takes the bound at ridge_t=0 (the ridge is already baked
+    /// into the diagonal it reads), so compare against `ridge_bump_to_make_pd`
+    /// with `ridge_t = 0`.
+    #[test]
+    fn ridge_bump_colmajor_matches_rowmajor_for_symmetric_block() {
+        // Symmetric 3×3 with a negative-definite-ish diagonal and off-diagonals.
+        let mut a = Array2::<f64>::zeros((3, 3));
+        a[[0, 0]] = -2.0;
+        a[[1, 1]] = 0.5;
+        a[[2, 2]] = 1.0;
+        a[[0, 1]] = 0.3;
+        a[[1, 0]] = 0.3;
+        a[[1, 2]] = -0.4;
+        a[[2, 1]] = -0.4;
+        a[[0, 2]] = 0.1;
+        a[[2, 0]] = 0.1;
+
+        let row_major_bump = ridge_bump_to_make_pd(a.view(), 0.0);
+
+        // Flatten column-major: block[c*d + r] = a[[r, c]].
+        let d = 3;
+        let mut col_major = vec![0.0_f64; d * d];
+        for c in 0..d {
+            for r in 0..d {
+                col_major[c * d + r] = a[[r, c]];
+            }
+        }
+        let col_major_bump = ridge_bump_to_make_pd_colmajor(&col_major, d);
+
+        assert!(
+            (row_major_bump - col_major_bump).abs() <= 1e-12 * row_major_bump.max(1.0),
+            "colmajor bump {col_major_bump:e} must match rowmajor bump \
+             {row_major_bump:e} for a symmetric block"
+        );
+
+        // And the bump must actually make it PD (sanity, same as the row-major test).
+        let mut shifted = a.clone();
+        for i in 0..d {
+            shifted[[i, i]] += col_major_bump;
+        }
+        assert!(
+            cholesky_factor_in_place(shifted.view(), CholeskyGuard::NonnegativePivot).is_some(),
+            "colmajor Gershgorin bump must make the symmetric block PD"
+        );
+    }
+
     fn device_pcg_fixture(k: usize) -> (Array2<f64>, Array1<f64>) {
         let mut s = Array2::<f64>::zeros((k, k));
         for row in 0..k {

--- a/tests/arrow_gpu/gpu/arrow_schur_gpu_v100_validation.rs
+++ b/tests/arrow_gpu/gpu/arrow_schur_gpu_v100_validation.rs
@@ -412,18 +412,44 @@ fn arrow_schur_gpu_ridge_bump_required_on_non_pd_row_recovers_after_bump() {
              have factored at ridge=0"
         ),
     };
-    // Re-launch at ridge_t = bump. The poisoned row is `-I`; the shifted
-    // `htt + bump·I = (bump − 1)·I`, which only becomes PD once `bump > 1`.
-    // The Ceres-style escalation already returns a `bump ≥ 1024·√ε ≈ 4.8e-5`
-    // baseline, so we may need a few geometric doublings. Iterate up to ten
-    // doublings — math block 3 §16 caps the escalation chain at ten before
-    // declaring the system genuinely rank-deficient.
+    // Re-launch at ridge_t = bump and escalate exactly as the production LM
+    // loop (`solve_with_lm_escalation_inner`) does. The poisoned row is `-I`;
+    // the deficit-aware Gershgorin bump now lifts that single block PAST its
+    // λ_min = −1 deficit on the first retry, so `htt + bump·I ≈ (bump − 1)·I`
+    // is genuinely positive definite (bump ≈ 1 + 1024·√ε). But a block that is
+    // only *barely* PD is still perfectly conditioned locally (κ = 1 for a
+    // scalar multiple of I) while its inverse is huge: `Y₂ = L₂⁻¹B₂` is
+    // amplified by ≈ 1/√(bump−1) ≈ 256×, which drives the REDUCED Schur
+    // complement `S_β = H_ββ + ρ_β I − Σ Yᵀ Y` strongly indefinite. That is a
+    // legitimate `SchurFactorFailed`, NOT a per-row defect — and the dense CPU
+    // reference fails identically at the very same ridge (verified below by the
+    // `Err` arm of `solve_arrow_newton_step_dense_reference`). The system only
+    // becomes globally PD once the ridge grows the block to O(1) (ridge ≈ 2).
+    //
+    // Production treats BOTH `RidgeBumpRequired` (per-row non-PD) and
+    // `SchurFactorFailed` (reduced-Schur non-PD) as ridge-recoverable
+    // (newton_step.rs `recoverable` match), geometrically growing a proximal
+    // ridge on either. We mirror that here. Iterate up to ten escalations —
+    // math block 3 §16 caps the chain at ten before declaring the system
+    // genuinely rank-deficient.
     let mut ridge = bump;
     for attempt in 0..10 {
-        match solve_arrow_newton_step(&sys, ridge, ridge_beta) {
+        let device = solve_arrow_newton_step(&sys, ridge, ridge_beta);
+        // Parity oracle: the dense CPU reference must agree with the device on
+        // BOTH success and failure at this ridge. If the device declined, the
+        // reference must also decline (otherwise the device dropped a step the
+        // CPU could take); if the device succeeded, the reference must succeed
+        // and match it to 1e-10.
+        let reference = solve_arrow_newton_step_dense_reference(&sys, ridge, ridge_beta);
+        match device {
             Ok(got) => {
-                let expected = solve_arrow_newton_step_dense_reference(&sys, ridge, ridge_beta)
-                    .expect("dense reference Cholesky must succeed at sufficiently large ridge");
+                let expected = reference.unwrap_or_else(|e| {
+                    panic!(
+                        "[arrow_schur_gpu_v100/ridge_bump_required] device solved at \
+                         ridge={ridge:e} but dense CPU reference failed ({e}) — the \
+                         device produced a step the parity oracle rejects"
+                    )
+                });
                 assert_solution_matches(
                     "arrow_schur_gpu_v100/ridge_bump_required/recovered",
                     sys.rows.len(),
@@ -435,10 +461,29 @@ fn arrow_schur_gpu_ridge_bump_required_on_non_pd_row_recovers_after_bump() {
                 );
                 return;
             }
+            // Per-row block still non-PD: take the suggested deficit-aware bump.
             Err(ArrowSchurGpuFailure::RidgeBumpRequired {
                 bump: next_bump, ..
             }) => {
+                assert!(
+                    reference.is_err(),
+                    "[arrow_schur_gpu_v100/ridge_bump_required] device wanted a ridge \
+                     bump at ridge={ridge:e} but the dense CPU reference factored — \
+                     parity violation"
+                );
                 ridge = (ridge + next_bump).max(ridge * 2.0);
+            }
+            // Reduced Schur non-PD at a barely-PD per-row ridge: a genuine,
+            // ridge-recoverable condition (the dense reference fails identically),
+            // so grow the ridge geometrically exactly as the production LM loop.
+            Err(ArrowSchurGpuFailure::SchurFactorFailed { .. }) => {
+                assert!(
+                    reference.is_err(),
+                    "[arrow_schur_gpu_v100/ridge_bump_required] device reported a \
+                     non-PD reduced Schur at ridge={ridge:e} but the dense CPU \
+                     reference factored — parity violation"
+                );
+                ridge *= 2.0;
             }
             // Runtime present + floor-clearing fixture ⇒ decline is a real fault.
             Err(ArrowSchurGpuFailure::Unavailable) => panic!(


### PR DESCRIPTION
## What

Deficit-aware **Gershgorin** ridge bump for the device-resident Arrow-Schur Newton solver, so a strongly-indefinite per-row latent block recovers in one outer-loop retry — matching the CPU oracle. Found while verifying the merged B/Y block-stride fix (#1691) against the V100 validation suite.

## The bug (pre-existing GPU correctness defect)

When a per-row block `H_tt + ridge_t·I` is not positive definite, the batched/fused device paths return `RidgeBumpRequired { row, bump }` so the outer LM escalation can retry at `ridge_t + bump`. But the suggested `bump` was `scale · |pivot| · √ε · 1024`, where `pivot` is the cuSOLVER POTRF `info` (or the NVRTC kernel status) — a **1-based pivot ROW INDEX, not the pivot magnitude**. A block indefinite by `O(1)` (e.g. `H_tt = -I`, `λ_min = -1`) thus got the same `bump ≈ 1.5e-5` as a block indefinite by `O(√ε)`. The bounded geometric LM escalation could never lift a strongly-indefinite block out of the negative regime, so the solve never recovered.

Surfaced by the V100 test `arrow_schur_gpu_ridge_bump_required_on_non_pd_row_recovers_after_bump` (fails on `main` too — confirmed by checkout).

## The fix (analytic, SPEC-clean — no finite differences)

New shared helper `ridge_bump_to_make_pd(htt, ridge_t)` sizes the bump from the block's own entries via the **Gershgorin circle theorem**: `λ_min(A) ≥ g := minᵢ(Aᵢᵢ − Σⱼ≠ᵢ|Aᵢⱼ|)`. Adding `t·I` shifts every eigenvalue up by `t`, so `A + (ridge_t + bump)·I` is PD once `bump > -(g + ridge_t)`. Return `max(0, -(g+ridge_t)) + margin`, where `margin = scale·√ε·1024` is the same rounding headroom the legacy estimate used. One retry now clears a strongly-indefinite block. A column-major-slice variant (`ridge_bump_to_make_pd_colmajor`) covers the multi-GPU tile path. All 8 `RidgeBumpRequired` producer sites in `gpu_kernels/arrow_schur.rs` are wired to the helpers.

## Test (parity oracle on the failure path too)

After the bump clears the per-row deficit, the poisoned `-I` block factors as a barely-PD `(bump−1)·I ≈ 1.5e-5·I` block: locally well-conditioned (κ=1) but with a huge inverse, so `Y₂ = L₂⁻¹B₂` is amplified ~256× and the **reduced** Schur `S_β` goes strongly indefinite. That is a legitimate `SchurFactorFailed`, not a per-row defect — and the **dense CPU reference fails identically at the same ridge**. Production's `solve_with_lm_escalation_inner` treats both `RidgeBumpRequired` and `SchurFactorFailed` as ridge-recoverable and grows a proximal ridge on either; the V100 test's manual recovery loop only handled the former, so it died on the (correct) Schur failure.

Updated the test to mirror production (escalate on both) and to assert at **every** ridge step that the dense CPU oracle agrees with the device on both success (match to 1e-10) and failure — closing the parity gap on the failure path, not just the recovered step.

## Verification (Tesla V100-SXM2-32GB, CC 7.0, `CUDA_VISIBLE_DEVICES=6`)

- `./build.sh` clean (`warnings = "deny"`); removed the now-dead `RowSlot.diag_scale` field.
- `arrow_schur_gpu_ridge_bump_required_on_non_pd_row_recovers_after_bump`: **FAIL → PASS**.
- Broader `arrow_schur_gpu` V100 suite: green (see PR comments).
- CPU path untouched; the CPU dense reference is the parity oracle the test checks against on every escalation step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
