### PR TITLE
fix(cli): reject active frailty in expectile inner fits

### DIFF
--- a/crates/gam-models/src/fit_orchestration/entry.rs
+++ b/crates/gam-models/src/fit_orchestration/entry.rs
@@ -493,18 +493,24 @@ fn fit_expectile_laws(
 ) -> Result<StandardFitResult, WorkflowError> {
     use gam_linalg::matrix::LinearOperator;
 
+    if config.frailty.as_ref().is_some_and(FrailtySpec::is_active) {
+        return Err(WorkflowError::InvalidConfig {
+            reason: "expectile regression does not support frailty; use a survival/frailty-aware family instead"
+                .to_string(),
+        });
+    }
+
     // Inner fits are ordinary Gaussian-identity GAMs; the τ asymmetry lives
     // entirely in the per-iteration prior weights this driver injects.
     let gaussian_config = FitConfig {
         family: Some("gaussian".to_string()),
         link: Some("identity".to_string()),
         expectile_tau: None,
-        // The inner Gaussian-identity design carries no frailty; the CLI always
-        // populates `frailty = Some(FrailtySpec::None)`, which the standard
-        // materializer's guard rejects (`config.frailty is not supported for
-        // standard family`). Clear it explicitly so the inner fit routes through
-        // the standard family (#1780). Guarded by the CLI regression test
-        // `bug_hunt_expectile_cli_fit_aborts_on_frailty_guard`.
+        // The inner Gaussian-identity design carries no frailty. Normalize the
+        // CLI/config-layer null value (`Some(FrailtySpec::None)`) to `None` so
+        // the expectile driver does not leak survival-only plumbing into the
+        // standard-family materializer, while the active-frailty guard above
+        // still rejects unsupported frailty requests explicitly.
         frailty: None,
         ..config.clone()
     };

--- a/crates/gam-pyffi/src/manifold/geometry_ffi.rs
+++ b/crates/gam-pyffi/src/manifold/geometry_ffi.rs
@@ -4137,6 +4137,7 @@ fn rust_extension(module: &Bound<'_, PyModule>) -> PyResult<()> {
     module.add_function(wrap_pyfunction!(analytic_penalty_hvp, module)?)?;
     module.add_function(wrap_pyfunction!(gumbel_schedule_tau, module)?)?;
     module.add_function(wrap_pyfunction!(sae_ibp_map_value_grad, module)?)?;
+    module.add_function(wrap_pyfunction!(sae_jumprelu_row_value_grad, module)?)?;
     module.add_function(wrap_pyfunction!(jumprelu_gate_value_grad, module)?)?;
     module.add_function(wrap_pyfunction!(equivariant_penalty_value, module)?)?;
     module.add_function(wrap_pyfunction!(riemannian_retract, module)?)?;

--- a/crates/gam-pyffi/src/manifold/manifold_and_posterior_ffi.rs
+++ b/crates/gam-pyffi/src/manifold/manifold_and_posterior_ffi.rs
@@ -2937,6 +2937,63 @@ fn sae_ibp_map_value_grad<'py>(
     ))
 }
 
