### PR TITLE
fix(#1266): per-term shrink-out so an irrelevant double-penalty smooth selects out

### DIFF
--- a/crates/gam-solve/src/estimate/optimizer.rs
+++ b/crates/gam-solve/src/estimate/optimizer.rs
@@ -1441,10 +1441,10 @@ where
                     // term selected out) strictly LOWERS the model's total EDF; a
                     // concurvity TRANSFER (#1476: one null-space shrinks but its
                     // correlated partner absorbs the signal via the inner β re-solve)
-                    // INFLATES it. Pure REML alone marginally prefers the transfer on
-                    // a flat concurvity ridge — exactly the allocation the degeneracy
-                    // prior exists to forbid — so the escape must additionally refuse
-                    // any adoption that does not reduce total EDF.
+                    // does NOT lower it. Pure REML alone marginally prefers the
+                    // transfer on a flat concurvity ridge — exactly the allocation the
+                    // degeneracy prior exists to forbid — so the escape additionally
+                    // refuses any adoption that does not reduce total EDF.
                     let edf_conv = reml_state
                         .obtain_eval_bundle(&strategy_result.rho)
                         .ok()
@@ -1465,52 +1465,146 @@ where
                         }
                         Some(c - prior)
                     };
-                    // Ascending over-smoothing grid in ABSOLUTE ρ (toward the
-                    // shrink-out rail at `RHO_BOUND`); only values strictly above a
-                    // coordinate's current ρ are over-smoothing candidates. Bounded:
-                    // at most 2 · |select| · 6 inner solves, and only fires when a
-                    // null-space coordinate is actually held below the rail.
-                    let rho_upper = crate::estimate::RHO_BOUND;
-                    const OUTWARD_GRID: [f64; 6] = [6.0, 9.0, 12.0, 18.0, 24.0, 30.0];
+                    // PER-TERM shrink-out search (gam#1266), the OUTWARD-direction dual
+                    // of the #1074 inward escape. The unit of an mgcv `select = TRUE`
+                    // shrink-out is the WHOLE SMOOTH TERM, not a single ρ-coordinate:
+                    // the term's effective d.f. is shared between its wiggliness
+                    // penalty and its `DoublePenaltyNullspace` shrinkage ridge, and the
+                    // bulk of the EDF of an only-mildly-penalized term lives in its
+                    // WIGGLINESS coordinate. Over-smoothing the null-space coordinate
+                    // ALONE (the previous behaviour) leaves the wiggliness coordinate
+                    // moderate, so the constrained reparametrization lets the basis
+                    // re-absorb the same EDF elsewhere — the term never actually
+                    // selects out, and pushing that lone coordinate to the λ rail only
+                    // injects a numerical EDF-saturation artifact. The genuine
+                    // shrink-out drives BOTH of a term's coordinates UP TOGETHER to a
+                    // MODERATE level, removing the whole smooth.
+                    //
+                    // Build term groups from the canonical penalties' `col_range`
+                    // (every penalty of one smooth shares its coefficient column
+                    // range), seeded from each well-determined null-space selection
+                    // coordinate. Over-smooth each candidate group jointly across a
+                    // MODERATE band that stops short of the λ-explosion rail (≈ ρ 24+,
+                    // where the inner reparametrization saturates total EDF toward `p`
+                    // and reports a spuriously-low deviance that is pure numerical
+                    // overfit, not a shrink-out). Adopt a group's move only if a COLD
+                    // re-score confirms it BOTH strictly lowers pure data-REML AND does
+                    // not increase the model's total inner EDF:
+                    //   * UNSUPPORTED, uncorrelated term (#1266 `s(z)`): over-smoothing
+                    //     the whole term drops total EDF (z carries no signal, nothing
+                    //     absorbs it) AND lowers pure REML → the escape fires, EDF → 0.
+                    //   * SUPPORTED term (#1371 slope / #1476 correlated `s(x1),s(x2)`):
+                    //     over-smoothing a real partial effect dumps its variance into
+                    //     σ̂², so pure REML strictly RISES across the whole moderate
+                    //     band → rejected on the pure-REML test alone (the concurvity
+                    //     "transfer" only looks cheap at the saturation rail, which the
+                    //     moderate band excludes), and the EDF guard backstops it.
+                    //
+                    // SCOPE: eligible groups are exactly those seeded by a
+                    // well-determined relaxed null-space degeneracy coordinate
+                    // (`is_nullspace_degeneracy_prior`, gated by `n ≥ 2·p`). This
+                    // EXCLUDES the under-determined regime (`n < 2·p`, #1392 `p > n`),
+                    // where the null-space prior is the AGGRESSIVE PC select-out — a
+                    // deliberate, load-bearing push onto a genuinely-flat REML score
+                    // that this data-REML search would undo.
+                    let term_key: Vec<(usize, usize)> = canonical_shared
+                        .iter()
+                        .map(|cp| (cp.col_range.start, cp.col_range.end))
+                        .collect();
+                    // Distinct term groups seeded by a selection coordinate, in first
+                    // appearance order; each group is the full set of penalty
+                    // coordinates sharing the seed's coefficient column range.
+                    let mut groups: Vec<Vec<usize>> = Vec::new();
+                    let mut seen_keys: Vec<(usize, usize)> = Vec::new();
+                    for &sc in &select_coords {
+                        let Some(key) = term_key.get(sc).copied() else {
+                            continue;
+                        };
+                        if seen_keys.contains(&key) {
+                            continue;
+                        }
+                        seen_keys.push(key);
+                        let group: Vec<usize> = (0..strategy_result.rho.len())
+                            .filter(|&i| term_key.get(i).copied() == Some(key))
+                            .collect();
+                        if !group.is_empty() {
+                            groups.push(group);
+                        }
+                    }
+                    // Moderate over-smoothing band: high enough to remove a genuinely
+                    // unsupported smooth, but strictly below the λ-explosion rail
+                    // (`RHO_BOUND` = 30) where total EDF saturates numerically. The
+                    // empirical separation between a real #1266 shrink-out and a
+                    // #1476 concurvity ridge is wide and clean inside [15, 21].
+                    const SHRINK_BAND: [f64; 3] = [15.0, 18.0, 21.0];
                     let mut best_rho = strategy_result.rho.clone();
                     let mut best_pure = base_pure;
