### PR TITLE
fix(#1254): make the nested_prefix dispatch guard behavioral, not a doc-comment grep

### DIFF
--- a/tests/autodiff/smooths/analytic_penalty_nested_prefix_dispatch_missing.rs
+++ b/tests/autodiff/smooths/analytic_penalty_nested_prefix_dispatch_missing.rs
@@ -1,19 +1,108 @@
-use std::fs;
+//! #1254 regression guard: the `nested_prefix` analytic-penalty descriptor must
+//! be DISPATCHED (built into a real `AnalyticPenaltyKind::NestedPrefix`), not
+//! silently dropped, by the JSON descriptor parser.
+//!
+//! HISTORY (#1254 re-fix): the original guard was a pair of source-text greps —
+//! it asserted that `crates/gam-pyffi/src/lib.rs` *contained the substring*
+//! `"nested_prefix"`. After the analytic-penalty JSON dispatch was unified into
+//! `gam_models::fit_orchestration::descriptors::build_analytic_penalty_registry_from_descriptors`
+//! (pyffi no longer parses these descriptors itself), the only remaining
+//! occurrence of `"nested_prefix"` in pyffi's `lib.rs` is a DOC COMMENT. So the
+//! grep passed purely off prose — the real dispatch arm could be deleted and the
+//! test would stay green. That is a vacuous guard.
+//!
+//! This version exercises the real dispatch path: it builds a `nested_prefix`
+//! descriptor through the production parser and asserts the resulting registry
+//! actually contains a `NestedPrefix` penalty. It also pins the negative
+//! (unknown kind is rejected, not silently ignored) so the guard catches a
+//! regression in BOTH directions.
+
+use gam::solver::fit_orchestration::descriptors::build_analytic_penalty_registry_from_descriptors;
+use serde_json::json;
+
+/// A latent block named `z` with shape (n=4, d=3), matching the `target` the
+/// descriptors below reference. The parser requires at least one latent block.
+fn latents() -> serde_json::Value {
+    json!({
+        "z": { "name": "z", "n": 4, "d": 3 },
+    })
+}
 
 #[test]
-fn analytic_penalty_nested_prefix_kind_is_missing_from_pyffi_json_dispatch() {
-    let pyffi = fs::read_to_string("crates/gam-pyffi/src/lib.rs")
-        .expect("BUG: could not read crates/gam-pyffi/src/lib.rs");
-    let registry = fs::read_to_string("crates/gam-terms/src/analytic_penalties/manifest.rs")
-        .expect("BUG: could not read crates/gam-terms/src/analytic_penalties/manifest.rs");
+fn nested_prefix_descriptor_is_dispatched_not_dropped() {
+    let latents = latents();
+    let penalties = json!([
+        {
+            "kind": "nested_prefix",
+            "target": "z",
+            "prefix_sizes": [1, 2],
+            "shell_weights": [1.0, 0.5],
+            "tier": "psi"
+        }
+    ]);
 
-    assert!(
-        registry.contains("register!(NestedPrefix, NestedPrefixPenalty);"),
-        "BUG: NestedPrefix is not registered in analytic_penalty_registry macro"
+    let registry = build_analytic_penalty_registry_from_descriptors(Some(&latents), Some(&penalties))
+        .expect("nested_prefix descriptor must build a registry");
+
+    // The descriptor must produce exactly one penalty, tagged `nested_prefix`.
+    // A silently-dropped kind would yield an empty registry (the #1254 symptom);
+    // a mis-dispatched kind would carry the wrong tag.
+    let tags: Vec<&str> = registry
+        .penalties
+        .iter()
+        .map(|penalty| penalty.kind_tag())
+        .collect();
+    assert_eq!(
+        tags,
+        vec!["nested_prefix"],
+        "BUG (#1254): nested_prefix descriptor was not dispatched to a \
+         NestedPrefix penalty (got tags {tags:?})"
     );
+}
 
+#[test]
+fn nested_prefix_accepts_hyphenated_and_uppercase_kind() {
+    // The parser lowercases and replaces '-' with '_', so these alias spellings
+    // must dispatch identically — pinning the normalization the dispatch relies on.
+    let latents = latents();
+    for kind in ["Nested-Prefix", "NESTED_PREFIX", "nestedprefix"] {
+        let penalties = json!([
+            {
+                "kind": kind,
+                "target": "z",
+                "prefix_sizes": [1, 2],
+                "shell_weights": [1.0, 0.5],
+                "tier": "psi"
+            }
+        ]);
+        let registry =
+            build_analytic_penalty_registry_from_descriptors(Some(&latents), Some(&penalties))
+                .unwrap_or_else(|err| panic!("kind alias {kind:?} must dispatch: {err}"));
+        let tags: Vec<&str> = registry
+            .penalties
+            .iter()
+            .map(|penalty| penalty.kind_tag())
+            .collect();
+        assert_eq!(
+            tags,
+            vec!["nested_prefix"],
+            "kind alias {kind:?} must dispatch to nested_prefix (got {tags:?})"
+        );
+    }
+}
+
+#[test]
+fn unknown_analytic_penalty_kind_is_rejected_not_silently_dropped() {
+    // Negative control: an unrecognized kind must ERROR, not be silently skipped.
+    // This is what makes the positive test above meaningful — it proves the
+    // parser genuinely discriminates kinds rather than ignoring everything.
+    let latents = latents();
+    let penalties = json!([
+        { "kind": "definitely_not_a_real_penalty_kind", "target": "z" }
+    ]);
+    let result = build_analytic_penalty_registry_from_descriptors(Some(&latents), Some(&penalties));
     assert!(
-        pyffi.contains("\"nested_prefix\"") || pyffi.contains("\"nestedprefix\""),
-        "BUG: pyffi build_analytic_penalty_registry_from_json does not dispatch NestedPrefix even though AnalyticPenaltyKind includes it"
+        result.is_err(),
+        "an unknown analytic-penalty kind must be rejected, not silently dropped"
     );
 }


### PR DESCRIPTION
Fixes #1254.

## The dispatch works; the regression guard is vacuous

The `nested_prefix` analytic-penalty kind is genuinely dispatched — but in `gam_models::fit_orchestration::descriptors::build_analytic_penalty_registry_from_descriptors` (`descriptors.rs:1263`, the `"nested_prefix" | "nestedprefix"` arm). pyffi no longer parses these descriptors itself; the dispatch was unified into gam-models.

The #1254 guard `analytic_penalty_nested_prefix_dispatch_missing` asserts:

```rust
pyffi.contains("\"nested_prefix\"") || pyffi.contains("\"nestedprefix\"")
```

against `crates/gam-pyffi/src/lib.rs`. The **only** remaining occurrence of `nested_prefix` in that file is a **doc comment** (line 14). So the test passes off prose alone — the real dispatch arm could be deleted and this guard would stay green. A vacuous guard over the exact behavior it was written to protect.

## This PR

One test file. Replaces the two source-text greps with a **behavioral** guard that exercises the real dispatch path:

- `nested_prefix_descriptor_is_dispatched_not_dropped` — build a `nested_prefix` descriptor through the production parser; assert the resulting `AnalyticPenaltyRegistry` contains exactly one penalty tagged `nested_prefix`. A silently-dropped kind → empty registry (the #1254 symptom); a mis-dispatch → wrong tag.
- `nested_prefix_accepts_hyphenated_and_uppercase_kind` — pins the `kind` normalization (lowercase + `-`→`_`) the dispatch relies on (`Nested-Prefix`, `NESTED_PREFIX`, `nestedprefix`).
- `unknown_analytic_penalty_kind_is_rejected_not_silently_dropped` — negative control: an unrecognized kind must ERROR, which is what makes the positive assertion meaningful (the parser genuinely discriminates kinds).

The production dispatch is additionally covered by the in-crate `accepts_the_full_kind_surface`; this integration guard pins the same contract from the public API at the descriptor-parser boundary the issue named.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
