### PR TITLE
Fix derivative-oracle test references

### DIFF
--- a/tests/manifolds/smooths/sphere_basis_jet.rs
+++ b/tests/manifolds/smooths/sphere_basis_jet.rs
@@ -81,19 +81,27 @@ fn assert_jet_matches_fd(spec: &SphericalSplineBasisSpec, label: &str) {
         analytic.shape(),
         fd.shape()
     );
-    let mut max_rel = 0.0_f64;
+    let rel_tol = 1.0e-4_f64;
+    let abs_tol = 1.0e-9_f64;
+    let mut max_scaled = 0.0_f64;
     for (a, f) in analytic.iter().zip(fd.iter()) {
-        let denom = f.abs().max(a.abs()).max(1.0e-6);
-        let rel = (a - f).abs() / denom;
-        max_rel = max_rel.max(rel);
         assert!(
             a.is_finite() && f.is_finite(),
             "{label}: non-finite jet entry analytic={a} fd={f}"
         );
+        let abs_err = (a - f).abs();
+        let scale = f.abs().max(a.abs());
+        let rel_scaled = if scale > 0.0 {
+            abs_err / (rel_tol * scale)
+        } else {
+            f64::INFINITY
+        };
+        let scaled_err = (abs_err / abs_tol).min(rel_scaled);
+        max_scaled = max_scaled.max(scaled_err);
     }
     assert!(
-        max_rel < 1.0e-4,
-        "{label}: analytic jet disagrees with central-difference (max rel err {max_rel:.3e})"
+        max_scaled < 1.0,
+        "{label}: analytic jet disagrees with central-difference (max abs-or-rel scaled err {max_scaled:.3e})"
     );
 }
 

--- a/tests/regressions/misc/inference_bug_hunt.rs
+++ b/tests/regressions/misc/inference_bug_hunt.rs
@@ -20,7 +20,7 @@ fn probability_normal_cdf_boundary_and_accuracy_contract() {
         "normal_cdf(-inf) must be 0"
     );
     let z = 0.37;
-    let expected = 0.644308823593; // high-precision reference
+    let expected = 0.6443087548005467; // high-precision reference
     assert!(
         (normal_cdf(z) - expected).abs() < 1e-12,
         "normal_cdf must match standard normal CDF within 1e-12"


### PR DESCRIPTION
### Motivation
- Two regression tests were flagging correct production behavior: the `normal_cdf` test used an incorrect hard-coded reference value, and the spherical-spline jet test applied a relative-error floor that misinterprets genuinely-zero analytic derivatives as large relative errors.
- These are test-only fixes to stop masking real failures while preserving production math and strict accuracy contracts.

### Description
- Corrected the high-precision standard-normal CDF reference for `z = 0.37` in `tests/regressions/misc/inference_bug_hunt.rs` to `0.6443087548005467`, keeping the `1e-12` accuracy contract for `normal_cdf`.
- Replaced the previous relative-error-with-floor logic in `tests/manifolds/smooths/sphere_basis_jet.rs` with an explicit absolute-or-relative scaled error check that uses `abs_tol = 1e-9` for genuinely-zero-scale entries and `rel_tol = 1e-4` for nonzero entries, computing a merged scaled error and asserting it is < 1.0.
- Changes are confined to tests only and do not modify production code or algorithmic behavior.

### Testing
- Ran `cargo test -p gam --test regressions misc::inference_bug_hunt::probability_normal_cdf_boundary_and_accuracy_contract -- --exact` and the test passed.
- Ran `cargo test -p gam --test manifolds smooths::sphere_basis_jet::pseudo_jet_matches_finite_difference_all_orders -- --exact` and the test passed.
- Ran `rustfmt --check` on the modified test files and they passed formatting checks.

---
🤖 Codex Cloud root-cause fix for #1823 (task `task_e_6a45741eea2c8324bbccaa3f465865d8`). **Unaudited** — review for reward-hacking before merge.

Closes #1823