### PR TITLE
fix(gpu): route NVRTC compiles through arch-pinned options

### DIFF
--- a/crates/gam-sae/src/sparse_dict/scoring_gpu.rs
+++ b/crates/gam-sae/src/sparse_dict/scoring_gpu.rs
@@ -332,7 +332,7 @@ mod device {
                 return Ok(m.clone());
             }
         }
-        let ptx = cudarc::nvrtc::compile_ptx(score_block_kernel_source(p))
+        let ptx = gam_gpu::device_cache::compile_ptx_arch(score_block_kernel_source(p))
             .gpu_ctx_with(|err| format!("sparse_dict score-block NVRTC (P={p}): {err}"))?;
         let module = b
             .ctx

--- a/crates/gam-solve/src/gpu_kernels/arrow_schur.rs
+++ b/crates/gam-solve/src/gpu_kernels/arrow_schur.rs
@@ -2013,7 +2013,7 @@ mod cuda {
             key.p_max as usize,
             key.r_template as usize,
         );
-        let ptx = cudarc::nvrtc::compile_ptx(&src).map_err(|err| {
+        let ptx = gam_gpu::device_cache::compile_ptx_arch(&src).map_err(|err| {
             ArrowSchurGpuFailure::SchurFactorFailed {
                 reason: format!(
                     "arrow-schur fused NVRTC compile (p_max={}, r={}): {err}",


### PR DESCRIPTION
### Motivation
- Fix the SAE device silent-CPU fallback rooted in NVRTC compiling kernels without an explicit `--gpu-architecture` (which defaulted below `sm_60` and rejected `atomicAdd(double*, double)`), so runtime NVRTC kernels actually compile for the selected device and the device-resident SAE path can engage.

### Description
- Replace bare `cudarc::nvrtc::compile_ptx(...)` calls with the arch-aware helper `gam_gpu::device_cache::compile_ptx_arch(...)` in the Arrow-Schur fused NVRTC module (`crates/gam-solve/src/gpu_kernels/arrow_schur.rs`) and the SAE sparse-dictionary scoring compile site (`crates/gam-sae/src/sparse_dict/scoring_gpu.rs`) so runtime compiles inherit the selected-device `compute_NN` NVRTC option and parity options.

### Testing
- Ran `cargo check -p gam-solve -p gam-sae` which completed successfully.
- Ran `cargo test -p gam-gpu nvrtc_arch --lib` and the `nvrtc_arch` unit tests passed (`4 passed`).
- Attempted `cargo test -p gam-solve sae_direct_inner_solve_engages_device_and_matches_cpu_1551 --lib` but the local CPU environment stalled/was too heavy to complete; this fail-loud GPU engagement test requires a CUDA-equipped CI/GPU host for final verification.

---
🤖 Codex Cloud root-cause fix for #1551 (task `task_e_6a4572c35ce483249770fa2466a80463`). **Unaudited** — review for reward-hacking before merge.

Closes #1551