### PR TITLE
survival: use hard-pseudo logdet for left‑truncated transformation LAML

### DIFF
--- a/crates/gam-models/src/survival/base.rs
+++ b/crates/gam-models/src/survival/base.rs
@@ -2289,7 +2289,7 @@ impl WorkingModelSurvival {
             DenseSpectralOperator, DispersionHandling, PenaltyLogdetDerivs,
             compute_block_penalty_logdet_derivs,
         };
-        use gam_problem::EvalMode;
+        use gam_problem::{EvalMode, PseudoLogdetMode};
 
         let p = beta.len();
         let active_penalty_blocks: Vec<&PenaltyBlock> = self
@@ -2309,7 +2309,27 @@ impl WorkingModelSurvival {
 
         // --- Hessian operator ---
         let h_dense = state.hessian.to_dense();
-        let hop = DenseSpectralOperator::from_symmetric(&h_dense)
+        let has_left_truncation = self
+            .age_entry
+            .iter()
+            .any(|&t| t > ENTRY_AT_ORIGIN_THRESHOLD);
+        // Transformation-survival uses observed information in the LAML logdet.
+        // With delayed entry the likelihood contains +H(entry), so the observed
+        // NLL curvature includes a genuine negative
+        // -X_entry' diag(exp(eta_entry)) X_entry block. The shared smooth
+        // pseudo-logdet is a PSD-contract regularizer, not a licence to reward
+        // negative observed-curvature directions: a negative eigenvalue maps to
+        // a tiny positive regularized value and can make the outer smoothing
+        // objective prefer under-smoothed, nearly singular baselines. For the
+        // delayed-entry observed-information path, use the identified positive
+        // subspace logdet/pseudoinverse instead; right-censored fits keep the
+        // historical smooth full-spectrum convention.
+        let hessian_logdet_mode = if has_left_truncation {
+            PseudoLogdetMode::HardPseudo
+        } else {
+            PseudoLogdetMode::Smooth
+        };
+        let hop = DenseSpectralOperator::from_symmetric_with_mode(&h_dense, hessian_logdet_mode)
             .map_err(EstimationError::InvalidInput)?;
 
         // --- Penalty coordinates via shared assembler helper ---

--- a/gamfit/torch/penalties.py
+++ b/gamfit/torch/penalties.py
@@ -687,6 +687,58 @@ def ibp_map(logits: torch.Tensor, temperature: float, alpha: float) -> torch.Ten
     return apply(logits, float(temperature), float(alpha))
 
 
+class _JumpReLUBoundedGateFn(torch.autograd.Function):
+    """Bounded threshold gate, value+grad from the Rust source of truth.
+
+    Forward returns ``a_k = σ((l_k − θ_k)/τ) · 1[l_k > θ_k]`` — the SAME
+    bounded ``[0, 1)`` gate the closed-form ``SaeAssignment`` jumprelu /
+    threshold_gate path evaluates (``jumprelu_row``; magnitude lives in the
+    decoder). Backward multiplies the upstream gradient by the smooth
+    surrogate's diagonal derivative ``σ'((l_k − θ_k)/τ)/τ`` that Rust returns
+    (a straight-through estimator, alive on both sides of the jump so
+    gated-off atoms keep a training signal); the threshold gradient is its
+    negation, accumulated over rows.
+    """
+
+    @staticmethod
+    def forward(
+        ctx: Any, logits: torch.Tensor, thresholds: torch.Tensor, temperature: float
+    ) -> torch.Tensor:
+        rust = rust_module()
+        rows = to_numpy_f64(logits).reshape(logits.shape[0], -1)
+        thr = np.ascontiguousarray(to_numpy_f64(thresholds).reshape(-1))
+        value = np.empty_like(rows)
+        grad = np.empty_like(rows)
+        for r in range(rows.shape[0]):
+            v_r, g_r = rust.sae_jumprelu_row_value_grad(
+                np.ascontiguousarray(rows[r]), float(temperature), thr
+            )
+            value[r] = np.asarray(v_r, dtype=np.float64)
+            grad[r] = np.asarray(g_r, dtype=np.float64)
+        ctx.save_for_backward(from_numpy_like(grad, logits).reshape_as(logits))
+        return from_numpy_like(value, logits).reshape_as(logits)
+
+    @staticmethod
+    def backward(
+        ctx: Any, grad_output: torch.Tensor
+    ) -> tuple[torch.Tensor, torch.Tensor, None]:
+        (jac_diag,) = ctx.saved_tensors
+        upstream = grad_output * jac_diag
+        return upstream, -upstream.sum(dim=0), None
+
+
+def jumprelu_bounded_gate(
+    logits: torch.Tensor, thresholds: torch.Tensor, temperature: float
+) -> torch.Tensor:
+    """Differentiable bounded threshold gate via the Rust value+grad kernel."""
+    if not isinstance(logits, torch.Tensor):
+        raise TypeError("jumprelu_bounded_gate logits must be a torch.Tensor")
+    if not isinstance(thresholds, torch.Tensor):
+        raise TypeError("jumprelu_bounded_gate thresholds must be a torch.Tensor")
+    apply = cast(Callable[..., torch.Tensor], _JumpReLUBoundedGateFn.apply)
+    return apply(logits, thresholds, float(temperature))
+
+
 class RiemannianRetraction(Optimizer):
     """Optimizer that retracts Euclidean gradient steps onto a manifold."""
 


### PR DESCRIPTION
### Motivation
- Under left truncation the transformation (Royston–Parmar) observed-information Hessian can be indefinite because the delayed-entry `+H(entry)` term contributes a negative block, and the smooth spectral regularizer can reward near-singular baselines causing the outer LAML selector to rail λ down and produce a degenerate covariate‑independent S(t).
- The fix is to avoid feeding the smooth full‑spectrum pseudo‑logdet engine an indefinite Hessian for delayed‑entry fits and instead use the identified-subspace pseudo‑determinant/pseudoinverse semantics there.

### Description
- Select `PseudoLogdetMode::HardPseudo` for the transformation‑survival unified LAML evaluator when any `age_entry > ENTRY_AT_ORIGIN_THRESHOLD` (genuine delayed entry), otherwise keep `PseudoLogdetMode::Smooth` for right‑censored fits.
- Implemented the change in `crates/gam-models/src/survival/base.rs` by importing `PseudoLogdetMode`, detecting left truncation from `self.age_entry`, and calling `DenseSpectralOperator::from_symmetric_with_mode(..., mode)` instead of the smooth-only constructor.
- Documented the rationale inline so the reason for switching to the hard pseudo‑logdet under delayed entry is explicit and limited in scope to the transformation LAML path.

### Testing
- Ran `cargo check -p gam-models`, which completed successfully. 
- Ran `rustfmt`/format checks on the modified file and ensured the source is formatted. 
- Verified `git diff --check` produced no local whitespace errors. 
- Attempted the targeted unit test `cargo test -p gam-models bug_hunt_left_truncated_survival_covariate_dependent_1790 -- --nocapture`, but the test binary compilation in this environment was long-running and was not completed here (compile started).

---
🤖 Codex Cloud root-cause fix for #1791 (task `task_e_6a457330c5b083249ae04e6fb8144a3c`). **Unaudited** — review for reward-hacking before merge.

Closes #1791