### PR TITLE
fix(#561): rebuild multinomial per-class λ/EDF from the #1587 joint penalty

### DIFF
--- a/crates/gam-custom-family/src/covariance.rs
+++ b/crates/gam-custom-family/src/covariance.rs
@@ -1071,6 +1071,21 @@ pub(crate) fn compute_joint_covariance<F: CustomFamily + Clone + Send + Sync + '
         h.slice_mut(ndarray::s![start..end, start..end])
             .scaled_add(1.0, &s_lambda);
     }
+    // gam#1587/#561: families whose smoothing is carried by a full-width JOINT
+    // penalty (the multinomial centered `Σ_t λ_t (M ⊗ S_t)` metric) leave their
+    // per-block penalty lists empty — every block above contributes nothing — so
+    // the exported posterior precision MUST also add the joint contribution
+    // `Σ_t exp(ρ_t) S_t` at the SAME selected `ρ_t` the inner solve used. Without
+    // this the reported covariance is the UNPENALIZED `H_lik⁻¹` (standard errors
+    // silently too wide) and the EDF trace `tr(H⁻¹ S_λ)` reads zero (no smoothing
+    // spent), even though `fit_custom_family` threads the joint bundle through
+    // `options` for exactly this reason. A no-op for every per-block-only family
+    // (`joint_penalties` is `None`).
+    if let Some(bundle) = options.joint_penalties.as_deref()
+        && !bundle.is_empty()
+    {
+        bundle.add_to_matrix(&mut h);
+    }
     symmetrize_dense_in_place(&mut h);
     if use_exact_newton_strict_spd(family) {
         // #748: the strict posterior precision is `H + S_λ` AT THE CONVERGED
@@ -1136,6 +1151,7 @@ pub(crate) fn compute_joint_geometry<F: CustomFamily + Clone + Send + Sync + 'st
     specs: &[ParameterBlockSpec],
     states: &[ParameterBlockState],
     per_block_log_lambdas: &[Array1<f64>],
+    options: &BlockwiseFitOptions,
 ) -> Result<Option<FitGeometry>, String> {
     if specs.len() != per_block_log_lambdas.len() {
         return Ok(None);
@@ -1194,6 +1210,18 @@ pub(crate) fn compute_joint_geometry<F: CustomFamily + Clone + Send + Sync + 'st
         for (k, s) in spec.penalties.iter().enumerate() {
             let s_dense = s.as_dense_cow();
             h.scaled_add(lambdas[k], &*s_dense);
+        }
+        // gam#1587/#561: add the full-width JOINT penalty (the multinomial
+        // centered `Σ_t λ_t (M ⊗ S_t)`) at the selected `ρ_t` so the exported
+        // geometry's penalized Hessian matches the inner-converged operator and
+        // the trace EDF `tr(H⁻¹ S_λ)` is non-zero. No-op for per-block-only
+        // families. (Single-block joint penalties are unusual but handled for
+        // symmetry with the multi-block branch.)
+        if let Some(bundle) = options.joint_penalties.as_deref()
+            && !bundle.is_empty()
+            && h.nrows() == bundle.specs.first().map(|s| s.dim()).unwrap_or(h.nrows())
+        {
+            bundle.add_to_matrix(&mut h);
         }
         // Exact-Newton families may return a Hessian assembled from directional
         // callbacks whose off-diagonal entries differ by floating-point order
@@ -1256,6 +1284,17 @@ pub(crate) fn compute_joint_geometry<F: CustomFamily + Clone + Send + Sync + 'st
                 return Ok(None);
             }
         }
