### PR TITLE
[agent][gpu] register the dense-GEMM dispatch hook + transpose-free device GEMM

### DIFF
--- a/crates/gam-gpu/src/blas.rs
+++ b/crates/gam-gpu/src/blas.rs
@@ -22,7 +22,9 @@ pub fn blas_backend_status() -> super::CudaBackendStatus {
 mod cuda_impl {
     use ndarray::{Array1, Array2, Array3, ArrayView1, ArrayView2, ArrayView3, Axis};
 
-    use crate::driver::{from_col_major, to_col_major, to_i32};
+    use crate::driver::{
+        array_from_row_major, from_col_major, to_col_major, to_i32, to_row_major,
+    };
 
     use super::super::device_runtime::GpuRuntime;
     use cudarc::cublas::sys::{
@@ -572,35 +574,60 @@ mod cuda_impl {
             return None;
         }
         let (stream, blas) = stream_and_blas_for(ordinal)?;
-        let a_col = to_col_major(&a);
-        let b_col = to_col_major(&b);
-        let a_dev = stream.clone_htod(&*a_col).ok()?;
-        let b_dev = stream.clone_htod(&*b_col).ok()?;
+        // Host-transpose-free path. The row-major output buffer of
+        // `C = op(A)·op(B)` (shape m×n) is bit-identical to the column-major
+        // buffer of `Cᵀ = op(B)ᵀ·op(A)ᵀ` (shape n×m). A row-major buffer,
+        // reinterpreted column-major, is already the transpose of its logical
+        // matrix — so uploading `a`/`b` row-major (a borrow when C-contiguous)
+        // gives cuBLAS `Aᵀ`/`Bᵀ` for free, and downloading straight into a
+        // row-major `Array2` skips the result permutation too. This removes the
+        // two O(rows·cols) scalar `to_col_major`/`from_col_major` passes that
+        // dominated tall-skinny GEMMs (e.g. the 200000×200 Wahba design
+        // reduction) and made the device path slower than the host SIMD GEMM.
+        //
+        // Uploading the row-major buffer of an `(r×c)` array and declaring it
+        // column-major with leading dim `c` hands cuBLAS exactly that array's
+        // transpose (a `(c×r)` col-major matrix). So with
+        //   X = b's row-major buffer  → col-major X = bᵀ  (rows = b_cols),
+        //   Y = a's row-major buffer  → col-major Y = aᵀ  (rows = a_cols),
+        // cuBLAS's `out = opX(X)·opY(Y)` yields `Cᵀ` when
+        //   opX = trans_b ? T : N,   opY = trans_a ? T : N,
+        //   (M,N,K) = (n, m, k),   lda = b_cols, ldb = a_cols, ldc = n.
+        // The column-major `Cᵀ` buffer (n rows) is bit-identical to the
+        // row-major `C` buffer (m×n), so the download wraps with no permute.
+        let b_rm = to_row_major(&b);
+        let a_rm = to_row_major(&a);
+        let x_dev = stream.clone_htod(&*b_rm).ok()?;
+        let y_dev = stream.clone_htod(&*a_rm).ok()?;
         let mut out_dev = stream.alloc_zeros::<f64>(m.checked_mul(n)?).ok()?;
         let cfg = GemmConfig::<f64> {
-            transa: if trans_a {
+            transa: if trans_b {
                 cublasOperation_t::CUBLAS_OP_T
             } else {
                 cublasOperation_t::CUBLAS_OP_N
             },
-            transb: if trans_b {
+            transb: if trans_a {
                 cublasOperation_t::CUBLAS_OP_T
             } else {
                 cublasOperation_t::CUBLAS_OP_N
             },
-            m: to_i32(m)?,
-            n: to_i32(n)?,
+            m: to_i32(n)?,
+            n: to_i32(m)?,
             k: to_i32(k_a)?,
             alpha: 1.0,
-            lda: to_i32(a_rows)?,
-            ldb: to_i32(b_rows)?,
+            // Leading dim of each physically-stored col-major operand =
+            // its row count: B̌ has `b_cols` rows, Ǎ has `a_cols` rows.
+            lda: to_i32(b_cols)?,
+            ldb: to_i32(a_cols)?,
             beta: 0.0,
-            ldc: to_i32(m)?,
+            ldc: to_i32(n)?,
         };
-        // SAFETY: buffers are column-major with dimensions validated above.
-        unsafe { blas.gemm(cfg, &a_dev, &b_dev, &mut out_dev) }.ok()?;
-        let out_col = stream.clone_dtoh(&out_dev).ok()?;
-        from_col_major(&out_col, m, n)
+        // SAFETY: dims validated above; buffers carry exactly the row counts
+        // declared as leading dimensions.
+        unsafe { blas.gemm(cfg, &x_dev, &y_dev, &mut out_dev) }.ok()?;
+        // `out_dev` is `Cᵀ` column-major == `C` row-major: wrap with no permute.
+        let out_rm = stream.clone_dtoh(&out_dev).ok()?;
+        array_from_row_major(out_rm, m, n)
     }
 
     /// Broadcast-B batched GEMM on a specific device ordinal. The caller

--- a/crates/gam-gpu/src/device_runtime.rs
+++ b/crates/gam-gpu/src/device_runtime.rs
@@ -216,14 +216,34 @@ impl GpuRuntime {
     pub fn global() -> Option<&'static Self> {
         static RUNTIME: OnceLock<Option<GpuRuntime>> = OnceLock::new();
         RUNTIME
-            .get_or_init(|| match Self::probe() {
-                Ok(runtime) => runtime,
-                Err(err) => {
-                    let reason = err.to_string();
-                    Self::record_cpu_reason(reason.clone());
-                    diagnostics::log_cuda_disabled(&reason);
-                    None
+            .get_or_init(|| {
+                let runtime = match Self::probe() {
+                    Ok(runtime) => runtime,
+                    Err(err) => {
+                        let reason = err.to_string();
+                        Self::record_cpu_reason(reason.clone());
+                        diagnostics::log_cuda_disabled(&reason);
+                        None
+                    }
+                };
+                // Install the dense-GEMM dispatch hook exactly when a usable
+                // device was probed. Without this, `gam_linalg::faer_ndarray::fast_ab`
+                // (and the `fast_atb`/`fast_av`/`xt_diag_x` family) never sees a
+                // dispatcher — `gpu_dispatch()` stays `None` — so every dense
+                // product in the engine silently runs on the CPU even when the
+                // V100 is present and the workload clears the policy flop floor.
+                // The hook is a first-write-wins `OnceLock` keyed only on the
+                // presence of a runtime; registering it here, inside the same
+                // `get_or_init` that decides the runtime, guarantees it is
+                // installed before any `fast_ab` caller can observe a `Some`
+                // runtime. The policy gate inside each `try_*` still decides
+                // CPU-vs-GPU per call, so small products are unaffected.
+                if runtime.is_some() {
+                    gam_linalg::gpu_hook::register_gpu_dispatch(Box::new(
+                        super::linalg_dispatch::CudaGemmDispatch,
+                    ));
                 }
+                runtime
             })
             .as_ref()
     }

--- a/crates/gam-gpu/src/driver.rs
+++ b/crates/gam-gpu/src/driver.rs
@@ -539,6 +539,48 @@ pub fn to_col_major<'a, S: Data<Elem = f64>>(a: &'a ArrayBase<S, Ix2>) -> Cow<'a
     Cow::Owned(out)
 }
 
+/// Borrow (or pack) a 2D array's buffer in ROW-major (C) order.
+///
+/// The col-major dual of [`to_col_major`]: when the input is already
+/// C-contiguous its raw buffer IS the row-major flat layout, so this borrows
+/// it with no allocation or copy. Non-contiguous / F-order inputs are packed
+/// row by row.
+///
+/// This is the host-transpose-free upload path. A row-major `(r × c)` buffer,
+/// reinterpreted as a column-major buffer, is exactly the transpose `(c × r)`
+/// of the logical matrix — which is what the swapped-operand cuBLAS GEMM
+/// (`Cᵀ = Bᵀ·Aᵀ`) consumes, letting both the design upload and the result
+/// download skip the O(r·c) scalar permutation that dominated tall-skinny
+/// GEMMs on the host.
+pub fn to_row_major<'a, S: Data<Elem = f64>>(a: &'a ArrayBase<S, Ix2>) -> Cow<'a, [f64]> {
+    let (rows, cols) = a.dim();
+    let strides = a.strides();
+    // C-order contiguous: row stride == cols, column stride == 1.
+    if rows > 0
+        && cols > 0
+        && strides[1] == 1
+        && strides[0] == cols as isize
+        && let Some(slice) = a.as_slice_memory_order()
+    {
+        return Cow::Borrowed(slice);
+    }
+    let mut out: Vec<f64> = Vec::with_capacity(rows.saturating_mul(cols));
+    for row in 0..rows {
+        out.extend(a.row(row).iter().copied());
+    }
+    Cow::Owned(out)
+}
+
+/// Wrap a row-major flat buffer of shape `(rows, cols)` as an `Array2<f64>`
+/// without permutation. The buffer is consumed (no copy when its length
+/// matches). Returns `None` on a length mismatch.
+pub fn array_from_row_major(values: Vec<f64>, rows: usize, cols: usize) -> Option<Array2<f64>> {
+    if values.len() != rows.checked_mul(cols)? {
+        return None;
+    }
+    Array2::from_shape_vec((rows, cols), values).ok()
+}
+
 /// Convert a column-major flat buffer back into row-major `Array2<f64>`.
 pub fn from_col_major_inplace(values: &[f64], out: &mut Array2<f64>) -> Option<()> {
     let (rows, cols) = out.dim();

--- a/crates/gam-gpu/src/linalg_dispatch.rs
+++ b/crates/gam-gpu/src/linalg_dispatch.rs
@@ -891,7 +891,7 @@ pub fn try_solve_upper_triangular_matrix(
 
 #[cfg(test)]
 mod tests {
-    use super::{DispatchOp, route_through_gpu};
+    use super::{DispatchOp, route_through_gpu, try_fast_ab};
     use crate::device_runtime::GpuRuntime;
 
     #[test]
@@ -938,6 +938,149 @@ mod tests {
             route_through_gpu(batched_potrf).is_some(),
             "uniform SAE row blocks should reach the small-dense batched POTRF gate"
         );
+    }
+
+    /// Touching `GpuRuntime::global()` must install the dense-GEMM dispatch
+    /// hook into `gam_linalg`, so a profitable `fast_ab` call routes through
+    /// the device — and the device result must match the CPU oracle within
+    /// IEEE reduction tolerance. This is the regression guard for the bug
+    /// where `CudaGemmDispatch` existed but `register_gpu_dispatch` was never
+    /// called, leaving every engine GEMM silently on the CPU.
+    #[test]
+    fn global_runtime_installs_fast_ab_hook_and_matches_cpu() {
+        use ndarray::Array2;
+
+        let Some(_runtime) = GpuRuntime::global() else {
+            eprintln!("[fast_ab hook] no CUDA runtime - skipping engagement check");
+            return;
+        };
+        // After `global()` returned `Some`, the hook MUST be installed.
+        assert!(
+            gam_linalg::gpu_hook::gpu_dispatch().is_some(),
+            "GpuRuntime::global() returned a device but did not register the \
+             dense-GEMM dispatch hook — fast_ab would silently stay on the CPU"
+        );
+
+        // A profitable GEMM (m=n=k=512 → 2·512³ ≈ 268 MFLOP, above the
+        // 100 MFLOP policy floor) must route to the device. Kept modest so
+        // the debug-build CPU oracle below stays a few seconds, not a minute.
+        let (m, k, n) = (512usize, 512usize, 512usize);
+        assert!(
+            route_through_gpu(DispatchOp::Gemm { m, n, k }).is_some(),
+            "a 268 MFLOP GEMM must clear the policy floor and route to GPU"
+        );
+
+        // Deterministic, well-conditioned operands.
+        let a = Array2::<f64>::from_shape_fn((m, k), |(i, j)| {
+            ((i * 7 + j * 3) % 13) as f64 * 0.01 - 0.06
+        });
+        let b = Array2::<f64>::from_shape_fn((k, n), |(i, j)| {
+            ((i * 5 + j * 11) % 17) as f64 * 0.01 - 0.08
+        });
+
+        // Device result via the dispatch entry point.
+        let gpu = try_fast_ab(a.view(), b.view())
+            .expect("profitable GEMM must produce a device result once admitted");
+
+        // CPU oracle (plain triple loop — independent of faer/matrixmultiply).
+        let mut cpu = Array2::<f64>::zeros((m, n));
+        for i in 0..m {
+            for j in 0..n {
+                let mut acc = 0.0f64;
+                for p in 0..k {
+                    acc += a[[i, p]] * b[[p, j]];
+                }
+                cpu[[i, j]] = acc;
+            }
+        }
+
+        let mut max_abs = 0.0f64;
+        for i in 0..m {
+            for j in 0..n {
+                max_abs = max_abs.max((gpu[[i, j]] - cpu[[i, j]]).abs());
+            }
+        }
+        assert!(
+            max_abs < 1e-9,
+            "device GEMM disagreed with the CPU oracle: max|Δ| = {max_abs:e}"
+        );
+    }
+
+    /// The transpose-free `gemm_cuda` path (`Cᵀ = op(B)ᵀ·op(A)ᵀ`, no host
+    /// `to_col_major`/`from_col_major`) must match a CPU oracle across all
+    /// four `(trans_a, trans_b)` combinations AND non-square, tall-skinny
+    /// shapes — the regime (200000×200 · 200×k) where the host transpose
+    /// previously dominated. This guards the leading-dimension/operand-swap
+    /// derivation against silent index bugs.
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn transpose_free_gemm_matches_cpu_all_trans_and_shapes() {
+        use crate::blas::gemm_cuda;
+        use ndarray::Array2;
+
+        let Some(runtime) = GpuRuntime::global() else {
+            eprintln!("[gemm transpose-free] no CUDA runtime - skipping");
+            return;
+        };
+
+        // (rows, inner, cols) logical product dims, deliberately all distinct
+        // and rectangular so any lda/ldb/ldc mix-up surfaces.
+        let cases = [(6usize, 4usize, 5usize), (17, 23, 9), (200, 31, 7)];
+        for (m, k, n) in cases {
+            // Base operands sized for the no-transpose orientation; transposed
+            // variants are built by swapping dims so the logical product is
+            // always (m × n).
+            let mk = Array2::<f64>::from_shape_fn((m, k), |(i, j)| {
+                ((i * 31 + j * 17) % 19) as f64 * 0.013 - 0.11
+            });
+            let km = Array2::<f64>::from_shape_fn((k, m), |(i, j)| {
+                ((i * 13 + j * 29) % 23) as f64 * 0.011 - 0.07
+            });
+            let kn = Array2::<f64>::from_shape_fn((k, n), |(i, j)| {
+                ((i * 7 + j * 5) % 17) as f64 * 0.017 - 0.09
+            });
+            let nk = Array2::<f64>::from_shape_fn((n, k), |(i, j)| {
+                ((i * 19 + j * 11) % 13) as f64 * 0.015 - 0.05
+            });
+
+            for &trans_a in &[false, true] {
+                for &trans_b in &[false, true] {
+                    let a = if trans_a { &km } else { &mk };
+                    let b = if trans_b { &nk } else { &kn };
+
+                    let gpu = gemm_cuda(runtime, a.view(), b.view(), trans_a, trans_b).expect(
+                        "transpose-free device GEMM must produce a result when a device is present",
+                    );
+                    assert_eq!(gpu.dim(), (m, n), "output shape wrong for trans_a={trans_a} trans_b={trans_b} ({m}×{k}×{n})");
+
+                    // CPU oracle on the logically-transposed operands.
+                    let mut cpu = Array2::<f64>::zeros((m, n));
+                    for i in 0..m {
+                        for j in 0..n {
+                            let mut acc = 0.0f64;
+                            for p in 0..k {
+                                let av = if trans_a { a[[p, i]] } else { a[[i, p]] };
+                                let bv = if trans_b { b[[j, p]] } else { b[[p, j]] };
+                                acc += av * bv;
+                            }
+                            cpu[[i, j]] = acc;
+                        }
+                    }
+
+                    let mut max_abs = 0.0f64;
+                    for i in 0..m {
+                        for j in 0..n {
+                            max_abs = max_abs.max((gpu[[i, j]] - cpu[[i, j]]).abs());
+                        }
+                    }
+                    assert!(
+                        max_abs < 1e-9,
+                        "transpose-free GEMM mismatch (trans_a={trans_a} trans_b={trans_b}, \
+                         {m}×{k}×{n}): max|Δ| = {max_abs:e}"
+                    );
+                }
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

The automatic dense-GEMM GPU path existed end-to-end but was **dead** — and would have been a *pessimization* even if it ran. Two coupled defects:

### 1. The dispatch hook was never registered
`CudaGemmDispatch` implements `gam_linalg::gpu_hook::GpuGemmDispatch`, and the engine's hot dense kernels (`fast_ab`, `fast_atb`, `fast_av`, `fast_atv`, `xt_diag_x`, `xt_diag_y`, `joint_hessian_2x2`) all consult `gpu_dispatch()` *before* their CPU fast path. But `register_gpu_dispatch(...)` was **never called anywhere in the tree** — verified by grep. So `gpu_dispatch()` always returned `None`, and **every dense product in the engine silently ran on the CPU** even with a V100 present and the workload far above the policy flop floor.

Fix: register `CudaGemmDispatch` inside the same `GpuRuntime::global()` `get_or_init` that decides the runtime, exactly when a usable device was probed. The hook is therefore installed before any `fast_ab` caller can observe a `Some` runtime. The per-call `route_through_gpu` policy gate still decides CPU-vs-GPU per call, so sub-threshold products are unaffected.

### 2. `gemm_cuda` did two full host-side scalar transposes
It packed each operand row-major→col-major (`to_col_major`) and unpacked the result (`from_col_major`) — O(rows·cols) scalar permutations. For a tall-skinny GEMM like the 200000×200 Wahba design reduction, that host transpose **dominated wall-clock and made the device path ~4× SLOWER than the host SIMD GEMM** (measured: end-to-end sphere build 4.3s → 19s once the hook above went live).

Fix: reformulate transpose-free via the identity that a row-major `C` buffer is bit-identical to the column-major `Cᵀ = op(B)ᵀ·op(A)ᵀ` buffer. Upload the row-major operand buffers as-is (a borrow when C-contiguous), swap operands + leading dims, and download straight into a row-major `Array2`. Zero host permutation; cuBLAS does the work. End-to-end sphere build recovered to 4.5s with the GEMM genuinely on-device.

## Correctness (CPU oracle parity, both paths)
- `global_runtime_installs_fast_ab_hook_and_matches_cpu`: asserts the hook is installed after `global()` returns a device, that a profitable `fast_ab` routes to GPU, and that the device result matches a CPU triple-loop oracle to < 1e-9.
- `transpose_free_gemm_matches_cpu_all_trans_and_shapes`: all four `(trans_a, trans_b)` combinations on rectangular/tall-skinny shapes vs CPU oracle.

## Device verification (this box's V100, device 7)
`nvidia-smi` during the dispatched GEMM showed nonzero utilization and **312 MiB resident** (jumping from a 1 MiB idle baseline), confirming real on-device execution — not a silent CPU fallback.

## CPU path preserved
Untouched: when no device is probed or the workload is below threshold, `fast_ab` falls through to the existing faer/SIMD kernel exactly as before. The device GEMM differs from CPU only by IEEE-754 reduction order.

## Test status
- All **44 gam-gpu tests pass**.
- All **306 gam-problem tests pass**.
- gam-solve / gam-models failures observed in the sweep (`rho_optimizer`, `seeding`, `structure_search`, `gaussian_location_scale_engine_matches_reference_flow`, `pcg_device_matches_dense_oracle`, `framed_sae_device_pcg`) were each reproduced **identically on `origin/main`** in a clean worktree — they are pre-existing and unrelated. The arrow-Schur device matvec operator-residual was **bit-identical** between this branch and main (`3.6344260934129125e-12`), confirming the GEMM rewrite does not perturb the operator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)