### PR TITLE
fix(sae): keep recoverable refusal probes finite

### DIFF
--- a/crates/gam-sae/src/manifold/outer_objective.rs
+++ b/crates/gam-sae/src/manifold/outer_objective.rs
@@ -1270,9 +1270,11 @@ impl SaeManifoldOuterObjective {
     /// Laplace normaliser is non-finite). Used ONLY by
     /// [`Self::value_consistent_outer_gradient`] to central-difference the outer
     /// criterion; the clone means the production converged state is untouched and
-    /// the probe re-solves warm from it. Returns `+∞` for a recoverable
-    /// infeasible ρ probe (non-PD joint Hessian), which the caller treats as an
-    /// adjacent wall and declines to difference across.
+    /// the probe re-solves warm from it. Returns the same finite collapse wall
+    /// used by the production value / gradient / EFS lanes for a recoverable
+    /// infeasible ρ probe (non-PD joint Hessian), so the consistency safeguard
+    /// differentiates the objective shape the line search actually sees instead
+    /// of reintroducing an `+∞` lane for the #1782 refusal class.
     fn probe_outer_criterion_value(&self, rho: &SaeManifoldRho) -> Result<f64, String> {
         let mut probe = self.term.clone();
         let reml = match probe.reml_criterion_with_cache(
@@ -1285,7 +1287,9 @@ impl SaeManifoldOuterObjective {
             self.ridge_beta,
         ) {
             Ok(evaluated) => evaluated.0,
-            Err(err) if Self::is_recoverable_value_probe_refusal(&err) => return Ok(f64::INFINITY),
+            Err(err) if Self::is_recoverable_value_probe_refusal(&err) => {
+                return Ok(Self::recoverable_refusal_wall_cost());
+            }
             Err(err) => return Err(err),
         };
         Ok(if reml.is_finite() {


### PR DESCRIPTION
### Motivation
- Non-PD Schur-complement failures at seed ρ were a recoverable infeasible-ρ class but the FD/value-probe lane returned `+∞`, desyncing it from the EFS/value lanes and causing the outer startup validation to reject all seeds (issue #1782). 

### Description
- Align the probe lane with the other outer lanes by returning `recoverable_refusal_wall_cost()` instead of `f64::INFINITY` when `is_recoverable_value_probe_refusal(...)` matches, and update the doc comment to reflect the behavior in `probe_outer_criterion_value`.

### Testing
- Ran `cargo test -p gam-sae non_pd_schur_seed_refusal_is_recoverable_1782` which passed.
- Ran `cargo test -p gam-sae all_assignment_topology_combinations_pass_startup_validation_1782` which passed.
- Ran `cargo check --lib -p gam-sae` which completed successfully.

---
🤖 Codex Cloud root-cause fix for #1782 (task `task_e_6a4573196c8c8324ba7f4b6a845c5593`). **Unaudited** — review for reward-hacking before merge.

Closes #1782