+    }
+    // gam#1587/#561: add the full-width JOINT penalty `Σ_t exp(ρ_t) S_t` at the
+    // selected `ρ_t`. The multinomial centered metric carries ALL of a fit's
+    // smoothing here (its per-block penalty lists are empty), so without this the
+    // exported geometry is the unpenalized likelihood Hessian and the trace EDF
+    // reads as the full coefficient count (no smoothing spent). No-op for the
+    // per-block-only families (`joint_penalties` is `None`).
+    if let Some(bundle) = options.joint_penalties.as_deref()
+        && !bundle.is_empty()
+    {
+        bundle.add_to_matrix(&mut h);
     }
     let working_len = states.first().map(|state| state.eta.len()).unwrap_or(0);
     Ok(Some(FitGeometry {

--- a/crates/gam-custom-family/src/fit.rs
+++ b/crates/gam-custom-family/src/fit.rs
@@ -111,6 +111,11 @@ pub(crate) struct BlockwiseFitAssembly<'a> {
     pub(crate) outer_gradient_norm: Option<f64>,
     pub(crate) criterion_certificate: Option<gam_solve::rho_optimizer::CriterionCertificate>,
     pub(crate) outer_converged: bool,
+    /// Selected per-component log-smoothing parameters of the full-width JOINT
+    /// penalty at ρ* (gam#1587/#561), surfaced on `FitArtifacts` so a
+    /// joint-penalized family (the multinomial centered metric) can recover its
+    /// converged smoothing. `None` for every per-block-only family.
+    pub(crate) joint_log_lambdas: Option<Array1<f64>>,
     pub(crate) context: &'static str,
 }
 
@@ -129,6 +134,7 @@ pub(crate) fn assemble_custom_family_fit_result(
         outer_gradient_norm,
         criterion_certificate,
         outer_converged,
+        joint_log_lambdas,
         context,
     } = assembly;
     let lambdas = rho_physical.mapv(f64::exp);
@@ -165,6 +171,7 @@ pub(crate) fn assemble_custom_family_fit_result(
             outer_converged,
             geometry,
             precomputed_edf,
+            joint_log_lambdas,
         },
         result_specs,
     )
@@ -758,11 +765,12 @@ pub fn fit_custom_family_with_rho_prior<F: CustomFamily + Clone + Send + Sync + 
         } else {
             0.0
         };
-        let geometry = compute_joint_geometry(family, specs, &inner.block_states, &per_block)
-            .map_err(|reason| CustomFamilyError::Optimization {
-                context: "fit_custom_family no-smoothing joint geometry",
-                reason,
-            })?;
+        let geometry =
+            compute_joint_geometry(family, specs, &inner.block_states, &per_block, options)
+                .map_err(|reason| CustomFamilyError::Optimization {
+                    context: "fit_custom_family no-smoothing joint geometry",
+                    reason,
+                })?;
         let penalized_objective = checked_penalizedobjective(
             inner.log_likelihood,
             inner.penalty_value,
@@ -805,6 +813,7 @@ pub fn fit_custom_family_with_rho_prior<F: CustomFamily + Clone + Send + Sync + 
                 outer_gradient_norm: None,
                 criterion_certificate: None,
                 outer_converged: inner_converged,
+                joint_log_lambdas: None,
                 context: "fit_custom_family no-smoothing result assembly",
             },
         );
@@ -851,6 +860,7 @@ pub fn fit_custom_family_with_rho_prior<F: CustomFamily + Clone + Send + Sync + 
                 outer_gradient_norm: Some(0.0),
                 criterion_certificate: None,
                 outer_converged: inner_converged,
+                joint_log_lambdas: None,
                 context: "fit_custom_family one-cycle result assembly",
             },
         );
@@ -1660,12 +1670,16 @@ pub fn fit_custom_family_with_rho_prior<F: CustomFamily + Clone + Send + Sync + 
         &final_options,
     )?;
 
-    let geometry = compute_joint_geometry(family, specs, &inner.block_states, &per_block).map_err(
-        |reason| CustomFamilyError::Optimization {
-            context: "fit_custom_family joint geometry",
-            reason,
-        },
-    )?;
+    // gam#1587/#561: pass `final_options` (carrying the joint penalty bundle at
+    // the selected ρ*) so the exported geometry's penalized Hessian — and the
+    // trace EDF derived from it — includes the full-width centered penalty,
+    // matching the covariance path above and the inner-converged mode.
+    let geometry =
+        compute_joint_geometry(family, specs, &inner.block_states, &per_block, &final_options)
+            .map_err(|reason| CustomFamilyError::Optimization {
+                context: "fit_custom_family joint geometry",
+                reason,
+            })?;
     let penalized_objective = inner_penalized_objective(
         &inner,
         include_exact_newton_logdet_h(family, options),
@@ -1847,6 +1861,15 @@ pub fn fit_custom_family_with_rho_prior<F: CustomFamily + Clone + Send + Sync + 
     }
     let rho_star_physical = expand_labeled_log_lambdas(&rho_star, &label_layout)?;
     let outer_converged = !nonconvergence_escalation;