+/// Bounded threshold-gate activations and the straight-through diagonal logit
+/// derivative of their smooth surrogate.
+///
+/// Returns `(a, da_dl)` where `a_k = σ((l_k − θ_k)/τ) · 1[l_k > θ_k]` — the
+/// SAME bounded `[0, 1)` gate the closed-form `SaeAssignment` jumprelu /
+/// threshold_gate path evaluates (`jumprelu_row`; magnitude lives in the
+/// decoder) — and `da_dl_k = σ'((l_k − θ_k)/τ)/τ` is the smooth surrogate's
+/// derivative on both sides of the jump (straight-through estimator).
+/// `∂a_k/∂θ_k = −da_dl_k`; torch negates. This is the single source of truth
+/// shared with `gamfit.torch`'s bounded jumprelu gate so the torch lane trains
+/// the family the closed-form fit solves.
+#[pyfunction(signature = (logits, temperature, thresholds))]
+fn sae_jumprelu_row_value_grad<'py>(
+    py: Python<'py>,
+    logits: PyReadonlyArray1<'py, f64>,
+    temperature: f64,
+    thresholds: PyReadonlyArray1<'py, f64>,
+) -> PyResult<(Py<PyArray1<f64>>, Py<PyArray1<f64>>)> {
+    if !(temperature.is_finite() && temperature > 0.0) {
+        return Err(py_value_error(format!(
+            "sae_jumprelu_row_value_grad: temperature must be finite and positive; got {temperature}"
+        )));
+    }
+    let logits_view = logits.as_array();
+    let thresholds_view = thresholds.as_array();
+    if logits_view.len() != thresholds_view.len() {
+        return Err(py_value_error(format!(
+            "sae_jumprelu_row_value_grad: thresholds length {} does not match logits length {}",
+            thresholds_view.len(),
+            logits_view.len()
+        )));
+    }
+    for (col, &v) in logits_view.iter().enumerate() {
+        if !v.is_finite() {
+            return Err(py_value_error(format!(
+                "sae_jumprelu_row_value_grad: non-finite logit at atom {col}: {v}"
+            )));
+        }
+    }
+    for (col, &v) in thresholds_view.iter().enumerate() {
+        if !v.is_finite() {
+            return Err(py_value_error(format!(
+                "sae_jumprelu_row_value_grad: non-finite threshold at atom {col}: {v}"
+            )));
+        }
+    }
+    let (value, grad) = gam::terms::sae::assignment::jumprelu_row_value_grad(
+        logits_view.view(),
+        temperature,
+        thresholds_view.view(),
+    );
+    Ok((
+        value.into_pyarray(py).unbind(),
+        grad.into_pyarray(py).unbind(),
+    ))
+}
+
 #[pyfunction(signature = (
     latents_json,
     penalties_json,

--- a/crates/gam-sae/src/assignment.rs
+++ b/crates/gam-sae/src/assignment.rs
@@ -1062,6 +1062,43 @@ pub fn jumprelu_row(logits: ArrayView1<'_, f64>, temperature: f64, threshold: f6
     out
 }
 
+/// Bounded threshold-gate activations together with the straight-through
+/// derivative `∂a_k/∂l_k` of the smooth surrogate, shared with the torch
+/// autograd `Function` so the torch `jumprelu` lane applies the SAME bounded
+/// gate as the closed-form fit (`jumprelu_row`): `a_k = σ((l_k − θ_k)/τ)` for
+/// `l_k > θ_k` and exactly `0` otherwise — magnitude lives in the decoder, the
+/// gate stays in `[0, 1)`. The returned derivative is the smooth surrogate's
+/// `σ'((l_k − θ_k)/τ)/τ` evaluated on BOTH sides of the jump (a straight-through
+/// estimator: the hard forward has zero derivative below threshold, which would
+/// permanently kill gradient flow to gated-off atoms). `∂a_k/∂θ_k` is the
+/// negation of the returned logit derivative; callers negate. `thresholds` is
+/// per-atom (the torch lane learns one threshold per atom); the scalar
+/// closed-form threshold is the constant-vector special case and the value
+/// arithmetic matches `jumprelu_row` exactly there.
+#[must_use]
+pub fn jumprelu_row_value_grad(
+    logits: ArrayView1<'_, f64>,
+    temperature: f64,
+    thresholds: ArrayView1<'_, f64>,
+) -> (Array1<f64>, Array1<f64>) {
+    assert_eq!(
+        logits.len(),
+        thresholds.len(),
+        "jumprelu_row_value_grad: logits/thresholds length mismatch"
+    );
+    let inv_tau = 1.0 / temperature;
+    let mut value = Array1::<f64>::zeros(logits.len());
+    let mut grad = Array1::<f64>::zeros(logits.len());
+    for i in 0..logits.len() {
+        let sig = gam_linalg::utils::stable_logistic((logits[i] - thresholds[i]) * inv_tau);
+        if logits[i] > thresholds[i] {
+            value[i] = sig;
+        }
+        grad[i] = sig * (1.0 - sig) * inv_tau;
+    }
+    (value, grad)
+}
+
 // #1557 — fill-into-caller-buffer variants of the three per-mode row functions.
 // These compute the EXACT SAME values as `softmax_row` / `ibp_map_row` /
 // `jumprelu_row` (same arithmetic, same order of operations) but write into a

