### PR TITLE
Make gamfit version-consistency test tolerant of missing Cargo.lock

### DIFF
--- a/tests/regressions/misc/uv_lock_gamfit_version_stale.rs
+++ b/tests/regressions/misc/uv_lock_gamfit_version_stale.rs
@@ -1,5 +1,5 @@
-use std::fs;
 use std::path::Path;
+use std::{fs, io};
 
 fn quoted_value_after<'a>(line: &'a str, prefix: &str) -> Option<&'a str> {
     let raw = line.trim().strip_prefix(prefix)?.trim();
@@ -53,10 +53,12 @@ fn uv_lock_gamfit_version(path: &Path) -> String {
     panic!("{} has no gamfit package version", path.display());
 }
 
-fn cargo_lock_package_version(path: &Path, package_name: &str) -> String {
-    let content = fs::read_to_string(path).unwrap_or_else(|err| {
-        panic!("read {}: {err}", path.display());
-    });
+fn cargo_lock_package_version(path: &Path, package_name: &str) -> Option<String> {
+    let content = match fs::read_to_string(path) {
+        Ok(content) => content,
+        Err(err) if err.kind() == io::ErrorKind::NotFound => return None,
+        Err(err) => panic!("read {}: {err}", path.display()),
+    };
     let mut inside_package = false;
     let mut inside_target = false;
     for line in content.lines() {
@@ -80,7 +82,7 @@ fn cargo_lock_package_version(path: &Path, package_name: &str) -> String {
         }
         if inside_target {
             if let Some(version) = quoted_value_after(trimmed, "version = ") {
-                return version.to_string();
+                return Some(version.to_string());
             }
         }
     }
@@ -103,8 +105,10 @@ fn gamfit_version_is_consistent_across_manifests() {
         pyproject, uv_lock,
         "uv.lock editable gamfit package must match pyproject.toml"
     );
-    assert_eq!(
-        pyproject, cargo_lock,
-        "Cargo.lock gam-pyffi package must match pyproject.toml"
-    );
+    if let Some(cargo_lock) = cargo_lock {
+        assert_eq!(
+            pyproject, cargo_lock,
+            "Cargo.lock gam-pyffi package must match pyproject.toml"
+        );
+    }
 }


### PR DESCRIPTION
### Motivation
- The regression guard read the workspace `Cargo.lock` unconditionally and panicked when the lockfile was absent, which happens on CI shards that check out the repo but do not generate the lockfile because `Cargo.lock` is git-ignored.
- The version-consistency check should treat the workspace `Cargo.lock` as an optional generated artifact and only assert when the lockfile actually exists.

### Description
- Update `tests/regressions/misc/uv_lock_gamfit_version_stale.rs` to make `cargo_lock_package_version` return `Option<String>` and treat `io::ErrorKind::NotFound` as `None` while still panicking for other read errors.
- Only perform the `Cargo.lock` version equality assertion when the helper returns `Some`, preserving the existing strict checks for `pyproject.toml`, `crates/gam-pyffi/Cargo.toml`, and `uv.lock`.

### Testing
- Ran `rustfmt --check tests/regressions/misc/uv_lock_gamfit_version_stale.rs`, which passed for the edited file.
- Ran `cargo test --test regressions misc::uv_lock_gamfit_version_stale::gamfit_version_is_consistent_across_manifests`, which passed.
- Executed the test binary with `Cargo.lock` temporarily moved aside to simulate an absent lockfile (`./target/debug/deps/regressions-... misc::uv_lock_gamfit_version_stale::gamfit_version_is_consistent_across_manifests`), which also passed.

---
🤖 Codex Cloud root-cause fix for #1804 (task `task_e_6a457393f5dc8324b9dac8543c947974`). **Unaudited** — review for reward-hacking before merge.

Closes #1804