### PR TITLE
Increase secondary smooth basis headroom

### DIFF
--- a/crates/gam-terms/src/basis/types.rs
+++ b/crates/gam-terms/src/basis/types.rs
@@ -446,10 +446,10 @@ pub fn default_num_centers(n: usize, d: usize) -> usize {
 /// the fitted scale is driven small the *observed* information collapses and
 /// the determinant penalty stops holding the wiggle down (#501). This mirrors
 /// standard GAMLSS/mgcv practice of giving distribution parameters a modest
-/// default (mgcv's `k = 10` for a 1-D `s()`), grown gently with dimensionality
-/// and never exceeding the generous primary-predictor default.
+/// default (mgcv's modest default basis for a 1-D `s()`), grown gently with
+/// dimensionality and never exceeding the generous primary-predictor default.
 pub fn conservative_secondary_centers(n: usize, d: usize) -> usize {
-    const BASE_1D_CENTERS: usize = 10;
+    const BASE_1D_CENTERS: usize = 15;
     let modest = BASE_1D_CENTERS.saturating_mul(d.max(1));
     default_num_centers(n, d).min(modest).max(1)
 }


### PR DESCRIPTION
### Motivation
- Give distributional/secondary predictors (e.g. location-scale / dispersion smooths) more basis capacity so low-frequency heteroscedastic structure can be recovered without matching the primary predictor's generous basis and while remaining conservatively capped.

### Description
- Raise the conservative 1-D secondary-predictor center cap from `10` to `15` by changing `BASE_1D_CENTERS` in `crates/gam-terms/src/basis/types.rs` and tidy the nearby documentation text.

### Testing
- Built the affected crate with `./build.sh crate gam-terms`, which completed successfully; a full workspace test run for the gated `gam_gaussian_location_scale_matches_gamlss` driver was attempted (`GAM_BUILD_TIMEOUT=900 ./build.sh test gam_gaussian_location_scale_matches_gamlss -- --nocapture`) but the compilation/test execution did not complete in this environment due to long compile/resource constraints.

---
🤖 Codex Cloud root-cause fix for #1561 (task `task_e_6a4572cb7f9483248133587da029e556`). **Unaudited** — review for reward-hacking before merge.

Closes #1561