### PR TITLE
Avoid bailing startup on repeated non-finite trial objectives (fix #1802)

### DIFF
--- a/crates/gam-solve/src/startup_stats.rs
+++ b/crates/gam-solve/src/startup_stats.rs
@@ -195,6 +195,30 @@ fn variant_tag(failure: &InnerFailure) -> FailureVariantTag {
     }
 }
 
+/// True only for repeated generic failures that are safe to treat as a
+/// cross-seed structural fingerprint.  Non-finite objective/domain failures are
+/// deliberately excluded even when they carry a repeated numeric marker: those
+/// are often rho-local trial-point pathologies on spatial/Duchon/sphere bases,
+/// and bailing early turns "the first few seeds were numerically bad" into the
+/// fatal and misleading "no candidate seeds passed" outcome before the stable
+/// heavy-smoothing candidates are ever tried (#1802).
+fn eligible_for_generic_structural_bail(failure: &InnerFailure) -> bool {
+    match failure {
+        InnerFailure::CertRefused { .. }
+        | InnerFailure::BudgetExhausted { .. }
+        | InnerFailure::TrustRegionFloor { .. }
+        | InnerFailure::IdentifiabilityFailure { .. } => true,
+        InnerFailure::LikelihoodFailure(_) => false,
+        InnerFailure::Other(message) => {
+            let lower = message.to_ascii_lowercase();
+            !(lower.contains("non-finite")
+                || lower.contains("not finite")
+                || lower.contains("nan")
+                || lower.contains("infinite"))
+        }
+    }
+}
+
 /// Signed order-of-magnitude bucket of the dominant diagnostic numeric:
 /// `sign` is the value's sign (`-1`/`0`/`+1`) and `order` is
 /// `floor(log10(|value|))`. Kept as two independent fields rather than a
@@ -345,6 +369,12 @@ pub(crate) fn consecutive_generic_signature(
         return None;
     }
     let tail = &rejections[rejections.len() - min_run..];
+    if tail
+        .iter()
+        .any(|rej| !eligible_for_generic_structural_bail(&rej.failure))
+    {
+        return None;
+    }
     let sig = generic_signature(&tail[0].failure);
     // An unquantified (None-magnitude) signature is excluded by contract.
     sig.1?;
@@ -907,6 +937,29 @@ mod tests {
                     order: -11
                 })
             )
+        );
+    }
+
+    /// #1802: a repeated non-finite objective at the first few trial rhos is a
+    /// numeric startup miss, not proof that the remaining spatial/Duchon/sphere
+    /// seed lattice is infeasible.  The live per-seed breakdown must keep
+    /// running so an over-smoothed or manifold-consistent seed can pass.
+    #[test]
+    fn generic_detector_does_not_bail_on_repeated_nonfinite_objectives() {
+        let nonfinite = |seed: usize| {
+            SeedRejection::from_message(
+                seed,
+                "validation",
+                "outer eval failed: non-finite objective at trial rho; \
+                 non-PD pivot -6.0e-11 at index 2"
+                    .into(),
+            )
+        };
+        let rejections = vec![nonfinite(0), nonfinite(1), nonfinite(2)];
+        assert!(
+            consecutive_generic_signature(&rejections, 3).is_none(),
+            "non-finite objective rejections are rho-local startup failures; \
+             the seed cascade must keep evaluating later candidates"
         );
     }
 


### PR DESCRIPTION
### Motivation

- The outer-startup generic structural bail could treat repeated non-finite objective/domain failures (e.g. NaN/infinite costs surfaced on early trial rhos for Duchon/sphere/manifold bases) as a structural fingerprint and skip remaining seeds, producing the fatal "no candidate seeds passed outer startup validation" outcome (#1802).

### Description

- Add `eligible_for_generic_structural_bail` to exclude likelihood/non-finite objective failures from the generic trailing-run structural bail logic found in `consecutive_generic_signature`.
- Gate the generic bail so it returns `None` when any of the trailing `min_run` rejections are ineligible (i.e. non-finite/objective-domain failures), preserving the live per-seed rejection breakdown and allowing later, stable/heavy-smoothing seeds to be evaluated (`crates/gam-solve/src/startup_stats.rs`).
- Add a unit test `generic_detector_does_not_bail_on_repeated_nonfinite_objectives` that asserts repeated non-finite objective messages with repeated numeric markers do NOT trigger the generic bail (so the seed cascade continues).

### Testing

- Ran `git diff --check` which showed no change-level issues for this patch (ok).
- Ran `cargo fmt --check`, which reported pre-existing formatting drift in unrelated files outside this change (not caused by this PR).
- Attempted `cargo test -p gam-solve startup_stats` to exercise the new unit test; compilation/test execution did not finish within the available time in this environment so the suite was not fully completed here (the new test is included and should pass under normal CI/full-local runs).

Please run the repository test matrix (or CI) to validate `startup_stats` unit tests pass and to verify that affected failing higher-level spatial/manifold startup regressions are resolved by this change.

---
🤖 Codex Cloud root-cause fix for #1802 (task `task_e_6a4573852ad48324b26d04c9f8387ebe`). **Unaudited** — review for reward-hacking before merge.

Closes #1802