### PR TITLE
fix(reml): avoid large Firth TK Hessian probes

### DIFF
--- a/crates/gam-solve/src/reml/gradient_hessian.rs
+++ b/crates/gam-solve/src/reml/gradient_hessian.rs
@@ -436,6 +436,24 @@ impl<'a> RemlState<'a> {
             );
             return false;
         }
+        // Canonical-logit Firth fits have an exact Tierney-Kadane Hessian, but
+        // its skewness correction contains an O(n²) row-pair contraction.  Keep
+        // that exact curvature for small separation-rescue fits, where it is
+        // cheap and useful; for ordinary multi-thousand-row binomial GAMs keep
+        // the same Firth objective and analytic gradient while routing outer
+        // curvature to BFGS instead of spending minutes on one Hessian probe
+        // (#1575).
+        if reml_robust_jeffreys_link(&self.config).is_some()
+            && self.tk_correction_is_canonical_logit()
+            && !Self::firth_tk_exact_hessian_scale_allows(n_obs, p_dim)
+        {
+            log::info!(
+                "[standard-GAM] declining canonical-logit Firth exact outer Hessian for \
+                 n={n_obs} p={p_dim} (row-pair TK Hessian work n²·p exceeds budget); \
+                 routing to analytic-gradient BFGS"
+            );
+            return false;
+        }
         // The analytic outer Hessian for a Firth fit folds in the Tierney-Kadane
         // curvature, whose c/d/e/f derivative arrays are implemented only for the
         // canonical Binomial Logit jet. #758 widened Firth to other Binomial
@@ -449,6 +467,16 @@ impl<'a> RemlState<'a> {
             return false;
         }
         true
+    }
+
+    pub(crate) fn firth_tk_exact_hessian_scale_allows(n_obs: usize, p_coeff: usize) -> bool {
+        // Separate from `firth_problem_scale_allows`, which gates the O(n·p²)
+        // dense Firth operator used by the inner solve and gradient.  The exact
+        // TK Hessian-only path is O(n²·p) after the #1575 matvec hoist and needs
+        // its own budget.
+        const FIRTH_TK_EXACT_HESSIAN_MAX_ROW_PAIR_WORK: usize = 10_000_000;
+        n_obs.saturating_mul(n_obs).saturating_mul(p_coeff)
+            <= FIRTH_TK_EXACT_HESSIAN_MAX_ROW_PAIR_WORK
     }
 
     /// Whether the Tierney-Kadane outer correction (its value, ρ-gradient, and

--- a/crates/gam-solve/src/reml/mod.rs
+++ b/crates/gam-solve/src/reml/mod.rs
@@ -652,6 +652,66 @@ mod tests {
         );
     }
 
+    #[test]
+    fn canonical_logit_firth_declines_exact_tk_hessian_when_row_pair_work_is_large() {
+        let n = 2_000usize;
+        let p = 28usize;
+        let y = Array1::from_iter((0..n).map(|i| if i % 3 == 0 { 1.0 } else { 0.0 }));
+        let w = Array1::<f64>::ones(n);
+        let mut x = Array2::<f64>::zeros((n, p));
+        for i in 0..n {
+            let t = (i as f64 + 0.5) / n as f64;
+            x[[i, 0]] = 1.0;
+            for j in 1..p {
+                x[[i, j]] = ((j as f64) * std::f64::consts::TAU * t).sin()
+                    + 0.25 * (((j + 1) as f64) * std::f64::consts::TAU * t).cos();
+            }
+        }
+        let mut s = Array2::<f64>::zeros((p, p));
+        for j in 1..p {
+            s[[j, j]] = 1.0;
+        }
+        let cfg = RemlConfig::external(binomial_logit_glm_spec(), 1e-10, true);
+        let state = build_logit_state(&y, &w, &x, &s, &cfg);
+
+        assert!(
+            !RemlState::firth_tk_exact_hessian_scale_allows(n, p),
+            "fixture must sit beyond the O(n²·p) exact-Hessian budget"
+        );
+        assert!(
+            !state.analytic_outer_hessian_enabled(),
+            "large canonical-logit Firth fits should keep exact value/gradient but route outer curvature to BFGS"
+        );
+    }
+
+    #[test]
+    fn canonical_logit_firth_keeps_exact_tk_hessian_for_small_separation_guards() {
+        let n = 40usize;
+        let p = 6usize;
+        let y = Array1::from_iter((0..n).map(|i| if i >= n / 2 { 1.0 } else { 0.0 }));
+        let w = Array1::<f64>::ones(n);
+        let mut x = Array2::<f64>::zeros((n, p));
+        for i in 0..n {
+            let t = (i as f64) / (n - 1) as f64;
+            x[[i, 0]] = 1.0;
+            for j in 1..p {
+                x[[i, j]] = t.powi(j as i32);
+            }
+        }
+        let mut s = Array2::<f64>::zeros((p, p));
+        for j in 1..p {
+            s[[j, j]] = 1.0;
+        }
+        let cfg = RemlConfig::external(binomial_logit_glm_spec(), 1e-10, true);
+        let state = build_logit_state(&y, &w, &x, &s, &cfg);
+
+        assert!(RemlState::firth_tk_exact_hessian_scale_allows(n, p));
+        assert!(
+            state.analytic_outer_hessian_enabled(),
+            "small Firth rescue fits should keep exact TK Hessian curvature"
+        );
+    }
+
     pub(crate) fn poisson_log_glm_spec() -> GlmLikelihoodSpec {
         GlmLikelihoodSpec::canonical(LikelihoodSpec::new(
             ResponseFamily::Poisson,


### PR DESCRIPTION
### Motivation
- The Tierney–Kadane (TK) exact outer Hessian for canonical-logit Firth includes an O(n²·p) row-pair skewness contraction that can dominate runtime for ordinary multi-thousand-row binomial GAMs (#1575). This is useful for small separation-rescue fits but unacceptable at production scale.

### Description
- Decline the exact TK Hessian for canonical-logit Firth when the estimated row-pair work n²·p exceeds a conservative budget, while preserving the exact Firth value and analytic gradient and routing outer curvature to the analytic-gradient quasi-Newton (BFGS) lane (changes in `crates/gam-solve/src/reml/gradient_hessian.rs`).
- Introduce `RemlState::firth_tk_exact_hessian_scale_allows(n_obs, p_coeff)` to encapsulate the budget check for the TK exact-Hessian path, separate from existing inner-solve Firth gating.
- Add unit tests that exercise both branches: a large n/p fixture that must decline the exact TK Hessian and a small separation-rescue fixture that keeps it (tests in `crates/gam-solve/src/reml/mod.rs`).

### Testing
- Ran `cargo check -p gam-solve` and the check succeeded.
- Ran targeted unit tests: `cargo test -p gam-solve --lib canonical_logit_firth -- --nocapture` and all added tests passed.
- Ran `git diff --check` to ensure no whitespace or diff issues.

---
🤖 Codex Cloud root-cause fix for #1575 (task `task_e_6a4572d34198832499224a577c924e60`). **Unaudited** — review for reward-hacking before merge.

Closes #1575