### PR TITLE
test(#1261): restore oversmoothing regime for average-derivative one-step (stale λ after penalty renormalization)

### DIFF
--- a/tests/inference/misc/functionals_average_derivative.rs
+++ b/tests/inference/misc/functionals_average_derivative.rs
@@ -102,7 +102,14 @@ fn average_derivative_onestep_corrects_oversmoothed_gaussian_spline() {
     for seed in seeds {
         let (x, y, truth) = draw_sample(seed);
         let (design, derivative_design, penalty) = bspline_design_and_derivative(&x);
-        let (beta, mu, scaled_penalty) = fit_penalized_gaussian(&design, &y, &penalty, 10.0);
+        // λ chosen to put the fit in the *oversmoothed* regime where the plug-in
+        // average derivative is biased toward zero and the one-step correction has
+        // real work to do (see `plugin_violations >= 3` below). The B-spline
+        // roughness penalty is normalized in the constrained frame (#1364/#1365/
+        // #1366), so a literal λ here is far weaker than it was before that
+        // rescale; λ≈1.5e3 reproduces the oversmoothing the original #1261
+        // fixture obtained at the old, un-normalized λ=10.
+        let (beta, mu, scaled_penalty) = fit_penalized_gaussian(&design, &y, &penalty, 1500.0);
         let penalty_beta = penalty_times_beta(scaled_penalty.view(), beta.view());
         let estimate =
             average_derivative_gaussian_identity(&GaussianIdentityAverageDerivativeInput {


### PR DESCRIPTION
Reopens and fixes #1261.

## Summary

The regression test `average_derivative_onestep_corrects_oversmoothed_gaussian_spline`
fails on `main`. It was closed as COMPLETED citing 4161ba3dc, whose closing
comment says the Riesz solve targets the *unpenalized* `X'X` — but #1427
(4bd4344ef) later switched the production code to the *penalized* Hessian
`H = XᵀX + λS`, and the test still fails. Genuine improper-close.

## Root cause — stale fixture, not an estimator regression

The test relies on λ placing the Gaussian B-spline fit in an **oversmoothed**
regime (`plugin_violations >= 3`) so the one-step (von Mises) correction has
bias to remove. The 1-D B-spline roughness penalty was **renormalized in the
constrained frame** (#1364 / #1365 / #1366) after this fixture was written, so a
literal `λ` now smooths far less. At `λ=10` the plug-in is already near-unbiased,
the precondition fails, and the sign/band assertions collapse.

## Fix

Bump the test `λ` from `10` → `1500`, restoring the oversmoothing the fixture
intended at the old un-normalized scale. **Production code is unchanged** — it
keeps #1427's penalized Hessian, which is the correct and *more robust* Riesz
target (the unpenalized `X'X` target overshoots toward the high-variance OLS
plug-in: worst one-step error 0.171 > 0.15, vs 0.087 for the penalized Hessian).

## Verification

- `average_derivative_onestep_corrects_oversmoothed_gaussian_spline` — **PASS**
  (all 5 seeds oversmoothed, worst one-step error 0.087 < 0.15).
- `gam-inference functionals::tests::{empty_design_returns_error,
  zero_penalty_perfect_fit_se_is_zero_and_onestep_equals_plugin,
  nonzero_penalty_shifts_onestep}` — all **PASS** (production untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)