### PR TITLE
fix(curv): anchor data-driven centers at chart pole

### DIFF
--- a/crates/gam-terms/src/basis/constant_curvature_smooth.rs
+++ b/crates/gam-terms/src/basis/constant_curvature_smooth.rs
@@ -627,7 +627,7 @@ pub fn build_constant_curvature_basis(
         crate::bail_invalid_basis!("constant-curvature smooth needs a finite kappa");
     }
     validate_chart_points(data, spec.kappa, "data")?;
-    let centers = select_centers_by_strategy(data, &spec.center_strategy)?;
+    let centers = select_constant_curvature_centers(data, &spec.center_strategy)?;
     if centers.nrows() < 2 {
         return Err(BasisError::InsufficientColumnsForConstraint {
             found: centers.nrows(),
@@ -769,6 +769,47 @@ pub fn build_constant_curvature_basis(
         null_eigenvectors,
         joint_null_rotation: None,
     })
+}
+
+/// Select constant-curvature centers.
+///
+/// The stereographic constant-curvature chart has a distinguished pole: the
+/// chart origin.  Curvature sign is visible first in the radial geodesic map
+/// from that pole (`2 atan(√κ r)/√κ` versus `2 atanh(√|κ| r)/√|κ|`).  A pure
+/// farthest-point subset can miss the pole on disk-like clouds, leaving the
+/// radial mode to be reconstructed indirectly from boundary centers; then the
+/// positive chart's distance compression becomes a generic interpolation
+/// advantage and the κ profile is sign-blind.  Keep the user's requested center
+/// count, but make data-driven center sets pole-aware by replacing the center
+/// closest to the origin with the exact origin.  User-provided centers are left
+/// verbatim.
+fn select_constant_curvature_centers(
+    data: ArrayView2<'_, f64>,
+    strategy: &CenterStrategy,
+) -> Result<Array2<f64>, BasisError> {
+    let mut centers = select_centers_by_strategy(data, strategy)?;
+    match strategy {
+        CenterStrategy::UserProvided(_) => return Ok(centers),
+        CenterStrategy::Auto(inner) => {
+            if matches!(inner.as_ref(), CenterStrategy::UserProvided(_)) {
+                return Ok(centers);
+            }
+        }
+        _ => {}
+    }
+    if centers.nrows() == 0 || centers.ncols() == 0 {
+        return Ok(centers);
+    }
+    let (closest, _) = centers
+        .outer_iter()
+        .enumerate()
+        .map(|(i, row)| (i, row.dot(&row)))
+        .min_by(|a, b| a.1.partial_cmp(&b.1).unwrap_or(std::cmp::Ordering::Equal))
+        .unwrap();
+    for j in 0..centers.ncols() {
+        centers[(closest, j)] = 0.0;
+    }
+    Ok(centers)
 }
 
 /// Closed-form profiled Gaussian-REML negative-log-evidence of a dense design


### PR DESCRIPTION
### Motivation
- The constant-curvature `curv()` basis could miss the stereographic chart pole when selecting data-driven centers (farthest-point / kmeans style), which lets the positive-chart distance compression become a generic interpolation advantage and makes the κ-profile sign-blind (hyperbolic truth recovered as spherical). 
- Ensure the realized basis always exposes the pole so radial curvature shape is directly observed by the RKHS design and κ sign becomes identifiable.

### Description
- Route the constant-curvature basis construction through a specialized center selector by replacing the generic `select_centers_by_strategy` call with `select_constant_curvature_centers` in `build_constant_curvature_basis` (`crates/gam-terms/src/basis/constant_curvature_smooth.rs`).
- Add `select_constant_curvature_centers` which preserves user-provided centers but, for data-driven center strategies, replaces the chosen center closest to the chart origin with the exact origin (0 vector) while keeping the requested center count unchanged.
- This pole-aware selection is a minimal, data-driven change that restores the radial mode visibility used by the curvature-identification machinery without changing default center counts or user-supplied centers.

### Testing
- Ran `cargo check -q -p gam-terms` which completed successfully. 
- Attempted the targeted unit test `cargo test --test basis_smooth curv_profiled_reml_identifies_curvature_sign_both_ways -- --nocapture` but the full compile/test run exceeded the interactive environment timeout and was not completed here; the change is intentionally minimal and localised to the constant-curvature basis selection path so it is low-risk to other modules.
- Committed the change and opened the PR for CI to run the full Rust test-suite and the existing curvature sign-identification gates.

---
🤖 Codex Cloud root-cause fix for #1464 (task `task_e_6a4572ba91a0832492c9ddec3293d115`). **Unaudited** — review for reward-hacking before merge.

Closes #1464