### PR TITLE
[agent] unblock RED main: 6 verified pre-existing unit failures (run_plan, seeding, e-process, operator adjoint, KKT diag, #577 freeze)

### DIFF
--- a/crates/gam-pyffi/src/inference/inference_instruments.rs
+++ b/crates/gam-pyffi/src/inference/inference_instruments.rs
@@ -100,6 +100,17 @@ impl PyAtomBirthGate {
         matches!(self.gate.verdict(), GateVerdict::Certified { .. })
     }
 
+    /// The realized time-to-certification: the shard count at which the running
+    /// supremum first crossed `1/alpha`, or `None` if it never has. This is the
+    /// first-passage time the design budget predicts; it is recorded SEPARATELY
+    /// from the absorbed-shard count, which keeps growing past the crossing
+    /// (absorption does not stop, so the dictionary-level e-BH certificate can
+    /// clear its higher multiplicity bar).
+    #[getter]
+    fn certified_at_step(&self) -> Option<usize> {
+        self.gate.certified_at_step()
+    }
+
     /// The current verdict: `{"verdict": "certified"|"contested", "log_e",
     /// "e_value", "alpha"}`. A contested gate has not *disproven* the atom —
     /// it has failed to prove it; its `log_e` is the value the dictionary-level

--- a/crates/gam-sae/src/manifold/fit_drivers.rs
+++ b/crates/gam-sae/src/manifold/fit_drivers.rs
@@ -3566,7 +3566,19 @@ impl SaeManifoldTerm {
         // current_state` writes the full-`B` decoder directly, which would desync the
         // factored frames the inner solve and `apply_newton_step` rely on; the
         // homotopy-arrival polish makes the same conservative choice.
-        if !self.frames_active() {
+        //
+        // GATE on `max_iter > 0`: `max_iter == 0` is the documented verbatim
+        // warm-start FREEZE (gam#577/#579, #850 — see
+        // `converge_inner_for_undamped_logdet`), where the caller hands in a
+        // seeded `(t, β)` and asks for a single factor at exactly that iterate
+        // WITHOUT moving it. The polish is a decoder least-squares solve, so
+        // running it on a freeze would silently overwrite the warm-started β
+        // with the data-optimal refit — breaking the verbatim-reuse contract the
+        // continuation pre-warm depends on for its speedup (the cold-vs-warm
+        // hint would always equal the cold LSQ decoder, never the seed). A freeze
+        // is by definition not a convergence request, so there is no
+        // under-converged decoder to rescue here.
+        if max_iter > 0 && !self.frames_active() {
             let mut best_objective =
                 self.penalized_objective_total(target, rho, analytic_penalties, 1.0)?;
             if best_objective.is_finite() {

--- a/crates/gam-solve/src/reml/reml_outer_engine/objective.rs
+++ b/crates/gam-solve/src/reml/reml_outer_engine/objective.rs
@@ -1167,6 +1167,13 @@ pub fn reml_laml_evaluate(
         // Only ρ coordinates carry an upper box bound; ψ/ext never freeze here.
         let mut active = upper_active_rho.clone();
         active.extend(std::iter::repeat_n(false, ext_dim));
+        // The KKT-correction self-derivative term `δ_ij·C_i` is non-zero only
+        // for coordinates whose r_i and A_i scale multiplicatively with their
+        // own coordinate. ρ coordinates do (`λ_i = exp(ρ_i)` ⇒ `∂_ρᵢrᵢ = rᵢ`,
+        // `∂_ρᵢAᵢ = Aᵢ`); ψ/ext coordinates feed a FROZEN drift (`∂A = 0`) and
+        // an affine score, so their second self-derivative is zero here.
+        let mut exponential_self_coupling = vec![true; k];
+        exponential_self_coupling.extend(std::iter::repeat_n(false, ext_dim));
         let subspace = solution.penalty_subspace_trace.as_deref();
         Some(compute_kkt_residual_theta_corrections(
             hop,
@@ -1176,6 +1183,7 @@ pub fn reml_laml_evaluate(
             r,
             mode == EvalMode::ValueGradientHessian,
             &active,
+            &exponential_self_coupling,
         )?)
     } else {
         None

--- a/crates/gam-solve/src/reml/reml_outer_engine/outer_derivatives/dense.rs
+++ b/crates/gam-solve/src/reml/reml_outer_engine/outer_derivatives/dense.rs
@@ -222,12 +222,7 @@ pub(crate) fn compute_outer_hessian(
     };
     let adjoint_z_c = if incl_logdet_h {
         match (glm_ingredients.as_ref(), leverage.as_ref()) {
-            (Some(ing), Some(h_g)) => Some(compute_adjoint_z_c(
-                ing,
-                hop,
-                h_g,
-                solution.penalty_subspace_trace.as_deref(),
-            )?),
+            (Some(ing), Some(h_g)) => Some(compute_adjoint_z_c(ing, hop, h_g)?),
             _ => None,
         }
     } else {

--- a/crates/gam-solve/src/reml/reml_outer_engine/outer_derivatives/kkt.rs
+++ b/crates/gam-solve/src/reml/reml_outer_engine/outer_derivatives/kkt.rs
@@ -45,18 +45,29 @@ pub(crate) struct KktThetaCorrections {
 /// `drift_apply(i, v) = A_i v` closure, so the SAME algebra produces every
 /// block — there is no separate ρ-only and ψ-only code path to drift apart.
 ///
-/// With `q = K r` and frozen first derivatives over this correction layer:
+/// With `q = K r` and the FIRST derivatives of the correction layer:
 ///   C_i  = −r_iᵀ q + ½ qᵀ A_i q,
-///   q_j  = K(r_j − A_j q),
-///   C_ij = −r_iᵀ q_j + q_jᵀ A_i q.
-/// Coordinate-curvature terms such as `∂²r/∂ρ²` and `∂²H/∂ρ²` belong to the
-/// outer pair assembly (`pair_a` / `h2_trace`) that already differentiates the
-/// log-λ coordinate map. Adding them again here over-corrects the ρρ diagonal.
-/// The dense/operator outer Hessian already carries the exact-KKT profile term
-/// `−r_iᵀ K r_j` for EVERY block (ρρ via the penalty profile, ρψ/ψψ via the
-/// IFT profile `a_iᵀ K a_j` in `outer_hessian_entry`), valid only at `r = 0`,
-/// so the correction adds back `r_iᵀ K r_j + C_ij`; the additive block vanishes
-/// identically at exact KKT (`r = 0 ⇒ q = 0`).
+///   q_j  = ∂_θⱼ q = K(r_j − A_j q),
+///   C_ij = −r_iᵀ q_j + q_jᵀ A_i q  +  δ_ij·[−(∂_ir_i)ᵀq + ½qᵀ(∂_iA_i)q].
+/// The bracketed diagonal term is the SECOND self-derivative of the correction
+/// (`∂²_θᵢ r` and `∂²_θᵢ H`), and it is non-zero precisely for coordinates whose
+/// score-derivative and drift scale MULTIPLICATIVELY with their own coordinate.
+/// The ρ coordinates are exactly such: `λᵢ = exp(ρᵢ)`, so `rᵢ = λᵢSᵢβ̂` and
+/// `Aᵢ = λᵢSᵢ` both obey `∂_ρᵢ rᵢ = rᵢ` and `∂_ρᵢ Aᵢ = Aᵢ`, which collapses the
+/// bracket to exactly `Cᵢ` (the gradient correction already computed at this
+/// coordinate). `exponential_self_coupling[i]` flags those coordinates; for an
+/// affine/frozen coordinate (`r`, `A` linear in θ ⇒ `∂²r = ∂²H = 0`, e.g. the
+/// ψ/ext frozen-drift block whose genuine second order lives elsewhere) the
+/// bracket is zero and the flag is `false`.
+///
+/// This self-derivative term is NOT carried by the outer pair assembly: with no
+/// KKT residual there is no correction `C(θ)` at all, so its curvature can only
+/// enter through this block. The dense/operator outer Hessian carries the
+/// exact-KKT profile term `−r_iᵀ K r_j` for EVERY block (ρρ via the penalty
+/// profile, ρψ/ψψ via the IFT profile `a_iᵀ K a_j` in `outer_hessian_entry`),
+/// valid only at `r = 0`, so the correction adds back `r_iᵀ K r_j + C_ij`; the
+/// additive block vanishes identically at exact KKT (`r = 0 ⇒ q = 0`, and the
+/// diagonal self-term is `Cᵢ = 0` there too).
 ///
 /// `active[i]` masks a coordinate at an active upper box bound (only ρ
 /// coordinates can be masked; the ψ entries are always `false`): a masked
@@ -70,6 +81,7 @@ pub(crate) fn compute_kkt_residual_theta_corrections<F>(
     residual: &Array1<f64>,
     include_hessian: bool,
     active: &[bool],
+    exponential_self_coupling: &[bool],
 ) -> Result<KktThetaCorrections, String>
 where
     F: Fn(usize, &Array1<f64>) -> Array1<f64>,
@@ -86,6 +98,16 @@ where
             reason: format!(
                 "KKT theta correction active-bound mask mismatch: mask={} coords={}",
                 active.len(),
+                m
+            ),
+        }
+        .into());
+    }
+    if exponential_self_coupling.len() != m {
+        return Err(RemlError::DimensionMismatch {
+            reason: format!(
+                "KKT theta correction self-coupling mask mismatch: mask={} coords={}",
+                exponential_self_coupling.len(),
                 m
             ),
         }
@@ -172,7 +194,18 @@ where
         for i in 0..m {
             for j in i..m {
                 let raw = if i == j {
-                    entry(i, j)
+                    // Diagonal: add the second self-derivative `δ_ij·C_i` for
+                    // coordinates whose r_i and A_i scale multiplicatively with
+                    // their own coordinate (λ = exp(ρ)); `gradient[i]` already
+                    // equals `C_i = −r_iᵀq + ½qᵀA_iq`, and `∂_ρᵢrᵢ = rᵢ`,
+                    // `∂_ρᵢAᵢ = Aᵢ` collapse the bracket to exactly C_i. Affine/
+                    // frozen coordinates (`∂²r = ∂²H = 0`) get no such term.
+                    let self_term = if exponential_self_coupling[i] && !active[i] {
+                        gradient[i]
+                    } else {
+                        0.0
+                    };
+                    entry(i, j) + self_term
                 } else {
                     0.5 * (entry(i, j) + entry(j, i))
                 };

--- a/crates/gam-solve/src/reml/reml_outer_engine/outer_derivatives/operator.rs
+++ b/crates/gam-solve/src/reml/reml_outer_engine/outer_derivatives/operator.rs
@@ -477,9 +477,11 @@ impl UnifiedOuterHessianOperator {
         };
 
         // Cheap adjoint shortcut: works for both full-Hessian and projected
-        // (subspace) regimes because §10 populates `leverage`/`adjoint_z_c`
-        // with the projected `h^{G,proj}` and `K · v` under subspace, and
-        // the identity tr(Kernel · C[u]) = uᵀ Xᵀ(c ⊙ h^G) carries through.
+        // (subspace) regimes because the build populates `leverage` with the
+        // projected `h^{G,proj}` under subspace while `adjoint_z_c = H⁻¹ · v`
+        // stays a full solve, and the identity
+        // tr(Kernel · C[u]) = uᵀ Xᵀ(c ⊙ h^G) = rhsᵀ H⁻¹ Xᵀ(c ⊙ h^G) carries
+        // through (the projection lives entirely in the leverage `h^G`).
         let z_c = self.adjoint_z_c.as_ref().ok_or_else(|| {
             "missing adjoint trace cache for scalar outer Hessian operator".to_string()
         })?;
@@ -1490,28 +1492,26 @@ pub(crate) fn build_outer_hessian_operator(
     };
 
     // Leverage and the scalar-GLM adjoint-z_c cache support both the
-    // full-Hessian and projected-subspace paths.  Under subspace,
+    // full-Hessian and projected-subspace paths.  The trace is
+    //   tr(Kernel · C[u]) = Σ_r c_r (Xu)_r (X Kernel Xᵀ)_rr
+    //                     = uᵀ · Xᵀ(c ⊙ h^G),   h^G = diag(X Kernel Xᵀ),
+    // with the SECOND mode response `u = β̈ = H⁻¹ rhs` solved with the FULL
+    // inner inverse in EVERY regime (it is an IFT stationarity derivative in
+    // full β-space — see `compute_ift_correction_trace`'s slow path and
+    // `compute_adjoint_z_c`).  Substituting,
+    //   tr(Kernel · C[u]) = rhsᵀ H⁻¹ Xᵀ(c ⊙ h^G) = rhsᵀ · z_c,
+    //   z_c = H⁻¹ · Xᵀ(c ⊙ h^G),
+    // so `scalar_correction_trace` can take the cheap branch `rhs · z_c`
+    // instead of materialising the second-derivative correction.  The
+    // PROJECTION enters ONLY through the leverage: under subspace,
     //   h^{G,proj}_i = Xᵢᵀ · K · Xᵢ                  (K = U_S H_proj⁻¹ U_Sᵀ)
-    //   u            = K · rhs                       (mirrors
-    //                                                  `compute_ift_correction_trace`
-    //                                                  slow path and the
-    //                                                  per-coord v computation
-    //                                                  above)
-    //   z_c^{proj}   = K · Xᵀ(c ⊙ h^{G,proj})
-    // and the adjoint identity
-    //   tr(K · C[u]) = uᵀ · Xᵀ(c ⊙ h^{G,proj})
-    //               = (K rhs)ᵀ · Xᵀ(c ⊙ h^{G,proj})
-    //               = rhsᵀ · K · Xᵀ(c ⊙ h^{G,proj})
-    //               = rhsᵀ · z_c^{proj}
-    // lets `scalar_correction_trace` take the cheap branch
-    // `rhs · z_c^{proj}` instead of materialising the second-derivative
-    // correction.  Both the leverage AND the adjoint vector must swap to
-    // their projected forms — gating only one (the historical bug) made the
-    // operator path's `scalar_correction_trace` compute
-    // `rhsᵀ H⁻¹ Xᵀ(c⊙h^{G,proj})` while `compute_ift_correction_trace`
-    // computes `rhsᵀ K · X'(c⊙h^{G,proj})`, so the operator-form Hessian
-    // disagreed with the dense path materialisation in the regression
-    // `projected_operator_hessian_matches_dense_subspace_trace`.
+    // while the solve in `compute_adjoint_z_c` stays `H⁻¹`.  A previous version
+    // ALSO projected the solve (`z_c = K · Xᵀ(c⊙h^{G,proj})`), making this path
+    // compute `rhsᵀ K Xᵀ(c⊙h^{G,proj})` while the dense materialisation
+    // correctly traces `tr(K · C[H⁻¹ rhs]) = rhsᵀ H⁻¹ Xᵀ(c⊙h^{G,proj})` — the
+    // `projected_operator_hessian_matches_dense_subspace_trace` /
+    // `outer_hessian_operator_matvec_matches_dense_subspace_with_null_alpha`
+    // regressions.  Only the leverage is projected; the solve is not.
     let leverage = if incl_logdet_h {
         match &kernel {
             OuterHessianDerivativeKernel::Gaussian => None,
@@ -1541,7 +1541,6 @@ pub(crate) fn build_outer_hessian_operator(
                 },
                 hop.as_ref(),
                 h_g,
-                subspace,
             )?),
             _ => None,
         }

--- a/crates/gam-solve/src/reml/reml_outer_engine/outer_derivatives/traces.rs
+++ b/crates/gam-solve/src/reml/reml_outer_engine/outer_derivatives/traces.rs
@@ -14,7 +14,6 @@ pub(crate) fn compute_adjoint_z_c(
     ing: &ScalarGlmIngredients<'_>,
     hop: &dyn HessianOperator,
     leverage: &Array1<f64>,
-    subspace: Option<&PenaltySubspaceTrace>,
 ) -> Result<Array1<f64>, String> {
     let mut weighted = Array1::<f64>::zeros(ing.c_array.len());
     Zip::from(&mut weighted)
@@ -24,33 +23,39 @@ pub(crate) fn compute_adjoint_z_c(
     // Matrix-free Xᵀ · weighted via DesignMatrix transpose-apply, so
     // operator-backed (Lazy) designs at large scale never densify.
     let v = ing.x.transpose_vector_multiply(&weighted);
-    // Adjoint identity: tr(Kernel · C[u]) = uᵀ · Xᵀ(c ⊙ h^G), where the
-    // kernel and the leverage `h^G` must come from the SAME operator.
+    // Adjoint shortcut for tr(Kernel · C[u]) where C[u] = Xᵀ diag(c ⊙ Xu) X
+    // and u = β̈ is the SECOND mode response. Expanding the trace,
     //
-    //   * Full-Hessian regime: Kernel = G_ε(H), leverage = diag(X G_ε(H) Xᵀ),
-    //     mode response u = H⁻¹ rhs, and the cheap shortcut reads
-    //     `rhs · z_c` with z_c = H⁻¹ · X'(c⊙h^G).
-    //   * Projected-subspace regime (rank-deficient LAML fix): Kernel = K,
-    //     leverage = h^{G,proj} = diag(X K Xᵀ). This adjoint `z_c` is a
-    //     TRACE-side quantity, so it carries the projected `K`; it is NOT the
-    //     β̈ mode response (which is solved with the full `H⁻¹` even here — see
-    //     `compute_ift_correction_trace`'s slow path). For the shortcut to hold
-    //     the adjoint must satisfy `rhs · z_c = (K rhs)ᵀ X'(c⊙h^{G,proj})
-    //                                     = rhsᵀ K · X'(c⊙h^{G,proj})`,
-    //     i.e. z_c^{proj} = K · X'(c ⊙ h^{G,proj}). Routing through
-    //     `hop.solve` here produces H⁻¹ · X'(c ⊙ h^{G,proj}) instead and
-    //     `scalar_correction_trace` then computes
-    //     `rhsᵀ H⁻¹ X'(c⊙h^{G,proj})` while the dense path's
-    //     `compute_ift_correction_trace` computes
-    //     `rhsᵀ K · X'(c⊙h^{G,proj})`, so the operator-form Hessian
-    //     disagrees with `compute_outer_hessian`'s materialisation on every
-    //     non-trivial subspace direction (the
-    //     `projected_operator_hessian_matches_dense_subspace_trace`
-    //     regression).
-    match subspace {
-        Some(kernel) => Ok(kernel.apply_pseudo_inverse(&v)),
-        None => Ok(hop.solve(&v)),
-    }
+    //     tr(Kernel · C[u]) = Σ_r c_r (Xu)_r (X Kernel Xᵀ)_rr
+    //                       = uᵀ Xᵀ (c ⊙ h^G),   h^G = diag(X Kernel Xᵀ),
+    //
+    // and the mode response is `u = β̈ = H⁻¹ rhs` — solved with the FULL inner
+    // inverse `hop.solve` in EVERY regime (it is an IFT stationarity derivative
+    // living in full β-space; see `compute_ift_correction_trace`'s slow path and
+    // `penalty_coordinate.rs`). Substituting,
+    //
+    //     tr(Kernel · C[u]) = rhsᵀ H⁻¹ Xᵀ(c ⊙ h^G) = rhsᵀ · z_c,
+    //     z_c = H⁻¹ · Xᵀ(c ⊙ h^G).
+    //
+    // The PROJECTION enters ONLY through the leverage `h^G`, never through the
+    // solve:
+    //   * Full-Hessian regime: Kernel = G_ε(H), h^G = diag(X G_ε(H) Xᵀ).
+    //   * Projected-subspace regime (rank-deficient LAML fix): Kernel = K, the
+    //     caller passes h^{G,proj} = diag(X K Xᵀ); the solve stays `H⁻¹`.
+    //
+    // A previous version routed the projected regime through
+    // `K · Xᵀ(c⊙h^{G,proj})` (the projected pseudo-inverse) instead of
+    // `H⁻¹ · …`. That made `scalar_correction_trace` compute
+    // `rhsᵀ K Xᵀ(c⊙h^{G,proj})` while the dense path's
+    // `compute_ift_correction_trace` materialisation correctly traces
+    // `tr(K · C[H⁻¹ rhs]) = rhsᵀ H⁻¹ Xᵀ(c⊙h^{G,proj})`, so the operator-form
+    // Hessian disagreed with `compute_outer_hessian` on every non-trivial
+    // subspace direction (the
+    // `projected_operator_hessian_matches_dense_subspace_trace` /
+    // `outer_hessian_operator_matvec_matches_dense_subspace_with_null_alpha`
+    // regressions). The solve is `H⁻¹` regardless of regime; only the leverage
+    // is projected.
+    Ok(hop.solve(&v))
 }
 
 /// Compute the fourth-derivative trace: tr(G_ε(H) Xᵀ diag(d ⊙ (Xvₖ)(Xvₗ)) X).

--- a/crates/gam-solve/src/reml/reml_outer_engine/tests.rs
+++ b/crates/gam-solve/src/reml/reml_outer_engine/tests.rs
@@ -1913,7 +1913,7 @@ pub(crate) fn test_compute_adjoint_z_c_streaming_matches_dense_reference() {
         }
         h_dense[i] = acc;
     }
-    let streamed = compute_adjoint_z_c(&ing, &hop, &h_dense, None).expect("adjoint path");
+    let streamed = compute_adjoint_z_c(&ing, &hop, &h_dense).expect("adjoint path");
 
     let mut t = h_dense.clone();
     Zip::from(&mut t)

--- a/crates/gam-solve/src/reml/reml_outer_engine/tests.rs
+++ b/crates/gam-solve/src/reml/reml_outer_engine/tests.rs
@@ -1276,6 +1276,7 @@ pub(crate) fn ift_gradient_correction_with_zero_projected_residual_is_zero() {
         &zero_residual,
         true,
         &[false, false],
+        &[true, true],
     )
     .expect("kkt correction must succeed at zero residual");
 
@@ -1321,6 +1322,7 @@ pub(crate) fn ift_rho_upper_bound_masks_residual_correction_direction() {
         &residual,
         true,
         &[false, true],
+        &[true, true],
     )
     .expect("kkt correction must succeed with a masked upper-bound coordinate");
 
@@ -1402,6 +1404,12 @@ pub(crate) fn kkt_theta_correction_cross_and_psi_hessian_matches_finite_differen
         drift_apply,
         &r0,
         true,
+        &[false, false, false],
+        // This fixture's r(θ)=r0+Σθ_i s_i and H(θ)=H0+Σθ_i A_i are AFFINE in θ,
+        // so every coordinate's second self-derivative ∂²r=∂²H=0 — no
+        // exponential self-coupling on any coordinate (unlike the production ρ
+        // map λ=exp(ρ)). The FD ground truth is built from this same affine
+        // model, so the correction must NOT add the δ_ij·C_i term here.
         &[false, false, false],
     )
     .expect("theta correction must succeed");

--- a/crates/gam-solve/src/rho_optimizer/run_plan_tests.rs
+++ b/crates/gam-solve/src/rho_optimizer/run_plan_tests.rs
@@ -1693,7 +1693,6 @@ fn arc_cost_stall_guard_uses_cached_initial_sample_as_feasible_best() {
 #[test]
 fn bfgs_bridge_halts_infeasible_probe_run_back_to_cached_seed() {
     let seed = array![0.0];
-    let trial = array![1.0];
     let problem = OuterProblem::new(1).with_gradient(Derivative::Analytic);
     let mut obj = problem.build_objective_with_eval_order(
         (),
@@ -1726,8 +1725,16 @@ fn bfgs_bridge_halts_infeasible_probe_run_back_to_cached_seed() {
         consecutive_probe_refusals: 0,
     };
 
+    // A real BFGS line search probes a *sequence of distinct* trial ρ along its
+    // search direction, not one point repeated. The bridge caches each probed ρ
+    // bit-exactly (`value_probe_cache`/`same_outer_point`) and short-circuits an
+    // exact repeat WITHOUT re-entering the cost-stall guard — so re-probing a
+    // single fixed ρ would only ever register ONE infeasible observation and the
+    // streak could never fill the window. Walk distinct points (1.0, 2.0, …) so
+    // each probe is a fresh guard observation, exactly as the line search does.
     let mut sentinel_fired = false;
-    for _ in 0..(COST_STALL_WINDOW + 2) {
+    for i in 0..(COST_STALL_WINDOW + 2) {
+        let trial = array![1.0 + i as f64];
         match ZerothOrderObjective::eval_cost(&mut bridge, &trial) {
             Ok(cost) => panic!("infeasible probe unexpectedly returned finite cost {cost}"),
             Err(ObjectiveEvalError::Fatal { message }) => {
@@ -3417,10 +3424,22 @@ fn run_screening_reorders_expensive_generated_seeds_before_full_startup_eval() {
         .run(&mut obj, "screening should reorder expensive seeds")
         .expect("screened startup should reach the best generated seed");
     assert_eq!(result.rho, valid_seed);
+    let started_snapshot: Vec<Array1<f64>> = started.lock().unwrap().clone();
+    // The interior-extreme promotion (#1074/#1373/#1426) reserves slot 0 for the
+    // most-flexible interior seed and slot 1 for the heaviest, so screening's
+    // cost rank resumes at slot 2. (This promotion runs INSIDE
+    // `rank_seeds_with_screening`, so its footprint at slots 0/1 — here the
+    // generator's `[0.0]` and `[12.0]`, NOT the raw generator-first `[1.0]` — is
+    // itself proof that screening ran.) The lowest-cost generated seed must lead
+    // that reorderable tail: screening moved it ahead of the other equal-or-
+    // higher-cost seeds it is allowed to reorder, exactly as the original "front"
+    // assertion intended before the promotion reserved the first two slots.
     assert_eq!(
-        started.lock().unwrap().first().cloned(),
+        started_snapshot.get(2).cloned(),
         Some(valid_seed),
-        "screening should move the lowest-cost seed to the front before full startup eval",
+        "screening should rank the lowest-cost seed at the head of the reorderable \
+         tail (slots 0/1 are reserved for the promoted flexible/heaviest seeds); \
+         started order was {started_snapshot:?}",
     );
     assert_eq!(screening_cap.load(std::sync::atomic::Ordering::Relaxed), 0);
 }
@@ -3430,7 +3449,16 @@ fn initial_rho_with_single_seed_budget_skips_expensive_screening() {
     let mut seed_config = gam_problem::SeedConfig::default();
     seed_config.max_seeds = 4;
     seed_config.seed_budget = 1;
-    seed_config.risk_profile = gam_problem::SeedRiskProfile::GeneralizedLinear;
+    // This test asserts the `initial_rho + seed_budget==1` screening-skip
+    // (`explicit_initial_rho_owns_single_seed_budget`) fires. That skip keys off
+    // the EFFECTIVE budget, not the requested one. `effective_seed_budget` floors
+    // `(Arc, GeneralizedLinear)` to 2 (#1074/#1426 — a GLM needs ≥2 seeds to also
+    // reach the heavily-penalized basin), so a GeneralizedLinear fixture would
+    // have effective budget 2, the `seed_budget == 1` skip guard would be false,
+    // and screening would run (the observed 5 screening solves). Pin the fixture
+    // to Gaussian, whose effective budget equals the requested 1, so the skip is
+    // genuinely exercised — the behaviour this test is meant to guard.
+    seed_config.risk_profile = gam_problem::SeedRiskProfile::Gaussian;
     let screening_cap = Arc::new(AtomicUsize::new(0));
     let screening_calls = Arc::new(AtomicUsize::new(0));
     let initial_seed = array![9.0];
@@ -3548,10 +3576,19 @@ fn run_screening_reorders_bfgs_seeds_before_full_startup_eval() {
         .expect("screened BFGS startup should reach the best generated seed");
     assert_eq!(result.plan_used.solver, Solver::Bfgs);
     assert_eq!(result.rho, valid_seed);
+    let started_snapshot: Vec<Array1<f64>> = started.lock().unwrap().clone();
+    // As in the analytic-gradient sibling test: the interior-extreme promotion
+    // (#1074/#1373/#1426) reserves slot 0 (most-flexible interior seed) and slot 1
+    // (heaviest interior seed — here the screened-in initial ρ=9.0), so screening's
+    // cost rank resumes at slot 2. The lowest-cost generated seed must lead that
+    // reorderable tail — screening moved it ahead of every other equal-or-higher-
+    // cost seed it is allowed to reorder.
     assert_eq!(
-        started.lock().unwrap().first().cloned(),
+        started_snapshot.get(2).cloned(),
         Some(valid_seed),
-        "BFGS screening should move the lowest-cost seed to the front before full startup eval",
+        "BFGS screening should rank the lowest-cost seed at the head of the \
+         reorderable tail (slots 0/1 are reserved for the promoted flexible/heaviest \
+         seeds); started order was {started_snapshot:?}",
     );
     assert!(
         screening_calls.load(Ordering::Relaxed) > 1,
@@ -4591,13 +4628,23 @@ fn cached_rho_is_prepended_as_first_seed() {
             seen.lock().unwrap().push(theta.clone());
             Ok((theta[0] - 2.5).powi(2))
         },
-        |_: &mut Arc<Mutex<Vec<Array1<f64>>>>, theta: &Array1<f64>| {
-            Ok(OuterEval {
-                cost: (theta[0] - 2.5).powi(2),
-                gradient: array![2.0 * (theta[0] - 2.5)],
-                hessian: HessianResult::Unavailable,
-                inner_beta_hint: None,
-            })
+        {
+            let seen = seen.clone();
+            move |_: &mut Arc<Mutex<Vec<Array1<f64>>>>, theta: &Array1<f64>| {
+                // Record full-eval points too: startup now performs a DIRECT full
+                // evaluation at the seed (the `run_starts_solver_with_direct_startup_eval`
+                // contract) routed through THIS eval path, not a separate cost-screening
+                // pass. The cached rho is consumed by that startup eval, so a recorder
+                // that watched only the cost closure never saw the exact cached ρ — it
+                // only caught the later line-search cost probes clustered near it.
+                seen.lock().unwrap().push(theta.clone());
+                Ok(OuterEval {
+                    cost: (theta[0] - 2.5).powi(2),
+                    gradient: array![2.0 * (theta[0] - 2.5)],
+                    hessian: HessianResult::Unavailable,
+                    inner_beta_hint: None,
+                })
+            }
         },
         None::<fn(&mut Arc<Mutex<Vec<Array1<f64>>>>)>,
         None::<

--- a/crates/gam-solve/src/seeding.rs
+++ b/crates/gam-solve/src/seeding.rs
@@ -639,17 +639,32 @@ where
                 }
             }
         }
-        for start in 0..n_smooths.saturating_sub(1) {
-            let anchor = best_seed.clone();
-            let mut candidate = anchor;
-            candidate[start] = saturation;
-            candidate[start + 1] = saturation;
-            if let Some(c) = eval_cost(&candidate)
-                && c.is_finite()
-                && best_cost.map(|b| c < b).unwrap_or(true)
-            {
-                best_cost = Some(c);
-                best_seed = candidate;
+        // Adjacent-pair over-smoothing corner: send one term's (mass, tension)
+        // / null-space pair fully to the bound while the SIBLING terms stay
+        // free. Probe this corner from BOTH the refined isotropic best AND the
+        // baseline anchor. Anchoring only on `best_seed` cannot express "shrink
+        // s(z), keep s(x) at its supported λ": the per-axis sweep above drives
+        // every coordinate toward the dominant over-smoothing optimum, so the
+        // kept siblings are already saturated and the genuine "keep the rest at
+        // baseline" corner is unreachable (the unsupported pair gets railed but
+        // the supported pair can never relax back below the ±3 refinement
+        // reach). Including the baseline anchor lets the grid seed exactly the
+        // asymmetric corner #1266 is about — one pair at the bound, the rest at
+        // the supported baseline λ. Both anchors are criterion-ranked (adopted
+        // only on a strict cost decrease), so this never displaces a better
+        // interior optimum and leaves balanced fits byte-identical.
+        for anchor in [best_seed.clone(), baseline_seed.clone()] {
+            for start in 0..n_smooths.saturating_sub(1) {
+                let mut candidate = anchor.clone();
+                candidate[start] = saturation;
+                candidate[start + 1] = saturation;
+                if let Some(c) = eval_cost(&candidate)
+                    && c.is_finite()
+                    && best_cost.map(|b| c < b).unwrap_or(true)
+                {
+                    best_cost = Some(c);
+                    best_seed = candidate;
+                }
             }
         }
     }

--- a/crates/gam-terms/src/inference/structure_evidence.rs
+++ b/crates/gam-terms/src/inference/structure_evidence.rs
@@ -372,6 +372,17 @@ pub struct AtomBirthGate {
     /// The level the certificate is claimed at; fixed at construction so a
     /// verdict can never be shopped across α after seeing the evidence.
     alpha: f64,
+    /// First-passage time: the shard count at which the running supremum
+    /// first crossed the single-hypothesis Ville bar `ln(1/α)`. `None` until
+    /// the crossing happens. This is the realized *time-to-certification* —
+    /// the design-relevant quantity (`expected_resolution_budget`) — recorded
+    /// SEPARATELY from the running evidence so that absorption can continue
+    /// past the crossing without losing the crossing time. By Ville the
+    /// crossing is permanent (it is a property of the running sup), so this is
+    /// monotone: once `Some`, never reset. `#[serde(default)]` keeps gates
+    /// persisted before this field was added (#973 resumability) loadable.
+    #[serde(default)]
+    certified_at_step: Option<usize>,
 }
 
 impl AtomBirthGate {
@@ -384,11 +395,24 @@ impl AtomBirthGate {
         Ok(Self {
             test: PredictablePluginEProcess::new(),
             alpha,
+            certified_at_step: None,
         })
     }
 
     pub fn alpha(&self) -> f64 {
         self.alpha
+    }
+
+    /// The realized time-to-certification: the shard count at which the
+    /// running supremum first crossed `ln(1/α)`, or `None` if it never did.
+    /// This is the first-passage time the design budget
+    /// ([`expected_resolution_budget`]) predicts — distinct from
+    /// [`EProcess::steps`] (total shards absorbed), which keeps growing after
+    /// the crossing because absorption does not stop (continuing to accumulate
+    /// is what lets the dictionary-level e-BH certificate clear its higher
+    /// multiplicity bar `ln(m/(α·k))`).
+    pub fn certified_at_step(&self) -> Option<usize> {
+        self.certified_at_step
     }
 
     /// Absorb one shard's split-likelihood ratio (see type-level contract).
@@ -398,7 +422,14 @@ impl AtomBirthGate {
         log_lik_null_sup_on_shard: f64,
     ) -> Result<(), String> {
         self.test
-            .try_absorb_batch(log_lik_alternative_prefit, log_lik_null_sup_on_shard)
+            .try_absorb_batch(log_lik_alternative_prefit, log_lik_null_sup_on_shard)?;
+        // Record the first-passage time once, the step the running sup first
+        // crosses the single-hypothesis bar. `rejects_at` reads the running
+        // maximum, so this latches permanently even if later evidence retreats.
+        if self.certified_at_step.is_none() && self.test.process.rejects_at(self.alpha) {
+            self.certified_at_step = Some(self.test.process.steps());
+        }
+        Ok(())
     }
 
     pub fn absorb_shard(
@@ -442,11 +473,31 @@ impl AtomBirthGate {
 ///
 /// `initial_alternative` is the K+1 fit from data BEFORE the stream (or a
 /// prior-driven init; validity never depends on its quality — a bad init
-/// only costs power). Stops absorbing early once certified (the crossing
-/// is permanent; further shards only cost compute), but still folds the
-/// remaining shards into the alternative so the returned state has seen
-/// the whole stream. Returns the gate (verdict + resumable evidence) and
-/// the final alternative state.
+/// only costs power). Absorbs EVERY shard's evidence into the e-process — it
+/// does NOT stop at the single-hypothesis Ville crossing. An earlier
+/// early-stop ("the crossing is permanent; further shards only cost compute")
+/// conflated two distinct bars:
+///   * the per-move VERDICT ([`AtomBirthGate::verdict`] via
+///     [`EProcess::rejects_at`]) tests the running SUPREMUM against the
+///     single-hypothesis bar `ln(1/α)`, where the crossing is indeed
+///     permanent and the realized crossing step is captured separately in
+///     [`AtomBirthGate::certified_at_step`]; but
+///   * the dictionary-level CERTIFICATE ([`StructureLedger::certify`] →
+///     [`e_benjamini_hochberg`]) consumes the CURRENT log e-value
+///     ([`EProcess::current_e_value_log`]) under a multiplicity correction
+///     whose bar `ln(m/(α·k))` is strictly higher for m > 1 claims.
+/// Stopping at the single-hypothesis bar banked just enough evidence for the
+/// move's own verdict but starved the FDR certificate, so a genuinely real
+/// atom (e.g. 0.8 nats/shard × 10 shards = 8 nats) failed e-BH confirmation
+/// against a second claim (bar `ln(2/0.05) ≈ 3.69`) even though it cleared
+/// its own `ln(1/0.05) ≈ 3.00` bar — it carried ample evidence but the early
+/// stop threw the surplus away. Continuing to absorb is always sound: the
+/// e-process is a supermartingale under H0, so additional
+/// conditionally-valid increments preserve validity, and the predictability
+/// contract is untouched (the alternative is still evaluated before it is
+/// refit with each shard). Returns the gate (verdict + resumable evidence,
+/// with `certified_at_step` holding the realized time-to-certification) and
+/// the final alternative state, which has seen the whole stream.
 pub fn run_atom_birth_gate<S, A>(
     alpha: f64,
     initial_alternative: A,
@@ -458,11 +509,9 @@ pub fn run_atom_birth_gate<S, A>(
     let mut gate = AtomBirthGate::new(alpha)?;
     let mut alt = initial_alternative;
     for shard in shards {
-        if !matches!(gate.verdict(), GateVerdict::Certified { .. }) {
-            let log_lik_alt = alternative_log_lik(&alt, &shard);
-            let log_lik_null = null_sup_log_lik(&shard);
-            gate.try_absorb_shard(log_lik_alt, log_lik_null)?;
-        }
+        let log_lik_alt = alternative_log_lik(&alt, &shard);
+        let log_lik_null = null_sup_log_lik(&shard);
+        gate.try_absorb_shard(log_lik_alt, log_lik_null)?;
         alt = refit_alternative(alt, &shard);
     }
     Ok((gate, alt))
@@ -1207,34 +1256,46 @@ mod tests {
     }
 
     /// POWER STUDY, alternative side, through the orchestration harness:
-    /// a planted K+1-th atom worth 0.5 nats/shard certifies in
-    /// ⌈log(1/α)/0.5⌉ = 6 shards — matching the design-time
-    /// `expected_resolution_budget` — after which the gate stops absorbing
-    /// (the crossing is permanent) while the alternative keeps refitting
-    /// on the remaining shards.
+    /// a planted K+1-th atom worth 0.5 nats/shard CROSSES the single-hypothesis
+    /// Ville bar in ⌈log(1/α)/0.5⌉ = 6 shards — the realized
+    /// time-to-certification matching the design-time
+    /// `expected_resolution_budget`. The gate keeps absorbing past the
+    /// crossing (the crossing time is latched in `certified_at_step`, so it is
+    /// not lost), banking the full stream's evidence — which is exactly what
+    /// the dictionary-level e-BH certificate needs to clear its higher
+    /// multiplicity bar. The alternative refits on every shard regardless.
     #[test]
     fn power_study_planted_atom_certifies_at_the_predicted_budget() {
         let growth = 0.5f64;
+        let n_shards = 20usize;
         let (gate, alt_state) = run_atom_birth_gate(
             0.05,
             0usize, // alt state = number of shards folded into the fit
-            0..20usize,
+            0..n_shards,
             |_, _| -99.5, // prefit alternative log-lik on the shard
             |_| -100.0,   // honest null sup on the shard
             |folded, _| folded + 1,
         )
         .expect("valid alpha");
 
+        // Full-stream evidence is banked: 0.5 nats/shard × 20 shards = 10 nats,
+        // far past the single-hypothesis bar — this surplus is what the e-BH
+        // dictionary certificate consumes against its `ln(m/(α·k))` bar.
         match gate.verdict() {
-            GateVerdict::Certified { log_e } => assert!((log_e - 3.0).abs() < 1e-12),
+            GateVerdict::Certified { log_e } => {
+                assert!((log_e - growth * n_shards as f64).abs() < 1e-12)
+            }
             v => panic!("planted atom must certify, got {v:?}"),
         }
-        // Realized time-to-certification == the design-time budget, rounded up.
+        // Realized time-to-certification (first-passage of the running sup over
+        // `ln(1/α)`) == the design-time budget, rounded up.
         let budget = expected_resolution_budget(0.05, growth).expect("budget");
-        assert_eq!(gate.test.process.steps(), budget.ceil() as usize);
-        assert_eq!(gate.test.process.steps(), 6);
-        // The alternative state saw the whole stream despite early stopping.
-        assert_eq!(alt_state, 20);
+        assert_eq!(gate.certified_at_step(), Some(budget.ceil() as usize));
+        assert_eq!(gate.certified_at_step(), Some(6));
+        // Absorption does NOT stop at the crossing: every shard is banked.
+        assert_eq!(gate.test.process.steps(), n_shards);
+        // The alternative state saw the whole stream.
+        assert_eq!(alt_state, n_shards);
     }
 
     /// Work-plan step 4, closed end-to-end: a contested claim gets a probe


### PR DESCRIPTION
## Unblock RED main: six independently-verified pre-existing unit failures

This branch fixes six classes of pre-existing RED-main unit failures across
`gam-solve`, `gam-terms`, and `gam-sae`. Every root cause was reproduced and
verified numerically (not taken on faith from a comment or a subagent claim),
and no test guard was weakened — where production genuinely improved, the
*expectation* was tightened to match. Rebased clean onto current `main`; two
earlier commits (ρ.`log_lambda_smooth` grow, born-atom topology REML) were
dropped during rebase because `main` had independently absorbed equivalents.

### Commits

1. **`run_plan` — un-stale 5 fixtures.** Interior-extreme promotion, GLM budget
   floor, probe cache, and direct startup-eval expectations had drifted from the
   current screening/seed-ordering production. Updated to the true contract
   (`arc_cost_stall_guard…`, `bfgs_bridge_halts…`, `cached_rho_is_prepended…`,
   `initial_rho_with_single_seed_budget…`, the two `run_screening_reorders…`).

2. **`seeding` (#1266) — probe the adjacent-pair over-smoothing corner from the
   baseline anchor too.** The asymmetric corner (one term's pair railed to the
   bound, the rest interior) was only probed off `best_seed`; now also anchored
   on the baseline. Verified by
   `objective_grid_can_seed_adjacent_pair_oversmoothing_corner`.

3. **e-process certificate — remove the early-stop that starved the e-BH
   dictionary certificate.** The structure-evidence power study could not certify
   a planted atom at the predicted budget because an e-process early-stop fired
   first. Verified by `power_study_planted_atom_certifies_at_the_predicted_budget`.

4. **Operator-path outer-Hessian adjoint must solve with the FULL `H⁻¹`, not the
   projected pseudo-inverse.** On the rank-deficient LAML / penalty-subspace
   path the matrix-free operator diverged from the dense materialisation at
   ~5th digit. The scalar-GLM IFT correction trace is
   `tr(K·C[β̈]) = β̈ᵀXᵀ(c⊙h^{G,proj})` where the second-mode response
   `β̈ = H⁻¹·rhs` is a full-β IFT stationarity derivative — the projection enters
   ONLY through the leverage `h^{G,proj}`, never the solve. `compute_adjoint_z_c`
   wrongly routed the subspace regime through `K·Xᵀ(…)`. Verified by
   `test_compute_adjoint_z_c_streaming_matches_dense_reference`,
   `projected_operator_hessian_matches_dense_subspace_trace`, and
   `outer_hessian_operator_matvec_matches_dense_subspace_with_null_alpha`.

5. **KKT Hessian correction missed the log-λ diagonal self-derivative.** The
   correction `C(θ) = −½ rᵀKr` dropped the second self-derivative `δ_ij·Cᵢ` on
   the diagonal. For ρ coordinates `λ=exp(ρ)` ⇒ `∂_ρr=r`, `∂_ρA=A`, which
   collapses the bracket to exactly `Cᵢ`; affine/frozen (ψ/ext) coordinates get
   no such term. Gated by a new `exponential_self_coupling[i]` flag (true for ρ,
   false for ψ/ext). Verified against a finite-difference ground truth for both
   the ρ fixture (term must be present) and the affine fixture (term must be
   absent). Verified by `ift_correction_recovers_fd_hessian_at_perturbed_beta`
   and the three sibling IFT/KKT tests.

6. **gam-sae #577/#579 — honor the inner-state FREEZE in the #1026 decoder
   polish.** The EV-gated decoder-LSQ polish ran unconditionally, including at
   `max_iter == 0` (the verbatim warm-start FREEZE), silently overwriting the
   seeded β with the cold data-optimal refit and defeating the continuation
   warm-start reuse. Gated the polish on `max_iter > 0`; the real-fit path is
   byte-for-byte unchanged. Verified by
   `seed_inner_state_installs_and_reuses_matching_beta`.

### Verification

All targeted contracts pass on the rebased tree (`./build.sh nextest run`):
the 4 IFT/KKT tests, 3 operator-path tests, 7 run_plan/seeding tests, the
e-process power-study test, and the 2 gam-sae freeze/layout tests — 16/16 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
