### PR TITLE
Align Duchon order-1 nullspace test with centered polynomial frame

### DIFF
--- a/tests/basis_smooth/smooths/duchon_order_nullspace.rs
+++ b/tests/basis_smooth/smooths/duchon_order_nullspace.rs
@@ -43,6 +43,7 @@ use faer::Side;
 use gam::basis::{
     CenterStrategy, DuchonBasisSpec, DuchonNullspaceOrder, DuchonOperatorPenaltySpec,
     OneDimensionalBoundary, SpatialIdentifiability, build_duchon_basis, duchon_nullspace_dimension,
+    select_centers_by_strategy,
 };
 use gam::faer_ndarray::FaerCholesky;
 use ndarray::{Array2, s};
@@ -245,8 +246,10 @@ fn duchon_order1_d3_with_orthogonal_identifiability_gives_k_minus_1() {
 /// The kernel-constraint reparameterisation enforces the side condition
 /// `P(centers)ᵀ Z = 0` on the kernel COEFFICIENTS, projecting the polynomial
 /// directions out of the kernel part. The observable, guaranteed consequence is
-/// that the polynomial block `[1, x₁, x₂, x₃]` is NOT representable by the kernel
-/// columns — the joint design `[kernel | poly]` has full column rank `k`.
+/// that the centered polynomial block `[1, x₁ - μ₁, x₂ - μ₂, x₃ - μ₃]` is NOT
+/// representable by the kernel columns — the joint design `[kernel | poly]` has
+/// full column rank `k`, where `μ` is the center-cloud mean used by the basis
+/// builder to keep the polynomial frame translation invariant.
 ///
 /// (This is deliberately NOT a data-row orthogonality `(ΦZ)ᵀP ≈ 0`: with reduced
 /// knots `k ≪ n` and data ≠ centers, the kernel functions evaluated at the data
@@ -287,8 +290,17 @@ fn duchon_order1_polynomial_block_is_independent_of_the_kernel_block() {
         "expected {k} total cols before identifiability"
     );
 
-    // Polynomial block: last `poly_dim` columns = [constant col | x1 | x2 | x3].
+    // Polynomial block: last `poly_dim` columns = [constant col |
+    // x1 - center_mean1 | x2 - center_mean2 | x3 - center_mean3].
+    // Since #1375 the basis builder assembles these columns in coordinates
+    // centered by the selected center cloud mean, preserving the same polynomial
+    // span while making the realized frame translation invariant.
     let poly_block = full.slice(s![.., kernel_cols..]).to_owned();
+    let centers = select_centers_by_strategy(data.view(), &spec.center_strategy)
+        .expect("centers can be selected");
+    let center_mean: Vec<f64> = (0..d)
+        .map(|col| centers.column(col).sum() / centers.nrows().max(1) as f64)
+        .collect();
 
     // Confirm polynomial block column 0 is all ones.
     let col0_max_dev = poly_block
@@ -301,17 +313,18 @@ fn duchon_order1_polynomial_block_is_independent_of_the_kernel_block() {
         "polynomial block column 0 should be all ones; max deviation = {col0_max_dev:e}"
     );
 
-    // Confirm polynomial block columns 1..4 match the data columns.
+    // Confirm polynomial block columns 1..4 match the centered data columns.
     for col in 0..d {
+        let mu = center_mean[col];
         let max_dev = poly_block
             .column(col + 1)
             .iter()
             .zip(data.column(col).iter())
-            .map(|(&a, &b)| (a - b).abs())
+            .map(|(&a, &x)| (a - (x - mu)).abs())
             .fold(0.0_f64, f64::max);
         assert!(
             max_dev < 1e-12,
-            "polynomial block col {}: max deviation from data = {max_dev:e}",
+            "polynomial block col {}: max deviation from centered data = {max_dev:e}",
             col + 1
         );
     }


### PR DESCRIPTION
### Motivation
- The test `duchon_order1_polynomial_block_is_independent_of_the_kernel_block` compared the realized polynomial columns to the raw data, but the basis builder now centers `data` by the center-cloud mean (translation-invariance fix #1375), so the test was asserting the wrong expected values and became stale.

### Description
- Update the test to import `select_centers_by_strategy` and compute the same center-cloud mean used by the builder so the expectation is formed in the same centered coordinates.
- Change the polynomial-column assertions to compare each realized polynomial column to `data_col - μ_col` (where `μ` is the center-cloud mean) while preserving the constant-ones check and the Gram/independence assertion.
- Tweak the test doc comment to document that the polynomial block is centered (`[1, x - μ]`) and why the builder uses a centered polynomial frame for translation invariance.

### Testing
- Ran `rustfmt --check tests/basis_smooth/smooths/duchon_order_nullspace.rs`, which succeeded.
- Ran `git diff --check`, which reported no formatting errors for the edited file.
- Attempted to run the targeted test (`cargo test -q duchon_order1_polynomial_block_is_independent_of_the_kernel_block`) and a focused crate test (`cargo test -q -p gam-terms --lib duchon_effective_nullspace_order`), but full verification was blocked in this environment by the repository build-script gate (existing file `crates/gam-sae/src/manifold/tests.rs` exceeds the project line-count limit), so those cargo runs could not complete here.

---
🤖 Codex Cloud root-cause fix for #1814 (task `task_e_6a4573d911588324b9d1b2dab0407ba0`). **Unaudited** — review for reward-hacking before merge.

Closes #1814