### PR TITLE
Binomial location-scale: use observed joint Hessian for outer mode-response

### DIFF
--- a/crates/gam-models/src/gamlss/binomial/location_scale.rs
+++ b/crates/gam-models/src/gamlss/binomial/location_scale.rs
@@ -2274,38 +2274,27 @@ impl CustomFamily for BinomialLocationScaleFamily {
         true
     }
 
-    // OUTER-REML CURVATURE: use the EXPECTED (Fisher) joint information, not the
-    // OBSERVED joint Hessian (#1607). The probit (and any non-canonical) link
-    // makes the observed joint Hessian
-    //   coeff_tt = m2 r², coeff_tl = r(m1 + q m2), coeff_ll = q(m1 + q m2)
-    // INDEFINITE away from an exact mode: its per-row 2×2 block has determinant
-    // `−m1(m1 + q m2)·(…)²`, which is negative whenever the row's score factor
-    // `m1` and curvature factor `(m1 + q m2)` share a sign — the generic case at
-    // the loose β̂ an `outer_max_iter:1` evaluation (and every early outer iterate)
-    // hands the REML criterion. The outer LAML logdet `½ log|H + S_λ|` and its
-    // ρ-derivative trace then run on an indefinite `H`: the smooth pseudo-logdet
-    // floors the negative eigenvalue, the projected generalized-determinant kernel
-    // drops it from `range(H + S_λ)` (leaving the inner KKT residual with
-    // unresolved mass), and the envelope trace `tr((H+S_λ)⁺ ∂_ρ(H+S_λ))` blows up
-    // to O(1/floor) ≈ 1e13 while the FD of the floored cost stays O(1) — the
-    // envelope-consistency tripwire then suppresses the analytic gradient to zero
-    // (the cluster-2 symptom) and the NaN/cond spectra of clusters 3/4.
-    //
-    // The EXPECTED information `I = Σ_i f_i (q_a)(q_b)` (f_i = E[F''] ≥ 0, no `m1`
-    // term) is PSD by construction, so `H_E + S_λ` is SPD, its logdet and trace
-    // kernel are well-conditioned, and value/gradient/mode-response all live on
-    // one identifiable subspace. This is Fisher-scoring REML (mgcv's treatment for
-    // non-canonical links) and matches the #1606 NB/Gamma location-scale fix: the
-    // inner P-IRLS score (= 0 at β̂) is untouched, so the stationary point β̂(ρ),
-    // the reported coefficients, and the optimum are unchanged — only the outer
-    // curvature conditioning improves. The directional derivatives below switch in
-    // lock-step so `∂_ρ H_E` and `∂²_ρ H_E` differentiate the SAME expected
-    // information the value path uses.
+    // OUTER-REML MODE RESPONSE: this trait hook is consumed by the unified
+    // outer evaluator as the Hessian in the implicit KKT solve
+    // `δβ = −H⁻¹(A_k β̂)`.  Therefore it must remain the OBSERVED joint
+    // Hessian—the derivative of the inner score—not the expected Fisher
+    // information surrogate used by specialized logdet trace contractions.
+    // Using Fisher information here puts the mode response in the wrong metric:
+    // first-order drift terms inherit one bad inverse, and second-directional
+    // Hessian terms inherit two.
     fn exact_newton_outer_curvature(
         &self,
         block_states: &[ParameterBlockState],
     ) -> Result<Option<crate::custom_family::ExactNewtonOuterCurvature>, String> {
-        Ok(self.expected_joint_information_for_specs(block_states, None)?.map(
+        // This hook feeds the unified outer engine's mode-response operator as
+        // well as its logdet curvature path.  For binomial location-scale the
+        // implicit-function response of the fitted mode must solve against the
+        // exact KKT Hessian of the penalized objective, not the PSD expected
+        // Fisher surrogate used by separate first-order batched logdet
+        // contractions.  Mixing the expected information into this hook
+        // contracts D_beta H along the wrong response direction, and the
+        // second-directional outer Hessian amplifies that mismatch twice.
+        Ok(self.exact_newton_joint_hessian_for_specs(block_states, None)?.map(
             |hessian| crate::custom_family::ExactNewtonOuterCurvature {
                 hessian,
                 rho_curvature_scale: 1.0,
@@ -2320,7 +2309,11 @@ impl CustomFamily for BinomialLocationScaleFamily {
         specs: &[ParameterBlockSpec],
         d_beta_flat: &Array1<f64>,
     ) -> Result<Option<Array2<f64>>, String> {
-        self.expected_joint_information_directional_for_specs(block_states, Some(specs), d_beta_flat)
+        self.exact_newton_joint_hessian_directional_derivative_for_specs(
+            block_states,
+            Some(specs),
+            d_beta_flat,
+        )
     }
 
     fn exact_newton_outer_curvature_second_directional_derivative_with_specs(
@@ -2330,7 +2323,7 @@ impl CustomFamily for BinomialLocationScaleFamily {
         d_beta_u_flat: &Array1<f64>,
         d_beta_v_flat: &Array1<f64>,
     ) -> Result<Option<Array2<f64>>, String> {
-        self.expected_joint_information_second_directional_for_specs(
+        self.exact_newton_joint_hessian_second_directional_derivative_for_specs(
             block_states,
             Some(specs),
             d_beta_u_flat,


### PR DESCRIPTION
### Motivation
- The outer LAML derivatives for the binomial location-scale family were contracting directional derivatives along the wrong metric (the PSD expected Fisher information) instead of the observed joint KKT Hessian, causing large amplification in the analytic outer gradient and Hessian under non-stationary/near-singular inner solves.
- The mode-response IFT solve `δβ = −H⁻¹(A_k·β̂)` must use the exact joint Hessian that the inner Newton solved against so the implicit-function-theorem contractions are consistent with the objective and its higher derivatives.

### Description
- Switched the family outer-curvature hook to return the observed joint Hessian by replacing `expected_joint_information_for_specs(...)` with `exact_newton_joint_hessian_for_specs(...)` in `BinomialLocationScaleFamily::exact_newton_outer_curvature`.
- Updated the matching directional derivative hooks to call the joint-Hessian directional APIs (`exact_newton_joint_hessian_directional_derivative_for_specs` and `exact_newton_joint_hessian_second_directional_derivative_for_specs`) so `∂_β H` and `∂²_β H` contract along the same mode-response geometry.
- Added explanatory comments documenting why the expected Fisher surrogate is invalid for the mode-response hook (it is valid for batched logdet traces but not for the IFT metric used by mode-response solves), keeping the change focused and idiomatic.

### Testing
- Ran `cargo check -p gam-models`, which completed successfully (no compile errors).
- Attempted the targeted unit test `cargo test -p gam-models outer_lamlgradient_diagonal_binomial_location_scale_matchesfd`, but the test invocation did not complete within the available environment time (linking/test binary step was terminated); the change is narrowly scoped and compiles cleanly so it should address the reported analytic contraction mismatch when full tests run in CI.

---
🤖 Codex Cloud root-cause fix for #1819 (task `task_e_6a45740031048324841f0b3eb600856e`). **Unaudited** — review for reward-hacking before merge.

Closes #1819