### PR TITLE
[agent] #1689: P-spline/thin-plate Gaussian fit perf (continuation)

### DIFF
--- a/crates/gam-cli/src/main.rs
+++ b/crates/gam-cli/src/main.rs
@@ -313,7 +313,9 @@ fn run() -> CliResult<()> {
     // Parse first so `--help` / `--version` exit cleanly without spawning the
     // runtime-threads INFO line clap can't suppress.
     let cli = Cli::parse();
-    gam::progress_log::init_logging();
+    gam::progress_log::init_logging_with_level(gam::progress_log::level_from_verbosity_delta(
+        cli.verbosity_delta(),
+    ));
     log::info!(
         "[STAGE] runtime threads | rayon_current_num_threads={} | std_available_parallelism={}",
         rayon::current_num_threads(),

--- a/crates/gam-cli/src/main/cli_args.rs
+++ b/crates/gam-cli/src/main/cli_args.rs
@@ -8,6 +8,35 @@ use super::*;
 pub(crate) struct Cli {
     #[command(subcommand)]
     pub(crate) command: Command,
+    /// Increase stderr log verbosity (repeatable): `-v` = info, `-vv` = debug,
+    /// `-vvv` = trace. The default is quiet (warnings + errors only) so a fit
+    /// doesn't flood the terminal with per-iteration progress chatter (#1689).
+    #[arg(
+        short = 'v',
+        long = "verbose",
+        action = clap::ArgAction::Count,
+        global = true,
+        conflicts_with = "quiet"
+    )]
+    pub(crate) verbose: u8,
+    /// Decrease stderr log verbosity (repeatable): `-q` = errors only,
+    /// `-qq` = silent. Mutually exclusive with `-v`.
+    #[arg(
+        short = 'q',
+        long = "quiet",
+        action = clap::ArgAction::Count,
+        global = true
+    )]
+    pub(crate) quiet: u8,
+}
+
+impl Cli {
+    /// Signed verbosity delta relative to the default level: positive for each
+    /// `-v`, negative for each `-q`. Fed to
+    /// [`gam::progress_log::level_from_verbosity_delta`].
+    pub(crate) fn verbosity_delta(&self) -> i32 {
+        i32::from(self.verbose) - i32::from(self.quiet)
+    }
 }
 
 #[derive(Subcommand, Debug)]

--- a/crates/gam-pyffi/src/manifold/geometry_ffi.rs
+++ b/crates/gam-pyffi/src/manifold/geometry_ffi.rs
@@ -30,6 +30,25 @@ fn sae_set_ibp_alpha(alpha: f64) {
     gam::terms::sae::assignment::set_ibp_alpha_override(alpha);
 }
 
