### PR TITLE
[agent] unblock RED main: 8 stale run_plan unit fixtures

### DIFF
--- a/crates/gam-solve/src/rho_optimizer/run_plan_tests.rs
+++ b/crates/gam-solve/src/rho_optimizer/run_plan_tests.rs
@@ -1353,10 +1353,15 @@ fn analytic_route_unavailable_hessian_is_fatal() {
 #[test]
 fn arc_bridge_cost_stall_certifies_at_bound_separation() {
     // A flat objective at the lower bound `rho = -10` whose raw gradient is a
-    // constant `g = -1` (points further DOWN, out of the feasible box): the
-    // projected KKT residual there is 0, so a stall is a CONVERGED optimum —
-    // exactly the separation signature (the REML score has bottomed out but the
-    // unprojected gradient keeps pushing λ→0 forever).
+    // constant `g = +1`: its descent step `-g = -1` points further DOWN, out of
+    // the feasible box, so under the corrected KKT projection (#1074, a14b71220)
+    // it is the infeasible bound-multiplier pull and projects to 0. The projected
+    // KKT residual there is 0, so a stall is a CONVERGED optimum — exactly the
+    // separation signature (the REML score has bottomed out but the unprojected
+    // gradient keeps pushing λ→0 forever). NOTE: a NEGATIVE gradient at a lower
+    // bound is FEASIBLE interior descent (step `-g = +1` points back into the
+    // box) and is retained by the projection — it would (correctly) report
+    // NON-converged, which is why the fixture uses `+1`.
     let lo = array![-10.0];
     let hi = array![10.0];
     let problem = OuterProblem::new(1)
@@ -1374,9 +1379,9 @@ fn arc_bridge_cost_stall_certifies_at_bound_separation() {
             Ok(OuterEval {
                 // Constant cost: the score has flat-lined (separation valley).
                 cost: 1.0,
-                // Gradient points out of the lower bound; raw norm = 1 forever,
-                // but the bound-projected residual at rho=-10 is 0.
-                gradient: array![-1.0],
+                // Gradient's descent step points out of the lower bound; raw norm
+                // = 1 forever, but the bound-projected residual at rho=-10 is 0.
+                gradient: array![1.0],
                 hessian: match order {
                     OuterEvalOrder::ValueGradientHessian => HessianResult::Analytic(array![[1.0]]),
                     _ => HessianResult::Unavailable,
@@ -1453,8 +1458,10 @@ fn arc_bridge_cost_stall_halts_on_kkt_stationary_bound_descent() {
     let lo = array![-10.0];
     let hi = array![10.0];
     // Strictly-decreasing cost so the cost-improvement test alone would NEVER
-    // fire; the gradient points out of the lower bound (raw |g|=1, projected
-    // KKT residual at rho=-10 is 0), so the halt rides on stationarity.
+    // fire; the gradient's descent step points out of the lower bound (`g = +1`,
+    // step `-g = -1` exits the box), so under the corrected KKT projection
+    // (#1074, a14b71220) it projects to 0 (raw |g|=1, projected KKT residual at
+    // rho=-10 is 0) and the halt rides on stationarity.
     let step = std::cell::Cell::new(0u32);
     let problem = OuterProblem::new(1)
         .with_gradient(Derivative::Analytic)
@@ -1474,9 +1481,9 @@ fn arc_bridge_cost_stall_halts_on_kkt_stationary_bound_descent() {
                 // Monotonically decreasing by far more than the rel-tol floor:
                 // a pure cost-stall test could never fill its window here.
                 cost: 1.0 - (k as f64),
-                // Out-of-bounds gradient at the lower bound: raw norm = 1 forever,
-                // bound-projected residual = 0 (KKT-stationary).
-                gradient: array![-1.0],
+                // Gradient whose descent step exits the lower bound: raw norm = 1
+                // forever, bound-projected residual = 0 (KKT-stationary).
+                gradient: array![1.0],
                 hessian: match order {
                     OuterEvalOrder::ValueGradientHessian => HessianResult::Analytic(array![[1.0]]),
                     _ => HessianResult::Unavailable,


### PR DESCRIPTION
RED main: 8 stale unit fixtures in crates/gam-solve/src/rho_optimizer/run_plan_tests.rs. All 8 encode behavior superseded by deliberate production changes after the tests were written; production is correct. Fixing fixtures to assert the corrected contract without weakening guards. Group A (bridge KKT sign, 2 tests) done; B (cost-stall, 2) and C (seed-screening, 4) in progress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)