+    // gam#1587/#561: a family whose smoothing rides on the full-width JOINT
+    // penalty (the multinomial centered `Σ_t λ_t (M ⊗ S_t)` metric) leaves its
+    // per-block penalty lists — and hence the physical `rho_physical`/`lambdas`
+    // expansion above — EMPTY, so the selected per-component `ρ_t` would be lost
+    // at assembly. Surface it on `FitArtifacts.joint_log_lambdas` so the
+    // reporting path can rebuild per-(class, term) λ and the influence-matrix
+    // EDF. `None` (no allocation) for every per-block-only family.
+    let joint_log_lambdas = (!label_layout.joint_specs.is_empty())
+        .then(|| Array1::from(label_layout.joint_log_lambdas(&rho_star)));
     assemble_custom_family_fit_result(
         inner,
         BlockwiseFitAssembly {
@@ -1860,6 +1883,7 @@ pub fn fit_custom_family_with_rho_prior<F: CustomFamily + Clone + Send + Sync + 
             outer_gradient_norm: outer_grad_norm,
             criterion_certificate: outer_certificate,
             outer_converged,
+            joint_log_lambdas,
             context: "fit_custom_family result assembly",
         },
     )
@@ -1895,12 +1919,13 @@ pub fn fit_custom_family_fixed_log_lambdas<
     refresh_all_block_etas(family, specs, &mut inner.block_states)?;
     let covariance_conditional =
         compute_joint_covariance_required(family, specs, &inner.block_states, &per_block, options)?;
-    let geometry = compute_joint_geometry(family, specs, &inner.block_states, &per_block).map_err(
-        |reason| CustomFamilyError::Optimization {
-            context: "fit_custom_family_fixed_log_lambdas joint geometry",
-            reason,
-        },
-    )?;
+    let geometry =
+        compute_joint_geometry(family, specs, &inner.block_states, &per_block, options).map_err(
+            |reason| CustomFamilyError::Optimization {
+                context: "fit_custom_family_fixed_log_lambdas joint geometry",
+                reason,
+            },
+        )?;
     let penalized_objective = inner_penalized_objective(
         &inner,
         include_exact_newton_logdet_h(family, options),
@@ -1924,6 +1949,7 @@ pub fn fit_custom_family_fixed_log_lambdas<
             outer_gradient_norm,
             criterion_certificate: None,
             outer_converged,
+            joint_log_lambdas: None,
             context: "fit_custom_family_fixed_log_lambdas result assembly",
         },
     )

--- a/crates/gam-custom-family/src/tests.rs
+++ b/crates/gam-custom-family/src/tests.rs
@@ -95,6 +95,7 @@ pub(crate) fn blockwise_fit_from_parts_accepts_stacked_solver_eta_with_canonical
                 working_response: Array1::zeros(2),
             }),
             precomputed_edf: Some((1.0, Vec::new(), vec![1.0], Vec::new())),
+            joint_log_lambdas: None,
         },
         &[spec],
     )

