### PR TITLE
docs(sae): align barrier override docs with evidence-derived strength

### DIFF
--- a/crates/gam-sae/src/manifold/term.rs
+++ b/crates/gam-sae/src/manifold/term.rs
@@ -636,11 +636,11 @@ pub struct SaeManifoldTerm {
     /// #1777 PER-FIT separation-barrier strength override `μ_C` — the source of
     /// truth for the barrier strength when set, replacing the process-global
     /// [`set_sae_barrier_overrides`] atomic. `Some(μ_C)` forces the absolute
-    /// strength (bypassing the data-derived overcompleteness ratio), scoped to
-    /// THIS term/fit so concurrent in-process fits are isolated; `0.0` disables the
-    /// barrier. `None` ⇒ fall back to the deprecated process-global override, then
-    /// the data-derived strength (bit-identical to the historical path when
-    /// neither override is set). Read via
+    /// strength (bypassing the #1610 evidence-derived per-pair reciprocal-margin
+    /// strengths), scoped to THIS term/fit so concurrent in-process fits are
+    /// isolated; `0.0` disables the barrier. `None` ⇒ fall back to the deprecated
+    /// process-global override, then the evidence-derived strength (bit-identical
+    /// to the historical path when neither override is set). Read via
     /// [`super::penalties::SaeManifoldTerm::separation_barrier_strength`]; set from
     /// the FFI through [`SaeManifoldTerm::set_fit_config`]. Carried across clones
     /// (persisted configuration, like the assignment mode).
@@ -662,7 +662,7 @@ pub struct SaeManifoldTerm {
 #[derive(Debug, Clone, Copy, Default, PartialEq)]
 pub struct SaeFitConfig {
     /// Per-fit separation-barrier strength `μ_C`. `Some` bypasses both the global
-    /// override and the data-derived overcompleteness ratio (`0.0` = barrier off).
+    /// override and the #1610 evidence-derived per-pair strengths (`0.0` = barrier off).
     pub separation_barrier_strength_override: Option<f64>,
     /// Per-fit truncated-IBP concentration `α`. `Some` bypasses both the global
     /// override and the mode's own `α` / learnable schedule.

--- a/crates/gam-sae/src/manifold/tests.rs
+++ b/crates/gam-sae/src/manifold/tests.rs
@@ -2512,7 +2512,8 @@ pub(crate) fn decoder_repulsion_strength_is_derived_and_scale_invariant_1610() {
     // (1) Strength is a DERIVED dimensionless fraction of the data-derived
     // separation-barrier strength μ_C, not an independent absolute constant.
     // (Checked on a constructed term below, after the fixture builder — μ_C is
-    // now a per-dictionary quantity, K / reachable_rank, not a global constant.)
+    // now read from the data-fit inseparability of the live design/routing, not a
+    // global constant or a rank-count heuristic.)
 
     // (2) End-to-end scale invariance of the repulsion value.
     let coords0 = array![[0.05], [0.20], [0.55], [0.80], [0.35], [0.65]];


### PR DESCRIPTION
### Motivation
- Clarify that the SAE separation-barrier strength is now evidence-derived per-pair (reciprocal-margin from design inseparability) rather than the removed overcompleteness-ratio heuristic so comments and test text reflect the real implementation.

### Description
- Update doc comments for the per-fit `separation_barrier_strength_override` to state it bypasses the #1610 evidence-derived per-pair reciprocal-margin strengths instead of the old rank-count heuristic (`crates/gam-sae/src/manifold/term.rs`).
- Update the `decoder_repulsion_strength_is_derived_and_scale_invariant_1610` test comment to describe that `μ_C` is read from the data-fit inseparability of the live design/routing rather than a global constant or rank-count heuristic (`crates/gam-sae/src/manifold/tests.rs`).

### Testing
- Ran `cargo test -p gam-sae --lib 1610 -- --nocapture`, which executed the related #1610 tests and all passed (5 passed; 0 failed).
- Ran `cargo check -p gam-sae --lib`, which completed cleanly.

---
🤖 Codex Cloud root-cause fix for #1610 (task `task_e_6a4572e3325c8324b169d53fddfb4417`). **Unaudited** — review for reward-hacking before merge.

Closes #1610