### PR TITLE
Restore IBP cross-row Woodbury coupling

### DIFF
--- a/crates/gam-terms/src/analytic_penalties/ibp.rs
+++ b/crates/gam-terms/src/analytic_penalties/ibp.rs
@@ -86,14 +86,20 @@ impl IBPAssignmentPenalty {
     fn pi_map(&self, z: ArrayView1<'_, f64>, alpha: f64) -> Array1<f64> {
         let n = z.len() / self.k_max;
         let a = alpha / self.k_max as f64;
+        // Use the Beta-Bernoulli posterior mean, `(M_k + a)/(N + a + 1)`, as
+        // the smooth empirical-π plug-in.  The old MAP plug-in
+        // `(M_k + a - 1)/(N + a - 1)` is pinned to the zero boundary whenever
+        // `a < 1` and the fitted mass is sparse, which incorrectly makes
+        // `∂π_k/∂M_k = 0` and drops the IBP cross-row Woodbury curvature for
+        // precisely the active-sparsity regimes this prior is meant to model.
         let mut pi = Array1::<f64>::zeros(self.k_max);
         for k in 0..self.k_max {
             let mut active_mass = 0.0;
             for row in 0..n {
                 active_mass += z[row * self.k_max + k];
             }
-            let denom = (n as f64 + a - 1.0).max(IBP_COUNT_DENOM_FLOOR);
-            let raw = (active_mass + a - 1.0) / denom;
+            let denom = (n as f64 + a + 1.0).max(IBP_COUNT_DENOM_FLOOR);
+            let raw = (active_mass + a) / denom;
             pi[k] = raw.clamp(IBP_INTERIOR_TOL, 1.0 - IBP_INTERIOR_TOL);
         }
         pi
@@ -145,7 +151,7 @@ impl IBPAssignmentPenalty {
         let z = self.concrete_logits(target);
         let pi = self.pi_map(z.view(), alpha);
         let n = z.len() / self.k_max;
-        let denom = (n as f64 + a - 1.0).max(IBP_COUNT_DENOM_FLOOR);
+        let denom = (n as f64 + a + 1.0).max(IBP_COUNT_DENOM_FLOOR);
 
         let mut active_mass = Array1::<f64>::zeros(self.k_max);
         for row in 0..n {
@@ -161,7 +167,7 @@ impl IBPAssignmentPenalty {
         for k in 0..self.k_max {
             let pk = pi[k].clamp(IBP_PROBABILITY_CLAMP, 1.0 - IBP_PROBABILITY_CLAMP);
             let mass = active_mass[k];
-            let raw = (mass + a - 1.0) / denom;
+            let raw = (mass + a) / denom;
             let pi_jac = if raw > IBP_INTERIOR_TOL && raw < 1.0 - IBP_INTERIOR_TOL {
                 1.0 / denom
             } else {
@@ -241,12 +247,12 @@ impl IBPAssignmentPenalty {
             if self.learnable_alpha {
                 let pk = pi[k].clamp(IBP_PROBABILITY_CLAMP, 1.0 - IBP_PROBABILITY_CLAMP);
                 let mass = active_mass[k];
-                let raw = (mass + a - 1.0) / denom;
+                let raw = (mass + a) / denom;
                 // Same interior gate / zero-π-Jacobian convention as
                 // `hessian_diag_log_alpha_derivative`; at the clamp the derivative is 0.
                 if raw > IBP_INTERIOR_TOL && raw < 1.0 - IBP_INTERIOR_TOL {
                     let one_minus = 1.0 - pk;
-                    let dpi_da = (n as f64 - mass) / (denom * denom);
+                    let dpi_da = (n as f64 + 1.0 - mass) / (denom * denom);
                     let inv_p = 1.0 / pk;
                     let inv_q = 1.0 / one_minus;
                     let a_channel = inv_p + inv_q;
@@ -292,7 +298,7 @@ impl IBPAssignmentPenalty {
         let z = self.concrete_logits(target);
         let pi = self.pi_map(z.view(), alpha);
         let n = z.len() / self.k_max;
-        let denom = (n as f64 + a - 1.0).max(IBP_COUNT_DENOM_FLOOR);
+        let denom = (n as f64 + a + 1.0).max(IBP_COUNT_DENOM_FLOOR);
         let mut active_mass = Array1::<f64>::zeros(self.k_max);
         for row in 0..n {
             let start = row * self.k_max;
@@ -302,7 +308,7 @@ impl IBPAssignmentPenalty {
         }
         let mut pi_jac = Array1::<f64>::zeros(self.k_max);
         for k in 0..self.k_max {
-            let raw = (active_mass[k] + a - 1.0) / denom;
+            let raw = (active_mass[k] + a) / denom;
             if raw > IBP_INTERIOR_TOL && raw < 1.0 - IBP_INTERIOR_TOL {
                 pi_jac[k] = 1.0 / denom;
             }
@@ -343,7 +349,7 @@ impl IBPAssignmentPenalty {
         let z = self.concrete_logits(target);
         let pi = self.pi_map(z.view(), alpha);
         let n = z.len() / self.k_max;
-        let denom = (n as f64 + a - 1.0).max(IBP_COUNT_DENOM_FLOOR);
+        let denom = (n as f64 + a + 1.0).max(IBP_COUNT_DENOM_FLOOR);
         let mut active_mass = Array1::<f64>::zeros(self.k_max);
         for row in 0..n {
             let start = row * self.k_max;
@@ -356,12 +362,12 @@ impl IBPAssignmentPenalty {
         for k in 0..self.k_max {
             let pk = pi[k].clamp(IBP_PROBABILITY_CLAMP, 1.0 - IBP_PROBABILITY_CLAMP);
             let mass = active_mass[k];
-            let raw = (mass + a - 1.0) / denom;
+            let raw = (mass + a) / denom;
             if raw <= IBP_INTERIOR_TOL || raw >= 1.0 - IBP_INTERIOR_TOL {
                 continue;
             }
             let one_minus = 1.0 - pk;
-            let dpi_da = (n as f64 - mass) / (denom * denom);
+            let dpi_da = (n as f64 + 1.0 - mass) / (denom * denom);
             let dpi_drho = a * dpi_da;
             let d_score_dpi = -1.0 / pk - 1.0 / one_minus;
             d_score[k] = d_score_dpi * dpi_drho;
@@ -469,7 +475,7 @@ impl AnalyticPenalty for IBPAssignmentPenalty {
         let z = self.concrete_logits(target);
         let pi = self.pi_map(z.view(), alpha);
         let n = z.len() / self.k_max;
-        let denom = (n as f64 + a - 1.0).max(IBP_COUNT_DENOM_FLOOR);
+        let denom = (n as f64 + a + 1.0).max(IBP_COUNT_DENOM_FLOOR);
         let mut out = Array1::<f64>::zeros(target.len());
         let mut active_mass = Array1::<f64>::zeros(self.k_max);
         for row in 0..n {
@@ -483,7 +489,7 @@ impl AnalyticPenalty for IBPAssignmentPenalty {
         for k in 0..self.k_max {
             let pk = pi[k].clamp(IBP_PROBABILITY_CLAMP, 1.0 - IBP_PROBABILITY_CLAMP);
             let mass = active_mass[k];
-            let raw = (mass + a - 1.0) / denom;
+            let raw = (mass + a) / denom;
             if raw > IBP_INTERIOR_TOL && raw < 1.0 - IBP_INTERIOR_TOL {
                 pi_jac[k] = 1.0 / denom;
             }
@@ -518,7 +524,7 @@ impl AnalyticPenalty for IBPAssignmentPenalty {
         let n = z.len() / self.k_max;
         let mut out = Array1::<f64>::zeros(target.len());
         let inv_tau2 = 1.0 / (tau * tau);
-        let denom = (n as f64 + a - 1.0).max(IBP_COUNT_DENOM_FLOOR);
+        let denom = (n as f64 + a + 1.0).max(IBP_COUNT_DENOM_FLOOR);
         let mut active_mass = Array1::<f64>::zeros(self.k_max);
         for row in 0..n {
             let start = row * self.k_max;
@@ -532,7 +538,7 @@ impl AnalyticPenalty for IBPAssignmentPenalty {
         for k in 0..self.k_max {
             let pk = pi[k].clamp(IBP_PROBABILITY_CLAMP, 1.0 - IBP_PROBABILITY_CLAMP);
             let mass = active_mass[k];
-            let raw = (mass + a - 1.0) / denom;
+            let raw = (mass + a) / denom;
             if raw > IBP_INTERIOR_TOL && raw < 1.0 - IBP_INTERIOR_TOL {
                 pi_jac[k] = 1.0 / denom;
             }
@@ -582,7 +588,7 @@ impl AnalyticPenalty for IBPAssignmentPenalty {
         let n = z.len() / self.k_max;
         let inv_tau = 1.0 / tau;
         let inv_tau2 = inv_tau * inv_tau;
-        let denom = (n as f64 + a - 1.0).max(IBP_COUNT_DENOM_FLOOR);
+        let denom = (n as f64 + a + 1.0).max(IBP_COUNT_DENOM_FLOOR);
 
         // Column aggregates (active_mass, pi_jac, pi_score, pi_score_derivative,
         // score, score_derivative). These are identical to hessian_diag and
@@ -600,7 +606,7 @@ impl AnalyticPenalty for IBPAssignmentPenalty {
         for k in 0..self.k_max {
             let pk = pi[k].clamp(IBP_PROBABILITY_CLAMP, 1.0 - IBP_PROBABILITY_CLAMP);
             let mass = active_mass[k];
-            let raw = (mass + a - 1.0) / denom;
+            let raw = (mass + a) / denom;
             let pi_jac = if raw > IBP_INTERIOR_TOL && raw < 1.0 - IBP_INTERIOR_TOL {
                 1.0 / denom
             } else {


### PR DESCRIPTION
### Motivation
- A converged IBP-MAP cache produced effectively-zero cross-row Woodbury coefficients `cross_row_d` (so `U D Uᵀ` vanished), because the empirical-π plug-in pinned `π_k` at the MAP boundary in sparse/low-`a` regimes and made `∂π_k/∂M_k = 0` (dropping the IBP cross-row curvature used by value/logdet/adjoint paths).
- The tests exercise the Woodbury cross-row term (`apply_exact_hessian_includes_ibp_cross_row_woodbury_1038` and related FD/adjoint gates), so the correct fix is to restore a smooth empirical-π that yields a material `∂π_k/∂M_k` rather than weakening tests.

### Description
- Replace the MAP plug-in `(M_k + a - 1)/(N + a - 1)` with the Beta-Bernoulli posterior mean `(M_k + a)/(N + a + 1)` in `IBPAssignmentPenalty::pi_map` so empirical-`π` is smooth and not pinned at sparse boundaries.
- Propagate the changed numerator/denominator convention through all IBP channels that depended on the old denominator, updating `denom` and `raw` computations in `hessian_diag`, `hessian_diag_logit_third_channels`, `log_alpha_target_mixed_derivative`, `hessian_diag_log_alpha_derivative`, `grad_target`, `hvp`, and related code so `pi_jac`, `score_derivative`, `cross_row_d`, and `cross_row_dd` remain correctly computed.
- Adjust the `dpi_da` formulawhere it depends on the denominator so learnable-`α` derivatives (`cross_row_d_logalpha` and `hessian_diag_log_alpha_derivative`) remain consistent with the posterior-mean plug-in.
- The change is localized to `crates/gam-terms/src/analytic_penalties/ibp.rs` and preserves the existing interior/clamp conventions (`IBP_INTERIOR_TOL`, `IBP_PROBABILITY_CLAMP`) and weight/learnable-α behavior.

### Testing
- Ran `git diff --check` to validate the patch formatting and local diffs.
- Started `cargo check -p gam-terms --lib` in this environment to validate compilation of the modified IBP module (cold dependency builds in this environment prevented a full end-to-end run here).
- Attempted targeted test runs `cargo test -p gam-terms ibp_ -- --nocapture` and `cargo test -p gam-sae apply_exact_hessian_includes_ibp_cross_row_woodbury_1038 -- --nocapture`, but the CI-style full builds were too large to complete within this interactive environment; CI should run the full test matrix (these tests exercise the restored Woodbury coupling).
- Recommendation: run full repository CI (or locally run the two targeted tests above) to verify the `cross_row_d` non-vacuity assertion and the related FD/adjoint/penalty tests pass.

---
🤖 Codex Cloud root-cause fix for #1798 (task `task_e_6a457366dddc832494e527d09bd39dd4`). **Unaudited** — review for reward-hacking before merge.

Closes #1798