### PR TITLE
Optimize binomial-logit PIRLS working updates

### DIFF
--- a/crates/gam-solve/src/pirls/glm_update.rs
+++ b/crates/gam-solve/src/pirls/glm_update.rs
@@ -5,6 +5,17 @@
 use super::*;
 use gam_problem::MIN_WEIGHT;
 
+#[inline]
+fn stable_logit_mu(eta: f64) -> f64 {
+    if eta >= 0.0 {
+        let z = (-eta).exp();
+        1.0 / (1.0 + z)
+    } else {
+        let z = eta.exp();
+        z / (1.0 + z)
+    }
+}
+
 pub fn update_glmvectors(
     y: ArrayView1<f64>,
     eta: &Array1<f64>,
@@ -79,20 +90,12 @@ pub fn update_glmvectors(
                 .zip(z_s.par_iter_mut())
                 .enumerate()
                 .for_each(|(i, ((mu_o, w_o), z_o))| {
-                    let eta_raw = eta[i];
-                    let eta_c = eta_raw.clamp(-ETA_CLAMP, ETA_CLAMP);
-                    let jet = logit_inverse_link_jet5(eta_c);
-                    let geom = bernoulli_logit_geometry_from_jet(
-                        eta_raw,
-                        eta_c,
-                        y[i],
-                        priorweights[i],
-                        jet,
-                        true,
-                    );
-                    *mu_o = geom.mu;
-                    *w_o = geom.weight;
-                    *z_o = geom.z;
+                    let eta_c = eta[i].clamp(-ETA_CLAMP, ETA_CLAMP);
+                    let mu = stable_logit_mu(eta_c);
+                    let fisher = mu * (1.0 - mu);
+                    *mu_o = mu;
+                    *w_o = priorweights[i] * fisher;
+                    *z_o = bernoulli_exact_working_response(eta_c, y[i], mu, fisher);
                 });
         }
         return Ok(());


### PR DESCRIPTION
### Motivation
- Reduce per-iteration overhead in the inner PIRLS loop for the common binomial-logit case by avoiding construction of the full 5-derivative logit jet when only `μ`, the Fisher weight, and the working response are required.

### Description
- Add a small stable scalar logistic helper `stable_logit_mu(eta: f64)` and use it in the hot non-derivative pure-logit path in `crates/gam-solve/src/pirls/glm_update.rs` so the inner loop computes only `mu`, `fisher = mu*(1-mu)`, and `z = bernoulli_exact_working_response(...)` instead of calling `logit_inverse_link_jet5` and `bernoulli_logit_geometry_from_jet` on every row.
- Preserve the derivative-producing branch unchanged so callers that need higher derivatives or observed-curvature still get the full jet and geometry.

### Testing
- Ran `cargo check -q -p gam-solve`, which completed successfully.
- Started the targeted unit test `cargo test -q -p gam-solve pirls::tests::update_glmvectors -- --nocapture`, but the build/test run did not complete within the available time (compile infrastructure work in progress); no test failures were observed from the earlier `cargo check` step.

---
🤖 Codex Cloud root-cause fix for #1727 (task `task_e_6a457309e14483249be7bc8487bb37b7`). **Unaudited** — review for reward-hacking before merge.

Closes #1727