### PR TITLE
[agent] fix RED-on-main joint-Newton weak-band test (boundary mis-parameterization)

### DIFF
--- a/crates/gam-custom-family/src/joint_newton.rs
+++ b/crates/gam-custom-family/src/joint_newton.rs
@@ -3087,9 +3087,13 @@ mod trust_region_subproblem_tests {
     #[test]
     pub(crate) fn weakly_identified_real_mode_blocks_premature_certification() {
         // λ_max = 1, p = 2 ⇒ numerical_floor = 1·√2·ε ≈ 3.1e-16,
-        // null_cutoff = max(rank_tol·1, floor) = rank_tol (≈ 1e-7).
-        // γ = 1e-10 is in the WEAK band: above numerical_floor, below null_cutoff.
-        let h = array![[1.0, 0.0], [0.0, 1e-10]];
+        // null_cutoff = max(rank_tol·λ_max, floor) = KKT_REFUSAL_RANK_TOL = 1e-10.
+        // γ = 1e-12 is in the WEAK band: above numerical_floor, below null_cutoff.
+        // (γ must sit STRICTLY below null_cutoff — a γ placed *at* the 1e-10
+        // cutoff lands on the `|γ| <= null_cutoff` boundary, where eigh round-off
+        // can return it marginally above and the raw decrement would wrongly keep
+        // it, inflating the decrement to c²/(2γ) instead of excluding the mode.)
+        let h = array![[1.0, 0.0], [0.0, 1e-12]];
         let rhs = array![1.0, 0.5];
         let d = array![1.0, 1.0];
         let spec = WhitenedHessianSpectrum::decompose(&h, &rhs, &d, KKT_REFUSAL_RANK_TOL).unwrap();
@@ -3101,7 +3105,7 @@ mod trust_region_subproblem_tests {
             "raw decrement excludes the weak mode; got {raw}"
         );
 
-        // ...but its real achievable improvement c²/(2γ) = 0.25/(2·1e-10) is huge,
+        // ...but its real achievable improvement c²/(2γ) = 0.25/(2·1e-12) is huge,
         // so the conditioning-robust decrement is large and blocks the certificate.
         let weak = spec.weakly_identified_decrement();
         assert!(


### PR DESCRIPTION
## Fixes a RED-on-main unit test (found while regression-checking #901/#855)

`gam-custom-family` test `joint_newton::trust_region_subproblem_tests::weakly_identified_real_mode_blocks_premature_certification` fails on clean `main`:

```
raw decrement excludes the weak mode; got 1249999897.074545
```

### Root cause — test mis-parameterization, not a code regression

The test's setup comment claims `null_cutoff = rank_tol ≈ 1e-7`. But the production constant is `KKT_REFUSAL_RANK_TOL = 1e-10` (verified unchanged since the constant was introduced — `git log -S` shows no other value ever existed). With `λ_max = 1`:

```
null_cutoff = max(rank_tol·λ_max, numerical_floor) = max(1e-10, √2·ε) = 1e-10
```

which is **exactly equal** to the chosen weak-mode curvature `γ = 1e-10`. The mode lands on the `|γ| <= null_cutoff` boundary, where the faer eigendecomposition returns it marginally above the cutoff, so `newton_decrement()` keeps it and returns `c²/(2γ) = 0.25/(2e-10) ≈ 1.25e9` instead of dropping it (expected `0.5`).

### Fix

Move the weak mode to `γ = 1e-12`, strictly inside the real weak band `(numerical_floor ≈ 3.1e-16, null_cutoff = 1e-10)` — exercising the intended "genuine-but-sub-cutoff curvature" path without sitting on the boundary — and correct the stale arithmetic in the comment. **Production code is untouched.**

All 10 `trust_region_subproblem_tests` pass; the change is test-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
