### PR TITLE
docs: clarify Arrow‑Schur row‑procedural reduction parity (#1175/#1017)

### DIFF
--- a/crates/gam-solve/src/gpu_kernels/arrow_schur.rs
+++ b/crates/gam-solve/src/gpu_kernels/arrow_schur.rs
@@ -665,14 +665,17 @@ fn build_row_procedural_matvec(
                         neg
                     })
                     .collect();
-                // #1017/#1175 floating-point parity contract: each chunk's row
-                // sum is formed locally, then chunk partials are folded
-                // left-to-right. That makes the parallel row-procedural Schur
-                // term deterministic for a fixed input and chunking, but it is
-                // not required to be bit-identical to the serial path because
-                // the additions are reassociated at chunk boundaries. CPU/GPU
-                // validation should therefore allow ULP-scale drift while
-                // expecting stable run-to-run results.
+                // #1017/#1175 floating-point parity contract: Rayon may
+                // schedule chunks on any worker, but `.chunks(CHUNK).collect()`
+                // returns partials in chunk-index order. Each chunk's row sum
+                // is formed locally in increasing row order, then chunk
+                // partials are folded left-to-right below. That makes the
+                // parallel row-procedural Schur term deterministic for a fixed
+                // input and chunking (no scheduling-dependent gather/scatter
+                // reordering), but it is not required to be bit-identical to
+                // the serial path because additions are reassociated at chunk
+                // boundaries. CPU/GPU validation should therefore allow
+                // ULP-scale drift while expecting stable run-to-run results.
                 let mut neg = Array1::<f64>::zeros(k);
                 for part in &partials {
                     for a in 0..k {


### PR DESCRIPTION
### Motivation
- Make explicit the floating‑point parity contract for the row‑procedural Schur matvec so reviewers and validators understand why the parallel chunked reduction is deterministic for a fixed chunking yet may differ from the serial path by ULP‑scale reassociation (see issues `#1017` / `#1175`).

### Description
- Small documentation-only change in `crates/gam-solve/src/gpu_kernels/arrow_schur.rs` that expands the comment above the parallel chunked reduction to state that Rayon `.chunks(...).collect()` preserves chunk index order, each chunk forms its per-row sum in increasing row order, and partials are folded left-to-right so scheduling cannot reorder the gather/scatter accumulation while chunk‑boundary reassociation may produce ULP-scale differences.

### Testing
- Ran `cargo check -p gam-solve --lib` which completed successfully. 
- Ran `git diff --check` to validate no whitespace/merge errors and it passed. 
- Attempted `cargo fmt --check` but the repository contains unrelated formatting drift outside this change, so formatting was not enforced by this PR.

---
🤖 Codex Cloud root-cause fix for #1175 (task `task_e_6a4572a33ae08324a3d473384c874a66`). **Unaudited** — review for reward-hacking before merge.

Closes #1175