### PR TITLE
Fix anisotropic Matérn derivative geometry (normalization, center RRQR, η seeding)

### DIFF
--- a/crates/gam-terms/src/basis/radial_jets_nd.rs
+++ b/crates/gam-terms/src/basis/radial_jets_nd.rs
@@ -1678,7 +1678,6 @@ pub fn matern_input_location_jet_nd(
     aniso_log_scales: Option<&[f64]>,
 ) -> Result<Array3<f64>, BasisError> {
     let n_rows = t.nrows();
-    let n_centers = centers.nrows();
     let dim = centers.ncols();
     if dim == 0 {
         crate::bail_invalid_basis!(
@@ -1701,6 +1700,15 @@ pub fn matern_input_location_jet_nd(
             dim
         );
     }
+    // Match the forward Matérn basis builder's realized column geometry: an
+    // over-specified center set is RRQR-reduced before the design matrix is
+    // formed. Input-location jets must differentiate those same realized basis
+    // columns; evaluating all pre-reduction centers desynchronizes derivative
+    // column indices from finite differences of the forward design.
+    let reduced_centers =
+        matern_rank_reduce_centers(t, &centers.to_owned(), length_scale, nu, aniso_log_scales)?;
+    let centers = reduced_centers.view();
+    let n_centers = centers.nrows();
     let weights = matern_metric_weights(dim, aniso_log_scales);
     let mut out = Array3::<f64>::zeros((n_rows, n_centers, dim));
     for n in 0..n_rows {

--- a/crates/gam-terms/src/basis/sphere_basis.rs
+++ b/crates/gam-terms/src/basis/sphere_basis.rs
@@ -3237,7 +3237,12 @@ pub fn build_matern_basis_log_kappa_aniso_derivatives(
     // (`build_matern_basis_log_kappa_derivativeswithworkspace`): pull the realized
     // centers / identifiability transform / resolved anisotropy from the value
     // build's metadata so the two are byte-consistent by construction.
-    let base = build_matern_basiswithworkspace(data, spec, &mut BasisWorkspace::default())?;
+    let base = build_matern_basis_seeded(
+        data,
+        spec,
+        &mut BasisWorkspace::default(),
+        AnisoSeedMode::Literal,
+    )?;
     let (base_centers, z_opt, base_aniso) = match &base.metadata {
         BasisMetadata::Matern {
             centers,
@@ -3286,8 +3291,8 @@ pub fn build_matern_basis_log_kappa_aniso_derivatives(
         let k = centers.nrows();
         let kernel_cols = z_opt.as_ref().map(|z| z.ncols()).unwrap_or(k);
         let total_cols = kernel_cols + usize::from(spec.include_intercept);
-        let mut primary_first = vec![Array2::<f64>::zeros((total_cols, total_cols)); dim];
-        let mut primary_second_diag = vec![Array2::<f64>::zeros((total_cols, total_cols)); dim];
+        let mut primary_first_raw = vec![Array2::<f64>::zeros((total_cols, total_cols)); dim];
+        let mut primary_second_diag_raw = vec![Array2::<f64>::zeros((total_cols, total_cols)); dim];
         let coefficient_gauge = z_opt
             .as_ref()
             .map(|z| gam_problem::Gauge::from_block_transforms(&[z.clone()]));
@@ -3312,10 +3317,10 @@ pub fn build_matern_basis_log_kappa_aniso_derivatives(
             } else {
                 std::mem::take(&mut raw_second_diag[a])
             };
-            primary_first[a]
+            primary_first_raw[a]
                 .slice_mut(s![0..kernel_cols, 0..kernel_cols])
                 .assign(&projected_first);
-            primary_second_diag[a]
+            primary_second_diag_raw[a]
                 .slice_mut(s![0..kernel_cols, 0..kernel_cols])
                 .assign(&projected_second);
         }
@@ -3332,44 +3337,55 @@ pub fn build_matern_basis_log_kappa_aniso_derivatives(
         let has_shrinkage = base.penaltyinfo.iter().any(|info| {
             info.active && matches!(info.source, PenaltySource::DoublePenaltyNullspace)
         });
-        // The un-normalized projected aniso kernel Gram `A = Zᵀ K Z` (embedded
-        // into `total_cols`) is what the value build's shrinkage block eigen-
-        // decomposes; its per-axis η_a derivatives are `primary_first[a]`. The
-        // shrinkage-projector derivative (#1122) is driven by exactly these.
+        // The value path emits the primary double-penalty block as
+        // `A / ||A||_F`. Differentiate that normalized block here too; the raw
+        // `A_a` / `A_aa` derivatives are still retained for the shrinkage
+        // projector, whose eigenspace is defined by the un-normalized `A`.
+        let kernel = build_matern_kernel_penalty(
+            centers.view(),
+            spec.length_scale,
+            spec.nu,
+            spec.include_intercept,
+            Some(eta),
+        )?;
+        let kblock = kernel.slice(s![0..k, 0..k]).to_owned();
+        let projected = if let Some(gauge) = coefficient_gauge.as_ref() {
+            gauge.restrict_penalty(&kblock)
+        } else {
+            kblock
+        };
+        let mut a_raw = Array2::<f64>::zeros((total_cols, total_cols));
+        a_raw
+            .slice_mut(s![0..kernel_cols, 0..kernel_cols])
+            .assign(&projected);
+        let mut primary_first = Vec::with_capacity(dim);
+        let mut primary_second_diag = Vec::with_capacity(dim);
+        for a in 0..dim {
+            let (_, first, second, _) = normalize_penaltywith_psi_derivatives(
+                &a_raw,
+                &primary_first_raw[a],
+                &primary_second_diag_raw[a],
+            );
+            primary_first.push(first);
+            primary_second_diag.push(second);
+        }
         let shrinkage_frame = if has_shrinkage {
-            let kernel = build_matern_kernel_penalty(
-                centers.view(),
-                spec.length_scale,
-                spec.nu,
-                spec.include_intercept,
-                Some(eta),
-            )?;
-            let kblock = kernel.slice(s![0..k, 0..k]).to_owned();
-            let mut a_raw = Array2::<f64>::zeros((total_cols, total_cols));
-            let projected = if let Some(gauge) = coefficient_gauge.as_ref() {
-                gauge.restrict_penalty(&kblock)
-            } else {
-                kblock
-            };
-            a_raw
-                .slice_mut(s![0..kernel_cols, 0..kernel_cols])
-                .assign(&projected);
             ShrinkageProjectorFrame::build(&a_raw)?
         } else {
             None
         };
         let shrinkage_first: Vec<Array2<f64>> = (0..dim)
             .map(|a| match &shrinkage_frame {
-                Some(frame) => frame.first(&primary_first[a]),
+                Some(frame) => frame.first(&primary_first_raw[a]),
                 None => Array2::<f64>::zeros((total_cols, total_cols)),
             })
             .collect();
         let shrinkage_second_diag: Vec<Array2<f64>> = (0..dim)
             .map(|a| match &shrinkage_frame {
                 Some(frame) => frame.second(
-                    &primary_first[a],
-                    &primary_first[a],
-                    &primary_second_diag[a],
+                    &primary_first_raw[a],
+                    &primary_first_raw[a],
+                    &primary_second_diag_raw[a],
                 ),
                 None => Array2::<f64>::zeros((total_cols, total_cols)),
             })
@@ -3402,7 +3418,8 @@ pub fn build_matern_basis_log_kappa_aniso_derivatives(
         // Per-axis projected first derivatives ∂A/∂η_a (embedded), so the
         // cross-pair shrinkage second derivative `∂²P/∂η_a∂η_b` can be formed
         // exactly inside the provider (#1122).
-        let primary_first_owned = primary_first.clone();
+        let primary_first_raw_owned = primary_first_raw.clone();
+        let a_raw_owned = a_raw.clone();
         let include_intercept = spec.include_intercept;
         result.penalties_cross_provider = Some(AnisoPenaltyCrossProvider::new(
             move |axis_a: usize, axis_b: usize| {
@@ -3431,6 +3448,13 @@ pub fn build_matern_basis_log_kappa_aniso_derivatives(
                 padded
                     .slice_mut(s![0..kernel_cols, 0..kernel_cols])
                     .assign(&projected);
+                let primary_cross = normalize_penalty_cross_psi_derivative(
+                    &a_raw_owned,
+                    &primary_first_raw_owned[a],
+                    &primary_first_raw_owned[b],
+                    &padded,
+                    trace_of_product(&a_raw_owned, &a_raw_owned).sqrt(),
+                );
                 // Exact cross second derivative of the shrinkage projector, if
                 // an active shrinkage block exists at this hyperparameter.
                 let shrinkage_cross = if penaltyinfo.iter().any(|info| {
@@ -3455,15 +3479,21 @@ pub fn build_matern_basis_log_kappa_aniso_derivatives(
                         .slice_mut(s![0..kernel_cols, 0..kernel_cols])
                         .assign(&projected_a);
                     match ShrinkageProjectorFrame::build(&a_raw)? {
-                        Some(frame) => {
-                            frame.second(&primary_first_owned[a], &primary_first_owned[b], &padded)
-                        }
+                        Some(frame) => frame.second(
+                            &primary_first_raw_owned[a],
+                            &primary_first_raw_owned[b],
+                            &padded,
+                        ),
                         None => Array2::<f64>::zeros((total_cols, total_cols)),
                     }
                 } else {
                     Array2::<f64>::zeros((total_cols, total_cols))
                 };
-                active_matern_double_penalty_derivatives(&penaltyinfo, &padded, &shrinkage_cross)
+                active_matern_double_penalty_derivatives(
+                    &penaltyinfo,
+                    &primary_cross,
+                    &shrinkage_cross,
+                )
             },
         ));
     } else {


### PR DESCRIPTION
### Motivation
- Triage showed three linked aniso-Matérn defects: the double-penalty derivative path omitted Frobenius-normalization quotient terms, input-location jets evaluated unreduced centers (column desync vs forward build), and analytic derivatives at `η=0` used auto-seeded contrasts while FD used literal ±h chords, producing mismatch. 

### Description
- Evaluate anisotropic ψ/penalty derivatives at the literal anisotropy seed by using `build_matern_basis_seeded(..., AnisoSeedMode::Literal)` so analytic evaluation matches FD chords around explicit zeros. 
- Differentiate the Frobenius-normalized double-penalty primary block: keep raw projected-kernel matrices for shrinkage eigenspace construction but compute normalized `∂S~/∂ψ` and `∂²S~/∂ψ²` via `normalize_penaltywith_psi_derivatives` and use those normalized derivatives as the primary penalty entries. 
- Preserve raw `A` / raw per-axis derivatives for the shrinkage projector and compute projector second-derivative contributions from the raw projected kernel as before, then combine with the normalized primary derivatives (including cross-axis normalization via `normalize_penalty_cross_psi_derivative`). 
- Make input-location jets (`matern_input_location_jet_nd`) apply the forward `matern_rank_reduce_centers` reduction before forming jets so derivative column indices align with the realized (reduced + expanded) forward basis. 

### Testing
- Ran `cargo check -p gam-terms` which completed successfully. 
- Attempted to run targeted package tests `cargo test -p gam-terms matern_aniso_input_loc` and `cargo test -p gam-models explicit_zero_aniso_jet_is_isotropic_and_matches_forward_fd` but compilation/dependency work was extensive and those runs were not completed in this session (build-stage aborted); the focused `cargo check` passed and the code compiles locally in the `gam-terms` package.

---
🤖 Codex Cloud root-cause fix for #1822 (task `task_e_6a4574175be083249b802fbf60da81b0`). **Unaudited** — review for reward-hacking before merge.

Closes #1822