### PR TITLE
Fix exact encode throughput gate routing

### DIFF
--- a/crates/gam-gpu/src/encode_throughput.rs
+++ b/crates/gam-gpu/src/encode_throughput.rs
@@ -288,18 +288,17 @@ pub const DEPLOYMENT_TARGET_ROWS_PER_SEC: f64 = GPU_THROUGHPUT_TARGET_ROWS_PER_S
 // `crates/gam-gpu/tests/encode_full_path_throughput.rs` (a dev-dependency cycle
 // onto `gam-sae`, allowed by cargo for test-only edges).
 //
-// HONEST DEVICE STATUS. There is currently NO device-resident exact-encode
-// kernel: the production `certified_encode_*` path is per-row host ndarray work
-// (the only SAE GPU kernel, `gam_sae::gpu_kernels::sae_rowjet`, accelerates the
-// *fitting* reconstruction-jet tower, not the encode). So the
-// [`FullEncodeThroughput::device_encode_engaged`] flag is `false` even on a GPU
-// host until such a kernel exists. This benchmark therefore does NOT yet
-// substantiate a device "batched exact per-row GPU encode" number — by design,
-// it refuses to fabricate one (the same fail-loud, never-false-route discipline
-// as the component benchmark). What it DOES establish is the real end-to-end
-// encode throughput (CPU today) and a correctness contract — support agreement,
-// coordinate error, reconstruction explained-variance, and fallback rate
-// against the production CPU encode — that any future device encode must match.
+// HONEST DEVICE STATUS. This helper is still backend-agnostic instrumentation:
+// callers must set `device_encode_engaged` to `true` only when their encode was
+// produced by a real device-resident exact-encode kernel. The current SAE device
+// driver that can make that assertion lives in
+// `gam_sae::gpu_kernels::sae_encode_resident::measure_device_encode_throughput`;
+// older host-only full-path harnesses pass `false`. This benchmark therefore
+// never fabricates a device "batched exact per-row GPU encode" number from a
+// host encode — it reports the full-path timing and a correctness contract
+// (support agreement, coordinate error, reconstruction explained-variance, and
+// fallback rate), while the caller-owned engagement flag decides whether the
+// #988 deployment/surrogate gate may consume the rate as a device measurement.
 // ===========================================================================
 
 /// End-to-end throughput of the FULL exact per-row encode for one batch.

--- a/crates/gam-sae/src/gpu_kernels/sae_encode_resident.rs
+++ b/crates/gam-sae/src/gpu_kernels/sae_encode_resident.rs
@@ -1234,11 +1234,24 @@ pub fn measure_device_encode_throughput(
         0.0
     };
     let engaged = matches!(path, EncodePath::Device);
-    // Key the surrogate decision on the measurement. When the device did not run
-    // the exact encode, report the honest blocked reason rather than a
-    // `DeviceNotEngaged` false-routing (the kernel exists, but no device ran it).
+    // Key the surrogate decision on the measurement. A CPU-emulator run is an
+    // honest non-measurement for the #988 device gate, but the reason matters:
+    //
+    //   * no CUDA runtime/device on the host => blocked on hardware;
+    //   * CUDA present and the batch was large enough to require the device path,
+    //     yet the kernel fell back to the emulator => false routing / device
+    //     non-engagement, which must be surfaced as such rather than laundered
+    //     into the same state as a CPU-only laptop.
+    //
+    // In either case the anti-green-wash contract is the same: an emulator rate
+    // can never declare the surrogate unneeded or justified.
+    let device_available = gam_gpu::device_runtime::GpuRuntime::global()
+        .map(|rt| rt.device_count() > 0)
+        .unwrap_or(false);
     let decision = if engaged {
         EncodeDeploymentDecision::from_device_measurement(true, rows_per_sec)
+    } else if device_available && n >= DEVICE_ROW_THRESHOLD {
+        EncodeDeploymentDecision::blocked(EncodeDecisionBlocked::DeviceNotEngaged)
     } else {
         EncodeDeploymentDecision::blocked(EncodeDecisionBlocked::NoDevice)
     };