--- a/crates/gam-custom-family/src/warm_start.rs
+++ b/crates/gam-custom-family/src/warm_start.rs
@@ -189,6 +189,12 @@ pub struct BlockwiseFitResultParts {
     /// where `penalty_trace[k] = λ_k·tr(H⁻¹S_k)` feeds the per-term EDF
     /// decomposition `|coeff_range| − Σ tr_k` (issue #1219).
     pub precomputed_edf: Option<(f64, Vec<f64>, Vec<f64>, Vec<f64>)>,
+    /// Selected per-component log-smoothing parameters of the full-width JOINT
+    /// penalty at ρ* (gam#1587/#561). Surfaced on `FitArtifacts.joint_log_lambdas`
+    /// so a joint-penalized family (the multinomial centered metric) can recover
+    /// its converged smoothing — the per-block `lambdas` are empty for it. `None`
+    /// for every per-block-only family.
+    pub joint_log_lambdas: Option<Array1<f64>>,
 }
 
 pub(crate) fn validate_parameter_block_state_finiteness(
@@ -437,6 +443,7 @@ pub fn blockwise_fit_from_parts(
         outer_converged,
         geometry,
         precomputed_edf,
+        joint_log_lambdas,
     } = parts;
 
     if block_states.is_empty() {
@@ -687,6 +694,7 @@ pub fn blockwise_fit_from_parts(
         artifacts: gam_solve::model_types::FitArtifacts {
             pirls: None,
             criterion_certificate,
+            joint_log_lambdas,
             ..Default::default()
         },
         inner_cycles,

--- a/crates/gam-models/src/inference/model.rs
+++ b/crates/gam-models/src/inference/model.rs
@@ -4704,6 +4704,7 @@ mod tests {
                 rho_posterior_certificate: None,
                 rho_posterior_escalation: None,
                 rho_covariance: None,
+                joint_log_lambdas: None,
             },
             inner_cycles: 0,
         }

--- a/crates/gam-models/src/multinomial.rs
+++ b/crates/gam-models/src/multinomial.rs
@@ -1734,12 +1734,112 @@ pub fn fit_penalized_multinomial_formula(
     // now carries one λ per smooth term, so a single λ per class would discard
     // the independent per-term selection that fixes #561. `lambdas_per_block`
     // segments the flat vector by class so callers can recover per-term λ.
-    let lambdas_per_block: Vec<usize> = fit.blocks.iter().map(|b| b.lambdas.len()).collect();
-    let lambdas_flat: Vec<f64> = fit
-        .blocks
-        .iter()
-        .flat_map(|b| b.lambdas.iter().copied())
-        .collect();
+    // ── gam#1587/#561 joint-penalty reconstruction ───────────────────────────
+    // Under the #1587 centered-metric architecture every active class block
+    // leaves its per-block penalty list EMPTY — the entire fit's smoothing rides
+    // on a single full-width JOINT penalty `S_λ = Σ_t λ_t (M ⊗ S_t)` whose one
+    // shared `λ_t` per smooth component is selected by the outer REML loop and
+    // surfaced on `fit.artifacts.joint_log_lambdas`. So `fit.blocks[a].lambdas`
+    // is `[]`, the inference layer's per-block trace channel is empty, and the
+    // older per-block reporting (`lambdas_per_block = [0, 0]`, `edf_per_class =
+    // None`, …) collapsed (#561 reopen).
+    //
+    // Reconstruct the per-(class, component) λ and the influence-matrix EDF
+    // directly from the selected joint `λ_t` and the COUPLED penalty
+    // `S_λ = Σ_t λ_t (M ⊗ S_t)` (NOT a block-diagonal `Σ_t λ_{a,t} S_t`: the
+    // centered metric `M` couples classes off the block diagonal, so a
+    // block-diagonal `S_λ` would mis-state both the influence matrix and every
+    // trace). With `H⁻¹ = fit.covariance_conditional` now assembled WITH the
+    // joint penalty (the `compute_joint_covariance` fix), the influence matrix is
+    // exactly `F = I − H⁻¹ S_λ`, its per-class diagonal-block trace is the honest
+    // per-class EDF, and `Σ_a edf_a = tr(F) = edf_total`.
+    let joint_recon = fit.artifacts.joint_log_lambdas.as_ref().and_then(|jll| {
+        let n_components = penalties_arc.len();
+        if jll.len() != n_components || n_components == 0 {
+            return None;
+        }
+        let expected_joint = p_per_class.saturating_mul(m);
+        let hinv = fit
+            .covariance_conditional
+            .as_ref()
+            .filter(|c| c.nrows() == expected_joint && c.ncols() == expected_joint)?;
+        // The coupled joint penalty components `M ⊗ S_t` at the selected `λ_t`,
+        // in raw stacked (class-major) coordinates — exactly the operator the
+        // inner solve and the now-fixed covariance path penalize with.
+        let joint_specs = family.centered_joint_penalty_specs();
+        if joint_specs.len() != n_components {
+            return None;
+        }
+        let lam: Vec<f64> = jll.iter().map(|&l| l.exp()).collect();
+        // Per-component `H⁻¹ (M ⊗ S_t)` (full mp×mp), reused for both the joint
+        // influence matrix and the per-(class, component) trace decomposition.
+        let mut hinv_st: Vec<Array2<f64>> = Vec::with_capacity(n_components);
+        for spec in &joint_specs {
+            if spec.matrix.nrows() != expected_joint || spec.matrix.ncols() != expected_joint {
+                return None;
+            }
+            hinv_st.push(hinv.dot(&spec.matrix));
+        }
+        // F = I − H⁻¹ S_λ = I − Σ_t λ_t H⁻¹ (M ⊗ S_t).
+        let mut f = Array2::<f64>::eye(expected_joint);
+        for (t, hs) in hinv_st.iter().enumerate() {
+            f.scaled_add(-lam[t], hs);
+        }
+        // Per-class diagonal-block trace of F (the honest per-class EDF), and the
+        // per-(class, component) penalty trace `tr_{a,t} = λ_t · Σ_{i∈class a}
+        // (H⁻¹ (M⊗S_t))[i,i]` for the per-penalty EDF rollup.
+        let mut edf_per_class = Vec::with_capacity(m);
+        // class-major per-penalty EDF (class 0's components, then class 1's, …),
+        // aligned 1:1 with the flat per-component λ replicated per class.
+        let mut edf_per_penalty = Vec::with_capacity(m * n_components);
+        for a in 0..m {
+            let base = a * p_per_class;
+            let mut class_trace = 0.0_f64;
+            for t in 0..n_components {
+                let mut tr_at = 0.0_f64;
+                for i in 0..p_per_class {
+                    tr_at += hinv_st[t][[base + i, base + i]];
+                }
+                tr_at *= lam[t];
+                class_trace += tr_at;
+                // A single component's per-class trace EDF `rank(S_t) − tr_{a,t}`,
+                // bounded by its local rank (≤ p_per_class).
+                let ns_t = nullspace_dims_arc.get(t).copied().unwrap_or(0);
+                let rank_t = (p_per_class as f64 - ns_t as f64).max(0.0);
+                edf_per_penalty.push((rank_t - tr_at).clamp(0.0, p_per_class as f64));
+            }
+            edf_per_class
+                .push((p_per_class as f64 - class_trace).clamp(0.0, p_per_class as f64));
+        }
+        Some((f, edf_per_class, edf_per_penalty, n_components, lam))
+    });
+
+    // Flatten every (class, component) smoothing parameter in class-major order.
+    // Under the joint-penalty architecture each active class carries the SAME
+    // per-component λ set (the centered metric ties `λ_t` across classes for
+    // reference-class invariance), so the flat vector is the selected `λ_t`
+    // replicated `K-1` times and `lambdas_per_block = [n_components; K-1]`. When
+    // the joint reconstruction is unavailable (legacy fixed-λ path or absent
+    // covariance) fall back to the raw — now empty — per-block λ lists.
+    let (lambdas_per_block, lambdas_flat): (Vec<usize>, Vec<f64>) = match joint_recon.as_ref() {
+        Some((_, _, _, n_components, lam)) => {
+            let per_block = vec![*n_components; m];
+            let mut flat = Vec::with_capacity(m * n_components);
+            for _ in 0..m {
+                flat.extend(lam.iter().copied());
+            }
+            (per_block, flat)
+        }
+        None => {
+            let per_block: Vec<usize> = fit.blocks.iter().map(|b| b.lambdas.len()).collect();
+            let flat: Vec<f64> = fit
+                .blocks
+                .iter()
+                .flat_map(|b| b.lambdas.iter().copied())
+                .collect();
+            (per_block, flat)
+        }
+    };
     // Per-active-class effective degrees of freedom, length `K-1`, summing to
     // the model `edf_total`. The REML inference block reports `edf_by_block` as
     // ONE entry per *penalty block* (per (class, term, penalty)), each computed
@@ -1761,25 +1861,29 @@ pub fn fit_penalized_multinomial_formula(
     // segmentation `lambdas_flat` uses). Fall back to `None` when the trace
     // channel is unavailable or mis-shaped (legacy fixed-λ path), exactly as the
     // raw `edf_by_block` map did before.
-    let edf_per_class = fit.inference.as_ref().and_then(|info| {
-        let traces = &info.penalty_block_trace;
-        if traces.len() != lambdas_per_block.iter().sum::<usize>() {
-            // Trace channel absent or not aligned with the per-class block
-            // segmentation — cannot assemble an honest per-class EDF.
-            return None;
-        }
-        let mut per_class = Vec::with_capacity(m);
-        let mut cursor = 0usize;
-        for &n_blocks in &lambdas_per_block {
-            let class_trace: f64 = traces[cursor..cursor + n_blocks].iter().sum();
-            // `tr(F)` over a class block ∈ [0, p_per_class]; clamp away
-            // round-off so a reported EDF can never be negative or exceed the
-            // class's own coefficient count.
-            per_class.push((p_per_class as f64 - class_trace).clamp(0.0, p_per_class as f64));
-            cursor += n_blocks;
-        }
-        Some(per_class)
-    });
+    let edf_per_class = joint_recon
+        .as_ref()
+        .map(|(_, epc, _, _, _)| epc.clone())
+        .or_else(|| {
+            // Legacy per-block trace path (fixed-λ / pre-#1587 fits whose
+            // smoothing is still carried per block). Segment the block-major
+            // `penalty_block_trace` by `lambdas_per_block`, exactly as before.
+            fit.inference.as_ref().and_then(|info| {
+                let traces = &info.penalty_block_trace;
+                if traces.len() != lambdas_per_block.iter().sum::<usize>() {
+                    return None;
+                }
+                let mut per_class = Vec::with_capacity(m);
+                let mut cursor = 0usize;
+                for &n_blocks in &lambdas_per_block {
+                    let class_trace: f64 = traces[cursor..cursor + n_blocks].iter().sum();
+                    per_class
+                        .push((p_per_class as f64 - class_trace).clamp(0.0, p_per_class as f64));
+                    cursor += n_blocks;
+                }
+                Some(per_class)
+            })
+        });
     // Per-PENALTY EDF: the inference layer's `edf_by_block` is already the
     // clamped per-penalty-block trace EDF `rank(S_k) − λ_k·tr(H⁻¹ S_k)`, one
     // entry per smoothing parameter and block-major aligned 1:1 with the flat
@@ -1789,17 +1893,25 @@ pub fn fit_penalized_multinomial_formula(
     // total: with double-penalty smooths `Σ_k rank(S_k) > p_per_class`, so the
     // entries deliberately need not sum to the model EDF (the per-class field
     // carries that contract instead).
-    let edf_per_penalty = fit.inference.as_ref().and_then(|info| {
-        if info.edf_by_block.len() != lambdas_flat.len() {
-            return None;
-        }
-        Some(
-            info.edf_by_block
-                .iter()
-                .map(|&e| e.max(0.0))
-                .collect::<Vec<f64>>(),
-        )
-    });
+    let edf_per_penalty = joint_recon
+        .as_ref()
+        .map(|(_, _, epp, _, _)| epp.clone())
+        .or_else(|| {
+            // Legacy per-block path: the inference layer's `edf_by_block` is
+            // already the clamped per-penalty-block trace EDF, aligned 1:1 with
+            // the flat `lambdas`.
+            fit.inference.as_ref().and_then(|info| {
+                if info.edf_by_block.len() != lambdas_flat.len() {
+                    return None;
+                }
+                Some(
+                    info.edf_by_block
+                        .iter()
+                        .map(|&e| e.max(0.0))
+                        .collect::<Vec<f64>>(),
+                )
+            })
+        });
     let coefficients_flat: Vec<f64> = coefficients_active.iter().copied().collect();
 
     // #1101: surface the joint Laplace posterior covariance `H⁻¹` (block-ordered
@@ -1862,46 +1974,52 @@ pub fn fit_penalized_multinomial_formula(
     // The influence matrix `F = H⁻¹ X'WX = H⁻¹(H − S_λ) = I − H⁻¹ S_λ`. The
     // exact-Newton multinomial blocks carry no IRLS pseudo-data, so the generic
     // inference path does not export `coefficient_influence`; reconstruct it
-    // exactly here from the joint covariance `H⁻¹` (above) and the REML-selected
-    // per-(class, term) `λ` scaling the shared penalties. Block-diagonal `S_λ`:
-    // class `a`'s block is `Σ_t λ_{a,t} · S_t`, embedded at `a·P .. (a+1)·P`.
-    let coefficient_influence_flat = fit
-        .covariance_conditional
-        .as_ref()
-        .filter(|c| c.nrows() == expected_joint && c.ncols() == expected_joint)
-        .and_then(|hinv| {
-            if fit.blocks.len() != m {
-                return None;
-            }
-            // Joint S_λ (block-diagonal across active classes).
-            let mut s_lambda = Array2::<f64>::zeros((expected_joint, expected_joint));
-            for (a, block) in fit.blocks.iter().enumerate() {
-                if block.lambdas.len() != penalties_arc.len() {
+    // exactly here. Under the #1587 joint-penalty architecture the penalty is the
+    // COUPLED centered metric `S_λ = Σ_t λ_t (M ⊗ S_t)` (off the class-block
+    // diagonal), already assembled in `joint_recon` above, so reuse that exact
+    // `F`. Only fall back to the legacy block-diagonal `Σ_t λ_{a,t} S_t`
+    // reconstruction when the joint reconstruction is unavailable (pre-#1587
+    // per-block fits whose class blocks still carry their own penalties).
+    let coefficient_influence_flat = match joint_recon.as_ref() {
+        Some((f, _, _, _, _)) => Some(f.iter().copied().collect::<Vec<f64>>()),
+        None => fit
+            .covariance_conditional
+            .as_ref()
+            .filter(|c| c.nrows() == expected_joint && c.ncols() == expected_joint)
+            .and_then(|hinv| {
+                if fit.blocks.len() != m {
                     return None;
                 }
-                let base = a * p_per_class;
-                for (t, pen) in penalties_arc.iter().enumerate() {
-                    let lam = block.lambdas[t];
-                    if lam == 0.0 {
-                        continue;
-                    }
-                    let dense = pen.to_dense();
-                    if dense.nrows() != p_per_class || dense.ncols() != p_per_class {
+                // Joint S_λ (block-diagonal across active classes).
+                let mut s_lambda = Array2::<f64>::zeros((expected_joint, expected_joint));
+                for (a, block) in fit.blocks.iter().enumerate() {
+                    if block.lambdas.len() != penalties_arc.len() {
                         return None;
                     }
-                    for i in 0..p_per_class {
-                        for j in 0..p_per_class {
-                            s_lambda[[base + i, base + j]] += lam * dense[[i, j]];
+                    let base = a * p_per_class;
+                    for (t, pen) in penalties_arc.iter().enumerate() {
+                        let lam = block.lambdas[t];
+                        if lam == 0.0 {
+                            continue;
+                        }
+                        let dense = pen.to_dense();
+                        if dense.nrows() != p_per_class || dense.ncols() != p_per_class {
+                            return None;
+                        }
+                        for i in 0..p_per_class {
+                            for j in 0..p_per_class {
+                                s_lambda[[base + i, base + j]] += lam * dense[[i, j]];
+                            }
                         }
                     }
                 }
-            }
-            // F = I − H⁻¹ S_λ.
-            let hinv_s = hinv.dot(&s_lambda);
-            let mut f = Array2::<f64>::eye(expected_joint);
-            f -= &hinv_s;
-            Some(f.iter().copied().collect::<Vec<f64>>())
-        });
+                // F = I − H⁻¹ S_λ.
+                let hinv_s = hinv.dot(&s_lambda);
+                let mut f = Array2::<f64>::eye(expected_joint);
+                f -= &hinv_s;
+                Some(f.iter().copied().collect::<Vec<f64>>())
+            }),
+    };
 
     // Per-(smooth term) coefficient span within a single class block, deduped by
     // col_range (the #561 double-penalty migration emits two penalty blocks per

--- a/crates/gam-models/src/survival/location_scale/fit.rs
+++ b/crates/gam-models/src/survival/location_scale/fit.rs
@@ -101,6 +101,7 @@ pub(crate) fn fit_reduced_parametric_aft(
             outer_converged: true,
             geometry,
             precomputed_edf: None,
+            joint_log_lambdas: None,
         },
         &assembly_specs,
     )

--- a/crates/gam-models/src/survival/location_scale/spec.rs
+++ b/crates/gam-models/src/survival/location_scale/spec.rs
@@ -616,6 +616,7 @@ pub fn survival_fit_from_parts(
             rho_posterior_certificate: None,
             rho_posterior_escalation: None,
             rho_covariance: None,
+            joint_log_lambdas: None,
         },
         inner_cycles: 0,
     })

--- a/crates/gam-solve/src/model_types/result_types.rs
+++ b/crates/gam-solve/src/model_types/result_types.rs
@@ -834,6 +834,16 @@ pub struct FitArtifacts {
     /// re-derivable, so it is not serialized.
     #[serde(default, skip_serializing, skip_deserializing)]
     pub rho_covariance: Option<Array2<f64>>,
+    /// Selected per-component log-smoothing parameters of the full-width JOINT
+    /// penalty (gam#1587/#561). Families whose smoothing is carried by a joint
+    /// penalty (the multinomial centered `Σ_t λ_t (M ⊗ S_t)` metric) leave their
+    /// per-block penalty lists — and hence [`UnifiedFitResult::lambdas`] — empty,
+    /// so the only place the converged `ρ_t` survives is here. `None` for every
+    /// per-block-only family. Re-derivable from a refit, so not serialized; it is
+    /// consumed by the multinomial reporting path to reconstruct per-(class,term)
+    /// λ, per-class EDF, and the influence matrix `F = I − H⁻¹ S_λ`.
+    #[serde(default, skip_serializing, skip_deserializing)]
+    pub joint_log_lambdas: Option<Array1<f64>>,
 }
 
 impl std::fmt::Debug for FitArtifacts {
@@ -859,6 +869,10 @@ impl std::fmt::Debug for FitArtifacts {
             .field(
                 "rho_covariance",
                 &self.rho_covariance.as_ref().map(|m| m.dim()),
+            )
+            .field(
+                "joint_log_lambdas",
+                &self.joint_log_lambdas.as_ref().map(|v| v.len()),
             )
             .finish()
     }


### PR DESCRIPTION
## Reopens #561

#561 was closed as fixed, but the **#1587 multinomial refactor** silently re-broke every channel #561 was supposed to deliver. On current `main`, `fit_penalized_multinomial_formula(... "y ~ s(x)" ...)` returns `lambdas_per_block=[0, 0]`, `edf_per_class=None`, `edf_per_penalty=None`, `coefficient_influence=None`, and an empty flat `lambdas` — and the exported covariance has *silently too-wide standard errors*. The regression test `multinomial_edf_per_class_is_per_class_not_per_block_overcount` fails on `main` with `got lambdas_per_block=[0, 0]`.

### Root cause

#1587 moved every multinomial smooth's penalization into a single full-width **JOINT** penalty `S_λ = Σ_t λ_t (M ⊗ S_t)` (the centered CLR metric — one shared `λ_t` per smooth *component*, tied across the K−1 classes for reference-class invariance) and **emptied each class block's per-block penalty list**. Three producer-side gaps followed:

1. **Exported covariance/geometry dropped the joint penalty.** `compute_joint_covariance` / `compute_joint_geometry` only summed the per-block penalties (empty for multinomial), so the reported posterior precision was the *unpenalized* `H_lik`, not `H_lik + S_λ`. SEs were silently too wide and the EDF trace `tr(H⁻¹ S_λ)` read zero — even though `fit.rs` threads the joint bundle through `options` and its comment claims `H = H_lik + S_λ`.
2. **The selected joint `ρ_t` was dropped at assembly** — only the (empty) per-block physical expansion survived into `UnifiedFitResult`.
3. **The reporting path read the now-empty per-block channels**, collapsing all λ/EDF outputs to `None`/`[0,0]`.

### Fix

1. `compute_joint_covariance` / `compute_joint_geometry` now add `options.joint_penalties` via `bundle.add_to_matrix` (no-op for every per-block-only family — multinomial is the only production family overriding `joint_penalty_specs`).
2. The selected per-component joint `ρ_t` is surfaced on `FitArtifacts.joint_log_lambdas` (re-derivable, `skip_serializing`, mirroring `rho_covariance`), threaded through `BlockwiseFitResultParts` / `BlockwiseFitAssembly`.
3. The multinomial reporting path rebuilds per-(class, component) λ and the influence-matrix EDF from the selected `λ_t` and the **coupled** metric `F = I − H⁻¹ Σ_t λ_t (M ⊗ S_t)`. The prior block-diagonal `Σ_t λ_{a,t} S_t` reconstruction ignored the centered metric's off-diagonal class coupling and was statistically wrong. The legacy per-block path is retained as a fallback for pre-#1587 fits.

### Verification

- `multinomial_edf_per_class_is_per_class_not_per_block_overcount` — **now passes** (was red on `main`).
- `./build.sh` ban-gate: **BUILD OK**.

(The two-smooth `multinomial_lambda_labels_are_one_per_penalty_component` exercises the same reporting contract; its `s(x)+s(z)` fixture surfaces a separate inner-solve convergence issue I am verifying against pristine `main` — tracked separately if pre-existing.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)