### PR TITLE
Avoid derivative setup for GAMLSS cost-only probes

### DIFF
--- a/crates/gam-models/src/gamlss/builders.rs
+++ b/crates/gam-models/src/gamlss/builders.rs
@@ -1854,13 +1854,27 @@ pub(crate) fn fit_location_scale_terms<B: LocationScaleFamilyBuilder>(
                         *noise_beta_hint_cell.borrow_mut() = Some(beta);
                     }
                     let family = builder.build_family(&designs[0], &designs[1]);
-                    let psiderivative_blocks = builder.build_psiderivative_blocks(
-                        data,
-                        &specs[0],
-                        &specs[1],
-                        &designs[0],
-                        &designs[1],
-                    )?;
+                    let psiderivative_blocks = if matches!(eval_mode, EvalMode::ValueOnly) {
+                        // Cost-only line-search probes need only the profiled
+                        // likelihood at the already-realized θ. The ψ
+                        // derivative payloads are O(n) to assemble and are
+                        // consumed solely by the IFT gradient/Hessian path;
+                        // building them for every backtracking probe made the
+                        // Gaussian location-scale path scale with sample size
+                        // even when the optimizer discarded the derivative
+                        // pieces. Pass empty blocks so the shared evaluator
+                        // performs the same fixed-design inner REML solve
+                        // without derivative-only setup work.
+                        (0..specs.len()).map(|_| Vec::new()).collect()
+                    } else {
+                        builder.build_psiderivative_blocks(
+                            data,
+                            &specs[0],
+                            &specs[1],
+                            &designs[0],
+                            &designs[1],
+                        )?
+                    };
                     let warm_start = hyper_warm_start_cell.borrow().clone();
                     // Forward the κ-staging row set to the family by installing it
                     // on the canonical `outer_score_subsample` option. Inner-PIRLS


### PR DESCRIPTION
### Motivation
- Joint (gaussian-location-scale) outer line-search probes were paying O(n) cost to assemble ψ-derivative payloads even when only the profiled objective value was required, causing the loc-scale path to scale super-linearly with `n` and dominate run time compared to the plain Gaussian path.

### Description
- In `crates/gam-models/src/gamlss/builders.rs` skip calling `build_psiderivative_blocks` when the outer evaluator requests `EvalMode::ValueOnly` and instead pass empty derivative blocks sized to the number of specs so cost-only probes avoid the O(n) derivative assembly.
- Preserve normal `build_psiderivative_blocks` behavior for `ValueAndGradient` and `ValueGradientHessian` evaluations so analytic gradients/Hessians remain correct and unchanged.
- The change is localized to the exact-joint closure used by `optimize_spatial_length_scale_exact_joint` and does not alter downstream fits or the warm-start logic.

### Testing
- Ran `cargo check -p gam-models` which completed successfully. 
- Ran `git diff --check` to verify no whitespace/format issues and found none. 
- Attempted `cargo test -p gam-models gamlss::tests::gaussian_location_scale --lib` in this environment but did not run to completion due to time constraints; the change is narrowly scoped and preserves derivative behavior for non-cost probes so it is expected to be functionally safe.

---
🤖 Codex Cloud root-cause fix for #1720 (task `task_e_6a4573024ee8832484b585bdfdd279c2`). **Unaudited** — review for reward-hacking before merge.

Closes #1720