@@ -1728,14 +1741,33 @@ mod tests {
             }
         } else {
             // CPU-only host (this dev box): the rate is honest but it is NOT a
-            // device measurement. The surrogate decision is BLOCKED on hardware —
-            // a fast CPU number can never declare the surrogate unneeded (the
-            // #1412 anti-green-wash property carried to the exact device encode).
+            // device measurement. The surrogate decision is BLOCKED — on a
+            // CPU-only host because there is no hardware, and on a CUDA host
+            // because falling back to the emulator despite a device-sized batch
+            // is false routing. A fast CPU number can never declare the
+            // surrogate unneeded (the #1412 anti-green-wash property carried to
+            // the exact device encode).
             assert!(
                 tput.decision.is_undetermined(),
                 "a CPU-emulator exact encode must leave the surrogate decision Undetermined, got {:?}",
                 tput.decision
             );
+            if gam_gpu::device_runtime::GpuRuntime::global()
+                .map(|rt| rt.device_count() > 0)
+                .unwrap_or(false)
+            {
+                assert_eq!(
+                    tput.decision,
+                    EncodeDeploymentDecision::blocked(EncodeDecisionBlocked::DeviceNotEngaged),
+                    "CUDA was present for a device-sized exact-encode batch, so an emulator path \
+                     must be reported as DeviceNotEngaged (false routing), not NoDevice"
+                );
+            } else {
+                assert_eq!(
+                    tput.decision,
+                    EncodeDeploymentDecision::blocked(EncodeDecisionBlocked::NoDevice)
+                );
+            }
             assert!(!tput.decision.surrogate_unneeded());
             assert!(!tput.decision.surrogate_justified());
         }
@@ -1815,4 +1847,3 @@ mod tests {
         }
     }
 }
-


### PR DESCRIPTION
### Motivation
- The Stage-3 encode decision must be driven by a measured device exact-encode rate per #988; CPU timings must never be laundered into a device pass, and emulator fallbacks on CUDA hosts must be reported as false routing rather than treated like a CPU-only host. 
- Existing logic collapsed all non-device runs into the same blocked state (`NoDevice`), obscuring the important distinction between "no device present" and "device present but not engaged" for device-sized batches.

### Description
- In `crates/gam-sae/src/gpu_kernels/sae_encode_resident.rs` updated `measure_device_encode_throughput` to consult `GpuRuntime::global()` and produce `EncodeDecisionBlocked::DeviceNotEngaged` when a CUDA runtime exists but the exact-encode batch fell back to the CPU emulator for a device-sized batch, while preserving `EncodeDecisionBlocked::NoDevice` for CPU-only hosts. 
- Strengthened the unit test `device_encode_throughput_gates_surrogate_on_measurement` to assert the correct blocked reason: `NoDevice` on CPU-only hosts and `DeviceNotEngaged` when CUDA exists but the encode used the emulator. 
- Clarified documentation in `crates/gam-gpu/src/encode_throughput.rs` so the `FullEncodeThroughput` helper remains backend-agnostic and callers must mark `device_encode_engaged` themselves, and pointed callers to the SAE resident device measurement path that performs honest device engagement checks.

### Testing
- Ran `cargo test -p gam-sae device_encode_throughput_gates_surrogate_on_measurement -- --nocapture` and the test passed (printed a CPU run example: `[device-encode #988] n=4160 rows/sec=264753.3 path=Cpu decision=Undetermined { reason: NoDevice }`).
- Ran `cargo test -p gam-gpu full_encode_metric_tests -- --nocapture` and all `full_encode_metric_tests` passed (3 tests).
- All modified tests passed locally; the changes are focused to the exact-encode routing/decision logic and unit tests that validate the anti-green-wash gating behavior.

---
🤖 Codex Cloud root-cause fix for #988 (task `task_e_6a45726647d88324906c1cff705b9b51`). **Unaudited** — review for reward-hacking before merge.

Closes #988