### PR TITLE
fix(#1690): re-certify Gamma flat-valley REML stall as converged + skip wasted ARC replay

### DIFF
--- a/crates/gam-solve/src/estimate/optimizer.rs
+++ b/crates/gam-solve/src/estimate/optimizer.rs
@@ -2546,6 +2546,57 @@ where
         outer_result.final_grad_norm.unwrap_or(0.0)
     };
 
+    // #1690: reconcile the convergence flag with the AUTHORITATIVE gradient of the
+    // fit we actually ship.
+    //
+    // `outer_result.converged` was decided by the in-loop cost-stall guard from
+    // the projected gradient it saw at the best-by-cost iterate DURING the ρ
+    // search. On a family whose dispersion is profiled into the inner working
+    // weight (Gamma log-link re-estimates the shape every solve) that reading is
+    // warm-start sensitive: at a weakly-identified flat ρ-valley the inner P-IRLS
+    // fixed point — and therefore the analytic ρ-gradient — depends on the β the
+    // solve started from. The guard can then halt `converged=false` on a point
+    // that is in fact stationary, because the gradient it sampled mid-search sat
+    // just above the score-relative bound. The accept-fit above (line ~2034,
+    // `refine_dispersion=true`) lands on the β actually reported and
+    // `compute_gradient` re-measures the ρ-gradient there — this `finalgrad_norm`
+    // is the value surfaced as `outer_gradient_norm`. When that authoritative
+    // gradient clears the SAME score-relative stationarity bound the in-loop guard
+    // uses (`FLAT_VALLEY_CONVERGED_REL_GRAD·(1+|score|)`, capped at
+    // `FLAT_VALLEY_CONVERGED_ABS_GRAD_CAP`), the halt was a false negative: certify
+    // converged. A genuinely non-stationary valley floor — and the #1426 stuck
+    // overfit, whose honest |g|≈11 ≫ bound — never clears it, so its
+    // non-convergence stands. The reconciliation is gated on the flat-valley stop
+    // reason so no other non-convergence path (max-iters, line-search collapse) is
+    // affected.
+    let outer_converged = {
+        let mut converged = outer_result.converged;
+        if !converged
+            && matches!(
+                outer_result.operator_stop_reason,
+                Some(crate::rho_optimizer::OperatorTrustRegionStopReason::CostStallFlatValley)
+            )
+            && finalgrad_norm.is_finite()
+        {
+            let score_relative_bound = (crate::rho_optimizer::FLAT_VALLEY_CONVERGED_REL_GRAD
+                * (1.0 + outer_result.final_value.abs()))
+            .min(crate::rho_optimizer::FLAT_VALLEY_CONVERGED_ABS_GRAD_CAP);
+            if finalgrad_norm <= score_relative_bound {
+                log::info!(
+                    "[OUTER] flat-valley cost-stall RE-CERTIFIED converged: the authoritative \
+                     gradient at the shipped θ̂ (|g|={:.3e}) clears the score-relative \
+                     stationarity bound ({:.3e}); the in-loop halt rode on a warm-start-sensitive \
+                     gradient readout on a flat ρ-valley (score={:.6e}).",
+                    finalgrad_norm,
+                    score_relative_bound,
+                    outer_result.final_value,
+                );
+                converged = true;
+            }
+        }
+        converged
+    };
+
     if opts.compute_inference {
         penalized_hessian = map_hessian_to_original_basis(&pirls_res)?;
         let p_cov = penalized_hessian.nrows();
@@ -2857,7 +2908,7 @@ where
         standard_deviation,
         iterations: iters,
         finalgrad_norm,
-        outer_converged: outer_result.converged,
+        outer_converged,
         pirls_status,
         deviance: pirls_res.deviance,
         stable_penalty_term: pirls_res.stable_penalty_term,

--- a/crates/gam-solve/src/rho_optimizer/run.rs
+++ b/crates/gam-solve/src/rho_optimizer/run.rs
@@ -1582,7 +1582,26 @@ pub(crate) fn run_outer_uncertified(
                         || arc_retries_left == 0
                         || matches!(
                             result.operator_stop_reason,
-                            Some(OperatorTrustRegionStopReason::RejectFloor)
+                            Some(
+                                OperatorTrustRegionStopReason::RejectFloor
+                                    // #1690: a flat-valley cost-stall is a CONVERGED
+                                    // cost plateau over the whole stall window, not a
+                                    // budget shortfall. The ARC retry only reseeds
+                                    // from the same last ρ with a reset trust radius
+                                    // and the same deterministic operator state, so it
+                                    // replays the identical trajectory and re-halts at
+                                    // the same valley floor with the same |g| (verified
+                                    // on the #1690 Gamma repro: two retries, each
+                                    // returning |g|=0.3646 byte-for-byte). Treat it
+                                    // like `RejectFloor` and stop — the genuine
+                                    // stationarity verdict is reconciled downstream
+                                    // against the authoritative shipped-β gradient
+                                    // (`optimizer.rs`), and a non-stationary floor is
+                                    // still reported non-converged. This skips the
+                                    // wasted full-trajectory replay that dominated the
+                                    // count-family slowdown.
+                                    | OperatorTrustRegionStopReason::CostStallFlatValley
+                            )
                         )
                     {
                         break Ok(result);

--- a/tests/perf_scale/families/mod.rs
+++ b/tests/perf_scale/families/mod.rs
@@ -1,1 +1,2 @@
 mod pirls_gradient_finite_difference_cross_family;
+mod poisson_gamma_outer_work_1690;

--- a/tests/perf_scale/families/poisson_gamma_outer_work_1690.rs
+++ b/tests/perf_scale/families/poisson_gamma_outer_work_1690.rs
@@ -1,0 +1,115 @@
+//! Diagnostic + regression harness for #1690 — Poisson (~28x) / Gamma (~7x)
+//! 1-D `s(x)` REML fits much slower than mgcv at equal accuracy.
+//!
+//! This file reproduces the issue's exact data-generating process at the Rust
+//! `fit_from_formula` level (n=600, single P-spline smooth, log link, REML +
+//! double penalty) and records the outer-loop work metrics (`outer_cost_evals`,
+//! `inner_pirls_solves`) for both families. The Poisson/Gamma path is
+//! structurally identical (same closed-form log-link inner kernel, same
+//! `DispersionHandling::Fixed` objective, no Firth), so any per-family
+//! wall-clock gap is an outer-iteration-count / surface-conditioning artifact,
+//! not extra coded work.
+//!
+//! The asserted contract is correctness + a coarse outer-work upper bound that
+//! trips if the count-family outer loop blows up. It does NOT depend on
+//! R / mgcv.
+
+use gam::{FitConfig, FitResult, encode_recordswith_inferred_schema, fit_from_formula};
+use csv::StringRecord;
+use rand::SeedableRng;
+use rand::rngs::StdRng;
+use rand_distr::{Distribution, Gamma, Poisson, Uniform};
+
+/// Mirror the issue's repro: `mu = exp(1 + sin(5x))`, x ~ U(0,1), n=600.
+/// Poisson draws counts; Gamma draws shape=4 positive-continuous with the same
+/// mean surface.
+fn build_data(family: &str, seed: u64) -> (Vec<f64>, Vec<f64>) {
+    let n = 600usize;
+    let mut rng = StdRng::seed_from_u64(seed);
+    let ux = Uniform::new(0.0, 1.0).expect("uniform 0..1");
+    let mut x = Vec::with_capacity(n);
+    let mut y = Vec::with_capacity(n);
+    for _ in 0..n {
+        let xi: f64 = ux.sample(&mut rng);
+        let mu = (1.0 + (5.0 * xi).sin()).exp();
+        let yi = if family == "poisson" {
+            let p = Poisson::new(mu).expect("poisson mean > 0");
+            p.sample(&mut rng)
+        } else {
+            // Gamma(shape=4, scale=mu/4) => mean = mu.
+            let g = Gamma::new(4.0, mu / 4.0).expect("gamma(shape,scale)");
+            g.sample(&mut rng)
+        };
+        x.push(xi);
+        y.push(yi);
+    }
+    (x, y)
+}
+
+#[test]
+fn poisson_gamma_single_smooth_outer_work_1690() {
+    gam::init_parallelism();
+    gam::progress_log::init_logging();
+
+    for family in ["poisson", "gamma"] {
+        let (x, y) = build_data(family, 0);
+        let n = x.len();
+        let headers: Vec<String> = ["y", "x"].into_iter().map(String::from).collect();
+        let rows: Vec<StringRecord> = (0..n)
+            .map(|i| StringRecord::from(vec![y[i].to_string(), x[i].to_string()]))
+            .collect();
+        let ds = encode_recordswith_inferred_schema(headers, rows).expect("encode dataset");
+
+        let cfg = FitConfig {
+            family: Some(family.to_string()),
+            ..FitConfig::default()
+        };
+        // k=12 P-spline, matching the mgcv arm `s(x, bs="ps", k=12)`.
+        let result = fit_from_formula("y ~ s(x, k=12)", &ds, &cfg)
+            .expect("single-smooth REML fit must succeed");
+        let FitResult::Standard(fit) = result else {
+            panic!("expected a standard GAM fit for {family}");
+        };
+        let fit = fit.fit;
+
+        assert!(fit.reml_score.is_finite(), "{family}: reml_score finite");
+        assert!(
+            fit.beta.iter().all(|b| b.is_finite()),
+            "{family}: beta finite"
+        );
+        let edf = fit
+            .edf_total()
+            .unwrap_or_else(|| panic!("{family}: inference EDF present"));
+        assert!(
+            edf.is_finite() && edf > 0.0,
+            "{family}: edf finite positive (got {edf})"
+        );
+
+        eprintln!(
+            "RECORD_1690 family={family} reml_score={:.10} edf={:.6} \
+             outer_cost_evals={} inner_pirls_solves={} grad_norm={:?} converged={}",
+            fit.reml_score,
+            edf,
+            fit.outer_cost_evals,
+            fit.inner_pirls_solves,
+            fit.outer_gradient_norm,
+            fit.outer_converged,
+        );
+
+        assert!(
+            fit.outer_converged,
+            "{family}: outer REML optimizer must certify convergence"
+        );
+
+        // Coarse outer-work upper bound. A plain 1-parameter smooth must not
+        // explode the outer loop. The seed-grid prepass for k=1 evaluates ~10-20
+        // grid points; with screening + multistart + ARC Newton the genuine
+        // full-n inner solves should stay well under 120. This trips if the
+        // count-family outer loop regresses toward the binomial-class blow-up.
+        assert!(
+            fit.inner_pirls_solves > 0 && fit.inner_pirls_solves < 400,
+            "{family}: inner_pirls_solves={} outside (0,400) — outer-work regression",
+            fit.inner_pirls_solves
+        );
+    }
+}

--- a/tests/perf_scale/families/poisson_gamma_outer_work_1690.rs
+++ b/tests/perf_scale/families/poisson_gamma_outer_work_1690.rs
@@ -101,14 +101,42 @@ fn poisson_gamma_single_smooth_outer_work_1690() {
             "{family}: outer REML optimizer must certify convergence"
         );
 
-        // Coarse outer-work upper bound. A plain 1-parameter smooth must not
-        // explode the outer loop. The seed-grid prepass for k=1 evaluates ~10-20
-        // grid points; with screening + multistart + ARC Newton the genuine
-        // full-n inner solves should stay well under 120. This trips if the
-        // count-family outer loop regresses toward the binomial-class blow-up.
+        // #1690 stationarity contract: a fit that reports `outer_converged` must
+        // carry an authoritative outer gradient that actually clears the
+        // score-relative stationarity bound the optimizer certifies against
+        // (`FLAT_VALLEY_CONVERGED_REL_GRAD·(1+|score|)`, capped at
+        // `FLAT_VALLEY_CONVERGED_ABS_GRAD_CAP` — mirrored here as 1e-3 / 1.0).
+        // This is the heart of the bug: the Gamma fit reached the optimum
+        // (|g|=0.2297 < bound≈0.330) but was mislabelled non-converged off a noisy
+        // in-loop gradient readout. Asserting the reported gradient clears the
+        // bound locks the fix to a real stationarity certificate, not a flag flip.
+        let grad_norm = fit
+            .outer_gradient_norm
+            .unwrap_or_else(|| panic!("{family}: converged fit must report an outer gradient norm"));
+        let score_relative_bound = (1.0e-3 * (1.0 + fit.reml_score.abs())).min(1.0);
         assert!(
-            fit.inner_pirls_solves > 0 && fit.inner_pirls_solves < 400,
-            "{family}: inner_pirls_solves={} outside (0,400) — outer-work regression",
+            grad_norm.is_finite() && grad_norm <= score_relative_bound,
+            "{family}: converged fit reports |g|={grad_norm:.6e} that does NOT clear the \
+             score-relative stationarity bound {score_relative_bound:.6e} (score={:.6}) — \
+             a converged flag without a stationarity certificate",
+            fit.reml_score,
+        );
+
+        // Outer-work upper bound. A plain 1-parameter smooth must not explode the
+        // outer loop. The dominant cost is the family-agnostic #1033 seed-grid
+        // prepass + multistart (~80 full-n solves on the first attempt); the
+        // genuine optimization adds a few dozen more. The #1690 fix removes the
+        // wasted deterministic-replay ARC retry that a false flat-valley
+        // non-convergence used to trigger (each replay re-ran the full attempt
+        // trajectory: Gamma dropped 146 → 128 solves once the retry was skipped).
+        // A bound of 200 sits comfortably above the genuine ~128 yet well below
+        // the ~190+ a single wasted full-attempt replay would push it back to, so
+        // this trips if the retry-skip (or the convergence reconciliation that
+        // makes it reachable) regresses.
+        assert!(
+            fit.inner_pirls_solves > 0 && fit.inner_pirls_solves < 200,
+            "{family}: inner_pirls_solves={} outside (0,200) — outer-work regression \
+             (a wasted flat-valley ARC replay may have returned)",
             fit.inner_pirls_solves
         );
     }


### PR DESCRIPTION
## Issue

#1690 — Poisson (~28x) and Gamma (~7x) 1-D `s(x)` REML fits much slower than mgcv at equal accuracy.

This PR fixes the **actionable Gamma-specific slice**: a false non-convergence that also triggered wasted deterministic-replay ARC retries. (The dominant family-agnostic per-solve cost — the #1033 seed-grid prepass / multistart — is load-bearing and tracked separately under #1033.)

## Root cause

The Gamma single-smooth `s(x,k=12)` n=600 REML fit reaches the genuine optimum (ρ≈[-1.367, 7.533], score=329.259) but reported `outer_converged=false`.

The in-loop cost-stall guard decides `converged` from the projected gradient it samples at the **best-by-cost iterate during the ρ search**. The Gamma log-link profiles the dispersion shape into the inner working weight, so at a weakly-identified flat ρ-valley the inner P-IRLS fixed point — and therefore the analytic ρ-gradient — is **warm-start sensitive**. The guard sampled `|g|=0.3646` (just above the `0.330` score-relative bound) and halted non-converged.

But the accept-fit's **authoritative** gradient, re-measured at the shipped (refined-dispersion) β — the value reported as `outer_gradient_norm` — is `|g|=0.2297 < 0.330`. The point IS stationary. Poisson (canonical link, `W=μ` gives curvature) never hits this and converges at `|g|≈1e-6`.

The false non-convergence then fired the ARC retry gate **twice**, each replaying the full ARC trajectory from the same flat-valley ρ and re-halting with the same `|g|=0.3646` byte-for-byte — pure wasted inner solves.

## Fixes

1. **`optimizer.rs`** — reconcile `outer_converged` against the authoritative gradient of the fit actually shipped. When a `CostStallFlatValley` halt's `finalgrad_norm` clears the *same* score-relative bound the in-loop guard uses (`FLAT_VALLEY_CONVERGED_REL_GRAD·(1+|score|)`, capped at `FLAT_VALLEY_CONVERGED_ABS_GRAD_CAP`), certify converged. Gated strictly on the flat-valley stop reason. A genuinely non-stationary floor — and the #1426 stuck overfit (honest `|g|≈11 ≫ bound`) — never clears it, so its non-convergence stands.

2. **`run.rs`** — treat `CostStallFlatValley` like `RejectFloor` in the ARC retry gate. A flat-valley stall is a converged cost plateau over the whole window; the retry only reseeds from the same last ρ with reset trust radius and identical deterministic operator state, so it replays the trajectory and re-halts at the same floor. Skipping it eliminates the wasted replay.

## Verification

`tests/perf_scale/families/poisson_gamma_outer_work_1690.rs` reproduces the issue DGP (n=600, log link, REML + double penalty) for both families and asserts `outer_converged`.

Before: `family=gamma … inner_pirls_solves=146 grad_norm=0.2297 converged=false` (test fails).
After:  `family=gamma … inner_pirls_solves=128 grad_norm=0.2297 converged=true` (test passes).

Same `reml_score` (329.2589734249) and `edf` (6.6989) — identical fit, now correctly certified, with the wasted retry's ~18 inner solves removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)