### PR TITLE
Fix marginal-slope z-column reservation

### DIFF
--- a/crates/gam-cli/src/main/run_fit.rs
+++ b/crates/gam-cli/src/main/run_fit.rs
@@ -2040,6 +2040,22 @@ pub(crate) fn validate_fit_args_preflight(
     args: &FitArgs,
     parsed: &ParsedFormula,
 ) -> Result<(), String> {
+    if let (Some(logslope_formula), Some(z_column)) =
+        (args.logslope_formula.as_deref(), args.z_column.as_deref())
+    {
+        let (_, parsed_logslope) = parse_matching_auxiliary_formula(
+            logslope_formula,
+            &parsed.response,
+            "--logslope-formula",
+        )?;
+        validate_marginal_slope_z_column_exclusion(
+            parsed,
+            &parsed_logslope,
+            z_column,
+            "bernoulli marginal-slope",
+            "--logslope-formula",
+        )?;
+    }
     if args.out.is_none() {
         return Err(
             "fit requires --out; refusing to run a training job that writes no model".to_string(),

--- a/crates/gam-terms/src/inference/formula_dsl.rs
+++ b/crates/gam-terms/src/inference/formula_dsl.rs
@@ -1361,17 +1361,24 @@ pub fn validate_marginal_slope_z_column_exclusion(
     logslope_label: &str,
 ) -> Result<(), String> {
     let surfaces = marginal_slope_logslope_surfaces(logslope_formula, z_column)?;
-    for z_column in surfaces.iter().map(|surface| surface.z_column.as_str()) {
-        if parsed_terms_reference_column(&main_formula.terms, z_column) {
+    // The CLI/configured z column is reserved even when the log-slope formula
+    // is intercept-only (`~ 1`) and therefore contributes no surface terms.
+    // Explicit logslope(...) declarations may reserve additional z coordinates.
+    let mut reserved_z_columns = std::collections::BTreeSet::<&str>::new();
+    reserved_z_columns.insert(z_column);
+    reserved_z_columns.extend(surfaces.iter().map(|surface| surface.z_column.as_str()));
+
+    for reserved in &reserved_z_columns {
+        if parsed_terms_reference_column(&main_formula.terms, reserved) {
             return Err(FormulaDslError::IncompatibleTerm {
                 reason: format!(
-                    "{context} reserves z column '{z_column}' as the auxiliary latent score; it cannot also appear in the main formula"
+                    "{context} reserves z column '{reserved}' as the auxiliary latent score; it cannot also appear in the main formula"
                 ),
             }
             .into());
         }
     }
-    for reserved in surfaces.iter().map(|surface| surface.z_column.as_str()) {
+    for reserved in &reserved_z_columns {
         if parsed_terms_reference_column(&logslope_formula.terms, reserved) {
             return Err(FormulaDslError::IncompatibleTerm {
                 reason: format!(

--- a/tests/src_modules/misc/cli_tests.rs
+++ b/tests/src_modules/misc/cli_tests.rs
@@ -3742,14 +3742,12 @@ fn cli_and_ffi_bernoulli_marginal_slope_payloads_have_one_contract() {
     let mut ffi_json = serde_json::to_value(&ffi_payload)
         .unwrap_or_else(|e| panic!("{} failed: {:?}", "serialize FFI payload", e));
     for json in [&mut cli_json, &mut ffi_json] {
-        // Field names are kebab-case under the payload's
-        // `#[serde(rename_all = "kebab-case")]`.
         let obj = json
             .as_object_mut()
             .unwrap_or_else(|| panic!("{} failed", "payload serializes to an object"));
-        obj.remove("training-feature-ranges");
-        obj.remove("offset-column");
-        obj.remove("noise-offset-column");
+        obj.remove("training_feature_ranges");
+        obj.remove("offset_column");
+        obj.remove("noise_offset_column");
     }
     assert_eq!(
         cli_json, ffi_json,


### PR DESCRIPTION
### Motivation
- `validate_marginal_slope_z_column_exclusion` failed to reserve the CLI-configured `z_column` when the `--logslope-formula` was intercept-only (`~ 1`), allowing a direct `z` reference in the main formula to sneak through and bypass the expected error. 
- The CLI preflight did not run this exclusion check early, so formula conflicts could be discovered after unrelated checks such as `--out` validation.

### Description
- Change `validate_marginal_slope_z_column_exclusion` to always reserve the configured `z_column` in addition to any `logslope(...)`-declared z coordinates by building a `reserved_z_columns` set and checking the main formula, the logslope formula, and each surface against that set (file: `crates/gam-terms/src/inference/formula_dsl.rs`).
- Run the same marginal-slope z-column exclusion during CLI preflight by invoking the validator from `validate_fit_args_preflight` when both `--logslope-formula` and `--z-column` are present so conflicts surface before unrelated argument errors (file: `crates/gam-cli/src/main/run_fit.rs`).
- Adjust the CLI/FFI payload parity test normalization to remove the actual snake_case source-specific fields from the serialized payloads before equality comparison (file: `tests/src_modules/misc/cli_tests.rs`).

### Testing
- Ran `cargo test -p gam-terms marginal_slope_z_column_validator_detects_linear_and_smooth_reuse` and it passed.
- Ran targeted CLI tests: `cargo test -p gam-cli cli_bernoulli_marginal_slope_rejects_z_column_in_main_formula`, `cli_bernoulli_marginal_slope_rejects_z_column_in_logslope_formula`, and the `bernoulli_marginal_slope` group, and they passed; the previously failing tests now succeed.
- Ran `cargo test -p gam-cli cli_and_ffi_bernoulli_marginal_slope_payloads_have_one_contract` and it passed, confirming payload parity normalization fix.

---
🤖 Codex Cloud root-cause fix for #1830 (task `task_e_6a4574551af0832499f85b62864ae4fd`). **Unaudited** — review for reward-hacking before merge.

Closes #1830