### PR TITLE
fix(#1017): keep SAE evidence logdet matrix-free

### DIFF
--- a/crates/gam-solve/src/arrow_schur/newton_step.rs
+++ b/crates/gam-solve/src/arrow_schur/newton_step.rs
@@ -317,8 +317,7 @@ pub(crate) fn maybe_inject_gpu_schur_matvec(
         return None;
     }
     let matvec =
-        crate::gpu_kernels::arrow_schur::gpu_schur_matvec_backend(sys, ridge_t, ridge_beta)
-            .ok()?;
+        crate::gpu_kernels::arrow_schur::gpu_schur_matvec_backend(sys, ridge_t, ridge_beta).ok()?;
     let mut device_options = options.clone();
     device_options.gpu_matvec = Some(matvec);
     Some(device_options)
@@ -570,15 +569,31 @@ pub(crate) fn try_device_arrow_direct_sae_pcg(
             // On any failure forming/factoring the Schur (non-PD pivot the LM
             // escalation must respond to), surface the error rather than returning a
             // cache that would silently starve the evidence of its log-det.
-            let schur = match build_dense_schur_direct(sys, htt_factors, ridge_beta, backend) {
-                Ok(schur) => schur,
-                Err(err) => return Some(Err(err)),
-            };
             let (schur_factor, schur_log_det_override) = if sys.k >= SCHUR_SLQ_LOGDET_MIN_DIM {
-                // Matrix-free (flop) log|S| via SLQ on the SPD reduced Schur.
-                let slq = crate::arrow_schur::slq_logdet(
-                    sys.k,
-                    |v| schur.dot(&v),
+                // Matrix-free log|S| via SLQ on the exact reduced-Schur apply.
+                //
+                // IMPORTANT (#1017): do not build the dense `k×k` Schur here.
+                // The old implementation still called `build_dense_schur_direct`
+                // before this branch and then ran SLQ over `schur.dot(v)`, which
+                // removed the Cholesky but left the production color/Qwen path
+                // paying (or refusing/OOMing) the dense assembly.  The whole
+                // point of the SAE Direct device-PCG seam is that the step is
+                // solved matrix-free; the evidence log-det must consume the same
+                // matrix-free reduced operator.  `slq_reduced_schur_log_det`
+                // stages the CPU resident row factors when available and then
+                // applies
+                //
+                //     S v = (H_ββ + ρ_β I)v
+                //           - Σ_i H_βt_i (H_tt_i + ρ_t I)⁻¹ H_tβ_i v
+                //
+                // without materialising `S`.
+                let resident = SaeResidentReducedSchur::build(sys, htt_factors, backend);
+                let slq = crate::arrow_schur::slq_reduced_schur_log_det(
+                    sys,
+                    htt_factors,
+                    ridge_beta,
+                    backend,
+                    resident.as_ref(),
                     SCHUR_SLQ_LOGDET_PROBES,
                     SCHUR_SLQ_LOGDET_LANCZOS_STEPS,
                     SCHUR_SLQ_LOGDET_SEED,
@@ -606,6 +621,10 @@ pub(crate) fn try_device_arrow_direct_sae_pcg(
                 // `solve_dense_reduced_system` (the exact CPU Direct reduce) so the
                 // emitted factor — and therefore the log-det — is bit-identical to
                 // the non-device path.
+                let schur = match build_dense_schur_direct(sys, htt_factors, ridge_beta, backend) {
+                    Ok(schur) => schur,
+                    Err(err) => return Some(Err(err)),
+                };
                 let factor = match solve_dense_reduced_system(&schur, rhs_beta, options, None) {
                     Ok((_cpu_delta_beta, Some(factor), _diag)) => factor,
                     Ok((_, None, _)) => {
@@ -649,7 +668,10 @@ pub(crate) fn try_device_arrow_direct_sae_pcg(
         // Unavailable / transient / framed-mismatch all mean "device declined" —
         // fall through to the CPU dense Direct path transparently.
         Err(other) => {
-            trace_decline!("device kernel returned {:?} — falling back to CPU dense", other);
+            trace_decline!(
+                "device kernel returned {:?} — falling back to CPU dense",
+                other
+            );
             None
         }
     }
@@ -1144,8 +1166,7 @@ pub(crate) fn factor_blocks_for_system<B: BatchedBlockSolver>(
     };
     let mut blocks = Vec::with_capacity(sys.rows.len());
     let mut count = 0usize;
-    let mut deflated_row_directions: Vec<Vec<Array1<f64>>> =
-        Vec::with_capacity(sys.rows.len());
+    let mut deflated_row_directions: Vec<Vec<Array1<f64>>> = Vec::with_capacity(sys.rows.len());
     let mut deflation_row_spectra: Vec<Option<RowDeflationSpectrum>> =
         Vec::with_capacity(sys.rows.len());
     for (row_idx, row) in sys.rows.iter().enumerate() {

--- a/crates/gam-solve/src/arrow_schur/reduced_solve.rs
+++ b/crates/gam-solve/src/arrow_schur/reduced_solve.rs
@@ -320,6 +320,21 @@ pub(crate) fn build_dense_schur_sqrt_ba<B: BatchedBlockSolver + Sync>(
                 .to_string(),
         });
     }
+    // Same fail-loud host-memory contract as the Direct reduction (#1017).  The
+    // square-root BA route still materialises the same dense `k×k` reduced
+    // Schur; letting this path bypass the budget would preserve an OOM-class
+    // fallback even after Direct learned to refuse matrix-free-only borders.
+    let dense_bytes = (k as u128).saturating_mul(k as u128).saturating_mul(8);
+    if dense_bytes > DENSE_SCHUR_BYTES_BUDGET {
+        return Err(ArrowSchurError::SchurFactorFailed {
+            reason: format!(
+                "square-root BA dense reduced Schur is {k}×{k} f64 = {} MiB, exceeding the \
+                 {} MiB host budget; this border is matrix-free-only",
+                dense_bytes / (1024 * 1024),
+                DENSE_SCHUR_BYTES_BUDGET / (1024 * 1024),
+            ),
+        });
+    }
     let mut schur = op.to_dense();
     for j in 0..k {
         schur[[j, j]] += ridge_beta;
@@ -1011,7 +1026,9 @@ impl SaeResidentReducedSchur {
             }
         }
         // acc += P_iᵀ prod = scatter φ_s · prod into base_s blocks.
-        let acc_slice = acc.as_slice_mut().expect("resident matvec acc must be contiguous");
+        let acc_slice = acc
+            .as_slice_mut()
+            .expect("resident matvec acc must be contiguous");
         for &(base, phi) in support {
             if phi == 0.0 {
                 continue;
@@ -1205,7 +1222,15 @@ pub(crate) fn slq_reduced_schur_log_det<B: BatchedBlockSolver + Sync>(
             // guarded off inside a worker, so there is no nested oversubscription.
             let x = v.to_owned();
             let mut out = Array1::<f64>::zeros(k);
-            schur_matvec(sys, htt_factors, ridge_beta, &x, &mut out, backend, resident);
+            schur_matvec(
+                sys,
+                htt_factors,
+                ridge_beta,
+                &x,
+                &mut out,
+                backend,
+                resident,
+            );
             out
         },
         num_probes,

--- a/crates/gam-solve/src/arrow_schur/tests.rs
+++ b/crates/gam-solve/src/arrow_schur/tests.rs
@@ -3481,11 +3481,10 @@ pub(crate) fn sae_direct_inner_solve_engages_device_and_matches_cpu_1551() {
     // Parity (holds on every host): the produced Newton step must match the dense
     // joint-system reference. On a GPU host this is the device==CPU parity gate;
     // on a CPU host it pins the matrix-free reduced solve to the dense oracle.
-    let reference =
-        crate::gpu_kernels::arrow_schur::solve_arrow_newton_step_dense_reference(
-            &sys, ridge_t, ridge_beta,
-        )
-        .expect("dense reference solve");
+    let reference = crate::gpu_kernels::arrow_schur::solve_arrow_newton_step_dense_reference(
+        &sys, ridge_t, ridge_beta,
+    )
+    .expect("dense reference solve");
     let db_scale = reference
         .delta_beta
         .iter()
@@ -3493,7 +3492,8 @@ pub(crate) fn sae_direct_inner_solve_engages_device_and_matches_cpu_1551() {
         .max(1.0);
     let mut max_db_rel = 0.0_f64;
     for a in 0..sys.k {
-        max_db_rel = max_db_rel.max((artifacts.delta_beta[a] - reference.delta_beta[a]).abs() / db_scale);
+        max_db_rel =
+            max_db_rel.max((artifacts.delta_beta[a] - reference.delta_beta[a]).abs() / db_scale);
     }
     assert!(
         max_db_rel <= 1e-7,
@@ -3639,8 +3639,8 @@ pub(crate) fn device_arrow_and_host_procedural_matvec_flags_are_mutually_exclusi
         ArrowSolveOptions::direct(),
     ] {
         let mode = options.mode;
-        let (_dt, _db, diag) = solve_arrow_newton_step_core(&sys, ridge_t, ridge_beta, &options)
-            .expect("core solve");
+        let (_dt, _db, diag) =
+            solve_arrow_newton_step_core(&sys, ridge_t, ridge_beta, &options).expect("core solve");
         assert!(
             !(diag.used_device_arrow && diag.injected_host_procedural_matvec),
             "#1209: used_device_arrow and injected_host_procedural_matvec are mutually \
@@ -4665,6 +4665,18 @@ pub(crate) fn build_dense_schur_direct_refuses_oversize_border_1017() {
         }
         other => panic!("expected SchurFactorFailed for oversize border, got {other:?}"),
     }
+
+    let err = build_dense_schur_sqrt_ba(&sys, &htt_factors, 1e-6, &backend)
+        .expect_err("oversize square-root BA border must be refused, not allocated");
+    match err {
+        ArrowSchurError::SchurFactorFailed { reason } => {
+            assert!(
+                reason.contains("host budget") && reason.contains("matrix-free"),
+                "sqrt-BA refusal must be actionable (border-too-large, matrix-free-only): {reason}"
+            );
+        }
+        other => panic!("expected SchurFactorFailed for oversize sqrt-BA border, got {other:?}"),
+    }
 }
 
 /// The parallel disjoint-range prefix fan-out in `CompositePenaltyOp::matvec`
@@ -4681,12 +4693,17 @@ fn composite_penalty_parallel_prefix_matches_serial_bit_exact() {
     let p = 32usize; // identity-right width
     let block = p_a * p; // 128
     let k = n_atoms * block; // 1024 ≥ SCHUR_PROLOGUE_PARALLEL_K_MIN (512)
-    assert!(k >= SCHUR_PROLOGUE_PARALLEL_K_MIN, "must trip the parallel prefix");
+    assert!(
+        k >= SCHUR_PROLOGUE_PARALLEL_K_MIN,
+        "must trip the parallel prefix"
+    );
 
     // Deterministic pseudo-random SPD-ish left factors and input.
     let mut state = 0x1234_5678u64;
     let mut next = || {
-        state = state.wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407);
+        state = state
+            .wrapping_mul(6364136223846793005)
+            .wrapping_add(1442695040888963407);
         ((state >> 11) as f64) / ((1u64 << 53) as f64) * 2.0 - 1.0
     };
 
@@ -4768,7 +4785,8 @@ fn slq_reduced_schur_log_det_matches_dense_evidence() {
     let exact_logdet: f64 = (0..k).map(|i| 2.0 * l[[i, i]].ln()).sum();
 
     // Matrix-free SLQ estimate — never forms S.
-    let slq = slq_reduced_schur_log_det(&sys, &htt_factors, ridge_beta, &backend, None, 48, 60, seed);
+    let slq =
+        slq_reduced_schur_log_det(&sys, &htt_factors, ridge_beta, &backend, None, 48, 60, seed);
     let rel = (slq.estimate - exact_logdet).abs() / exact_logdet.abs();
     eprintln!(
         "matrix-free reduced-Schur log|S|: slq={:.6} exact={:.6} rel={:.3e} std_err={:.3e}",


### PR DESCRIPTION
### Motivation
- Avoid materialising a dense `k×k` reduced Schur when computing the evidence `log|S|` for large SAE/LLM borders so the production matrix-free device-PCG seam does not pay an OOM / expensive dense assembly cost that defeats matrix-free residency benefits.

### Description
- For large `k ≥ SCHUR_SLQ_LOGDET_MIN_DIM`, compute the evidence `log|S|` by running SLQ over the matrix-free reduced-Schur apply instead of forming `S` first, using `slq_reduced_schur_log_det` and staging `SaeResidentReducedSchur` when available (file: `crates/gam-solve/src/arrow_schur/newton_step.rs`).
- Preserve the exact dense Cholesky/logdet path for small `k` so small problems keep bit-identical behavior.
- Add the same host-memory (fail-loud) budget guard to the Square-Root BA dense reduced-Schur path so it cannot bypass the Direct-path protection and accidentally allocate an oversize `k×k` Schur (file: `crates/gam-solve/src/arrow_schur/reduced_solve.rs`).
- Extend the oversize-border regression test to assert the Square-Root BA route also refuses matrix-free-only borders (file: `crates/gam-solve/src/arrow_schur/tests.rs`).

### Testing
- Ran `cargo check -p gam-solve --no-default-features` successfully in this environment.
- Verified `git diff --check` and formatted changes (`rustfmt`).
- Extended the oversize-border unit test to cover square-root BA; attempted to run the targeted unit test locally (`build_dense_schur_direct_refuses_oversize_border_1017`) but full test runs in this workspace trigger long rebuilds of heavy deps and were environment-limited; the change is small, local type-checking passes and CI should exercise the full test battery.

---
🤖 Codex Cloud root-cause fix for #1017 (task `task_e_6a45726e64d4832499b0ce36306c5c4f`). **Unaudited** — review for reward-hacking before merge.

Closes #1017