+/// #1689 — adjust the process-global stderr log verbosity at runtime. The
+/// extension installs the logger at module import defaulting to `warn` (a fit
+/// no longer floods stderr with thousands of per-iteration progress lines); a
+/// caller that wants the chatter back opts in with
+/// `gamfit.set_log_level("info")` (or `debug`/`trace`), and `off`/`silent`
+/// quiets it entirely. Accepts the standard `off|error|warn|info|debug|trace`
+/// spellings (case-insensitive); an unrecognized value raises `ValueError`.
+#[pyfunction]
+fn set_log_level(level: &str) -> PyResult<()> {
+    let parsed = gam::solver::progress_log::parse_log_level(level).ok_or_else(|| {
+        py_value_error(format!(
+            "unrecognized log level {level:?}; expected one of \
+             off|error|warn|info|debug|trace"
+        ))
+    })?;
+    gam::solver::progress_log::set_log_level(parsed);
+    Ok(())
+}
+
 #[pyfunction(signature = (points, mode = "kneedle", knee_slope_fraction = 0.10, complexity_penalty = 0.05, flat_span_tol = 1.0e-6))]
 fn sae_select_k(
     py: Python<'_>,
@@ -4177,6 +4196,7 @@ fn rust_extension(module: &Bound<'_, PyModule>) -> PyResult<()> {
     module.add_function(wrap_pyfunction!(equivariant_gauge_companion_loss, module)?)?;
     module.add_function(wrap_pyfunction!(sae_set_barrier_overrides, module)?)?;
     module.add_function(wrap_pyfunction!(sae_set_ibp_alpha, module)?)?;
+    module.add_function(wrap_pyfunction!(set_log_level, module)?)?;
     module.add_function(wrap_pyfunction!(sae_select_k, module)?)?;
     module.add_function(wrap_pyfunction!(sae_auto_k_recommendation, module)?)?;
     module.add_function(wrap_pyfunction!(sae_manifold_fit, module)?)?;

--- a/crates/gam-solve/src/inference/alo.rs
+++ b/crates/gam-solve/src/inference/alo.rs
@@ -665,8 +665,9 @@ fn log_leverage_diagnostics(leverage: &Array1<f64>, phi: f64) {
     let a_max = finite_leverage.last().copied().unwrap_or(0.0);
 
     // Routine per-ALO leverage summary: a diagnostic snapshot, not an
-    // anomaly. Emitted at `info!` so it is visible under `GAM_LOG=info` but
-    // silent at the default `Warn` level (genuine anomalies — invalid / very
+    // anomaly. Emitted at `info!` so it is visible when the host raises
+    // verbosity (CLI `-v`; `gamfit.set_log_level("info")`) but silent at the
+    // default `Warn` level (genuine anomalies — invalid / very
     // high leverage — are logged at `warn!` above and stay visible). This
     // line fires once per ALO computation, which recurs across the outer
     // smoothing loop, so at `warn!` it was a dominant source of stderr noise

--- a/crates/gam-solve/src/progress_log.rs
+++ b/crates/gam-solve/src/progress_log.rs
@@ -114,7 +114,8 @@ fn human_elapsed(elapsed: Duration) -> String {
     }
 }
 
-/// Default verbosity when the user has set no environment override.
+/// Default verbosity when the caller installs the logger without an explicit
+/// level.
 ///
 /// A single ordinary fit (e.g. a 400-row `s(x)` P-spline) emits thousands of
 /// per-iteration `[OUTER ...]` / `[GAM ALO]` `info!`/`warn!` records. Writing
@@ -123,27 +124,20 @@ fn human_elapsed(elapsed: Duration) -> String {
 /// (a library call from Python that just wants the model back) the stream is
 /// pure noise. So the out-of-the-box level is `Warn`: genuine problems still
 /// surface, but the routine progress chatter is silent unless explicitly
-/// requested. Power users opt back in with `GAM_LOG=info` (or `=debug` /
-/// `=trace`), and `RUST_LOG` is honored as a fallback for ecosystem muscle
-/// memory.
-const DEFAULT_LOG_LEVEL: LevelFilter = LevelFilter::Warn;
+/// requested. Callers opt back in via [`init_logging_with_level`] (the CLI's
+/// `-v`/`-q` flags; the Python `gamfit.set_log_level(...)` shim).
+///
+/// This crate is deliberately env-var-free (the project bans `env::var`), so
+/// verbosity is always a programmatic decision made by the host, never an
+/// ambient `RUST_LOG`.
+pub const DEFAULT_LOG_LEVEL: LevelFilter = LevelFilter::Warn;
 
-/// Resolve the active log level from the environment, falling back to
-/// [`DEFAULT_LOG_LEVEL`]. `GAM_LOG` takes precedence over `RUST_LOG`; both
-/// accept the standard `off|error|warn|info|debug|trace` spellings (case
-/// insensitive). An unset or unrecognized value yields the default, so a typo
-/// never silently turns logging fully off or on.
-fn resolve_log_level() -> LevelFilter {
-    // Reading env vars in non-test src is banned by build.rs (no env-var gates),
-    // so the active level is the compile-time default. The precedence helper is
-    // retained (and unit-tested) for callers that pass explicit overrides.
-    log_level_from_overrides(None, None)
-}
-
-/// Parse one verbosity spelling into a [`LevelFilter`]. Case-insensitive,
+/// Map a verbosity *level name* to a [`LevelFilter`]. Case-insensitive,
 /// surrounding whitespace ignored. Returns `None` for anything unrecognized so
-/// the caller can fall through to the next source rather than guessing.
-fn parse_log_level(value: &str) -> Option<LevelFilter> {
+/// a caller surfacing a `--log-level` string can reject typos rather than
+/// silently guessing. Accepts the standard `off|error|warn|info|debug|trace`
+/// spellings plus a few friendly aliases.
+pub fn parse_log_level(value: &str) -> Option<LevelFilter> {
     match value.trim().to_ascii_lowercase().as_str() {
         "off" | "none" | "silent" => Some(LevelFilter::Off),
         "error" => Some(LevelFilter::Error),
@@ -155,28 +149,59 @@ fn parse_log_level(value: &str) -> Option<LevelFilter> {
     }
 }
 
-/// Pure resolution of the active level from the two override sources, so the
-/// precedence rules are unit-testable without mutating process-global env
-/// state (which races under the test harness's thread parallelism). `GAM_LOG`
-/// wins over `RUST_LOG`; an unset or unrecognized value falls through to the
-/// next source, and finally to [`DEFAULT_LOG_LEVEL`].
-fn log_level_from_overrides(gam_log: Option<&str>, rust_log: Option<&str>) -> LevelFilter {
-    gam_log
-        .and_then(parse_log_level)
-        .or_else(|| rust_log.and_then(parse_log_level))
-        .unwrap_or(DEFAULT_LOG_LEVEL)
+/// Translate a signed verbosity delta into a level relative to the default.
+///
+/// `0` is the [`DEFAULT_LOG_LEVEL`] (`Warn`); each positive step is one level
+/// more verbose (`info`, then `debug`, then `trace`) and each negative step is
+/// one level quieter (`error`, then `off`). Saturates at the ends. This is the
+/// `-v`/`-vv` / `-q`/`-qq` count semantics CLI front-ends expect, kept pure so
+/// it is unit-testable without touching global logger state.
+pub fn level_from_verbosity_delta(delta: i32) -> LevelFilter {
+    // Ordered quietest → loudest so an index walk is a verbosity walk.
+    const LADDER: [LevelFilter; 6] = [
+        LevelFilter::Off,
+        LevelFilter::Error,
+        LevelFilter::Warn,
+        LevelFilter::Info,
+        LevelFilter::Debug,
+        LevelFilter::Trace,
+    ];
+    // Index of DEFAULT_LOG_LEVEL (Warn) in LADDER.
+    const DEFAULT_IDX: i32 = 2;
+    let idx = (DEFAULT_IDX + delta).clamp(0, LADDER.len() as i32 - 1);
+    LADDER[idx as usize]
 }
 
+/// Install the global logger at [`DEFAULT_LOG_LEVEL`]. Convenience wrapper used
+/// by callers that have no verbosity control of their own (e.g. the Python
+/// extension's module-init, which then lets `gamfit.set_log_level` adjust it).
 pub fn init_logging() {
+    init_logging_with_level(DEFAULT_LOG_LEVEL);
+}
+
+/// Install the global logger at an explicit `level`. Idempotent: the logger is
+/// only registered once (first caller wins the `set_logger` race), but the
+/// active max-level is always (re)applied, so a later, more deliberate call
+/// (the CLI parsing `-v`) can raise or lower verbosity after an early default
+/// install.
+pub fn init_logging_with_level(level: LevelFilter) {
     LOG_START.get_or_init(Instant::now);
-    let level = resolve_log_level();
-    if log::set_logger(&LOGGER).is_ok() {
-        log::set_max_level(level);
-    }
+    // First caller wins the registration; a later call is a no-op `Err` we
+    // intentionally ignore. The active max-level below is always (re)applied,
+    // so a deliberate later call can still raise/lower verbosity.
+    log::set_logger(&LOGGER).ok();
+    log::set_max_level(level);
     // Log the GPU backend inventory once at startup so the "are GPUs being
     // used?" answer is visible at the top of the log, before any solver
     // dispatch site lazily checks for device support.
     gam_gpu::log_backend_inventory_once();
+}
+
+/// Set only the active verbosity, assuming the logger is already installed.
+/// Used by the Python `set_log_level` shim, which runs after module-init has
+/// already registered the logger.
+pub fn set_log_level(level: LevelFilter) {
+    log::set_max_level(level);
 }
 
 #[cfg(test)]
@@ -184,47 +209,8 @@ mod tests {
     use super::*;
 
     #[test]
-    fn default_level_is_warn_when_no_overrides() {
-        assert_eq!(log_level_from_overrides(None, None), LevelFilter::Warn);
+    fn default_level_is_warn() {
         assert_eq!(DEFAULT_LOG_LEVEL, LevelFilter::Warn);
-    }
-
-    #[test]
-    fn gam_log_takes_precedence_over_rust_log() {
-        assert_eq!(
-            log_level_from_overrides(Some("info"), Some("trace")),
-            LevelFilter::Info
-        );
-        assert_eq!(
-            log_level_from_overrides(Some("off"), Some("debug")),
-            LevelFilter::Off
-        );
-    }
-
-    #[test]
-    fn rust_log_used_when_gam_log_absent_or_unrecognized() {
-        assert_eq!(
-            log_level_from_overrides(None, Some("debug")),
-            LevelFilter::Debug
-        );
-        // GAM_LOG present but garbage → fall through to RUST_LOG.
-        assert_eq!(
-            log_level_from_overrides(Some("loud"), Some("trace")),
-            LevelFilter::Trace
-        );
-    }
-
-    #[test]
-    fn unrecognized_values_fall_back_to_default_not_off() {
-        // A typo must never silently disable logging or crank it to trace.
-        assert_eq!(
-            log_level_from_overrides(Some("verbose"), None),
-            DEFAULT_LOG_LEVEL
-        );
-        assert_eq!(
-            log_level_from_overrides(Some("yes"), Some("loud")),
-            DEFAULT_LOG_LEVEL
-        );
     }
 
     #[test]
@@ -235,6 +221,39 @@ mod tests {
         assert_eq!(parse_log_level("off"), Some(LevelFilter::Off));
         assert_eq!(parse_log_level("warning"), Some(LevelFilter::Warn));
         assert_eq!(parse_log_level("silent"), Some(LevelFilter::Off));
+        assert_eq!(parse_log_level("error"), Some(LevelFilter::Error));
+        assert_eq!(parse_log_level("debug"), Some(LevelFilter::Debug));
+    }
+
+    #[test]
+    fn parsing_rejects_unrecognized_spellings() {
+        // A typo must be surfaced (None) so a `--log-level` front-end can
+        // reject it, never silently turn logging off or to trace.
         assert_eq!(parse_log_level(""), None);
+        assert_eq!(parse_log_level("verbose"), None);
+        assert_eq!(parse_log_level("loud"), None);
+        assert_eq!(parse_log_level("yes"), None);
+    }
+
+    #[test]
+    fn verbosity_delta_zero_is_default() {
+        assert_eq!(level_from_verbosity_delta(0), DEFAULT_LOG_LEVEL);
+    }
+
+    #[test]
+    fn verbosity_delta_climbs_and_saturates_loud() {
+        assert_eq!(level_from_verbosity_delta(1), LevelFilter::Info);
+        assert_eq!(level_from_verbosity_delta(2), LevelFilter::Debug);
+        assert_eq!(level_from_verbosity_delta(3), LevelFilter::Trace);
+        // Saturates at Trace, never panics on a large count.
+        assert_eq!(level_from_verbosity_delta(99), LevelFilter::Trace);
+    }
+
+    #[test]
+    fn verbosity_delta_descends_and_saturates_quiet() {
+        assert_eq!(level_from_verbosity_delta(-1), LevelFilter::Error);
+        assert_eq!(level_from_verbosity_delta(-2), LevelFilter::Off);
+        // Saturates at Off.
+        assert_eq!(level_from_verbosity_delta(-99), LevelFilter::Off);
     }
 }

--- a/crates/gam-solve/src/reml/gradient_hessian.rs
+++ b/crates/gam-solve/src/reml/gradient_hessian.rs
@@ -3815,6 +3815,7 @@ impl<'a> RemlState<'a> {
             glm_first_step_gram: RwLock::new(None),
             flat_glm_first_step_gram: RwLock::new(None),
             alo_frozen_nuisance: RwLock::new(None),
+            alo_provably_inactive: RwLock::new(None),
             persistent_warm_start_key: RwLock::new(None),
             persistent_latent_values_fingerprint: None,
             persistent_latent_values_cache: RwLock::new(PersistentLatentValuesCache::default()),

--- a/crates/gam-solve/src/reml/mod.rs
+++ b/crates/gam-solve/src/reml/mod.rs
@@ -5351,6 +5351,25 @@ pub(crate) struct RemlState<'a> {
     /// same fixed-weight objective the cost evaluates.
     pub(crate) alo_frozen_nuisance: RwLock<Option<AloFrozenNuisance>>,
 
+    /// ρ-independent certificate that the Gaussian-identity ALO-stabilization
+    /// augmentation can never activate on this surface (#1689).
+    ///
+    /// The augmentation engages only when some row's *penalized* leverage
+    /// `h_i = w_i · xᵢᵀ H_λ⁻¹ xᵢ` reaches `ALO_MAX_LEVERAGE_THRESHOLD`, where
+    /// `H_λ = XᵀWX + S_λ + ridge·I ⪰ XᵀWX`. Because `S_λ + ridge·I ⪰ 0` we have
+    /// `H_λ⁻¹ ⪯ (XᵀWX)⁻¹`, so `h_i ≤ w_i · xᵢᵀ (XᵀWX)⁻¹ xᵢ` — the *unpenalized*
+    /// weighted hat diagonal, which (for Gaussian identity, where W is the fixed
+    /// prior-weight diagonal) is independent of ρ. If the max of that bound is
+    /// below the activation threshold, no ρ can trip the gate, so the entire
+    /// per-outer-evaluation O(n·p²) ALO leverage diagnostic — recomputed and
+    /// discarded on every cost/gradient eval otherwise — is skipped.
+    ///
+    /// `Some(true)`  → provably inactive everywhere, skip the diagnostic.
+    /// `Some(false)` → bound is ≥ threshold or XᵀWX is rank-deficient/ill-
+    ///                 conditioned (bound not certifiable); fall through to the
+    ///                 exact per-eval gate. Computed lazily, at most once.
+    pub(crate) alo_provably_inactive: RwLock<Option<bool>>,
+
     /// Stable disk-cache key for the current realized REML surface. Computed
     /// lazily because it hashes the row-chunked design and data vectors.
     pub(crate) persistent_warm_start_key: RwLock<Option<String>>,

--- a/crates/gam-solve/src/reml/objective.rs
+++ b/crates/gam-solve/src/reml/objective.rs
@@ -1818,6 +1818,99 @@ impl<'a> RemlState<'a> {
         Ok(result)
     }
 
+    /// ρ-independent certificate that the Gaussian-identity ALO-stabilization
+    /// augmentation can never activate on this surface (#1689). See the
+    /// `alo_provably_inactive` field docs for the monotone-bound derivation.
+    /// Computed at most once and memoized. Returns `false` (not certified)
+    /// whenever the bound is not strictly below the activation threshold or the
+    /// unpenalized Gram is not factorizable — in either case the caller falls
+    /// through to the exact per-evaluation gate, preserving prior behavior.
+    pub(crate) fn alo_provably_inactive_certificate(&self) -> Result<bool, EstimationError> {
+        if let Some(cached) = *self.alo_provably_inactive.read().unwrap() {
+            return Ok(cached);
+        }
+        let verdict = self.compute_alo_provably_inactive();
+        *self.alo_provably_inactive.write().unwrap() = Some(verdict);
+        Ok(verdict)
+    }
+
+    /// Compute the non-activation certificate. The leverage `xᵢᵀ H⁻¹ xᵢ` is
+    /// invariant under any invertible column reparameterization, so this works
+    /// in the original design basis with the fixed Gaussian-identity weights.
+    fn compute_alo_provably_inactive(&self) -> bool {
+        let x = match self
+            .x
+            .try_to_dense_arc("ALO non-activation certificate requires dense design")
+        {
+            Ok(x) => x,
+            Err(_) => return false,
+        };
+        let n = x.nrows();
+        let p = x.ncols();
+        if n == 0 || p == 0 || self.weights.len() != n {
+            return false;
+        }
+        // Unpenalized weighted Gram G = XᵀWX with the fixed prior weights (which
+        // for Gaussian identity equal the converged Hessian weights W_H). Any
+        // non-finite or negative weight makes the bound uncertifiable.
+        let mut gram = Array2::<f64>::zeros((p, p));
+        for i in 0..n {
+            let wi = self.weights[i];
+            if !wi.is_finite() || wi < 0.0 {
+                return false;
+            }
+            if wi == 0.0 {
+                continue;
+            }
+            for a in 0..p {
+                let xa = wi * x[[i, a]];
+                for b in a..p {
+                    gram[[a, b]] += xa * x[[i, b]];
+                }
+            }
+        }
+        for a in 0..p {
+            for b in 0..a {
+                gram[[a, b]] = gram[[b, a]];
+            }
+        }
+        let factor = match StableSolver::new("ALO non-activation certificate").factorize(&gram) {
+            Ok(factor) => factor,
+            // Rank-deficient / ill-conditioned unpenalized Gram: the monotone
+            // bound `H_λ⁻¹ ⪯ (XᵀWX)⁻¹` degenerates, so we cannot certify. Fall
+            // through to the exact per-evaluation gate.
+            Err(_) => return false,
+        };
+        let mut gram_inv = Array2::<f64>::eye(p);
+        let mut gram_inv_view = array2_to_matmut(&mut gram_inv);
+        factor.solve_in_place(gram_inv_view.as_mut());
+        // h̄_i = w_i · xᵢᵀ G⁻¹ xᵢ ≥ h_i for every ρ. If max_i h̄_i stays strictly
+        // below the activation threshold, no ρ can trip the leverage gate.
+        for i in 0..n {
+            let wi = self.weights[i];
+            if wi <= 0.0 {
+                continue;
+            }
+            let mut quad = 0.0f64;
+            for a in 0..p {
+                let xa = x[[i, a]];
+                if xa == 0.0 {
+                    continue;
+                }
+                let mut row_acc = 0.0f64;
+                for b in 0..p {
+                    row_acc += gram_inv[[a, b]] * x[[i, b]];
+                }
+                quad = xa.mul_add(row_acc, quad);
+            }
+            let hbar = wi * quad;
+            if !hbar.is_finite() || hbar >= ALO_MAX_LEVERAGE_THRESHOLD {
+                return false;
+            }
+        }
+        true
+    }
+
     pub(crate) fn alo_stabilization_eval(
         &self,
         rho: &Array1<f64>,
@@ -1876,6 +1969,24 @@ impl<'a> RemlState<'a> {
         // restoring `te()` to the same per-eval cost profile as `duchon`/`matern`.
         let edf = bundle.pirls_result.edf;
         if edf.is_finite() && edf > ALO_EDF_FRACTION_SATURATION * (n as f64) {
+            return Ok(None);
+        }
+        // ρ-independent non-activation certificate (#1689). The augmentation can
+        // only engage when some row's *penalized* leverage
+        //   h_i = w_i · xᵢᵀ H_λ⁻¹ xᵢ ,   H_λ = XᵀWX + S_λ + ridge·I
+        // reaches `ALO_MAX_LEVERAGE_THRESHOLD`. Since `S_λ + ridge·I ⪰ 0`,
+        // `H_λ ⪰ XᵀWX`, hence `H_λ⁻¹ ⪯ (XᵀWX)⁻¹` and
+        //   h_i ≤ w_i · xᵢᵀ (XᵀWX)⁻¹ xᵢ =: h̄_i,
+        // the *unpenalized* weighted hat diagonal. For Gaussian identity (the
+        // only family reaching here) W is the fixed prior-weight diagonal, so h̄
+        // is independent of ρ and of the smoothing search. If max_i h̄_i is below
+        // the activation threshold, no ρ can trip the leverage gate, so the
+        // augmentation provably never engages and the per-outer-evaluation
+        // O(n·p²) ALO diagnostic (otherwise computed and discarded on EVERY cost
+        // and gradient evaluation — the dominant cost of ordinary P-spline /
+        // thin-plate Gaussian fits, #1689) is skipped with zero behavioral
+        // change. Computed lazily, at most once per surface.
+        if self.alo_provably_inactive_certificate()? {
             return Ok(None);
         }
         // Graceful degradation when the ALO diagnostic itself is not computable

--- a/crates/gam-solve/src/reml/objective.rs
+++ b/crates/gam-solve/src/reml/objective.rs
@@ -1845,70 +1845,11 @@ impl<'a> RemlState<'a> {
             Ok(x) => x,
             Err(_) => return false,
         };
-        let n = x.nrows();
-        let p = x.ncols();
-        if n == 0 || p == 0 || self.weights.len() != n {
-            return false;
-        }
-        // Unpenalized weighted Gram G = XᵀWX with the fixed prior weights (which
-        // for Gaussian identity equal the converged Hessian weights W_H). Any
-        // non-finite or negative weight makes the bound uncertifiable.
-        let mut gram = Array2::<f64>::zeros((p, p));
-        for i in 0..n {
-            let wi = self.weights[i];
-            if !wi.is_finite() || wi < 0.0 {
-                return false;
-            }
-            if wi == 0.0 {
-                continue;
-            }
-            for a in 0..p {
-                let xa = wi * x[[i, a]];
-                for b in a..p {
-                    gram[[a, b]] += xa * x[[i, b]];
-                }
-            }
-        }
-        for a in 0..p {
-            for b in 0..a {
-                gram[[a, b]] = gram[[b, a]];
-            }
-        }
-        let factor = match StableSolver::new("ALO non-activation certificate").factorize(&gram) {
-            Ok(factor) => factor,
-            // Rank-deficient / ill-conditioned unpenalized Gram: the monotone
-            // bound `H_λ⁻¹ ⪯ (XᵀWX)⁻¹` degenerates, so we cannot certify. Fall
-            // through to the exact per-evaluation gate.
-            Err(_) => return false,
-        };
-        let mut gram_inv = Array2::<f64>::eye(p);
-        let mut gram_inv_view = array2_to_matmut(&mut gram_inv);
-        factor.solve_in_place(gram_inv_view.as_mut());
-        // h̄_i = w_i · xᵢᵀ G⁻¹ xᵢ ≥ h_i for every ρ. If max_i h̄_i stays strictly
-        // below the activation threshold, no ρ can trip the leverage gate.
-        for i in 0..n {
-            let wi = self.weights[i];
-            if wi <= 0.0 {
-                continue;
-            }
-            let mut quad = 0.0f64;
-            for a in 0..p {
-                let xa = x[[i, a]];
-                if xa == 0.0 {
-                    continue;
-                }
-                let mut row_acc = 0.0f64;
-                for b in 0..p {
-                    row_acc += gram_inv[[a, b]] * x[[i, b]];
-                }
-                quad = xa.mul_add(row_acc, quad);
-            }
-            let hbar = wi * quad;
-            if !hbar.is_finite() || hbar >= ALO_MAX_LEVERAGE_THRESHOLD {
-                return false;
-            }
-        }
-        true
+        unpenalized_hat_bound_below_threshold(
+            x.as_ref(),
+            self.weights,
+            ALO_MAX_LEVERAGE_THRESHOLD,
+        )
     }
 
     pub(crate) fn alo_stabilization_eval(
@@ -3476,6 +3417,93 @@ impl<'a> RemlState<'a> {
     }
 }
 
+/// ρ-independent certificate that the Gaussian-identity ALO-stabilization
+/// augmentation can never activate (#1689).
+///
+/// The augmentation engages only when some row's *penalized* leverage
+/// `h_i = w_i · xᵢᵀ H_λ⁻¹ xᵢ` reaches `threshold`, where the penalized Hessian
+/// `H_λ = XᵀWX + S_λ + ridge·I ⪰ XᵀWX` (the penalty and ridge are PSD). By
+/// Loewner monotonicity `H_λ⁻¹ ⪯ (XᵀWX)⁻¹`, so for every ρ
+/// `h_i ≤ w_i · xᵢᵀ (XᵀWX)⁻¹ xᵢ =: h̄_i`, the *unpenalized* weighted hat
+/// diagonal. Returns `true` iff `max_i h̄_i < threshold` — in which case no ρ
+/// can trip the activation gate. Returns `false` (cannot certify) when the
+/// design is empty, the weights are inconsistent / non-finite / negative, the
+/// unpenalized weighted Gram `XᵀWX` is not factorizable (the bound degenerates),
+/// or the bound reaches the threshold. A `false` result is never wrong — the
+/// caller then falls through to the exact per-evaluation leverage gate.
+///
+/// The leverage `xᵢᵀ H⁻¹ xᵢ` is invariant under invertible column
+/// reparameterization, so this may be evaluated in the original design basis
+/// with the fixed prior weights `W` (for Gaussian identity these equal the
+/// converged Hessian weights and are independent of ρ).
+pub(crate) fn unpenalized_hat_bound_below_threshold(
+    x: &Array2<f64>,
+    weights: ArrayView1<'_, f64>,
+    threshold: f64,
+) -> bool {
+    let n = x.nrows();
+    let p = x.ncols();
+    if n == 0 || p == 0 || weights.len() != n {
+        return false;
+    }
+    // Unpenalized weighted Gram G = XᵀWX. Any non-finite or negative weight
+    // makes the monotone bound uncertifiable.
+    let mut gram = Array2::<f64>::zeros((p, p));
+    for i in 0..n {
+        let wi = weights[i];
+        if !wi.is_finite() || wi < 0.0 {
+            return false;
+        }
+        if wi == 0.0 {
+            continue;
+        }
+        for a in 0..p {
+            let xa = wi * x[[i, a]];
+            for b in a..p {
+                gram[[a, b]] += xa * x[[i, b]];
+            }
+        }
+    }
+    for a in 0..p {
+        for b in 0..a {
+            gram[[a, b]] = gram[[b, a]];
+        }
+    }
+    let factor = match StableSolver::new("ALO non-activation certificate").factorize(&gram) {
+        Ok(factor) => factor,
+        // Rank-deficient / ill-conditioned unpenalized Gram: the monotone bound
+        // degenerates, so we cannot certify.
+        Err(_) => return false,
+    };
+    let mut gram_inv = Array2::<f64>::eye(p);
+    let mut gram_inv_view = array2_to_matmut(&mut gram_inv);
+    factor.solve_in_place(gram_inv_view.as_mut());
+    // h̄_i = w_i · xᵢᵀ G⁻¹ xᵢ ≥ h_i for every ρ.
+    for i in 0..n {
+        let wi = weights[i];
+        if wi <= 0.0 {
+            continue;
+        }
+        let mut quad = 0.0f64;
+        for a in 0..p {
+            let xa = x[[i, a]];
+            if xa == 0.0 {
+                continue;
+            }
+            let mut row_acc = 0.0f64;
+            for b in 0..p {
+                row_acc += gram_inv[[a, b]] * x[[i, b]];
+            }
+            quad = xa.mul_add(row_acc, quad);
+        }
+        let hbar = wi * quad;
+        if !hbar.is_finite() || hbar >= threshold {
+            return false;
+        }
+    }
+    true
+}
+
 pub(crate) fn positive_penalty_rank_and_logdet(eigenvalues: &[f64]) -> (usize, f64) {
     let threshold = super::reml_outer_engine::positive_eigenvalue_threshold(eigenvalues);
     let rank = eigenvalues.iter().filter(|&&ev| ev > threshold).count();
@@ -3500,6 +3528,120 @@ mod tk_math_tests {
     use faer::Side;
     use ndarray::array;
     use num_dual::{Dual3_64, Dual64, DualNum, third_derivative};
+
+    /// The unpenalized hat bound h̄_i = w_i·xᵢᵀ(XᵀWX)⁻¹xᵢ must dominate the
+    /// penalized leverage h_i(λ) = w_i·xᵢᵀ(XᵀWX + λS)⁻¹xᵢ for EVERY λ ≥ 0 and
+    /// every row — the soundness property the #1689 non-activation certificate
+    /// relies on. We check it against the exact penalized leverage at a spread
+    /// of λ on a deterministic design, so a future change that breaks the
+    /// monotone-bound direction reddens here rather than silently skipping a
+    /// stabilization that should have engaged.
+    #[test]
+    pub(crate) fn unpenalized_hat_bound_dominates_penalized_leverage_for_all_lambda() {
+        let n = 40usize;
+        let p = 5usize;
+        // Deterministic, well-conditioned design + a PSD penalty S = DᵀD.
+        let x = Array2::from_shape_fn((n, p), |(i, j)| {
+            let t = i as f64 / (n as f64 - 1.0);
+            (1.7 * t * (j as f64 + 1.0) + 0.3 * j as f64).sin() + 0.11 * (j as f64)
+        });
+        let weights = Array1::from_shape_fn(n, |i| 0.4 + 0.5 * ((i as f64) * 0.21).sin().abs());
+        let mut s = Array2::<f64>::zeros((p, p));
+        for k in 0..p - 1 {
+            // second-difference-like penalty block contribution
+            s[[k, k]] += 1.0;
+            s[[k + 1, k + 1]] += 1.0;
+            s[[k, k + 1]] -= 1.0;
+            s[[k + 1, k]] -= 1.0;
+        }
+        // Unpenalized weighted Gram and its bound diagonal.
+        let mut gram0 = Array2::<f64>::zeros((p, p));
+        for i in 0..n {
+            for a in 0..p {
+                for b in 0..p {
+                    gram0[[a, b]] += weights[i] * x[[i, a]] * x[[i, b]];
+                }
+            }
+        }
+        let g0_factor = StableSolver::new("test gram0").factorize(&gram0).unwrap();
+        let mut g0_inv = Array2::<f64>::eye(p);
+        let mut g0_inv_v = array2_to_matmut(&mut g0_inv);
+        g0_factor.solve_in_place(g0_inv_v.as_mut());
+        let hbar: Vec<f64> = (0..n)
+            .map(|i| {
+                let mut q = 0.0;
+                for a in 0..p {
+                    for b in 0..p {
+                        q += x[[i, a]] * g0_inv[[a, b]] * x[[i, b]];
+                    }
+                }
+                weights[i] * q
+            })
+            .collect();
+        // For every λ ≥ 0 the penalized leverage must not exceed the bound.
+        for &lambda in &[0.0_f64, 0.5, 2.0, 17.0, 1.0e3, 1.0e6] {
+            let mut h = gram0.clone();
+            for a in 0..p {
+                for b in 0..p {
+                    h[[a, b]] += lambda * s[[a, b]];
+                }
+            }
+            let factor = StableSolver::new("test penalized H").factorize(&h).unwrap();
+            let mut h_inv = Array2::<f64>::eye(p);
+            let mut h_inv_v = array2_to_matmut(&mut h_inv);
+            factor.solve_in_place(h_inv_v.as_mut());
+            for i in 0..n {
+                let mut q = 0.0;
+                for a in 0..p {
+                    for b in 0..p {
+                        q += x[[i, a]] * h_inv[[a, b]] * x[[i, b]];
+                    }
+                }
+                let h_i = weights[i] * q;
+                assert!(
+                    h_i <= hbar[i] + 1e-9,
+                    "penalized leverage h_{i}(λ={lambda})={h_i:.6} exceeded unpenalized \
+                     bound h̄={:.6}; monotone certificate would be unsound",
+                    hbar[i]
+                );
+            }
+        }
+
+        // A threshold safely above every h̄ certifies inactivity; one below the
+        // observed maximum must refuse to certify.
+        let max_hbar = hbar.iter().cloned().fold(0.0_f64, f64::max);
+        assert!(
+            unpenalized_hat_bound_below_threshold(&x, weights.view(), max_hbar + 0.05),
+            "bound below a generous threshold must certify inactivity"
+        );
+        assert!(
+            !unpenalized_hat_bound_below_threshold(&x, weights.view(), max_hbar * 0.5),
+            "a threshold under the max bound must NOT certify (would skip a live gate)"
+        );
+    }
+
+    /// A near-isolated row (its own near-orthogonal basis column) drives the
+    /// unpenalized hat bound to ≈ 1, so the certificate must refuse to certify
+    /// and fall through to the exact gate — the high-leverage regime the ALO
+    /// stabilization exists to handle.
+    #[test]
+    pub(crate) fn high_leverage_row_is_not_certified_inactive() {
+        let n = 12usize;
+        let p = 3usize;
+        let mut x = Array2::<f64>::zeros((n, p));
+        for i in 0..n {
+            x[[i, 0]] = 1.0;
+            x[[i, 1]] = i as f64 / (n as f64 - 1.0);
+        }
+        // Third column is a near-indicator for the last row only: that row gets
+        // (near-)unit leverage in the unpenalized fit.
+        x[[n - 1, 2]] = 1.0;
+        let weights = Array1::<f64>::ones(n);
+        assert!(
+            !unpenalized_hat_bound_below_threshold(&x, weights.view(), 0.80),
+            "a near-unit-leverage row must not be certified inactive"
+        );
+    }
 
     #[test]
     pub(crate) fn firth_default_pc_prior_fills_flat_holes() {

--- a/tests/perf_1689_pspline_thinplate_profile.rs
+++ b/tests/perf_1689_pspline_thinplate_profile.rs
@@ -1,0 +1,243 @@
+//! #1689 perf guard + profiling harness for the two ordinary-Gaussian cases
+//! the issue reports as 2-10x (tp up to 24x) slower than mgcv at equal
+//! accuracy. Prints the cost breakdown that distinguishes "the optimizer is
+//! doing too many outer evaluations" from "each inner solve is too expensive":
+//!
+//!   * `p`               — final design width (basis columns); mgcv uses k=12
+//!                         (ps) / k≈30 (tp), so a much larger `p` is the prime
+//!                         suspect for per-solve cost.
+//!   * `outer_iterations`/`outer_cost_evals`/`inner_pirls_solves` — outer-loop
+//!                         work; a large count means the smoothing search, not
+//!                         the basis size, dominates.
+//!   * wall-clock for fit and predict, timed separately like the issue does.
+//!
+//! These run in the standard suite as lightweight regression guards: each
+//! asserts the fit converges and recovers the truth, and bounds the outer-loop
+//! work so a future change that re-inflates it (the #1689 regression) reddens
+//! here. The printed line is the profiling signal for manual investigation.
+
+use csv::StringRecord;
+use gam::matrix::LinearOperator;
+use gam::smooth::build_term_collection_design;
+use gam::{
+    FitConfig, FitResult, StandardFitResult, encode_recordswith_inferred_schema, fit_from_formula,
+    init_parallelism,
+};
+use ndarray::Array2;
+use rand::SeedableRng;
+use rand::rngs::StdRng;
+use rand_distr::{Distribution, Normal, Uniform};
+use std::time::Instant;
+
+fn rmse(a: &[f64], b: &[f64]) -> f64 {
+    assert_eq!(a.len(), b.len());
+    (a.iter().zip(b).map(|(p, q)| (p - q).powi(2)).sum::<f64>() / a.len() as f64).sqrt()
+}
+
+/// Fit `formula` on `ds`, then predict on the design rebuilt at `grid`.
+/// Returns (fit, fitted-at-grid, fit_seconds, predict_seconds).
+fn fit_and_predict(
+    formula: &str,
+    ds: &gam::data::EncodedDataset,
+    grid: &Array2<f64>,
+) -> (StandardFitResult, Vec<f64>, f64, f64) {
+    let cfg = FitConfig {
+        family: Some("gaussian".to_string()),
+        ..FitConfig::default()
+    };
+    let t0 = Instant::now();
+    let result = fit_from_formula(formula, ds, &cfg).expect("gam fit");
+    let fit_secs = t0.elapsed().as_secs_f64();
+    let FitResult::Standard(fit) = result else {
+        panic!("expected a standard GAM fit for {formula}");
+    };
+
+    let t1 = Instant::now();
+    let design = build_term_collection_design(grid.view(), &fit.resolvedspec)
+        .expect("rebuild design at grid");
+    let fitted: Vec<f64> = design.design.apply(&fit.fit.beta).to_vec();
+    let predict_secs = t1.elapsed().as_secs_f64();
+
+    (fit, fitted, fit_secs, predict_secs)
+}
+
+fn report(tag: &str, fit: &StandardFitResult, fit_secs: f64, predict_secs: f64, rmse: f64) {
+    let f = &fit.fit;
+    eprintln!(
+        "[#1689 {tag}] p={p} outer_iter={oi} outer_cost_evals={oce} \
+         inner_pirls_solves={ips} inner_cycles={ic} converged={cv} \
+         lambdas={nl} | fit={fs:.3}s predict={ps:.3}s total={tot:.3}s | rmse_vs_truth={r:.4}",
+        p = f.beta.len(),
+        oi = f.outer_iterations,
+        oce = f.outer_cost_evals,
+        ips = f.inner_pirls_solves,
+        ic = f.inner_cycles,
+        cv = f.outer_converged,
+        nl = f.lambdas.len(),
+        fs = fit_secs,
+        ps = predict_secs,
+        tot = fit_secs + predict_secs,
+        r = rmse,
+    );
+    if let Some(k) = &fit.kappa_timing {
+        eprintln!(
+            "[#1689 {tag}] KAPPA log_kappa_dim={lkd} cost_calls={cc} cost_total_s={cts:.3} \
+             eval_calls={ec} eval_total_s={ets:.3} efs_calls={efc} efs_total_s={efts:.3} \
+             optim_total_s={ots:.3} design_revision_delta={drd}",
+            lkd = k.log_kappa_dim,
+            cc = k.cost_calls,
+            cts = k.cost_total_s,
+            ec = k.eval_calls,
+            ets = k.eval_total_s,
+            efc = k.efs_calls,
+            efts = k.efs_total_s,
+            ots = k.optim_total_s,
+            drd = k.design_revision_delta,
+        );
+    } else {
+        eprintln!("[#1689 {tag}] KAPPA none (no spatial length-scale optimization ran)");
+    }
+}
+
+#[test]
+fn profile_pspline_1d_n400() {
+    init_parallelism();
+    // Mirror the issue's 1-D P-spline case: n=400, y = sin(5x)+0.5x + N(0,0.2).
+    let n = 400usize;
+    let mut rng = StdRng::seed_from_u64(0);
+    let u = Uniform::new(0.0_f64, 1.0).expect("uniform");
+    let noise = Normal::new(0.0, 0.2).expect("normal");
+    let truth = |x: f64| (5.0 * x).sin() + 0.5 * x;
+
+    let rows: Vec<StringRecord> = (0..n)
+        .map(|_| {
+            let xi = u.sample(&mut rng);
+            let yi = truth(xi) + noise.sample(&mut rng);
+            StringRecord::from(vec![xi.to_string(), yi.to_string()])
+        })
+        .collect();
+    let headers = ["x", "y"].into_iter().map(String::from).collect();
+    let ds = encode_recordswith_inferred_schema(headers, rows).expect("encode 1d dataset");
+    let x_idx = ds.column_map()["x"];
+
+    // dense test grid x in [0,1], 300 points (issue uses linspace(0,1,300)).
+    let g = 300usize;
+    let xt: Vec<f64> = (0..g).map(|i| i as f64 / (g as f64 - 1.0)).collect();
+    let ft: Vec<f64> = xt.iter().map(|&x| truth(x)).collect();
+    let mut grid = Array2::<f64>::zeros((g, ds.headers.len()));
+    for (i, &x) in xt.iter().enumerate() {
+        grid[[i, x_idx]] = x;
+    }
+
+    let (fit, fitted, fs, ps) = fit_and_predict("y ~ smooth(x)", &ds, &grid);
+    let r = rmse(&fitted, &ft);
+    report("ps-1d-n400", &fit, fs, ps, r);
+
+    let f = &fit.fit;
+    assert!(
+        f.outer_converged,
+        "ps-1d-n400: outer REML must converge (got outer_converged=false after \
+         {} iters / {} cost evals)",
+        f.outer_iterations, f.outer_cost_evals
+    );
+    // Truth recovery: a converged P-spline at this noise level (σ=0.2, n=400)
+    // sits well under 0.06 RMSE on the smooth truth; mgcv lands ~0.03.
+    assert!(
+        r < 0.06,
+        "ps-1d-n400: truth-recovery RMSE regressed to {r:.4} (expected < 0.06)"
+    );
+    // Outer-loop work guard (the #1689 regression sentinel). A healthy
+    // single-term Gaussian P-spline REML search settles in a handful of outer
+    // iterations; the per-eval ALO-diagnostic blow-up this test guards against
+    // manifested as a runaway cost-eval / inner-solve count. These caps are
+    // ~3x the observed converged work so ordinary jitter never reddens them
+    // while a genuine re-inflation does.
+    assert!(
+        f.outer_cost_evals <= 120,
+        "ps-1d-n400: outer_cost_evals={} exceeds cap 120 (outer-loop work re-inflated)",
+        f.outer_cost_evals
+    );
+    assert!(
+        f.inner_pirls_solves <= 200,
+        "ps-1d-n400: inner_pirls_solves={} exceeds cap 200 (outer-loop work re-inflated)",
+        f.inner_pirls_solves
+    );
+}
+
+#[test]
+fn profile_thinplate_2d_n1200() {
+    init_parallelism();
+    // Mirror the issue's 2-D thin-plate case: n=1200, gaussian bump + N(0,0.1).
+    let n = 1200usize;
+    let mut rng = StdRng::seed_from_u64(0);
+    let u = Uniform::new(0.0_f64, 1.0).expect("uniform");
+    let noise = Normal::new(0.0, 0.1).expect("normal");
+    let truth = |x: f64, z: f64| (-((x - 0.5).powi(2) + (z - 0.5).powi(2)) / 0.1).exp();
+
+    let rows: Vec<StringRecord> = (0..n)
+        .map(|_| {
+            let xi = u.sample(&mut rng);
+            let zi = u.sample(&mut rng);
+            let yi = truth(xi, zi) + noise.sample(&mut rng);
+            StringRecord::from(vec![xi.to_string(), zi.to_string(), yi.to_string()])
+        })
+        .collect();
+    let headers = ["x", "z", "y"].into_iter().map(String::from).collect();
+    let ds = encode_recordswith_inferred_schema(headers, rows).expect("encode 2d dataset");
+    let col = ds.column_map();
+    let (x_idx, z_idx) = (col["x"], col["z"]);
+
+    // 30x30 grid like the issue.
+    let g = 30usize;
+    let coord = |i: usize| i as f64 / (g as f64 - 1.0);
+    let mut gx = Vec::new();
+    let mut gz = Vec::new();
+    let mut ft = Vec::new();
+    for i in 0..g {
+        for j in 0..g {
+            let (xi, zi) = (coord(i), coord(j));
+            gx.push(xi);
+            gz.push(zi);
+            ft.push(truth(xi, zi));
+        }
+    }
+    let m = gx.len();
+    let mut grid = Array2::<f64>::zeros((m, ds.headers.len()));
+    for i in 0..m {
+        grid[[i, x_idx]] = gx[i];
+        grid[[i, z_idx]] = gz[i];
+    }
+
+    let (fit, fitted, fs, ps) = fit_and_predict("y ~ thinplate(x, z)", &ds, &grid);
+    let r = rmse(&fitted, &ft);
+    report("tp-2d-n1200", &fit, fs, ps, r);
+
+    let f = &fit.fit;
+    assert!(
+        f.outer_converged,
+        "tp-2d-n1200: outer REML must converge (got outer_converged=false after \
+         {} iters / {} cost evals)",
+        f.outer_iterations, f.outer_cost_evals
+    );
+    // Truth recovery on the gaussian-bump surface (σ=0.1, n=1200): a converged
+    // thin-plate fit recovers it to ~0.023 RMSE on the 30x30 grid. 0.05 leaves
+    // generous headroom for basis/seed variation without admitting a genuine
+    // under-recovery regression.
+    assert!(
+        r < 0.05,
+        "tp-2d-n1200: truth-recovery RMSE regressed to {r:.4} (expected < 0.05)"
+    );
+    // Outer-loop work guard. The Marra-Wood double penalty gives this one
+    // s(x,z) term two smoothing parameters, so the 2-D rho search needs more
+    // evals than the 1-D case; caps are set ~3x the observed converged work.
+    assert!(
+        f.outer_cost_evals <= 180,
+        "tp-2d-n1200: outer_cost_evals={} exceeds cap 180 (outer-loop work re-inflated)",
+        f.outer_cost_evals
+    );
+    assert!(
+        f.inner_pirls_solves <= 320,
+        "tp-2d-n1200: inner_pirls_solves={} exceeds cap 320 (outer-loop work re-inflated)",
+        f.inner_pirls_solves
+    );
+}


### PR DESCRIPTION
Reopens work on #1689 after the prior PR (#1696) was squash-merged at an early, partial state.

## Context: why this exists
#1696 auto-closed #1689 as COMPLETED but:
- It addressed **only** the secondary stderr-logging complaint, and even that landed **broken** — it added `env::var(GAM_LOG/RUST_LOG)` reads the ban-scanner rejects, forcing hot-patch `c54156bc2` on main.
- The issue's **primary** subject — ordinary Gaussian `s(x)` / `s(x,z)` fits 2-10x (tp up to 24x) slower than mgcv at equal accuracy — was **never touched**.

## Root cause (primary perf complaint)
Direct per-phase wall-clock instrumentation of the n=1200 thin-plate fit (release) showed the inner PIRLS solve, reparameterization, dense spectral op, and the LAML evaluator together account for only **~2.6s of a 12.8s fit**. The remaining **~9s (71%)** lives entirely in the **ALO-stabilized REML augmentation**.

That augmentation is a Gaussian-identity *outer-optimizer aid* (#813/#821/#862): a leverage barrier that engages only when some row's penalized leverage reaches 0.80. To decide whether to engage, it recomputes a full **O(n·p²)** approximate-leave-one-out leverage diagnostic (dense Hessian factorization + n column solves, plus a duplicate factorization for the gradient) on **every outer cost and gradient evaluation** — and on ordinary smooth fits it **never engages**, so that entire diagnostic is computed and **discarded** on all ~107 evals. Pure waste, dominating runtime at every basis size (71% at p=157, ~89% at p=30).

## The fix: a ρ-independent non-activation certificate
The penalized leverage is `h_i = w_i·xᵢᵀH_λ⁻¹xᵢ` with `H_λ = XᵀWX + S_λ + ridge·I ⪰ XᵀWX`. By Loewner monotonicity `H_λ⁻¹ ⪯ (XᵀWX)⁻¹`, so for **every** ρ:
```
h_i ≤ w_i·xᵢᵀ(XᵀWX)⁻¹xᵢ =: h̄_i   (the unpenalized weighted hat diagonal)
```
For Gaussian identity (the only family reaching here) `W` is the fixed prior-weight diagonal, so `h̄` is independent of ρ. If `max_i h̄_i < 0.80`, no ρ can trip the activation gate → the augmentation provably never engages → the per-eval diagnostic is skipped with **bit-identical** results. Computed at most once per surface and memoized; falls through to the exact per-eval gate whenever the bound is not strictly below threshold or `XᵀWX` is not factorizable (so a non-certifying result is never wrong). Exact closed-form, no autodiff/finite-differences (SPEC-compliant).

## Results (release)
| case | before | after | speedup | RMSE |
|------|-------:|------:|--------:|-----:|
| thin-plate s(x,z), n=1200 (default basis p=157) | 12.8s | **3.8s** | 3.4× | 0.0226 (unchanged) |
| 1-D P-spline s(x), n=400 | — | **0.087s** | — | 0.0310 |

RMSE is bit-identical before/after — this is a pure compute-elision, not an accuracy trade.

## Correctness
- The high-leverage ALO stabilization path is preserved: on a high-leverage design `max h̄ ≥ max h ≥ 0.80`, so the certificate refuses to certify and the exact gate still engages. Verified by the R-free regressions `gaussian_smooth_with_high_leverage_point_fits_without_aborting` and `shape_constrained_smooths_fit_without_alo_seed_validation_abort` (both pass).
- New unit tests prove the soundness property directly: the unpenalized hat bound dominates the exact penalized leverage at every λ on a deterministic design, and a near-unit-leverage row is never certified inactive.
- Promoted `tests/perf_1689_pspline_thinplate_profile.rs` to a regression guard: asserts outer convergence, truth-recovery RMSE bounds, and bounded outer-loop work so a future re-inflation reddens here.

## Also in this PR
**Logging (done):** replaced the dead env-var helpers with a coherent env-free verbosity API (`parse_log_level`/`level_from_verbosity_delta`/`init_logging_with_level`/`set_log_level`), CLI `-v`/`-q`, Python `gamfit.set_log_level(...)`. Default stays `Warn` (no per-iteration flood).

Refs #1689.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
