### PR TITLE
fix(#795): scale-invariant SAE isometry Gauss-Newton curvature + re-enable the gauge

### DIFF
--- a/crates/gam-sae/src/manifold/construction.rs
+++ b/crates/gam-sae/src/manifold/construction.rs
@@ -6248,7 +6248,29 @@ impl SaeManifoldTerm {
                 let is_reversal = self.evidence_gauge_deflation_last_delta_sign != 0
                     && delta_sign != self.evidence_gauge_deflation_last_delta_sign;
                 self.evidence_gauge_deflation_last_delta_sign = delta_sign;
-                if is_reversal {
+                // A reversal alone is NOT the pathology — a BOUNDED flicker of a
+                // few rows crossing the near-null deflation floor reverses
+                // direction every step yet is the discretization jitter of a
+                // continuous evidence spectrum, fully evidence-neutral (each
+                // deflated direction contributes `log 1 = 0` either way). The
+                // genuine "quotient dimension not stabilizing" pathology is a
+                // WIDE-amplitude oscillation: a substantial FRACTION of the
+                // dimension flipping back and forth. The count is an O(N) per-row
+                // sum, so the discriminator must be the reversal AMPLITUDE
+                // relative to the dimension level, not the bare reversal. Charge
+                // the reversal budget only when a reversal's step exceeds a
+                // relative jitter band; a converged-but-flickering fit (e.g.
+                // 150<->147 on N=200, ~2% of the level) re-anchors freely while a
+                // true runaway (e.g. 9<->2, ~80% of the level) still trips every
+                // reversal and exhausts the budget. This was the second #795 root
+                // cause: the single-planted-circle fit's per-row count flickers
+                // 150<->147 near the deflation floor, so the bare-reversal guard
+                // refused the simplest possible fit — with the isometry gauge ON
+                // *or* OFF — long before the gauge magnitude mattered.
+                let amplitude = expected.abs_diff(count);
+                let level = expected.max(count);
+                let jitter_band = (level / 4).max(2);
+                if is_reversal && amplitude > jitter_band {
                     self.evidence_gauge_deflation_reanchors += 1;
                 }
                 let reversal_budget = self

--- a/crates/gam-sae/src/manifold/penalties.rs
+++ b/crates/gam-sae/src/manifold/penalties.rs
@@ -1419,7 +1419,30 @@ impl SaeManifoldTerm {
         // rho.exp()` overflows to `inf` for `rho ≳ 709`, and the downstream
         // `inf · jacobian` / `inf · 0.0` then injects NaN into the GN curvature
         // block and β-penalty, poisoning the joint solve (#742, Issue 4).
-        let mu = resolve_learnable_weight(corrected.scalar_weight, rho_local[corrected.rho_index]);
+        //
+        // #795 scale-invariant curvature: the value / gradient paths penalize
+        // the SCALE-INVARIANT residual `R_n = g_n/gbar − g^ref_n` (normalized by
+        // the shared `gbar = mean tr(g)/d`), so the assembled gradient is free
+        // of the decoder magnitude. This Gauss-Newton block, however, is built
+        // below from the RAW weighted Jacobian `wj ∝ ‖B‖`, so `AᵀA ∝ ‖B‖⁴` — it
+        // is the GN block of the UN-normalized `½μ‖g_n − g^ref‖²`. Pairing a
+        // scale-free gradient with a `‖B‖⁴` curvature collapses the joint Newton
+        // step (`H⁻¹g ∝ ‖B‖⁻⁴`) as the decoder grows, the proximal ridge
+        // saturates at 1e15, and every trial step is rejected — the exact #795
+        // failure. The Gauss-Newton block of the NORMALIZED residual is the raw
+        // block times `1/gbar²` (freezing the shared normalizer, the same
+        // convention `normalized_metric_state`'s majorizer uses): a positive
+        // scalar on an already-PSD Gram block, so the Schur complement stays PSD,
+        // and `1/gbar² ∝ ‖B‖⁻⁴` exactly cancels the raw `‖B‖⁴`. Fold it into `mu`
+        // so every `mu * acc` write below carries it. `gbar` is read from the
+        // penalty (the single source of truth shared with the gradient); if it
+        // is unavailable/degenerate we skip the block rather than write a
+        // mis-scaled one.
+        let mu_raw = resolve_learnable_weight(corrected.scalar_weight, rho_local[corrected.rho_index]);
+        let Some(gbar) = corrected.metric_normalizer(d) else {
+            return;
+        };
+        let mu = mu_raw / (gbar * gbar);
         // A negligible (or non-finite) effective isometry weight contributes a
         // zero curvature block; writing zeros would still flip the solver onto
         // the dense-supplement Schur path (and invalidate caches) for no model
@@ -1664,7 +1687,25 @@ impl SaeManifoldTerm {
         // rho.exp()` overflows to `inf` for `rho ≳ 709`, and the downstream
         // `inf · jacobian` / `inf · 0.0` then injects NaN into the GN curvature
         // block and β-penalty, poisoning the joint solve (#742, Issue 4).
-        let mu = resolve_learnable_weight(corrected.scalar_weight, rho_local[corrected.rho_index]);
+        //
+        // #795 scale-invariant curvature (decoder β block): the `gb` gradient
+        // accumulated above routes through the gbar-normalized
+        // `grad_jacobian`, so it is free of the decoder magnitude. This dense
+        // `hbb` Gauss-Newton block is the decoder-side pullback of the SAME raw
+        // `wj`-built block as the coord-side `htt` (`add_sae_isometry_metric_gn_blocks`),
+        // so it scales ∝‖B‖⁴ and would re-introduce the #795 step collapse on
+        // the β tier. Fold the same `1/gbar²` frozen-normalizer factor in here
+        // so the decoder curvature matches its scale-free gradient. PSD-
+        // preserving (positive scalar on a PSD Gram block); skip on a degenerate
+        // normalizer rather than write a mis-scaled block.
+        let mu_raw = resolve_learnable_weight(corrected.scalar_weight, rho_local[corrected.rho_index]);
+        let Some(gbar) = corrected.metric_normalizer(d) else {
+            return;
+        };
+        let mu = mu_raw / (gbar * gbar);
+        if !(mu.is_finite() && mu > 0.0) {
+            return;
+        }
         let mut metric_jvp = Array2::<f64>::zeros((d, d));
         let mut jac_hvp = Array2::<f64>::zeros((p, d));
         let mut beta_hvp = Array2::<f64>::zeros((m, p));

--- a/crates/gam-sae/src/manifold/sae_contract_probe_tests.rs
+++ b/crates/gam-sae/src/manifold/sae_contract_probe_tests.rs
@@ -634,6 +634,112 @@ fn sae_isometry_assembled_curvature_is_decoder_scale_invariant() {
     }
 }
 
+/// #795 — the end-to-end joint `(t, β)` fit with the isometry gauge ENABLED must
+/// CONVERGE at every decoder scale, not just hold the scale-invariance property of
+/// a single assembled step.
+///
+/// This is the user-visible symptom the issue reports: with the un-normalized
+/// ‖B‖⁴ curvature, a large planted decoder makes the isometry Gauss-Newton block
+/// dominate the well-conditioned data-fit block by orders of magnitude, the
+/// arrow-Schur row blocks lose positive-definiteness, and the proximal ridge
+/// escalates to its 1e15 saturation without ever taking a productive Newton step —
+/// the fit stalls far from stationarity. With the `1/gbar²` fold the isometry
+/// block tracks the (scale-free) gradient, so the same handful of full-Newton
+/// steps reach the planted circle at λ=1 AND at λ=25. We assert a finite converged
+/// loss and a SCALE-INVARIANT reconstruction error (the fit recovers the same
+/// circle regardless of decoder magnitude) across scales.
+#[test]
+fn sae_isometry_joint_fit_converges_across_decoder_scales() {
+    use gam_terms::analytic_penalties::{
+        AnalyticPenaltyKind, AnalyticPenaltyRegistry, IsometryPenalty, PsiSlice,
+    };
+    let n = 24usize;
+    let p = 4usize;
+    let coords = Array2::from_shape_fn((n, 1), |(row, _)| (row as f64 + 0.5) / n as f64);
+    let (phi, jet) = periodic_basis(&coords);
+    let m = phi.ncols();
+    let base_decoder = Array2::from_shape_fn((m, p), |(b, c)| {
+        let scale = 1.0 / (1.0 + b as f64);
+        scale * ((b as f64 + 1.0) * (c as f64 + 1.0)).cos()
+    });
+
+    // Returns the converged relative reconstruction error ‖Φ(t̂)·B̂ − target‖/‖target‖
+    // for a joint fit run with the isometry gauge ON at the given decoder scale.
+    let converged_recon_rel = |lambda: f64| -> f64 {
+        let decoder = &base_decoder * lambda;
+        let atom = SaeManifoldAtom::new(
+            "iso_converge",
+            SaeAtomBasisKind::Periodic,
+            1,
+            phi.clone(),
+            jet.clone(),
+            decoder.clone(),
+            Array2::<f64>::eye(m),
+        )
+        .unwrap()
+        .with_basis_evaluator(Arc::new(TestPeriodicEvaluator));
+        let target = phi.dot(&decoder);
+        let assignment = SaeAssignment::from_blocks_with_mode_and_manifolds(
+            Array2::<f64>::zeros((n, 1)),
+            vec![coords.clone()],
+            vec![LatentManifold::Circle { period: 1.0 }],
+            AssignmentMode::softmax(1.0),
+        )
+        .unwrap();
+        let mut term = SaeManifoldTerm::new(vec![atom], assignment).unwrap();
+
+        let mut registry = AnalyticPenaltyRegistry::new();
+        registry.push(AnalyticPenaltyKind::Isometry(Arc::new(
+            IsometryPenalty::new_euclidean(PsiSlice::full(n, Some(1)), 1),
+        )));
+        let mut rho = SaeManifoldRho::new(0.0, 0.8_f64.ln(), vec![array![1.0_f64.ln()]]);
+
+        let loss = term
+            .run_joint_fit_arrow_schur(
+                target.view(),
+                &mut rho,
+                Some(&registry),
+                12,
+                1.0,
+                1.0e-4,
+                1.0e-4,
+            )
+            .expect("joint fit with isometry gauge ON must converge at every decoder scale");
+        assert!(
+            loss.total().is_finite(),
+            "converged loss must be finite at λ={lambda}, got {}",
+            loss.total()
+        );
+
+        let recon = term.try_fitted_for_rho(&rho).expect("fitted reconstruction exists");
+        let mut num = 0.0_f64;
+        let mut den = 0.0_f64;
+        for (r, t) in recon.iter().zip(target.iter()) {
+            num += (r - t) * (r - t);
+            den += t * t;
+        }
+        (num / den).sqrt()
+    };
+
+    let base = converged_recon_rel(1.0);
+    assert!(
+        base < 1.0e-3,
+        "the joint fit must recover the planted circle at unit scale; rel recon {base:.3e}"
+    );
+    // The un-normalized curvature would make the larger-decoder fits stall (the
+    // ridge saturates and the recon error stays O(1)); the fix keeps the recovered
+    // circle scale-invariant.
+    for &lambda in &[5.0_f64, 25.0] {
+        let scaled = converged_recon_rel(lambda);
+        assert!(
+            scaled < 1.0e-3,
+            "joint fit with isometry ON must converge to the planted circle at \
+             λ={lambda} (rel recon {scaled:.3e}); a non-converging fit is the #795 \
+             ridge-saturation symptom of the un-normalized ‖B‖⁴ curvature."
+        );
+    }
+}
+
 /// #1206 — the gradient lane's `(cost, gradient)` pair must be SELF-CONSISTENT
 /// for the outer BFGS Armijo line search. The amortized-encoder consistency
 /// fold `c(ρ)` (#1154) has no analytic gradient (under Design A the exact

--- a/crates/gam-sae/src/manifold/sae_contract_probe_tests.rs
+++ b/crates/gam-sae/src/manifold/sae_contract_probe_tests.rs
@@ -532,6 +532,108 @@ fn circle_phase_gap(a: f64, b: f64) -> f64 {
         .min((1.0 - raw.fract()).abs())
 }
 
+/// #795 — the SAE-assembled isometry Gauss-Newton curvature must be
+/// decoder-scale-invariant, matching its already-scale-free gradient.
+///
+/// The isometry value/gradient penalize the SCALE-INVARIANT normalized residual
+/// `R_n = g_n/gbar − g^ref_n`, so they are free of the decoder magnitude `‖B‖`.
+/// But the arrow-Schur curvature blocks (`htt`/`htbeta`/`hbb`) are built from
+/// the RAW weighted Jacobian `wj ∝ ‖B‖`, i.e. the Gauss-Newton block of the
+/// UN-normalized `½μ‖g_n − g^ref‖²`, which scales ∝‖B‖⁴. Pairing a scale-free
+/// gradient with a ‖B‖⁴ curvature collapses the joint Newton step as the decoder
+/// grows and the proximal ridge saturates at 1e15 — the #795 failure. The fix
+/// folds the frozen-normalizer factor `1/gbar²` into the curvature so it is the
+/// GN block of the normalized residual; `1/gbar² ∝ ‖B‖⁻⁴` cancels the raw `‖B‖⁴`.
+///
+/// This pins the cancellation directly on the production assembly: scaling the
+/// decoder (hence the target, so the well-fit residual is unchanged) by λ leaves
+/// the ISOLATED isometry curvature contribution `htt(with) − htt(without)`
+/// invariant, while WITHOUT the fix it would scale ∝λ⁴ (≈10⁴× at λ=10).
+#[test]
+fn sae_isometry_assembled_curvature_is_decoder_scale_invariant() {
+    use gam_terms::analytic_penalties::{
+        AnalyticPenaltyKind, AnalyticPenaltyRegistry, IsometryPenalty, PsiSlice,
+    };
+    let n = 24usize;
+    let p = 4usize;
+    let coords = Array2::from_shape_fn((n, 1), |(row, _)| (row as f64 + 0.5) / n as f64);
+    let (phi, jet) = periodic_basis(&coords);
+    let m = phi.ncols();
+    let base_decoder = Array2::from_shape_fn((m, p), |(b, c)| {
+        let scale = 1.0 / (1.0 + b as f64);
+        scale * ((b as f64 + 1.0) * (c as f64 + 1.0)).cos()
+    });
+
+    let isometry_curvature_norm = |lambda: f64| -> f64 {
+        let decoder = &base_decoder * lambda;
+        let atom = SaeManifoldAtom::new(
+            "iso_scale",
+            SaeAtomBasisKind::Periodic,
+            1,
+            phi.clone(),
+            jet.clone(),
+            decoder.clone(),
+            Array2::<f64>::eye(m),
+        )
+        .unwrap()
+        .with_basis_evaluator(Arc::new(TestPeriodicEvaluator));
+        // Target is the exact decoded curve at this scale, so the well-fit
+        // residual (and thus the data-fit curvature) is the same shape at every
+        // λ — only the isometry block carries the scale dependence we probe.
+        let target = phi.dot(&decoder);
+        let assignment = SaeAssignment::from_blocks_with_mode_and_manifolds(
+            Array2::<f64>::zeros((n, 1)),
+            vec![coords.clone()],
+            vec![LatentManifold::Circle { period: 1.0 }],
+            AssignmentMode::softmax(1.0),
+        )
+        .unwrap();
+        let mut term = SaeManifoldTerm::new(vec![atom], assignment).unwrap();
+
+        let mut registry = AnalyticPenaltyRegistry::new();
+        registry.push(AnalyticPenaltyKind::Isometry(Arc::new(
+            IsometryPenalty::new_euclidean(PsiSlice::full(n, Some(1)), 1),
+        )));
+        let rho = SaeManifoldRho::new(0.0, 0.8_f64.ln(), vec![array![1.0_f64.ln()]]);
+
+        // Isolate the isometry contribution to the coordinate curvature: the
+        // data-fit `htt` legitimately grows with the target scale, so we
+        // difference assemble-with-isometry against assemble-without.
+        let sys = term
+            .assemble_arrow_schur(target.view(), &rho, Some(&registry))
+            .expect("assemble with isometry succeeds");
+        let bare = term
+            .assemble_arrow_schur(target.view(), &rho, None)
+            .expect("bare assemble succeeds");
+        let mut htt_iso = 0.0_f64;
+        for (r, b) in sys.rows.iter().zip(bare.rows.iter()) {
+            for (v, bv) in r.htt.iter().zip(b.htt.iter()) {
+                htt_iso += (v - bv) * (v - bv);
+            }
+        }
+        htt_iso.sqrt()
+    };
+
+    let base = isometry_curvature_norm(1.0);
+    assert!(
+        base > 1.0,
+        "the planted-circle fixture must produce a non-trivial isometry \
+         curvature block to make the scale test meaningful; got {base:.3e}"
+    );
+    for &lambda in &[3.0_f64, 10.0, 50.0] {
+        let scaled = isometry_curvature_norm(lambda);
+        let rel = (scaled - base).abs() / base;
+        assert!(
+            rel < 1.0e-6,
+            "SAE-assembled isometry curvature must be decoder-scale-invariant \
+             (#795): λ=1 → {base:.6e}, λ={lambda} → {scaled:.6e} (rel diff {rel:.3e}). \
+             A λ-dependent block is the un-normalized ‖B‖⁴ Gauss-Newton curvature \
+             whose mismatch with the scale-free gradient saturates the proximal \
+             ridge at 1e15."
+        );
+    }
+}
+
 /// #1206 — the gradient lane's `(cost, gradient)` pair must be SELF-CONSISTENT
 /// for the outer BFGS Armijo line search. The amortized-encoder consistency
 /// fold `c(ρ)` (#1154) has no analytic gradient (under Design A the exact

--- a/crates/gam-sae/src/manifold/tests.rs
+++ b/crates/gam-sae/src/manifold/tests.rs
@@ -171,6 +171,60 @@ pub(crate) fn trivial_k1_euclidean_term() -> SaeManifoldTerm {
     SaeManifoldTerm::new(vec![atom], assignment).unwrap()
 }
 
+/// #795 (second root cause) — a BOUNDED low-amplitude flicker of the per-row
+/// gauge-deflation count is benign jitter, NOT the oscillating-quotient
+/// pathology, so it must re-anchor freely no matter how many times it reverses.
+///
+/// The count is an O(N) per-row sum of near-null evidence directions; a handful
+/// of rows sitting right at the deflation floor cross it back and forth as the
+/// ρ-walk nudges the conditioning, reversing direction every step while staying
+/// within a few of a large level (the single-planted-circle fit flickers
+/// 150<->147 on N=200). Each such change is evidence-neutral (a deflated
+/// direction contributes the ρ-independent `log 1 = 0` to `½log|H|` either way),
+/// so re-anchoring is exactly correct and the fit must not be refused. The
+/// bare-reversal guard charged the budget on every one of these and aborted the
+/// simplest possible manifold-SAE fit (isometry on OR off) — this pins that a
+/// sustained small-amplitude flicker survives indefinitely.
+#[test]
+pub(crate) fn evidence_gauge_deflation_count_bounded_flicker_reanchors_freely() {
+    let mut term = trivial_k1_euclidean_term();
+    // Pin the expected count at a realistic large level (like the circle fit).
+    term.record_evidence_gauge_deflation_count(150).unwrap();
+    // A sustained 150<->147 flicker reverses direction on EVERY step — far more
+    // reversals than the K=1 budget of 6 — yet the amplitude (3) is well inside
+    // the relative jitter band (150/4 = 37), so none charge the budget.
+    let flicker = [147usize, 150, 147, 150, 147, 150, 147, 150, 147, 150, 147, 150, 147, 150];
+    for &c in &flicker {
+        term.record_evidence_gauge_deflation_count(c)
+            .expect("a bounded low-amplitude flicker must re-anchor, never abort");
+    }
+    assert_eq!(
+        term.evidence_gauge_deflation_reanchors, 0,
+        "a flicker inside the relative jitter band charges no reversals"
+    );
+    assert_eq!(
+        term.expected_evidence_gauge_deflated_directions,
+        Some(150),
+        "the comparison re-anchors to the latest observed count"
+    );
+
+    // But a WIDE-amplitude oscillation at the SAME level is still the runaway
+    // pathology and must still be refused: 150<->40 swings ~73% of the level.
+    let mut term2 = trivial_k1_euclidean_term();
+    term2.record_evidence_gauge_deflation_count(150).unwrap();
+    let mut errored = false;
+    for &c in &[40usize, 150, 40, 150, 40, 150, 40, 150, 40, 150, 40, 150, 40, 150] {
+        if term2.record_evidence_gauge_deflation_count(c).is_err() {
+            errored = true;
+            break;
+        }
+    }
+    assert!(
+        errored,
+        "a wide-amplitude oscillation must still exhaust the reversal budget"
+    );
+}
+
 /// The #1037 quotient-dimension guard, with #1217 oscillation semantics: the
 /// recorded count of gauge-deflated evidence directions need not be CONSTANT —
 /// it is a per-ROW-summed O(N) count of near-null evidence directions that

--- a/crates/gam-terms/src/analytic_penalties/isometry.rs
+++ b/crates/gam-terms/src/analytic_penalties/isometry.rs
@@ -897,6 +897,38 @@ impl IsometryPenalty {
         Some(g_all)
     }
 
+    /// The scale normalizer `gbar = (1 / (N d)) Σ_n tr(g_n)` of the cached
+    /// pullback metric — the single shared denominator the scale-invariant
+    /// gauge divides every per-row metric by.
+    ///
+    /// `value` / `grad_*` / `hvp` consume this implicitly through
+    /// [`Self::normalized_metric_state`]; the SAE arrow-Schur assembly cannot
+    /// (it builds explicit per-row `htt` / `htbeta` / `hbb` curvature blocks
+    /// from the raw pullback `g_n`, not through the trait operators), so it
+    /// reads `gbar` here and folds `1/gbar²` into its Gauss-Newton curvature.
+    /// That `1/gbar²` factor is exactly the frozen-normalizer Gauss-Newton
+    /// block of the normalized residual `R_n = g_n/gbar − g^ref_n`: the raw
+    /// block (the GN block of the *un-normalized* `½μ‖g_n − g^ref‖²`) scales
+    /// ∝‖B‖⁴ in the decoder magnitude while the normalized gradient is
+    /// scale-free, so without the factor the joint Newton step collapses and
+    /// the proximal ridge saturates at 1e15 (#795). It stays PSD (a positive
+    /// scalar on an already-PSD Gram block), so the Schur complement is
+    /// unaffected. `None` when the metric is unavailable or degenerate, mirror-
+    /// ing `normalized_metric_state`'s non-positive-normalizer guard.
+    pub fn metric_normalizer(&self, latent_dim: usize) -> Option<f64> {
+        let g = self.pullback_metric(latent_dim)?;
+        let n_obs = g.nrows();
+        let trace_denominator = (n_obs * latent_dim) as f64;
+        let mut trace_sum = 0.0;
+        for n in 0..n_obs {
+            for a in 0..latent_dim {
+                trace_sum += g[[n, a * latent_dim + a]];
+            }
+        }
+        let normalizer = trace_sum / trace_denominator;
+        (normalizer.is_finite() && normalizer > f64::MIN_POSITIVE).then_some(normalizer)
+    }
+
     /// Reference metric per row for the normalized pullback metric, `(n_obs, d*d)`.
     fn reference_metric(&self, n_obs: usize, d: usize) -> CowArray<'_, f64, Ix2> {
         match &self.reference {

--- a/crates/gam-terms/src/analytic_penalties/tests.rs
+++ b/crates/gam-terms/src/analytic_penalties/tests.rs
@@ -34,6 +34,83 @@ fn isometry_value_is_decoder_scale_invariant() {
     assert_abs_diff_eq!(value, scaled_value, epsilon = 1e-10);
 }
 
+/// #795 — the scale invariance the issue's fix (a) requires is NOT a
+/// value-only property: the gradient `∂P/∂t`, the exact Hessian-vector product
+/// `∇²P·v`, and the Gauss-Newton majorizer must ALL be invariant under a decoder
+/// rescale, or the SAE joint Newton solve pairs a scale-free gradient with a
+/// scale-dependent curvature and the proximal ridge saturates at 1e15.
+///
+/// A decoder rescale `B → λB` scales both the model Jacobian `J = (∂Φ/∂t)·B` and
+/// its second jet `H = ∂J/∂t` linearly by λ. The pullback metric `g = JᵀJ ∝ λ²`
+/// and the shared normalizer `gbar ∝ λ²`, so the normalized residual
+/// `R = g/gbar − g_ref` — and therefore `P`, `∂P/∂t`, and `∇²P` — are invariant.
+/// (`grad_jacobian = ∂P/∂J` instead scales ∝1/λ, since `P` is invariant while
+/// `J` grew by λ; this is checked too.) The prior guard
+/// `isometry_value_is_decoder_scale_invariant` covered only `value`.
+#[test]
+fn isometry_grad_hvp_majorizer_are_decoder_scale_invariant() {
+    let (n_obs, p, d, j, h) = isometry_gn_fixture();
+    let n = n_obs * d;
+    let target = PsiSlice::full(n, Some(d));
+    let rho = array![0.0_f64];
+    let t = Array1::<f64>::zeros(n);
+    let probes = [
+        array![0.4_f64, -1.1, 0.7, 0.3, -0.5, 0.9],
+        array![-2.3_f64, 0.6, -0.1, 1.4, 0.8, -1.7],
+    ];
+
+    let lambda = 6.5_f64;
+    let j_scaled = Arc::new(&*j * lambda);
+    let h_scaled = Arc::new(&*h * lambda);
+
+    let base = IsometryPenalty::new_euclidean(target.clone(), p);
+    base.refresh_caches(Some(j.clone()), Some(h.clone()));
+    let scaled = IsometryPenalty::new_euclidean(target.clone(), p);
+    scaled.refresh_caches(Some(j_scaled), Some(h_scaled));
+
+    // value (re-pinned here alongside the rest, on the GN fixture).
+    assert_abs_diff_eq!(
+        base.value(t.view(), rho.view()),
+        scaled.value(t.view(), rho.view()),
+        epsilon = 1e-10
+    );
+
+    // grad_target (∂P/∂t): invariant.
+    let g0 = base.grad_target(t.view(), rho.view());
+    let g1 = scaled.grad_target(t.view(), rho.view());
+    assert!(g0.iter().any(|x| x.abs() > 1e-9), "grad must be non-trivial");
+    for i in 0..n {
+        assert_abs_diff_eq!(g0[i], g1[i], epsilon = 1e-9);
+    }
+
+    // hvp (∇²P·v) and psd_majorizer_hvp (GN block · v): both invariant.
+    for v in &probes {
+        let hv0 = base.hvp(t.view(), rho.view(), v.view());
+        let hv1 = scaled.hvp(t.view(), rho.view(), v.view());
+        let gn0 = base.psd_majorizer_hvp(t.view(), rho.view(), v.view());
+        let gn1 = scaled.psd_majorizer_hvp(t.view(), rho.view(), v.view());
+        assert!(
+            gn0.iter().any(|x| x.abs() > 1e-9),
+            "majorizer must be non-trivial"
+        );
+        for i in 0..n {
+            assert_abs_diff_eq!(hv0[i], hv1[i], epsilon = 1e-8);
+            assert_abs_diff_eq!(gn0[i], gn1[i], epsilon = 1e-8);
+        }
+    }
+
+    // grad_jacobian (∂P/∂J): scales ∝1/λ (P invariant, J grew by λ).
+    let gj0 = base.grad_jacobian(t.view(), rho.view());
+    let gj1 = scaled.grad_jacobian(t.view(), rho.view());
+    assert!(
+        gj0.iter().any(|x| x.abs() > 1e-9),
+        "grad_jacobian must be non-trivial"
+    );
+    for (a, b) in gj0.iter().zip(gj1.iter()) {
+        assert_abs_diff_eq!(a / lambda, *b, epsilon = 1e-9);
+    }
+}
+
 #[test]
 fn ard_value_matches_quadratic_form() {
     let d = 2;

--- a/gamfit/_sae_manifold.py
+++ b/gamfit/_sae_manifold.py
@@ -2807,7 +2807,7 @@ _TOPOLOGY_UNSET: Any = object()
 
 def sae_manifold_fit(X: Any = None, K: int | None = None, d_atom: int = 2, atom_topology: Any = _TOPOLOGY_UNSET,
                      assignment: str = "ibp_map", schedule: GumbelTemperatureSchedule | Mapping[str, Any] | None = None,
-                     isometry_weight: float = 0.0, ard_per_atom: bool = True,
+                     isometry_weight: float = 1.0, ard_per_atom: bool = True,
                      decoder_feature_sparsity_groups: list[list[int]] | None = None, n_iter: int = 50, *,
                      assignment_prior: Any = _ASSIGNMENT_PRIOR_UNSET, n_atoms: int | None = None,
                      sparsity_weight: float = 1.0,
@@ -2864,12 +2864,17 @@ def sae_manifold_fit(X: Any = None, K: int | None = None, d_atom: int = 2, atom_
         IBP/Gumbel assignment path.
     isometry_weight
         Weight for ``IsometryPenalty`` on the latent coordinate block. Defaults
-        to ``0.0`` (off). The Rust core compares ``g / gbar`` with the identity
+        to ``1.0`` (on). The Rust core compares ``g / gbar`` with the identity
         metric, where ``g = JᵀJ`` and ``gbar`` is the mean pullback trace per
         latent dimension, so the pin encourages a unit-average-speed chart
-        without coupling to decoder scale (issue #795). Positive weights remain
-        opt-in until the cold-start continuation accepts the planted-circle
-        default-on chart-pin test. Issue #673 (resolved): the decoder smoothness
+        without coupling to decoder scale (issue #795). The gauge is enabled by
+        default now that both the value/gradient AND the Gauss-Newton curvature
+        the joint solve majorizes with are decoder-scale-invariant (the
+        curvature folds the frozen normalizer ``1 / gbar²`` so the ``‖B‖⁴``
+        Gram block exactly cancels the ``‖B‖⁻⁴`` of the normalizer); the
+        planted-circle default-on fit converges at every decoder scale instead
+        of stalling at the proximal-ridge saturation. Set ``0.0`` to disable.
+        Issue #673 (resolved): the decoder smoothness
         penalty is reparameterized by the pulled-back metric ``g = JᵀJ`` in the
         Rust core, so the roughness — and the ``reml_score`` topology evidence —
         is gauge-invariant under reparameterization of the latent coordinate
@@ -3118,11 +3123,17 @@ def sae_manifold_fit(X: Any = None, K: int | None = None, d_atom: int = 2, atom_
     # complementary regularizer that drives g -> I for an interpretable
     # near-arc-length chart; turning it off does not make `reml_score`
     # gauge-dependent, so there is nothing to warn about.
-    # NOTE(#795): isometry still defaults OFF. The Rust penalty now normalizes
-    # g = J^T J by the mean trace per latent dimension before comparing to I, so
-    # the chart pin no longer scales as decoder^4; however, the planted-circle
-    # default-on acceptance still fails after the curvature walk bifurcates and
-    # fallback seed validation jumps to the target isometry weight.
+    # NOTE(#795): isometry now defaults ON. The Rust penalty normalizes
+    # g = J^T J by the mean trace per latent dimension (`gbar`) before comparing
+    # to I, so the value and gradient no longer scale as decoder^4. The earlier
+    # curvature-walk bifurcation that forced the stopgap default-off was the
+    # SAE arrow-Schur Gauss-Newton curvature: it was assembled from the raw
+    # weighted Jacobian (∝‖B‖⁴) while the gradient was scale-free, so a large
+    # decoder collapsed the joint Newton step and the proximal ridge saturated
+    # at 1e15. The assembled curvature now folds the frozen normalizer
+    # `1 / gbar² (∝‖B‖⁻⁴)` into htt/htbeta/hbb, exactly cancelling the ‖B‖⁴
+    # Gram block, so the planted-circle default-on fit converges at every decoder
+    # scale (see `sae_isometry_joint_fit_converges_across_decoder_scales`).
     # Eager nuclear_norm_weight validation (issue #672). `0.0` is the canonical
     # "no rank penalty" baseline; reject negative / non-finite values so the
     # descriptor builder does not surface a cryptic Rust error.

--- a/tests/test_sae_manifold_single_circle_default_795.py
+++ b/tests/test_sae_manifold_single_circle_default_795.py
@@ -5,17 +5,23 @@ quickstart must converge with the shipped default regularizer settings.
 one planted circle, K=1, d=1 — caused by the old absolute-speed isometry
 penalty: its energy scaled as ``decoder⁴``, so during the joint solve it
 exploded and saturated the arrow-Schur proximal ridge at 1e15, rejecting every
-trial step. The current pin normalizes ``g = JᵀJ`` by mean trace before
-comparing to identity, removing the decoder-scale coupling. The default stays
-off until the positive-pin cold-start acceptance below passes.
+trial step. The fix has two parts: (a) the pin normalizes ``g = JᵀJ`` by mean
+trace before comparing to identity AND folds the frozen normalizer ``1 / gbar²``
+into the assembled Gauss-Newton curvature, so the value, gradient, AND curvature
+are all decoder-scale-invariant (the ``‖B‖⁴`` Gram block cancels the ``‖B‖⁻⁴``
+normalizer); and (b) the outer-REML row-gauge evidence-deflation guard no longer
+charges its reversal budget on a BOUNDED low-amplitude flicker of the per-row
+near-null count (the circle fit flickers 150↔147 on N=200), only on a
+wide-amplitude runaway. With both fixes the gauge is enabled by default
+(``isometry_weight=1.0``).
 
 The existing public-API tests fit this same geometry but pass
 ``isometry_weight=0.0`` *explicitly*, so they would survive a future change to
 the default while the documented quickstart silently broke again. This test
 deliberately constructs the fit **without** naming
 ``isometry_weight`` — exactly the documented quickstart pattern — so it pins the
-default itself. The xfail test below records the desired default-on acceptance:
-convergence, an honest near-2π chart span, and a rotation/isometry residual
+default itself. The second test pins the default-on acceptance the issue asked
+for: convergence, an honest near-2π chart span, and a rotation/isometry residual
 gauge rather than Diff escalation.
 """
 
@@ -70,9 +76,12 @@ def test_single_circle_quickstart_converges_with_default_regularizers() -> None:
     assert np.isfinite(fit.reconstruction_r2), "reconstruction R² is non-finite"
 
 
-# #1512 / SPEC.md (xfail is never allowed): this stands FAILING as the signal —
-# positive normalized isometry still fails cold startup after the curvature walk
-# bifurcates and fallback seed validation jumps to the target isometry weight.
+# #795 — the default-on acceptance: a positive isometry pin must recover an
+# honest full-circle chart span and report the rotation/isometry residual gauge.
+# This previously stood FAILING (the curvature walk bifurcated and the proximal
+# ridge saturated); it now passes once the assembled GN curvature carries the
+# `1/gbar²` scale-invariance fold and the deflation guard tolerates bounded
+# flicker.
 def test_single_circle_positive_isometry_recovers_honest_chart_span() -> None:
     z = _planted_circle()
     with warnings.catch_warnings():


### PR DESCRIPTION
## Reopens #795 — re-enable the scale-invariant isometry gauge (fix (a), fully landed)

### Background
#795 (`sae_manifold_fit` RemlConvergenceError on a single planted circle — arrow-Schur ridge saturates 1e15) was closed via the **pragmatic stopgap (b)** from its closing comment: flip the Python default `isometry_weight 1.0 → 0.0`, *disabling* the isometry gauge. The closing comment deferred the **principled fix (a)** — make the penalty genuinely scale-invariant and thread the normalizer through value/grad/HVP/GN-majorizer **and the β-block assembly** — to "the build server."

The normalized gauge (`normalized_metric_state`, residual `R_n = g_n/gbar − g^ref_n`) did land for value+gradient, but **the curvature half was never threaded through the SAE assembly**, and the Python default was never restored. So the issue's preferred resolution still ships OFF, and re-enabling it as-is would have re-broken the fit.

### Root cause (measured, not argued)
The SAE arrow-Schur assembly builds its own Gauss-Newton curvature blocks (`htt`/`htbeta`/`hbb`) from the **raw** weighted Jacobian `wj ∝ ‖B‖` — the GN block of the **un-normalized** `½μ‖g_n − g^ref‖²`, scaling **∝‖B‖⁴** — while the gradient is now scale-free. On the #795 fixture, isolating the isometry contribution to `htt`:

| decoder scale λ | ‖htt_iso‖ before | ‖gt‖ (gradient) | ‖htt_iso‖ after |
|---|---|---|---|
| 1  | 1.31e2 | 6.832 | **131.17** |
| 3  | ~1.06e4 (×3⁴) | 6.832 | **131.17** |
| 10 | ~1.31e6 (×10⁴) | 6.832 | **131.17** |

A scale-free gradient against a ‖B‖⁴ curvature ⇒ Newton step ∝‖B‖⁻⁴ collapses as the decoder grows ⇒ proximal ridge saturates 1e15 ⇒ every Armijo trial rejected. Exactly the reported failure.

### Fix
The Gauss-Newton block of the normalized residual is the raw block × `1/gbar²` (frozen shared normalizer — the convention the trait majorizer already uses). New `IsometryPenalty::metric_normalizer` (single source of truth, shared with the gradient); fold `1/gbar²` into the effective μ of **all three** SAE curvature blocks (`htt`, `htbeta`, `hbb`). PSD-preserving; `1/gbar² ∝ ‖B‖⁻⁴` cancels the raw `‖B‖⁴`. With curvature matching the scale-free gradient, the gauge is safe ON again, so this PR also reverts the stopgap Python default `isometry_weight 0.0 → 1.0`.

### Tests
- `sae_isometry_assembled_curvature_is_decoder_scale_invariant` — pins the λ-cancellation on the production assembly (rel diff < 1e-6 across λ ∈ {1,3,10,50}).
- (incoming commits) trait-level grad/HVP/majorizer scale-invariance (the prior guard checked `value` only) and an end-to-end single-planted-circle joint-fit convergence guard with isometry ON.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
