### PR TITLE
Honor quantile knot placement for tensor margins

### DIFF
--- a/crates/gam-terms/src/term_builder.rs
+++ b/crates/gam-terms/src/term_builder.rs
@@ -3223,6 +3223,7 @@ pub fn build_smooth_basis(
                     None | Some("cr") | Some("cs") | Some("tp") | Some("tps")
                 )
             };
+            let requested_knot_placement = parse_knot_placement(options)?;
             let mut margins: Vec<BSplineBasisSpec> = Vec::with_capacity(dim);
             let mut emitted_periods: Vec<Option<f64>> = Vec::with_capacity(dim);
             for axis in 0..dim {
@@ -3341,7 +3342,10 @@ pub fn build_smooth_basis(
                         },
                         Some(period_value),
                     )
-                } else if margin_wants_cr(&per_axis_bs[axis]) && k_axis >= 3 {
+                } else if margin_wants_cr(&per_axis_bs[axis])
+                    && requested_knot_placement != crate::basis::BSplineKnotPlacement::Quantile
+                    && k_axis >= 3
+                {
                     // mgcv `te()`/`ti()` default cr margin: place exactly
                     // `k_axis` Lancaster–Salkauskas value-knots at data
                     // quantiles. The cr basis dimension equals the knot count,
@@ -3350,7 +3354,11 @@ pub fn build_smooth_basis(
                     // (one interior); a `k_axis < 3` margin (e.g. a binary
                     // tensor axis requesting a linear margin) falls through to
                     // the B-spline branch below, exactly as before #1074 — mgcv
-                    // likewise does not build a `cr` margin below k=3.
+                    // likewise does not build a `cr` margin below k=3. An
+                    // explicit `knot_placement=quantile` also falls through:
+                    // that option selects the generated B-spline knot strategy
+                    // represented by `Automatic { Quantile }`, whereas the cr
+                    // margin has already materialized its quantile value-knots.
                     let cr_knots =
                         crate::basis::select_cr_knots(ds.values.column(c), k_axis)
                             .map_err(|e| e.to_string())?;
@@ -3371,7 +3379,7 @@ pub fn build_smooth_basis(
                     } else {
                         k_axis.saturating_sub(degree + 1).max(1)
                     };
-                    let knotspec = match parse_knot_placement(options)? {
+                    let knotspec = match requested_knot_placement {
                         crate::basis::BSplineKnotPlacement::Uniform => BSplineKnotSpec::Generate {
                             data_range: (data_min, data_max),
                             num_internal_knots,


### PR DESCRIPTION
### Motivation
- Tensor margins were defaulting to the natural cubic regression (`cr`) realization before honoring an explicit `knot_placement=quantile` request, causing quantile placement to be silently dropped for tensor margins. 
- The behavior diverged from the intended B-spline automatic quantile strategy and caused a test to observe `NaturalCubicRegression` where `Automatic{Quantile}` was expected. 

### Description
- Parse `knot_placement` once up-front with `requested_knot_placement = parse_knot_placement(options)?` and reuse it while realizing tensor margins. 
- Make the `cr` (natural cubic regression) shortcut skip when `requested_knot_placement == BSplineKnotPlacement::Quantile` so an explicit `knot_placement=quantile` falls through to the B-spline branch. 
- Use the parsed `requested_knot_placement` in the B-spline branch instead of calling `parse_knot_placement(options)?` again, so quantile placement emits `BSplineKnotSpec::Automatic { placement: Quantile }`. 
- Affected file: `crates/gam-terms/src/term_builder.rs` (minimal, focused change). 

### Testing
- Ran `cargo test -p gam --test basis_smooth smooths::bspline_knot_options_formula::tensor_margins_honor_quantile_placement`, and the targeted test passed (`ok`). 
- Ran `cargo fmt --check`, which reported pre-existing formatting diffs elsewhere in the repository unrelated to this focused change (format check failure not caused by the patch).

---
🤖 Codex Cloud root-cause fix for #1825 (task `task_e_6a45742e1f68832497530e893ee603e4`). **Unaudited** — review for reward-hacking before merge.

Closes #1825