+                    let mut best_edf = edf_conv;
                     let mut improved = false;
-                    for _pass in 0..2 {
-                        let mut pass_improved = false;
-                        for &coord in &select_coords {
-                            let mut local_best = best_rho.clone();
-                            let mut local_pure = best_pure;
-                            for &cand in &OUTWARD_GRID {
-                                let target = cand.min(rho_upper);
-                                if target <= best_rho[coord] + 1e-9 {
-                                    continue;
-                                }
-                                let mut probe = best_rho.clone();
-                                probe[coord] = target;
-                                if let Some(c) = pure_reml(&probe)
-                                    && c < local_pure - 1e-6 * (1.0 + local_pure.abs())
-                                {
-                                    local_pure = c;
-                                    local_best = probe;
+                    for group in &groups {
+                        // Warm pure-REML screen over the band; remember the
+                        // most-improving level for this group.
+                        let mut group_best: Option<(Array1<f64>, f64)> = None;
+                        for &lvl in &SHRINK_BAND {
+                            let mut probe = best_rho.clone();
+                            let mut raised = false;
+                            for &i in group {
+                                if lvl > probe[i] + 1e-9 {
+                                    probe[i] = lvl;
+                                    raised = true;
                                 }
                             }
-                            if local_pure < best_pure - 1e-6 * (1.0 + best_pure.abs()) {
-                                best_rho = local_best;
-                                best_pure = local_pure;
-                                improved = true;
-                                pass_improved = true;
+                            if !raised {
+                                continue;
+                            }
+                            if let Some(c) = pure_reml(&probe)
+                                && c < best_pure - 1e-6 * (1.0 + best_pure.abs())
+                                && group_best.as_ref().is_none_or(|(_, gp)| c < *gp)
+                            {
+                                group_best = Some((probe, c));
                             }
                         }
-                        if !pass_improved {
-                            break;
+                        // COLD-confirm the group's best candidate on BOTH axes (the
+                        // warm probes ran off each other's inner warm starts — the
+                        // #1074 lesson): pure REML strictly down AND total EDF not up.
+                        let Some((cand, _)) = group_best else { continue };
+                        reml_state.reset_outer_seed_state();
+                        let cold_pen = reml_state.compute_cost(&cand);
+                        let cold_pure = cold_pen.as_ref().ok().and_then(|&c| {
+                            c.is_finite().then(|| {
+                                c - reml_state.configured_rho_prior_atom(&cand).cost()
+                                    - reml_state.soft_rho_guard_prior_atom(&cand).cost()
+                            })
+                        });
+                        let cand_edf = reml_state
+                            .obtain_eval_bundle(&cand)
+                            .ok()
+                            .map(|b| b.pirls_result.edf);
+                        let parsimonious = match (cand_edf, best_edf) {
+                            (Some(ec), Some(eb)) => ec <= eb + 1e-6,
+                            _ => false,
+                        };
+                        if let Some(cp) = cold_pure
+                            && cp.is_finite()
+                            && cp < best_pure - 1e-6 * (1.0 + best_pure.abs())
+                            && parsimonious
+                        {
+                            best_rho = cand;
+                            best_pure = cp;
+                            best_edf = cand_edf;
+                            improved = true;
                         }
                     }
                     if improved {
-                        // COLD confirmation (mirror of #1074): the warm grid probes
-                        // ran off each other's inner warm starts and can report a
-                        // spuriously-low cost. Clear the inner cache and re-score the
-                        // candidate cold; adopt only if its PURE REML STILL strictly
-                        // beats the authoritative converged baseline.
+                        // Each accepted group move was already cold-confirmed strictly
+                        // cheaper AND parsimonious against the running point, so the
+                        // final `best_rho` strictly beats the converged baseline on
+                        // pure REML without inflating total EDF. Re-score it cold once
+                        // more to install β̂ and recover the PENALIZED cost there (the
+                        // last cold eval in the loop need not have landed on
+                        // `best_rho`), then adopt it as the objective so the cached
+                        // inner state and `final_value` agree with the adopted ρ for
+                        // the downstream cap-guard / assembly.
                         reml_state.reset_outer_seed_state();
                         let cold_penalized = reml_state.compute_cost(&best_rho);
                         let cold_pure = cold_penalized.as_ref().ok().and_then(|&c| {
@@ -1519,42 +1613,24 @@ where
                                     - reml_state.soft_rho_guard_prior_atom(&best_rho).cost()
                             })
                         });
-                        // Total inner EDF at the candidate (cached from the cold eval).
-                        // The PARSIMONY guard: a genuine shrink-out must not INCREASE
-                        // the model's effective dimension (see `edf_conv`). When either
-                        // EDF is unavailable, refuse the adoption — a shrink that can't
-                        // be certified parsimonious is not worth the #1476 risk.
-                        let edf_best = reml_state
-                            .obtain_eval_bundle(&best_rho)
-                            .ok()
-                            .map(|b| b.pirls_result.edf);
-                        let edf_non_increasing = match (edf_best, edf_conv) {
-                            (Some(eb), Some(ec)) => eb <= ec + 1e-6,
-                            _ => false,
-                        };
                         if let (Ok(penalized), Some(cold_pure)) = (cold_penalized, cold_pure)
                             && cold_pure.is_finite()
                             && cold_pure < base_pure - 1e-6 * (1.0 + base_pure.abs())
-                            && edf_non_increasing
                         {
-                            // β̂ already installed at `best_rho` by the cold eval above.
-                            // Report the PENALIZED cost there as the objective so the
-                            // cached inner state and `final_value` agree with the
-                            // adopted ρ for the downstream cap-guard / assembly.
                             log::info!(
                                 "[OUTER] #1266 null-space shrink-out escape: pure REML \
                              {base_pure:.6e} → {cold_pure:.6e} (cold-confirmed), total \
-                             EDF {edf_conv:?} → {edf_best:?} (parsimonious) by \
-                             over-smoothing {} selection coord(s); adopting the \
-                             shrink-out ρ (penalized cost {penalized:.6e})",
-                                select_coords.len()
+                             EDF {edf_conv:?} → {best_edf:?} (parsimonious) by \
+                             over-smoothing whole selection term(s); adopting the \
+                             shrink-out ρ (penalized cost {penalized:.6e})"
                             );
                             strategy_result.rho = best_rho;
                             strategy_result.final_value = penalized;
                         } else {
-                            // The improvement did not survive a cold re-score (or the
-                            // re-score failed) — a warm-start artifact. Keep the
-                            // certified ρ and restore its inner state.
+                            // The assembled point did not survive its final cold
+                            // re-score (or the re-score failed) — a warm-start
+                            // artifact. Keep the certified ρ and restore its inner
+                            // state.
                             reml_state.reset_outer_seed_state();
                             reml_state.compute_cost(&strategy_result.rho)?;
                         }


### PR DESCRIPTION
## Reopened issue #1266

Issue #1266 was closed but the **"Half B"** contract — *an irrelevant covariate's default-double-penalty smooth must shrink out (EDF → 0)* — was never met. The RED regression `default_double_penalty_shrinks_irrelevant_covariate_edf_below_one` (fit `y ~ s(x) + s(z)`, `y = sin(6x) + N(0,0.3)`, `x ⊥ z`, seeds 200-204, n=800) shows the irrelevant `s(z)` keeping **mean EDF ≈ 1.9** (worst seed 3.28), so z tests falsely significant.

## Root cause (optimizer convergence bug, not criterion/test-bar)

The default-double-penalty (mgcv `select = TRUE`) **null-space shrink-out escape** in the outer REML optimizer (`optimize_external_design…`) over-smoothed a *single* null-space ρ-coordinate at a time, then gated the whole greedy bundle on one total-EDF parsimony check. Two defects:

1. **Wrong unit.** A smooth term's EDF is shared between its wiggliness penalty and its `DoublePenaltyNullspace` ridge; the bulk of an only-mildly-penalized term's EDF lives in its **wiggliness** coordinate. Over-smoothing the null-space coordinate *alone* leaves the wiggliness coordinate moderate, so the constrained reparametrization re-absorbs the same EDF elsewhere — the term never selects out. Pushing that lone coordinate to the λ rail only injects a **numerical EDF-saturation artifact** (total EDF jumps toward `p`), which the parsimony guard then correctly vetoes. Net: the escape was a silent **no-op** on the case it targets.

2. **Wrong bundling.** For `s(x_supported) + s(z_irrelevant)` *both* null spaces are degeneracy-prior selection coords, so the greedy bundle mixed the good z-shrink with a harmful over-smooth of the supported x null space; the single end-of-bundle EDF guard saw net inflation and vetoed everything.

Cold-confirmed diagnostics (seed 201) make the mechanism unambiguous:

| move | pure REML | total EDF |
|---|---|---|
| converged | 210.5 | 13.4 |
| z null-coord → 30 (alone) | 106.3 | **46** (saturation artifact) |
| **z term [wig,null] → 20 (joint)** | **207.3** | **10.7** (genuine shrink-out) |
| x supported term → 20 (joint) | 944 | — (pure REML rises → rejected) |

## Fix

Search **per-TERM**, not per-coordinate. Build term groups from the canonical penalties' shared `col_range` and over-smooth each selection-seeded group's coordinates **up together** across a **moderate band `[15, 21]`** that stops short of the λ-explosion rail (ρ≈24+). Adopt a group's move only if a **cold re-score** confirms it *both* strictly lowers pure data-REML *and* does not raise total inner EDF.

This cleanly separates the regimes:
- **irrelevant uncorrelated term (#1266 `s(z)`):** moderate joint over-smooth lowers pure REML **and** drops total EDF → fires, EDF → 0.
- **supported term (#1371 slope) / correlated supported pair (#1476 `s(x1)+s(x2)`):** over-smoothing a real partial effect dumps variance into σ̂², so pure REML strictly **rises** across the whole moderate band → rejected on the pure-REML test alone (the concurvity "transfer" only looked cheap at the saturation rail, now excluded).
- **under-determined `p > n` (#1392):** unchanged — escape stays gated to the well-determined `n ≥ 2·p` degeneracy-prior regime.

## Verification

- ✅ `default_double_penalty_shrinks_irrelevant_covariate_edf_below_one` — **GREEN** (mean z-EDF < 1.0 over seeds 200-204).
- ✅ `default_double_penalty_keeps_supported_slope_while_shrinking_unsupported` (discriminator sibling) — still passes.
- ✅ No new regressions across the smooth / selection / parsimony / invariance regression surface. The remaining `#1476` / `double_penalty_inflates` / `wine_shaped` reds **pre-exist on `origin/main`** (verified by stash-and-rerun) and are unaffected — `#1476`'s numbers in fact *improve* (mean edf x1 6.24→8.72, x2 1.55→1.73).
- ✅ `./build.sh` clean (ban-scanner included).

Single-file change: `crates/gam-solve/src/estimate/optimizer.rs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)