--- a/gamfit/torch/manifold_sae.py
+++ b/gamfit/torch/manifold_sae.py
@@ -3,10 +3,18 @@
 Atom ``i`` is a 1-D parametric curve in ambient ``R^D`` parameterized by a
 point ``theta_i`` on a manifold ``M`` (Circle, Cylinder, Sphere, Product) and
 a decoder block ``D_i`` of shape ``(K, D)``. A shared encoder maps each input
-``x`` to per-atom on-manifold coordinates ``theta_i(x)`` and a scalar
-amplitude ``amp_i(x)``. The atom's contribution to reconstruction is
+``x`` to per-atom on-manifold coordinates ``theta_i(x)`` and a gate logit
+``l_i(x)``. The atom's contribution to reconstruction is
 
-    amp_i(x) * sum_k phi_k(theta_i(x)) * D_i[k, :]
+    a_i(x) * sum_k phi_k(theta_i(x)) * D_i[k, :]
+
+where ``a_i(x)`` is the Rust-computed sparsity gate. For the closed-form-
+mappable gate families (IBP-Gumbel / JumpReLU) the gate is bounded in
+``[0, 1)`` and all reconstruction magnitude lives in the decoder curves —
+exactly the family the Rust closed-form solve optimizes; there is no separate
+per-token amplitude. The torch-only ``softmax_topk`` lane keeps its
+magnitude-carrying activation (it has no closed-form counterpart and is
+refused by ``closed_form_assignment``).
 
 Architectural rule
 ------------------
@@ -56,6 +64,7 @@ from .penalties import (
     JumpReLUPenalty,
     MonotonicityPenalty,
     ibp_map,
+    jumprelu_bounded_gate,
 )
 
 
@@ -371,12 +380,13 @@ class ManifoldSAEOutput:
     ``amplitudes`` is the **honest** per-atom magnitude the decoder actually
     applied — it equals the reconstruction code ``z`` (so an atom that
     contributes nothing to ``x_hat`` reports a zero amplitude). For the
-    magnitude-carrying gates (``jumprelu`` / ``softmax_topk``) the raw,
-    *pre-mask* softplus activation — which is strictly positive even for atoms
-    the top-k / threshold dropped — is exposed separately as ``raw_magnitudes``
+    gate families the closed form solves (``ibp_gumbel`` / ``jumprelu``) the
+    code IS the bounded Rust gate — magnitude lives in the decoder curves, so
+    there is no distinct raw magnitude and ``raw_magnitudes == z``, matching
+    the closed-form forward. For the torch-only magnitude-carrying
+    ``softmax_topk`` gate the raw, *pre-mask* activation — strictly positive
+    even for atoms the top-k mask dropped — is exposed as ``raw_magnitudes``
     so interpretability code never mistakes a dropped atom for an active one.
