### PR TITLE
Handle reduced AFT MLE nonconvergence gracefully

### DIFF
--- a/crates/gam-models/src/survival/location_scale/family_solver.rs
+++ b/crates/gam-models/src/survival/location_scale/family_solver.rs
@@ -136,6 +136,8 @@ impl SurvivalLocationScaleFamily {
         }
 
         // Newton iterations on −ℓ(θ).
+        let mut converged = false;
+        let mut last_grad_norm = f64::INFINITY;
         for _ in 0..max_iter {
             let (ll_now, block_gradients) =
                 self.evaluate_log_likelihood_and_block_gradients(&states)?;
@@ -203,7 +205,9 @@ impl SurvivalLocationScaleFamily {
                 g = kernel_g;
             }
             let grad_norm = g.iter().fold(0.0_f64, |acc, &v| acc.max(v.abs()));
+            last_grad_norm = grad_norm;
             if grad_norm <= grad_tol {
+                converged = true;
                 break;
             }
 
@@ -300,10 +304,34 @@ impl SurvivalLocationScaleFamily {
                     states = new_states;
                     ll = new_ll;
                 }
-                // No further increase achievable along this direction: the
-                // current iterate is (numerically) stationary. Stop here.
-                None => break,
+                // No further increase was achievable along this direction even
+                // though the stationarity test above has not passed. This is a
+                // real optimizer failure (usually ill-conditioning or a bad
+                // local curvature model), not an MLE. Returning it as a
+                // structured error keeps the reduced-AFT route consistent with
+                // the coupled location-scale solvers instead of handing an
+                // unconverged/possibly indefinite Hessian to downstream linear
+                // algebra, where panic=abort builds can terminate the CLI.
+                None => {
+                    return Err(SurvivalLocationScaleError::NumericalFailure {
+                        reason: format!(
+                            "direct parametric-AFT MLE: line search failed before convergence \
+                             (gradient sup-norm {grad_norm:.6e} > tolerance {grad_tol:.6e})"
+                        ),
+                    }
+                    .into());
+                }
             }
+        }
+
+        if !converged {
+            return Err(SurvivalLocationScaleError::NumericalFailure {
+                reason: format!(
+                    "direct parametric-AFT MLE: failed to converge after {max_iter} Newton iterations \
+                     (last gradient sup-norm {last_grad_norm:.6e} > tolerance {grad_tol:.6e})"
+                ),
+            }
+            .into());
         }
 
         // Observed information at the MLE: the joint negative-log-likelihood


### PR DESCRIPTION
### Motivation
- A reduced parametric-AFT direct-Newton MLE path could stop improving during Armijo backtracking or exhaust iterations and then hand an unconverged/possibly indefinite Hessian to downstream linear algebra, which in panic=abort builds caused an uncatchable SIGABRT instead of a structured error.

### Description
- In `fit_parametric_aft_direct_mle` (`crates/gam-models/src/survival/location_scale/family_solver.rs`) add explicit convergence tracking with `converged` and `last_grad_norm` and set them when the gradient sup-norm meets `grad_tol`.
- Convert the case where Armijo backtracking fails to find an acceptable step into a structured `Err(SurvivalLocationScaleError::NumericalFailure { ... })` instead of silently breaking the loop.
- After the Newton loop return a `NumericalFailure` `Err` when the iteration budget is exhausted without satisfying the gradient tolerance, preventing downstream code from receiving an unconverged Hessian.

### Testing
- Ran `git diff --check` which passed without issues.
- Ran `rustfmt --check crates/gam-models/src/survival/location_scale/family_solver.rs` which reported pre-existing formatting drift in unchanged portions (failure reported but unrelated to this fix).
- Attempted `cargo check -p gam-models` and `cargo test --test regressions reduced_aft_location_scale_predicts_correct_log_t_surface` in this environment but both timed out; local CI should verify these end-to-end and confirm the reduced-AFT regression no longer aborts and instead yields a catchable `IntegrationFailed`/`NumericalFailure` error when nonconvergence occurs.

---
🤖 Codex Cloud root-cause fix for #1799 (task `task_e_6a45736e77088324934ab2a232b34f65`). **Unaudited** — review for reward-hacking before merge.

Closes #1799