### PR TITLE
fix(sae): thread Schur PD floor through cross-row solve

### DIFF
--- a/crates/gam-solve/src/arrow_schur/newton_step.rs
+++ b/crates/gam-solve/src/arrow_schur/newton_step.rs
@@ -1297,8 +1297,13 @@ pub(crate) fn try_mixed_precision_arrow_solve(
         }));
     }
 
-    let schur_factor =
-        cholesky_lower(schur).map_err(|e| ArrowSchurError::SchurFactorFailed { reason: e })?;
+    let (schur_factor, floored_schur) = factor_dense_reduced_schur(schur, options.schur_pd_floor)?;
+    if floored_schur.is_some() {
+        return Ok(Some(MixedPrecisionAttempt::Fallback {
+            reason: "reduced Schur required the spectral PD-floor; using the f64 dense solve"
+                .to_string(),
+        }));
+    }
     if !options.tolerate_ill_conditioning {
         let schur_kappa = cholesky_factor_kappa_estimate(&schur_factor);
         if !schur_kappa.is_finite() || schur_kappa > safe_spd_kappa_max(schur.nrows()) {
@@ -2014,6 +2019,7 @@ impl<'a, B: BatchedBlockSolver> ArrowBlockDiagInverse<'a, B> {
         sys: &'a ArrowSchurSystem,
         ridge_t: f64,
         ridge_beta: f64,
+        schur_pd_floor: Option<f64>,
         tolerate_ill_conditioning: bool,
         backend: &'a B,
     ) -> Result<Self, ArrowSchurError>
@@ -2023,8 +2029,7 @@ impl<'a, B: BatchedBlockSolver> ArrowBlockDiagInverse<'a, B> {
         let htt_factors =
             backend.factor_blocks(&sys.rows, ridge_t, sys.d, tolerate_ill_conditioning)?;
         let schur = build_dense_schur_direct(sys, &htt_factors, ridge_beta, backend)?;
-        let schur_factor =
-            cholesky_lower(&schur).map_err(|e| ArrowSchurError::SchurFactorFailed { reason: e })?;
+        let (schur_factor, _) = factor_dense_reduced_schur(&schur, schur_pd_floor)?;
         Ok(Self {
             sys,
             backend,
@@ -2324,6 +2329,7 @@ pub(crate) fn solve_arrow_newton_step_cross_row(
         sys,
         ridge_t,
         ridge_beta,
+        options.schur_pd_floor,
         options.tolerate_ill_conditioning,
         &backend,
     )?;

--- a/crates/gam-solve/src/arrow_schur/reduced_solve.rs
+++ b/crates/gam-solve/src/arrow_schur/reduced_solve.rs
@@ -504,64 +504,31 @@ pub(crate) fn spectral_pd_floored_schur(
     Some(conditioned)
 }
 
-pub(crate) fn solve_dense_reduced_system(
+pub(crate) fn factor_dense_reduced_schur(
     schur: &Array2<f64>,
-    rhs_beta: &Array1<f64>,
-    options: &ArrowSolveOptions,
-    metric_weights: Option<&MetricWeights>,
-) -> Result<(Array1<f64>, Option<Array2<f64>>, PcgDiagnostics), ArrowSchurError> {
-    let factor = match cholesky_lower(schur) {
-        Ok(factor) => factor,
+    schur_pd_floor: Option<f64>,
+) -> Result<(Array2<f64>, Option<Array2<f64>>), ArrowSchurError> {
+    let (factor, floored_schur) = match cholesky_lower(schur) {
+        Ok(factor) => (factor, None),
         Err(e) => {
-            // #1026 — opt-in spectral PD-floor on the indefinite reduced Schur.
-            // When enabled (SAE solve path), condition ONLY the collapsed
-            // directions and re-factor, instead of erroring out and letting the
-            // outer LM loop inflate `ridge_β` over every β direction (the
-            // co-collapse "crawl"). Disabled (default `None`) keeps the strict
-            // refusal so BA / non-SAE callers are bit-for-bit unchanged.
-            match options.schur_pd_floor {
+            // #1026/#1038 — every dense reduced-Schur factorization in the SAE
+            // path must honor the same opt-in spectral floor. Otherwise
+            // auxiliary entry points (mixed precision and cross-row IBP
+            // preconditioning) can reject the collapsed dead-atom subspace even
+            // though the main direct solve would floor it and continue.
+            match schur_pd_floor {
                 Some(relative_floor) => match spectral_pd_floored_schur(schur, relative_floor) {
-                    Some(floored) => match cholesky_lower(&floored) {
-                        Ok(factor) => {
-                            // Solve against the floored (PD) Schur. The healthy β
-                            // subspace keeps its exact eigenvalues, so its Δβ is
-                            // the exact Newton component; only the collapsed
-                            // subspace is minimally damped.
-                            let direct =
-                                mixed_precision_reduced_beta(&floored, &factor, rhs_beta, options)
-                                    .unwrap_or_else(|| cholesky_solve_vector(&factor, rhs_beta));
-                            if step_inside_trust_region(
-                                direct.view(),
-                                options.trust_region.radius,
-                                metric_weights,
-                            ) {
-                                return Ok((direct, Some(factor), PcgDiagnostics::default()));
-                            }
-                            let identity = IdentityPreconditioner;
-                            let (delta, diag) = steihaug_dense_system(
-                                &floored,
-                                rhs_beta,
-                                &identity,
-                                &ArrowPcgOptions {
-                                    max_iterations: options.trust_region.max_iterations,
-                                    relative_tolerance: options
-                                        .trust_region
-                                        .steihaug_relative_tolerance,
-                                },
-                                &options.trust_region,
-                                metric_weights,
-                            )?;
-                            return Ok((delta, Some(factor), diag));
-                        }
-                        Err(floored_err) => {
-                            return Err(ArrowSchurError::SchurFactorFailed {
+                    Some(floored) => (
+                        cholesky_lower(&floored).map_err(|floored_err| {
+                            ArrowSchurError::SchurFactorFailed {
                                 reason: format!(
                                     "reduced Schur non-PD ({e}); spectral PD-floor \
                                      reconstruction still non-PD: {floored_err}"
                                 ),
-                            });
-                        }
-                    },
+                            }
+                        })?,
+                        Some(floored),
+                    ),
                     None => {
                         return Err(ArrowSchurError::SchurFactorFailed {
                             reason: format!(
@@ -575,6 +542,36 @@ pub(crate) fn solve_dense_reduced_system(
             }
         }
     };
+    Ok((factor, floored_schur))
+}
+
+pub(crate) fn solve_dense_reduced_system(
+    schur: &Array2<f64>,
+    rhs_beta: &Array1<f64>,
+    options: &ArrowSolveOptions,
+    metric_weights: Option<&MetricWeights>,
+) -> Result<(Array1<f64>, Option<Array2<f64>>, PcgDiagnostics), ArrowSchurError> {
+    let (factor, floored_schur) = factor_dense_reduced_schur(schur, options.schur_pd_floor)?;
+    if let Some(floored) = floored_schur {
+        let direct = mixed_precision_reduced_beta(&floored, &factor, rhs_beta, options)
+            .unwrap_or_else(|| cholesky_solve_vector(&factor, rhs_beta));
+        if step_inside_trust_region(direct.view(), options.trust_region.radius, metric_weights) {
+            return Ok((direct, Some(factor), PcgDiagnostics::default()));
+        }
+        let identity = IdentityPreconditioner;
+        let (delta, diag) = steihaug_dense_system(
+            &floored,
+            rhs_beta,
+            &identity,
+            &ArrowPcgOptions {
+                max_iterations: options.trust_region.max_iterations,
+                relative_tolerance: options.trust_region.steihaug_relative_tolerance,
+            },
+            &options.trust_region,
+            metric_weights,
+        )?;
+        return Ok((delta, Some(factor), diag));
+    }
     // Ill-conditioned-but-PD Schur guard. The per-row factor checks reject
     // any single barely-PD H_tt^(i) block, but the reduced Schur complement
     //     S = H_ββ + ridge_β·I − Σ_i H_tβ^(i)ᵀ (H_tt^(i))⁻¹ H_tβ^(i)


### PR DESCRIPTION
### Motivation
- Cross-row IBP / preconditioner factorization used a raw `cholesky_lower` and ignored `options.schur_pd_floor`, causing spurious `non-PD pivot` aborts for floorable (near-rank-deficient) reduced Schur complements. 
- The intent is to ensure every dense reduced-Schur factorization in the SAE paths honors the same opt-in spectral PD-floor so collapsed/near-zero eigen-directions are conditioned consistently across all solver entry points.

### Description
- Introduce a shared helper `factor_dense_reduced_schur` that performs the reduced-Schur Cholesky, applies the opt-in `spectral_pd_floored_schur` when needed, and returns both the factor and the floored matrix when used. 
- Replace direct `cholesky_lower(...).map_err(SchurFactorFailed)` sites with calls to `factor_dense_reduced_schur` so the spectral floor is consulted uniformly. 
- Thread `options.schur_pd_floor` into the mixed-precision dense path and into `ArrowBlockDiagInverse::build` so the cross-row IBP preconditioner uses the same floor-aware factorization. 
- Adjust `solve_dense_reduced_system` to preserve the floored matrix/behavior so direct dense solves continue to use the floored Schur when the helper floored it.

### Testing
- Ran `cargo check -p gam-solve --no-default-features`, which completed successfully. 
- Attempted `cargo test -p gam-solve --lib arrow_schur --no-default-features` in this environment but the test target compilation did not complete here (run was started but not finished within the session).

---
🤖 Codex Cloud root-cause fix for #1795 (task `task_e_6a45735039188324b07f132e1aff5902`). **Unaudited** — review for reward-hacking before merge.

Closes #1795