### PR TITLE
fix(#500): guard the bc=clamped interior-quality fix + reject tensor endpoint BCs

### DIFF
--- a/crates/gam-terms/src/term_builder.rs
+++ b/crates/gam-terms/src/term_builder.rs
@@ -1201,6 +1201,45 @@ fn parse_tensor_periodic_axes(
     Ok(axes)
 }
 
+/// Reject endpoint boundary conditions (`clamped`/`anchored`) requested on a
+/// tensor-product margin.
+///
+/// Tensor smooths support `bc=`/`boundary=` only for *periodic* margin
+/// selection (`periodic`/`cyclic`/`cc`), which [`parse_tensor_periodic_axes`]
+/// consumes. Endpoint boundary conditions are a 1-D B-spline structural
+/// reparameterization and are NOT implemented for tensor margins, but the
+/// periodic-axes parser silently ignores every non-periodic token — so
+/// `te(x, y, bc=['clamped', 'natural'])` used to be accepted as a no-op and
+/// fit an ordinary unconstrained tensor, dropping the user's clamp without a
+/// word. Surface it as a clean, explicit error instead of a silent drop. The
+/// inert margin tokens (`natural`/`free`/`none`/empty) and the periodic
+/// selectors are accepted; anything else is an unsupported endpoint BC.
+fn reject_tensor_endpoint_boundary_conditions(
+    options: &BTreeMap<String, String>,
+    dim: usize,
+) -> Result<(), String> {
+    let Some(raw) = options.get("boundary").or_else(|| options.get("bc")) else {
+        return Ok(());
+    };
+    let entries = parse_option_list(raw);
+    for (axis, value) in entries.iter().enumerate() {
+        let inert = matches!(
+            value.as_str(),
+            "natural" | "free" | "none" | "" | "periodic" | "cyclic" | "cc"
+        );
+        if !inert {
+            return Err(TermBuilderError::unsupported_feature(format!(
+                "tensor smooth margin {axis} endpoint boundary condition '{value}' is not supported \
+                 (got bc/boundary={raw:?} on a {dim}-D tensor); tensor margins accept only periodic \
+                 selection (periodic/cyclic/cc) or the inert natural/free token. Apply clamped/anchored \
+                 endpoint boundary conditions with a 1-D s(x, bc=...) term instead."
+            ))
+            .to_string());
+        }
+    }
+    Ok(())
+}
+
 fn tensor_k_axis_option_axis(
     key: &str,
     cols: &[usize],
@@ -2954,6 +2993,7 @@ pub fn build_smooth_basis(
                 }
             }
             let periodic_axes = parse_tensor_periodic_axes(options, dim)?;
+            reject_tensor_endpoint_boundary_conditions(options, dim)?;
             let periods_opt = parse_periods(options, &periodic_axes)?;
             let origins_opt = parse_period_origins(options, &periodic_axes)?;
             let degree = option_usize(options, "degree").unwrap_or(DEFAULT_BSPLINE_DEGREE);

--- a/tests/basis_smooth/optimization/reml_iter_reduction_correctness.rs
+++ b/tests/basis_smooth/optimization/reml_iter_reduction_correctness.rs
@@ -206,7 +206,11 @@ fn reml_outer_iter_reduction_cyclic_1d_deterministic_betas_match_tightly() {
 fn reml_outer_iter_reduction_bc_anchored_deterministic_betas_match_tightly() {
     init_parallelism();
     let data = data_bc(N);
-    let formula = "y ~ bc(x, anchor=0)";
+    // Endpoint boundary conditions are an OPTION on s(), not a term function:
+    // there is no `bc(...)` term (the parser rejects it as unknown). Exercise
+    // the anchored-endpoint reparameterized smooth via the supported syntax so
+    // the determinism contract actually fits instead of failing at parse time.
+    let formula = "y ~ s(x, bc=anchored)";
     let beta_a = fit_beta(formula, &data);
     let beta_b = fit_beta(formula, &data);
     let diff = beta_max_abs_diff(&beta_a, &beta_b);

--- a/tests/regressions/optimization/bc_clamped_startup_kkt_abort.rs
+++ b/tests/regressions/optimization/bc_clamped_startup_kkt_abort.rs
@@ -14,17 +14,27 @@
 //! (geometric) coordinates, consistent with the solver's contract, so the
 //! refusal no longer fires and the fit proceeds.
 //!
-//! SCOPE: this test guards the ABORT regression only — that the clamped fit
-//! completes and returns finite predictions. It does NOT assert interior
-//! fit quality, because a separate, deeper, deterministic defect remains:
-//! REML over-smooths to the λ-ceiling whenever a linear inequality
-//! constraint is active, so the returned clamped fit is near-constant
-//! (interior RMSE ≈ 0.77 vs ≈ 0.02 unconstrained). That degeneracy is
-//! independent of the vertical offset — the same collapse occurs on
-//! `sin(2πx) + 0.3` (see `bc_fit_quality_sanity.rs`, currently failing) —
-//! so the issue's premise that the +0.3 variant "fits without trouble" is
-//! empirically false. The over-smoothing is tracked as the remaining work
-//! on #500; conflating it with the abort in one assertion would be wrong.
+//! SCOPE: this test guards two things, both of which the #500 reopen confirmed
+//! are now genuinely fixed (the original close left the SECOND one unguarded):
+//!   1. the ABORT regression — the clamped fit must COMPLETE, not refuse every
+//!      seed during outer startup validation; and
+//!   2. interior fit QUALITY — the returned clamped smooth must actually track
+//!      the signal, not collapse to a near-constant.
+//!
+//! When this issue was first closed, only (1) was fixed and (2) was explicitly
+//! deferred with the claim that "REML over-smooths to the λ-ceiling whenever a
+//! linear inequality constraint is active, so the returned clamped fit is
+//! near-constant (interior RMSE ≈ 0.77 vs ≈ 0.02 unconstrained)". That claim
+//! is no longer true: `bc=clamped` no longer lowers to a runtime active-set
+//! inequality at all — since #1238 it is a *structural nullspace
+//! reparameterization* (the pinned endpoint-derivative DOF is removed from the
+//! basis before the solver sees it), so the smooth fits on the ordinary
+//! unconstrained REML path and recovers the interior at ≈ unconstrained
+//! quality. The deferred degeneracy was fixed but left UNGUARDED — a future
+//! regression in the constrained-chart penalty geometry would silently
+//! re-collapse the clamped fit with nothing red. This test now pins the
+//! quality so the fix cannot rot. (The sibling `bc_fit_quality_sanity.rs`
+//! pins the same contract on the `+0.3`-offset dataset.)
 
 use csv::StringRecord;
 use gam::matrix::LinearOperator;
@@ -134,15 +144,31 @@ fn clamped_zero_offset_sine_does_not_abort_startup_validation() {
         "clamped fit produced non-finite predictions"
     );
 
-    // Informational only (NOT asserted): the unconstrained reference and the
-    // clamped interior RMSE. The clamped value is expected to be poor here
-    // (≈0.77, near-constant) because of the separate, deeper REML
-    // over-smoothing-under-constraints degeneracy documented in the module
-    // header and tracked as the remaining work on #500. Asserting quality
-    // here would conflate two distinct bugs.
+    // QUALITY GATE (the part the original close left unguarded): the clamped
+    // smooth must recover the interior signal at ≈ unconstrained quality, NOT
+    // collapse to the λ-ceiling near-constant the original triage feared.
+    // Since #1238 `bc=clamped` is a structural nullspace reparameterization —
+    // the pinned endpoint-derivative DOF is removed from the basis before the
+    // solver runs — so the fit takes the ordinary unconstrained REML path and
+    // the interior RMSE tracks the free fit within a small multiple.
+    //
+    // Concrete numbers at this seed/n: free ≈ 0.018, clamped ≈ 0.022. We assert
+    // a generous bar (clamped ≤ 5× free, and an absolute ceiling of 0.10) so the
+    // test is robust to platform FP drift yet still RED if the fit ever
+    // re-collapses toward the ≈0.77 near-constant degeneracy.
     let rmse_free = rmse(&fit_and_probe("y ~ s(x, k=12)", &data, &eval_xs), &eval_xs);
     let rmse_clamped = rmse(&pred_clamped, &eval_xs);
-    eprintln!(
-        "[bc-500] free={rmse_free:.4} clamped={rmse_clamped:.4} (clamped quality tracked separately)"
+    eprintln!("[bc-500] free={rmse_free:.4} clamped={rmse_clamped:.4}");
+    assert!(
+        rmse_clamped <= 0.10,
+        "#500 quality regression: clamped interior RMSE={rmse_clamped:.4} exceeds the 0.10 \
+         absolute ceiling — the structural bc=clamped reparameterization appears to have \
+         re-collapsed toward the old λ-ceiling near-constant (≈0.77) degeneracy"
+    );
+    assert!(
+        rmse_clamped <= 5.0 * rmse_free,
+        "#500 quality regression: clamped RMSE={rmse_clamped:.4} is more than 5× the \
+         unconstrained reference RMSE={rmse_free:.4}; the clamped fit is no longer tracking \
+         the interior signal at unconstrained quality"
     );
 }


### PR DESCRIPTION
Reopens / closes #500.

## Why #500 was improperly closed

#500 was closed with the status *"abort root-caused & fixed; a separate over-smoothing degeneracy remains."* Two problems with that closure:

1. **The deferred degeneracy was never tracked.** The closing comment said the over-smoothing-under-constraints collapse "is tracked as the remaining work on #500" — but the issue was then *closed*, and no follow-up issue was ever filed. The deferred bug fell on the floor.

2. **Its regression test was left with documentation that is now factually wrong, and it explicitly DISCLAIMED asserting fit quality** — so even once the degeneracy got fixed, nothing guarded it. The module header of `tests/regressions/optimization/bc_clamped_startup_kkt_abort.rs` claimed:

   > REML over-smooths to the λ-ceiling whenever a linear inequality constraint is active, so the returned clamped fit is near-constant (interior RMSE ≈ 0.77 vs ≈ 0.02 unconstrained) … the issue's premise that the +0.3 variant "fits without trouble" is empirically false.

   And the test body said *"Asserting quality here would conflate two distinct bugs"* and only checked finiteness.

## What's actually true now

The deferred degeneracy **is fixed** — by #1238, which changed `bc=clamped`/`bc=anchored` from runtime linear-inequality constraints into a **structural nullspace reparameterization**: the pinned endpoint-derivative DOF is removed from the basis *before* the solver runs (`bspline_boundary_nullspace_transform`). So a plain `s(x, bc=clamped)` reaches the solver with `linear_constraints = None` and fits on the ordinary unconstrained REML path. Measured on the exact #500 dataset (`sin(2πx)`, n=300, σ=0.1, seed=7):

```
[bc-500] free=0.0176 clamped=0.0215
```

i.e. clamped interior RMSE ≈ unconstrained, **not** the ≈0.77 near-constant collapse. The sibling `+0.3` dataset agrees: `clamped_both=0.0131 vs free=0.0100`. The old header's claims are stale and false.

The defect that remained at closure time (the fix existing but **unguarded**, behind a test that disclaimed quality) is the improper-closure: this PR locks the fix in.

## Adjacent RED tests fixed (mission: kill neighbors)

Two pre-existing red tests in the same BC area (identical failures on `origin/main`):

- **`tensor_with_endpoint_bc_margin_rejected_cleanly`** — `te(x, y, bc=['clamped','natural'])` was *silently accepted as a no-op*: `parse_tensor_periodic_axes` only flips periodic axes for periodic/cyclic/cc tokens and ignores `clamped`/`anchored`, so the user's endpoint clamp was dropped without a word and an ordinary unconstrained tensor was fit. Now `reject_tensor_endpoint_boundary_conditions` surfaces a clean, explicit error directing the user to a 1-D `s(x, bc=...)` term.

- **`reml_outer_iter_reduction_bc_anchored_deterministic_betas_match_tightly`** — used the invalid formula `bc(x, anchor=0)`. There is no `bc(...)` term function (the parser rejects it as unknown), so the test failed at parse time and never exercised the anchored reparam it was meant to pin. Corrected to the supported `s(x, bc=anchored)` syntax.

## Changes

- `tests/regressions/optimization/bc_clamped_startup_kkt_abort.rs`: rewrite the stale header with the correct structural-reparam explanation; add an asserted interior-quality gate (clamped ≤ 5× free, absolute ceiling 0.10).
- `crates/gam-terms/src/term_builder.rs`: add `reject_tensor_endpoint_boundary_conditions`.
- `tests/basis_smooth/optimization/reml_iter_reduction_correctness.rs`: fix the broken anchored-determinism formula.

## Verification (self-run; GitHub Actions does not gate)

All via `./build.sh` (the only allowed cargo wrapper). `BUILD OK`. Tests:

- `clamped_zero_offset_sine_does_not_abort_startup_validation` — PASS (`free=0.0176 clamped=0.0215`)
- `bc_clamped_fit_tracks_interior_well` (3 tests) — PASS
- `tensor_with_endpoint_bc_margin_rejected_cleanly` — PASS (was RED)
- `reml_iter_reduction_correctness` (5 tests, incl. the corrected anchored one) — PASS (was RED)
- `tensor_3d_smooth_robust` (4), `gam-terms` unit `term_builder` (38) — PASS (no regression from the new tensor-bc gate)
- build.rs ban-gate — clean (no `#[allow]`/`#[ignore]`/`eprintln!`/`println!`/`std::env::var` introduced)

🤖 Generated with [Claude Code](https://claude.com/claude-code)