### PR TITLE
fix(#240): route ard_per_atom to native_ard_enabled (kill the silent no-op)

### DIFF
--- a/gamfit/_sae_manifold.py
+++ b/gamfit/_sae_manifold.py
@@ -3184,7 +3184,6 @@ def sae_manifold_fit(X: Any = None, K: int | None = None, d_atom: int = 2, atom_
     # previously these knobs only populated `primitive_names` metadata.
     analytic_penalties_json = _build_analytic_penalties_payload(
         isometry_weight=isometry_weight,
-        ard_per_atom=ard_per_atom,
         gate_sparsity=gate_sparsity_kind,
         sparsity_weight=sparsity,
         scad_mcp_gamma=scad_mcp_gamma_value,
@@ -3306,6 +3305,18 @@ def sae_manifold_fit(X: Any = None, K: int | None = None, d_atom: int = 2, atom_
         initial_logits=logits_init,
         initial_coords=coords_init,
         jumprelu_threshold=float(jumprelu_threshold),
+        # #240: `ard_per_atom` is the user-facing ARD switch. The ONLY thing that
+        # actually enables/disables ARD in the SAE objective is the native
+        # `ArdAxisPrior`, gated by `native_ard_enabled` (it sizes each atom's
+        # `log_ard` to `d` when on, length-0 when off, adding/removing those
+        # per-atom precisions from the outer ρ search and the inner Arrow-Schur
+        # prior). The registry `{"kind":"ard"}` descriptor is deliberately a
+        # no-op on every SAE path (`AnalyticPenaltyKind::Ard(_)` is skipped in
+        # both the gradient assembly and the value total — the native prior is
+        # the single source of truth, avoiding a double-counted, period-
+        # discontinuous ½λt² energy). So route the flag to the switch that works
+        # instead of leaving it a dead toggle (bit-identical fits on/off).
+        native_ard_enabled=bool(ard_per_atom),
         fisher_factors=None if fisher_shard is None else fisher_shard[0],
         fisher_mass_residual=None if fisher_shard is None else fisher_shard[1],
         fisher_provenance=None if fisher_shard is None else fisher_shard[2],
@@ -3355,7 +3366,6 @@ def _require_sae_row_block_penalty(kind: str, kwarg: str) -> None:
 def _build_analytic_penalties_payload(
     *,
     isometry_weight: float,
-    ard_per_atom: bool,
     decoder_feature_sparsity_groups: list[list[int]] | None,
     block_orthogonality_weight: float,
     d_max: int,
@@ -3371,9 +3381,12 @@ def _build_analytic_penalties_payload(
     """Translate the SAE regularizer knobs into the analytic-penalty JSON
     payload consumed by ``sae_manifold_fit_minimal``.
 
-    The SAE regularizer knobs route through ``src/terms/sae_manifold.rs``.
-    ``ard_per_atom``, ``isometry_weight``, and ``block_orthogonality_weight``
-    target the row-block driver ("t" latent block).
+    The SAE regularizer knobs route through ``crates/gam-sae``.
+    ``isometry_weight`` and ``block_orthogonality_weight`` target the row-block
+    driver ("t" latent block). ``ard_per_atom`` is NOT a registry descriptor:
+    it routes to the native ``ArdAxisPrior`` via the ``native_ard_enabled`` FFI
+    flag (see ``sae_manifold_fit``), since the registry ``ard`` penalty is
+    intentionally skipped on every SAE path.
     ``gate_sparsity="scad"`` or ``"mcp"`` emits the row-block
     ``scad_mcp`` descriptor on the same "t" block, using ``sparsity_weight`` as
     its non-convex sparsity strength. The default ``"l1"`` emits no analytic
@@ -3395,9 +3408,15 @@ def _build_analytic_penalties_payload(
     values penalized.
     """
     items: list[dict[str, Any]] = []
-    if bool(ard_per_atom):
-        _require_sae_row_block_penalty("ard", "ard_per_atom")
-        items.append({"kind": "ard", "target": "t"})
+    # #240: `ard_per_atom` does NOT emit a registry `ard` descriptor. The SAE
+    # objective deliberately skips `AnalyticPenaltyKind::Ard(_)` on every path
+    # (gradient assembly AND value total) because the native `ArdAxisPrior` is
+    # the single source of truth for the per-atom coordinate precision — a
+    # registry `½λt²` ridge would double-count it and is period-discontinuous on
+    # the circular bases. The flag is instead routed to `native_ard_enabled` at
+    # the FFI call (see `sae_manifold_fit`), which sizes / drops each atom's
+    # `log_ard` precisions. Emitting a descriptor here would be a guaranteed
+    # no-op (the exact issue-#240 silent-no-op anti-pattern).
     if gate_sparsity in {"scad", "mcp"} and float(sparsity_weight) > 0.0:
         _require_sae_row_block_penalty("scad_mcp", "gate_sparsity")
         items.append({

--- a/tests/test_sae_facade_audit.py
+++ b/tests/test_sae_facade_audit.py
@@ -30,7 +30,6 @@ def _no_row_block_probe(monkeypatch):
 def test_isometry_weight_changes_payload(monkeypatch):
     _no_row_block_probe(monkeypatch)
     common = dict(
-        ard_per_atom=False,
         gate_sparsity="l1",
         sparsity_weight=0.0,
         scad_mcp_gamma=3.7,
@@ -63,7 +62,6 @@ def test_isometry_weight_zero_omits_descriptor(monkeypatch):
     _no_row_block_probe(monkeypatch)
     payload = sae._build_analytic_penalties_payload(
         isometry_weight=0.0,
-        ard_per_atom=False,
         gate_sparsity="l1",
         sparsity_weight=0.0,
         scad_mcp_gamma=3.7,
@@ -84,7 +82,6 @@ def test_decoder_incoherence_payload_builder_default_is_on_for_multi_atom(monkey
     _no_row_block_probe(monkeypatch)
     payload = sae._build_analytic_penalties_payload(
         isometry_weight=0.0,
-        ard_per_atom=False,
         gate_sparsity="l1",
         sparsity_weight=0.0,
         scad_mcp_gamma=3.7,
@@ -281,17 +278,16 @@ class _FakeRustModule:
         initial_logits=None,
         initial_coords=None,
         jumprelu_threshold=0.0,
+        native_ard_enabled=True,
         **_forward_compat_kwargs,
     ):
-        # ARD-per-atom is now plumbed as an `{"kind": "ard"}` analytic-penalty
-        # descriptor rather than a dedicated `native_ard_enabled` FFI flag.
-        if analytic_penalties is None:
-            self.last_native_ard_enabled = False
-        else:
-            items = json.loads(str(analytic_penalties))
-            self.last_native_ard_enabled = any(
-                str(it.get("kind")) == "ard" for it in items
-            )
+        # #240: `ard_per_atom` controls ARD via the dedicated `native_ard_enabled`
+        # FFI flag (the switch that sizes/drops each atom's `log_ard` precisions),
+        # NOT via a registry `{"kind": "ard"}` descriptor. The registry `ard`
+        # penalty is deliberately skipped on every SAE objective path, so plumbing
+        # the flag through the descriptor was a silent no-op (issue #240). Read the
+        # real flag the facade now forwards.
+        self.last_native_ard_enabled = bool(native_ard_enabled)
         z = np.asarray(z, dtype=float)
         n_obs, p_out = z.shape
         k_atoms = len(atom_basis)


### PR DESCRIPTION
Fixes #240 (reopened).

## The bug

`gamfit.sae_manifold_fit`'s `ard_per_atom` parameter was a **silent no-op**. Two distinct things are named "ARD" in this codebase:

1. A registry analytic-penalty descriptor `{"kind":"ard","target":"t"}` — what `ard_per_atom=True` emitted.
2. The native von-Mises `ArdAxisPrior`, gated by the `native_ard_enabled` FFI flag.

(1) is **deliberately skipped on every SAE objective path** — both the gradient assembly (`crates/gam-sae/src/manifold/penalties.rs:1068`) and the value total (`crates/gam-sae/src/manifold/construction.rs:3253`) `continue` past `AnalyticPenaltyKind::Ard(_)`, because the native prior is the single source of truth (a registry `½λt²` ridge would double-count it and is period-discontinuous on circular bases). So the descriptor did nothing.

(2) is the switch that actually works — it sizes each atom's `log_ard` to `d` when on, length-0 when off. It defaults to `true` and **was never wired to `ard_per_atom`**.

Net: `ard_per_atom=True` and `ard_per_atom=False` produced **bit-identical fits**. This is precisely the silent-no-op anti-pattern issue #240 was filed to eliminate. The closing comment claimed the registry-descriptor mechanism fixed it; that mechanism cannot — see the two `continue` skips above.

## The fix

- Route `ard_per_atom -> native_ard_enabled=bool(ard_per_atom)` at the `sae_manifold_fit_minimal` FFI call.
- Drop the dead `{"kind":"ard"}` descriptor and the now-unused `ard_per_atom` parameter from `_build_analytic_penalties_payload`.
- Update `_FakeRustModule` in the facade audit to read the real `native_ard_enabled` kwarg (it was sniffing `analytic_penalties` for a `"kind":"ard"` item — encoding the buggy contract) and drop `ard_per_atom=False` from 3 builder call sites.

## Verification

`./build.sh` green. `tests/test_sae_manifold_regularizer_noops_issue_240.py` + `tests/test_sae_facade_audit.py` — **36 passed**. Toggling `ard_per_atom` is now observable: born-atom count 4→3, fitted-coord max |Δ| ~0.51 on the #240 regression.

No SPEC.md violation: ARD precisions remain REML/LAML-driven via the native prior; no hand-set λ, no autodiff, no finite differences.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
