### PR TITLE
Use deterministic row reductions for REML folds

### DIFF
--- a/crates/gam-models/src/multinomial_reml.rs
+++ b/crates/gam-models/src/multinomial_reml.rs
@@ -817,43 +817,38 @@ impl MultinomialFamily {
     /// the reduction order and break the bit-identical contract whenever
     /// rayon splits the dense path's row range into more than one chunk.
     fn hessian_diagonal_with_probs(&self, probs_full: ArrayView2<'_, f64>) -> Array1<f64> {
-        use rayon::iter::{IntoParallelIterator, ParallelIterator};
         let p = self.design.ncols();
         let m = self.active_classes();
         let n = self.weights.len();
         let dim = m * p;
         let design = self.design.view();
-        (0..n)
-            .into_par_iter()
-            .fold(
-                || Array1::<f64>::zeros(dim),
-                |mut acc, row| {
-                    let w = self.weights[row];
-                    if w == 0.0 {
-                        return acc;
+        gam_problem::outer_subsample::RowSet::All.par_reduce_fold(
+            n,
+            || Array1::<f64>::zeros(dim),
+            |mut acc, row, _row_weight| {
+                let w = self.weights[row];
+                if w == 0.0 {
+                    return acc;
+                }
+                for a in 0..m {
+                    let pa = probs_full[[row, a]];
+                    let waa = w * pa * (1.0 - pa);
+                    if waa == 0.0 {
+                        continue;
                     }
-                    for a in 0..m {
-                        let pa = probs_full[[row, a]];
-                        let waa = w * pa * (1.0 - pa);
-                        if waa == 0.0 {
-                            continue;
-                        }
-                        let base = a * p;
-                        for i in 0..p {
-                            let xi = design[[row, i]];
-                            acc[base + i] += waa * xi * xi;
-                        }
+                    let base = a * p;
+                    for i in 0..p {
+                        let xi = design[[row, i]];
+                        acc[base + i] += waa * xi * xi;
                     }
-                    acc
-                },
-            )
-            .reduce(
-                || Array1::<f64>::zeros(dim),
-                |mut a, b| {
-                    a += &b;
-                    a
-                },
-            )
+                }
+                acc
+            },
+            |mut a, b| {
+                a += &b;
+                a
+            },
+        )
     }
 
     /// Directional derivative of the per-row Fisher block along a

--- a/crates/gam-models/src/survival/construction.rs
+++ b/crates/gam-models/src/survival/construction.rs
@@ -27,6 +27,7 @@ use crate::wiggle::{
 use gam_terms::inference::formula_dsl::LinkWiggleFormulaSpec;
 use gam_linalg::matrix::{DenseDesignMatrix, DesignMatrix, SparseDesignMatrix, symmetrize_in_place};
 use crate::probability::{normal_pdf, standard_normal_quantile};
+use gam_problem::outer_subsample::RowSet;
 use gam_problem::{InverseLink, StandardLink};
 use ndarray::{Array1, Array2, array, s};
 use rayon::prelude::*;
@@ -2875,61 +2876,61 @@ pub fn marginal_slope_baseline_chain_rule_hessian(
     // Per-row Hessian contractions are independent. Each row contributes a
     // dim×dim increment combining second partials (exit/entry channels) with
     // the curvature-weighted outer product of the (entry, exit, derivative)
-    // first-partial Jacobians. Parallel try_fold/try_reduce accumulates them.
-    let hessian = (0..n)
-        .into_par_iter()
-        .try_fold(
-            || Array2::<f64>::zeros((dim, dim)),
-            |mut acc, i| -> Result<Array2<f64>, String> {
-                let exit_parts =
-                    marginal_slope_baseline_offset_theta_second_partials(age_exit[i], cfg)?
+    // first-partial Jacobians. Fixed row chunks are combined in chunk-index
+    // order so floating-point addition stays deterministic across Rayon
+    // scheduling decisions.
+    let hessian = RowSet::All.par_try_reduce_fold(
+        n,
+        || Array2::<f64>::zeros((dim, dim)),
+        |mut acc, i, _row_weight| -> Result<Array2<f64>, String> {
+            let exit_parts =
+                marginal_slope_baseline_offset_theta_second_partials(age_exit[i], cfg)?
+                    .ok_or_else(|| {
+                        "unexpected None from marginal-slope second partials at exit".to_string()
+                    })?;
+            if exit_parts.first.len() != dim {
+                return Err(
+                    "marginal_slope_baseline_chain_rule_hessian: theta_dim drifted".to_string(),
+                );
+            }
+            let mut entry_parts = None;
+            if residuals.entry[i] != 0.0 {
+                entry_parts = Some(
+                    marginal_slope_baseline_offset_theta_second_partials(age_entry[i], cfg)?
                         .ok_or_else(|| {
-                            "unexpected None from marginal-slope second partials at exit"
+                            "unexpected None from marginal-slope second partials at entry"
                                 .to_string()
-                        })?;
-                if exit_parts.first.len() != dim {
-                    return Err(
-                        "marginal_slope_baseline_chain_rule_hessian: theta_dim drifted".to_string(),
-                    );
-                }
-                let mut entry_parts = None;
-                if residuals.entry[i] != 0.0 {
-                    entry_parts = Some(
-                        marginal_slope_baseline_offset_theta_second_partials(age_entry[i], cfg)?
-                            .ok_or_else(|| {
-                                "unexpected None from marginal-slope second partials at entry"
-                                    .to_string()
-                            })?,
-                    );
-                }
-                for a in 0..dim {
-                    for b in 0..dim {
-                        let j_exit_a = exit_parts.first[a].0;
-                        let j_exit_b = exit_parts.first[b].0;
-                        let j_deriv_a = exit_parts.first[a].1;
-                        let j_deriv_b = exit_parts.first[b].1;
-                        let mut value = residuals.exit[i] * exit_parts.second[a][b].0
-                            + residuals.derivative[i] * exit_parts.second[a][b].1;
-                        if let Some(parts) = entry_parts.as_ref() {
-                            value += residuals.entry[i] * parts.second[a][b].0;
-                        }
-                        let curv = curvatures.rows[i];
-                        let j_entry_a = entry_parts.as_ref().map_or(0.0, |parts| parts.first[a].0);
-                        let j_entry_b = entry_parts.as_ref().map_or(0.0, |parts| parts.first[b].0);
-                        let ja = [j_entry_a, j_exit_a, j_deriv_a];
-                        let jb = [j_entry_b, j_exit_b, j_deriv_b];
-                        for u in 0..3 {
-                            for v in 0..3 {
-                                value += ja[u] * curv[u][v] * jb[v];
-                            }
-                        }
-                        acc[[a, b]] += value;
+                        })?,
+                );
+            }
+            for a in 0..dim {
+                for b in 0..dim {
+                    let j_exit_a = exit_parts.first[a].0;
+                    let j_exit_b = exit_parts.first[b].0;
+                    let j_deriv_a = exit_parts.first[a].1;
+                    let j_deriv_b = exit_parts.first[b].1;
+                    let mut value = residuals.exit[i] * exit_parts.second[a][b].0
+                        + residuals.derivative[i] * exit_parts.second[a][b].1;
+                    if let Some(parts) = entry_parts.as_ref() {
+                        value += residuals.entry[i] * parts.second[a][b].0;
                     }
+                    let curv = curvatures.rows[i];
+                    let j_entry_a = entry_parts.as_ref().map_or(0.0, |parts| parts.first[a].0);
+                    let j_entry_b = entry_parts.as_ref().map_or(0.0, |parts| parts.first[b].0);
+                    let ja = [j_entry_a, j_exit_a, j_deriv_a];
+                    let jb = [j_entry_b, j_exit_b, j_deriv_b];
+                    for u in 0..3 {
+                        for v in 0..3 {
+                            value += ja[u] * curv[u][v] * jb[v];
+                        }
+                    }
+                    acc[[a, b]] += value;
                 }
-                Ok(acc)
-            },
-        )
-        .try_reduce(|| Array2::<f64>::zeros((dim, dim)), |a, b| Ok(a + b))?;
+            }
+            Ok(acc)
+        },
+        |a, b| Ok(a + b),
+    )?;
     Ok(Some(hessian))
 }
 

--- a/crates/gam-models/src/survival/marginal_slope/joint_eval.rs
+++ b/crates/gam-models/src/survival/marginal_slope/joint_eval.rs
@@ -346,9 +346,10 @@ impl SurvivalMarginalSlopeFamily {
             )
         };
 
-        let final_acc = (0..self.n)
-            .into_par_iter()
-            .try_fold(make_acc, |mut acc, row| -> Result<_, String> {
+        let final_acc = gam_problem::outer_subsample::RowSet::All.par_try_reduce_fold(
+            self.n,
+            make_acc,
+            |mut acc, row, _row_weight| -> Result<_, String> {
                 let (state, q_geom) = &mut acc;
                 self.row_dynamic_q_geometry_into(row, block_states, q_geom)?;
                 let (row_nll, f_pi, f_pipi) = if flex_active {
@@ -373,13 +374,14 @@ impl SurvivalMarginalSlopeFamily {
                     &mut state.2,
                 )?;
                 Ok(acc)
-            })
-            .try_reduce(make_acc, |mut left, right| -> Result<_, String> {
+            },
+            |mut left, right| -> Result<_, String> {
                 left.0.0 += right.0.0;
                 left.0.1 += &right.0.1;
                 left.0.2 += &right.0.2;
                 Ok(left)
-            })?;
+            },
+        )?;
         Ok(final_acc.0)
     }
 

--- a/crates/gam-solve/src/pirls/deviance.rs
+++ b/crates/gam-solve/src/pirls/deviance.rs
@@ -122,10 +122,10 @@ pub fn calculate_deviance(
     const MU_FLOOR: f64 = 1e-10;
     match &likelihood.spec.response {
         ResponseFamily::Binomial => {
-            use rayon::iter::{IntoParallelIterator, ParallelIterator};
-            let total_residual: f64 = (0..y.len())
-                .into_par_iter()
-                .map(|i| {
+            let total_residual: f64 = RowSet::All.par_reduce_fold(
+                y.len(),
+                || 0.0_f64,
+                |acc, i, _row_weight| {
                     let yi = y[i];
                     // Inverse links (probit, cloglog, logit) can saturate to
                     // exactly 0 or 1 in finite precision; clamp before ln so
@@ -144,9 +144,10 @@ pub fn calculate_deviance(
                     } else {
                         0.0
                     };
-                    wi * (term1 + term2)
-                })
-                .sum();
+                    acc + wi * (term1 + term2)
+                },
+                |a, b| a + b,
+            );
             2.0 * total_residual
         }
         ResponseFamily::Gaussian => {

--- a/crates/gam-solve/src/pirls/dispersion.rs
+++ b/crates/gam-solve/src/pirls/dispersion.rs
@@ -32,23 +32,21 @@ pub(crate) fn estimate_gamma_shape_from_eta(
 ) -> f64 {
     const EPS: f64 = 1e-12;
 
-    use rayon::iter::{IntoParallelIterator, ParallelIterator};
-    let (weighted_target, total_weight) = (0..eta.len())
-        .into_par_iter()
-        .map(|i| {
+    let (weighted_target, total_weight) = RowSet::All.par_reduce_fold(
+        eta.len(),
+        || (0.0_f64, 0.0_f64),
+        |(target_acc, weight_acc), i, _row_weight| {
             let wi = priorweights[i].max(0.0);
             if wi == 0.0 {
-                return (0.0_f64, 0.0_f64);
+                return (target_acc, weight_acc);
             }
             let yi = y[i].max(EPS);
             let mui = eta[i].clamp(-ETA_CLAMP, ETA_CLAMP).exp().max(EPS);
             let ratio = yi / mui;
-            (wi * (ratio - ratio.ln() - 1.0), wi)
-        })
-        .reduce(
-            || (0.0_f64, 0.0_f64),
-            |(t1, w1), (t2, w2)| (t1 + t2, w1 + w2),
-        );
+            (target_acc + wi * (ratio - ratio.ln() - 1.0), weight_acc + wi)
+        },
+        |(t1, w1), (t2, w2)| (t1 + t2, w1 + w2),
+    );
 
     if total_weight <= 0.0 {
         return 1.0;

--- a/crates/gam-solve/src/pirls/prelude.rs
+++ b/crates/gam-solve/src/pirls/prelude.rs
@@ -34,6 +34,7 @@ pub(crate) use gam_problem::{
     GlmLikelihoodSpec, InverseLink, LikelihoodSpec, LinkFunction, MixtureLinkState, ResponseFamily,
     SasLinkState, is_valid_tweedie_power,
 };
+pub(crate) use gam_problem::outer_subsample::RowSet;
 
 pub(crate) use dyn_stack::{MemBuffer, MemStack};
 


### PR DESCRIPTION
### Motivation
- Several nondeterministic test failures were traced to non-associative f64 reductions performed via Rayon worker combine trees, causing tiny run-to-run drift amplified by Newton/REML iteration; the goal is to fix the reduction ordering for per-observation folds so results are invariant to Rayon scheduling and worker count. 
- The repository already provides a deterministic helper (`RowSet::par_reduce_fold` / `par_try_reduce_fold`) that processes fixed-size row chunks and combines chunk accumulators in chunk-index order, so route all observation reductions through it.

### Description
- Replaced Rayon parallel row reductions with deterministic `RowSet::par_reduce_fold` or `RowSet::par_try_reduce_fold` while preserving the per-row math in these hotspots: `crates/gam-solve/src/pirls/deviance.rs`, `crates/gam-solve/src/pirls/dispersion.rs`, `crates/gam-models/src/multinomial_reml.rs`, `crates/gam-models/src/survival/marginal_slope/joint_eval.rs`, and `crates/gam-models/src/survival/construction.rs`.
- Exported `RowSet` into the PIRLS prelude so PIRLS modules can call the deterministic reducer (`crates/gam-solve/src/pirls/prelude.rs`).
- Used `par_try_reduce_fold` for fallible per-row accumulators to preserve existing `try_fold`/`try_reduce` semantics and used `par_reduce_fold` for pure accumulations; comments were added to document deterministic chunk-index-order combining in the survival construction path.
- Kept all per-row computations unchanged and only altered the parallel chunking / combine order (no algorithmic math changes beyond deterministic reduction ordering).

### Testing
- Ran `cargo check -p gam-solve -p gam-models` and the check completed successfully.
- Ran formatting and diff checks (`git diff --check` / `rustfmt`) and resolved any issues; static checks passed for the edited modules.
- Attempted to run the targeted regression test(s) but execution of `cargo test` for the full regression was blocked by an existing repository build gate unrelated to this change (monolith ban: `crates/gam-sae/src/manifold/tests.rs` exceeds the 10k-line limit), so those exact-target tests could not be completed here.

---
🤖 Codex Cloud root-cause fix for #1809 (task `task_e_6a4573b98cc88324972be8ffc4648007`). **Unaudited** — review for reward-hacking before merge.

Closes #1809