### PR TITLE
[agent][gpu] #1412/#988 follow-up: CI-fast parity (736s→2s), fail-loud oracle, false-routing guard

### DIFF
--- a/crates/gam-gpu/src/encode_throughput.rs
+++ b/crates/gam-gpu/src/encode_throughput.rs
@@ -211,7 +211,18 @@ pub fn cpu_oracle_normal_equations_solve(
         for s in 0..j {
             diag -= l[[j, s]] * l[[j, s]];
         }
-        let ljj = diag.max(0.0).sqrt();
+        // The oracle exists to be the truth the device is checked against, so a
+        // non-PD pivot must fail loudly here rather than clamp to 0 and launder
+        // a divide-by-zero into a silent NaN in the back-substitution. For the
+        // ridge·I + XᵀWX systems this is called on (ridge > 0, w > 0) the pivot
+        // is always strictly positive; a non-positive pivot means the caller
+        // passed a degenerate system and parity would be meaningless.
+        assert!(
+            diag > 0.0,
+            "cpu_oracle: non-positive Cholesky pivot {diag:.3e} at index {j} — \
+             the Gram is not positive-definite (need ridge>0 and w>0)"
+        );
+        let ljj = diag.sqrt();
         l[[j, j]] = ljj;
         for i in (j + 1)..p {
             let mut off = gram[[i, j]];

--- a/tests/gpu_encode_throughput_measured_1412.rs
+++ b/tests/gpu_encode_throughput_measured_1412.rs
@@ -91,11 +91,12 @@ fn device_resident_solve_matches_cpu_oracle() {
 
     assert_eq!(gpu_beta.len(), cpu_beta.len());
     // Tolerance: the two solves differ only by IEEE-754 reduction order in the
-    // Gram and the triangular solves (device fused POTRF/TRSM vs host
-    // left-looking Cholesky). For a p=2048, well-conditioned ridge=1e-3 system
-    // with O(0.05)-scale entries, accumulated reduction-order drift across the
-    // p² Gram dot-products and the two triangular sweeps stays well under 1e-6
-    // relative. We assert a conservative absolute+relative bound on β.
+    // Gram and the triangular solves (device cuSOLVER POTRF + cuBLAS TRSM vs
+    // host left-looking Cholesky). For this well-conditioned ridge=1e-3, p=512
+    // system with O(0.05)-scale entries, accumulated reduction-order drift
+    // across the p² Gram dot-products and the two triangular sweeps stays well
+    // under 1e-6 relative (measured ~1e-14 on the V100). We assert a
+    // conservative absolute+relative bound on β.
     let mut max_abs = 0.0_f64;
     let mut max_rel = 0.0_f64;
     for (g, c) in gpu_beta.iter().zip(cpu_beta.iter()) {

--- a/tests/gpu_encode_throughput_measured_1412.rs
+++ b/tests/gpu_encode_throughput_measured_1412.rs
@@ -70,10 +70,14 @@ fn device_resident_solve_matches_cpu_oracle() {
     let handle = match ResidentDesignGram::try_new(x.view()) {
         Some(h) => h,
         None => {
+            // A device-profitable shape (2·n·p² ≈ 1.0e9 ≫ the 1e8 flop floor)
+            // declining is only legitimate on a CPU-only host. If a CUDA device
+            // is present and the resident gram still declines, that is false
+            // routing — fail loud rather than silently skip the parity check.
             assert!(
-                !device_present()
-                    || ResidentDesignGram::try_new(x.view()).is_none(),
-                "device present but resident gram declined a GPU-profitable shape"
+                !device_present(),
+                "a CUDA device is present but ResidentDesignGram declined a GPU-profitable \
+                 shape (n={n}, p={p}, 2·n·p²≈1.0e9 ≫ the 1e8 flop floor) — false GPU routing"
             );
             eprintln!("device_resident_solve_matches_cpu_oracle: no device — skipped");
             return;

--- a/tests/gpu_encode_throughput_measured_1412.rs
+++ b/tests/gpu_encode_throughput_measured_1412.rs
@@ -55,8 +55,12 @@ fn planted_design(n: usize, p: usize) -> Array2<f64> {
 /// device result).
 #[test]
 fn device_resident_solve_matches_cpu_oracle() {
-    // A GPU-profitable wide-decoder shape that clears the Gram work gate.
-    let (n, p) = (2_000usize, 2_048usize);
+    // A GPU-profitable shape that clears the XtDiagX work gate
+    // (2·n·p² = 2·2000·512² ≈ 1.0e9 ≫ the 1e8 flop floor) while keeping the
+    // O(n·p²) CPU-oracle Gram cheap enough for CI. The wide-border shapes are
+    // exercised for *throughput* in the other test; parity only needs the
+    // device path to engage, not the largest p.
+    let (n, p) = (2_000usize, 512usize);
     let x = planted_design(n, p);
     let mut s = 0x988_5ae_e0c0_de01u64;
     let w = Array1::from_shape_fn(n, |_| lcg(&mut s).abs() + 1e-3);


### PR DESCRIPTION
Follow-up to #1684 (merged). That merge captured an early state of the encode-throughput parity test that has three issues worth fixing; this PR lands the improvements I verified on the V100 after the merge.

## What & why
1. **CI-fast parity shape (736s → ~2s).** The merged `device_resident_solve_matches_cpu_oracle` runs the CPU oracle Gram at `p=2048` (O(n·p²) — ~736s in CI; this is the same setup-cost slowness #988 documented). Parity only needs the device path to *engage*, not the largest `p`. Shrunk to `p=512` (`2·n·p² ≈ 1.0e9 ≫ the 1e8 flop floor`, so it still routes to GPU). Parity is now `max_rel_diff = 9.3e-15` (near machine epsilon) and the test runs in ~2s.
2. **Fail-loud CPU oracle.** The oracle's lower-Cholesky used `diag.max(0.0).sqrt()`, which on a non-PD pivot silently yields `ljj=0` → divide-by-zero → NaN laundered into the parity diff. Replaced with an `assert!(diag > 0.0, ...)` so a degenerate system fails loudly (the oracle is the definition of truth; it must not silently produce garbage).
3. **False-routing guard, not a tautology.** The merged parity test's device-decline arm re-called `try_new` inside its own `None` branch (always `None` — tautological). Now it asserts `!device_present()`: a device present but declining a GPU-profitable shape is false GPU routing and fails loud.

## Verified on V100 device 4 (this box)
- Parity: `max_rel_diff = 9.3e-15`.
- Throughput: sae-8k-1024 = **1.44M rows/sec = 14.4× the 100K target** (meets_target=true), sae-2k-2048 = 94k, sae-4k-4096 = 48k; all `engaged=true`.
- GPU engagement confirmed earlier via `nvidia-smi` (util 44%, mem 738 MiB).
- CPU-only host (`CUDA_VISIBLE_DEVICES=""`): all 3 tests pass, honest decline, no fabricated target.
- Full suite: 8.6s (was 736s+ for the parity test alone).

Refs #988, #1412.