### PR TITLE
Tune SAE GPU offload gate for thin (d_atom=1) curve atoms

### DIFF
--- a/crates/gam-gpu/src/policy.rs
+++ b/crates/gam-gpu/src/policy.rs
@@ -174,6 +174,16 @@ impl GpuDispatchPolicy {
     /// drops accordingly.
     pub const MATVEC_OFFLOAD_FLOPS_MIN: u128 = 10_000_000;
 
+    /// Thin-curve (`d_atom = 1`) SAE dictionaries are the common manifold-SAE
+    /// production shape: each per-row frame is a scalar, so the staged device
+    /// payload is much smaller than the general `d > 1` row-frame bundle, while
+    /// the work is still a large batched gather/scatter over `K` atoms and `n`
+    /// rows.  Use a lower admission floor for this scalar-frame regime so a
+    /// realistic token block with a moderately wide curve dictionary is not kept
+    /// on the CPU solely because the conservative general-frame lower-bound
+    /// undercounts the transpose cross term.
+    pub const THIN_CURVE_MATVEC_OFFLOAD_FLOPS_MIN: u128 = 1_000_000;
+
     /// Conservative seed for the reduced-Schur PCG iteration count when the
     /// caller cannot supply a measured budget. InexactPCG on an SAE β-block of
     /// width `k` converges in `O(√κ)` iterations; this floor keeps the work
@@ -280,7 +290,12 @@ impl GpuDispatchPolicy {
         }
         let per_apply = Self::admission_work_lower_bound(n, k, d);
         let total = per_apply.saturating_mul(cg_iters as u128);
-        total >= Self::MATVEC_OFFLOAD_FLOPS_MIN
+        let floor = if d == 1 {
+            Self::THIN_CURVE_MATVEC_OFFLOAD_FLOPS_MIN
+        } else {
+            Self::MATVEC_OFFLOAD_FLOPS_MIN
+        };
+        total >= floor
     }
 }
 
@@ -884,6 +899,19 @@ mod reduced_schur_matvec_offload_tests {
     fn admits_llm_shape_with_one_cg_iter() {
         let pol = GpuDispatchPolicy::default();
         assert!(pol.reduced_schur_matvec_should_offload(2_000, 2_048, 8, 1));
+    }
+
+    /// #1783: the primary manifold-SAE regime is a `d_atom = 1` curve
+    /// dictionary.  Its scalar row frames have much lower staging cost than the
+    /// general framed matvec, so realistic token blocks must not be stranded on
+    /// the CPU merely because the conservative admission lower bound is thin in
+    /// `d`.
+    #[test]
+    fn admits_thin_curve_atoms_at_realistic_scale() {
+        let pol = GpuDispatchPolicy::default();
+        assert!(pol.reduced_schur_matvec_should_offload(24_576, 64, 1, 1));
+        assert!(pol.reduced_schur_matvec_should_offload(40_456, 256, 1, 1));
+        assert!(!pol.reduced_schur_matvec_should_offload(300, 6, 1, 8));
     }
 
     /// Tiny shapes where the host↔device transfer dominates must stay on the


### PR DESCRIPTION
### Motivation
- Real-world manifold-SAE fits with `d_atom = 1` (curve/circle atoms) were staying on CPU with idle GPU because the reduced-Schur matvec offload predicate used a conservative general-frame flop floor that undercounts scalar-frame (d=1) staging/work tradeoffs.
- The intent is to allow the common scalar-frame manifold regime to route the InexactPCG reduced‑Schur matvec to the device at realistic token / dictionary scales while preserving the conservative behaviour for wider frames and genuinely tiny shapes.

### Description
- Added a dedicated lower admission floor `THIN_CURVE_MATVEC_OFFLOAD_FLOPS_MIN` to `GpuDispatchPolicy` for scalar per-row frames (`d == 1`) in `crates/gam-gpu/src/policy.rs`.
- Updated `reduced_schur_matvec_should_offload(n, k, d, cg_iters)` to use the thin-curve floor when `d == 1` and keep the existing `MATVEC_OFFLOAD_FLOPS_MIN` for `d > 1` so only the scalar-frame regime is affected.
- Added a unit test `admits_thin_curve_atoms_at_realistic_scale` that asserts realistic reported shapes (e.g. `n=24576,k=64,d=1` and `n=40456,k=256,d=1`) are admitted while small shapes remain rejected.

### Testing
- Ran the focused unit tests: `cargo test -p gam-gpu reduced_schur_matvec_offload_tests -- --nocapture`, and all tests in that group passed (8 passed, 0 failed).
- The change is limited to the policy gating logic and the added test; no numerical algorithmic behaviour was altered for the CPU/device kernels themselves.

---
🤖 Codex Cloud root-cause fix for #1783 (task `task_e_6a457321077c8324bc05570394422236`). **Unaudited** — review for reward-hacking before merge.

Closes #1783