-    For IBP-Gumbel the code factorizes as ``z = gate · amp``; there
-    ``raw_magnitudes`` is that separate ``amp`` magnitude.
     """
 
     z: torch.Tensor
@@ -736,8 +746,14 @@ class _SparsityLayer(nn.Module):
             return assignments, logits
         if self.kind == "softmax_topk":
             return self._topk_gate(logits), logits
-        # JumpReLU activation: hard threshold forward, Rust-STE backward.
-        assignments = self._jumprelu.gate(logits)
+        # JumpReLU: the bounded [0, 1) threshold gate the closed-form fit
+        # evaluates (Rust `jumprelu_row`; magnitude lives in the decoder), with
+        # the Rust straight-through surrogate derivative as backward. The
+        # magnitude-carrying `z · 1[z > τ]` activation would train a per-token
+        # amplitude the closed-form family does not have.
+        tau = max(float(self.tau.item()), 1e-6)
+        thresholds = self._jumprelu.effective_thresholds(logits.dtype).to(logits.device)
+        assignments = jumprelu_bounded_gate(logits, thresholds, tau)
         return assignments, logits
 
     def _topk_activation(self, logits: torch.Tensor) -> torch.Tensor:
@@ -1403,21 +1419,6 @@ class _SparsityLayer(nn.Module):
                 bias = bias - bias.mean()
         return log_scores + bias
 
-    def compose_code(self, assignments: torch.Tensor, amp: torch.Tensor) -> torch.Tensor:
-        """Per-atom latent code ``z`` from gate ``assignments`` and ``amp``.
-
-        The factorization depends on the gate's range. The IBP-Gumbel gate is a
-        dimensionless activation probability in ``[0, 1]``, so the code is the
-        gate scaled by the separate non-negative magnitude ``amp`` (``z = gate ·
-        amp``). The JumpReLU and top-k gates are *magnitude-carrying*
-        activations — the gate already equals the SAE code — so multiplying by
-        ``amp`` again would square the magnitude and distort the
-        reconstruction gradient; the gate is returned as the code directly.
-        """
-        if self.kind == "ibp_gumbel":
-            return assignments * amp
-        return assignments
-
     def penalty(self, logits: torch.Tensor) -> torch.Tensor:
         """Rust-backed scalar penalty value at ``logits``."""
         if self.kind == "ibp_gumbel":
@@ -1640,7 +1641,6 @@ class ManifoldSAE(nn.Module):
             self._forward_centers,
         )
         per_atom_recon = torch.einsum("nfk,fkd->nfd", curves, self.decoder_blocks)
-        amp = F_torch.softplus(amp_logits)
         if self.cfg.sparsity.kind == "softmax_topk":
             gate_pre = amp_logits
             # Issue #1282: break expert collapse with an early *committed*
@@ -1655,18 +1655,24 @@ class ManifoldSAE(nn.Module):
                 x, per_atom_recon, step=step
             )
             z = assignments
+            # Honest pre-mask magnitude: the independent non-negative activation
+            # the top-k selection masks, strictly positive even for dropped atoms.
+            raw_magnitudes = self.sparsity._topk_activation(amp_logits)
         else:
+            # IBP-Gumbel / JumpReLU: the code IS the Rust-computed bounded gate,
+            # exactly the family the closed-form fit solves — magnitude lives in
+            # the decoder curves, never in a Python-side per-token amplitude
+            # (which the closed form has no counterpart for).
             assignments, gate_pre = self.sparsity(amp_logits)
-            z = self.sparsity.compose_code(assignments, amp)
+            z = assignments
+            raw_magnitudes = z
         x_hat = (z.unsqueeze(-1) * per_atom_recon).sum(dim=1)
 
         reml_score = torch.tensor(float("nan"), dtype=x.dtype, device=x.device)
         lambdas = torch.exp(self.log_lambda).to(dtype=x.dtype, device=x.device)
 
-        # `amplitudes` is the magnitude the decoder actually used (== z): for the
-        # magnitude-carrying gates z is the top-k/threshold-masked code, so a
-        # dropped atom reports zero, not its raw softplus value. The raw softplus
-        # magnitude is preserved separately as `raw_magnitudes`.
+        # `amplitudes` is the magnitude the decoder actually used (== z), so a
+        # dropped atom reports zero, never its raw pre-mask activation.
         return ManifoldSAEOutput(
             z=z,
             x_hat=x_hat,
@@ -1677,7 +1683,7 @@ class ManifoldSAE(nn.Module):
             assignments=assignments,
             reml_score=reml_score,
             lambdas=lambdas,
-            raw_magnitudes=amp,
+            raw_magnitudes=raw_magnitudes,
         )
 
     def _forward_from_closed_form(self, x: torch.Tensor) -> ManifoldSAEOutput:

--- a/gamfit/torch/penalties.py
+++ b/gamfit/torch/penalties.py
@@ -687,6 +687,58 @@ def ibp_map(logits: torch.Tensor, temperature: float, alpha: float) -> torch.Ten
     return apply(logits, float(temperature), float(alpha))
 
 
+class _JumpReLUBoundedGateFn(torch.autograd.Function):
+    """Bounded threshold gate, value+grad from the Rust source of truth.
+
+    Forward returns ``a_k = σ((l_k − θ_k)/τ) · 1[l_k > θ_k]`` — the SAME
+    bounded ``[0, 1)`` gate the closed-form ``SaeAssignment`` jumprelu /
+    threshold_gate path evaluates (``jumprelu_row``; magnitude lives in the
+    decoder). Backward multiplies the upstream gradient by the smooth
+    surrogate's diagonal derivative ``σ'((l_k − θ_k)/τ)/τ`` that Rust returns
+    (a straight-through estimator, alive on both sides of the jump so
+    gated-off atoms keep a training signal); the threshold gradient is its
+    negation, accumulated over rows.
+    """
+
+    @staticmethod
+    def forward(
+        ctx: Any, logits: torch.Tensor, thresholds: torch.Tensor, temperature: float
+    ) -> torch.Tensor:
+        rust = rust_module()
+        rows = to_numpy_f64(logits).reshape(logits.shape[0], -1)
+        thr = np.ascontiguousarray(to_numpy_f64(thresholds).reshape(-1))
+        value = np.empty_like(rows)
+        grad = np.empty_like(rows)
+        for r in range(rows.shape[0]):
+            v_r, g_r = rust.sae_jumprelu_row_value_grad(
+                np.ascontiguousarray(rows[r]), float(temperature), thr
+            )
+            value[r] = np.asarray(v_r, dtype=np.float64)
+            grad[r] = np.asarray(g_r, dtype=np.float64)
+        ctx.save_for_backward(from_numpy_like(grad, logits).reshape_as(logits))
+        return from_numpy_like(value, logits).reshape_as(logits)
+
+    @staticmethod
+    def backward(
+        ctx: Any, grad_output: torch.Tensor
+    ) -> tuple[torch.Tensor, torch.Tensor, None]:
+        (jac_diag,) = ctx.saved_tensors
+        upstream = grad_output * jac_diag
+        return upstream, -upstream.sum(dim=0), None
+
+
+def jumprelu_bounded_gate(
+    logits: torch.Tensor, thresholds: torch.Tensor, temperature: float
+) -> torch.Tensor:
+    """Differentiable bounded threshold gate via the Rust value+grad kernel."""
+    if not isinstance(logits, torch.Tensor):
+        raise TypeError("jumprelu_bounded_gate logits must be a torch.Tensor")
+    if not isinstance(thresholds, torch.Tensor):
+        raise TypeError("jumprelu_bounded_gate thresholds must be a torch.Tensor")
+    apply = cast(Callable[..., torch.Tensor], _JumpReLUBoundedGateFn.apply)
+    return apply(logits, thresholds, float(temperature))
+
+
 class RiemannianRetraction(Optimizer):
     """Optimizer that retracts Euclidean gradient steps onto a manifold."""
 


### PR DESCRIPTION
### Motivation
- The expectile LAWS driver cloned the caller `FitConfig` into an inner Gaussian fit and could silently carry survival/frailty plumbing (either the CLI null `Some(FrailtySpec::None)` or an active frailty), causing the standard-family materializer to abort or to silently drop a user-requested frailty.
- The intent is to keep the inner Gaussian-identity fit clean of any frailty plumbing while explicitly rejecting requests that actually ask for an active frailty rather than silently ignoring them.

### Description
- Add an explicit guard in `fit_expectile_laws` to reject active frailty requests via `if config.frailty.as_ref().is_some_and(FrailtySpec::is_active) { ... }`, returning a clear `WorkflowError::InvalidConfig`.
- Preserve the intended behavior for the inner Gaussian configuration by normalizing the CLI/config null (`Some(FrailtySpec::None)`) to `frailty: None` when constructing the inner `gaussian_config` so the standard-family materializer sees no frailty.

### Testing
- Ran `cargo test -p gam-cli --test bug_hunt_expectile_cli_fit_aborts_on_frailty_guard -- --nocapture` and it passed.
- Ran `cargo test -p gam-cli --test bug_hunt_explicit_family_emits_wrong_inferred_family_note -- --nocapture` and it passed.
- Ran `cargo test -p gam-cli --test bug_hunt_sas_link_outer_inner_cap_guard -- --nocapture` and it passed.
- Ran `cargo test -p gam-cli --test bug_hunt_sas_link_finalize_inner_cap_leak -- --nocapture` and it passed.

---
🤖 Codex Cloud root-cause fix for #1831 (task `task_e_6a45745c9a14832483342d7a031252ce`). **Unaudited** — review for reward-hacking before merge.

Closes #1831