### PR TITLE
Fix negbin dispersion location-scale rho optimization

### DIFF
--- a/crates/gam-custom-family/src/custom_family_persistent_warm_start.rs
+++ b/crates/gam-custom-family/src/custom_family_persistent_warm_start.rs
@@ -601,6 +601,17 @@ pub(crate) fn update_custom_outer_inner_cap_from_warm_start(
         }
     }
 
+    // Keep the adaptive cap as a performance budget, not a mathematical
+    // admissibility constraint.  Some valid smooth/nonlinear custom-family
+    // profiles (notably negative-binomial dispersion location-scale) need a
+    // few dozen polishing cycles at nearby trial rho values even after a
+    // warm-started evaluation converged quickly.  Capping the next derivative
+    // evaluation at `last_cycles + 5` can then reject an otherwise valid rho
+    // point before the KKT certificate has a chance to fire, causing the outer
+    // optimizer to exhaust fallbacks on a spurious "inner solve did not
+    // converge".  Preserve the adaptive shrink for easy regions, but never
+    // drive the ordinary outer-evaluation budget below a small polishing floor.
+    let cap_floor = full_budget.min(64);
     let next_cap = if cached_inner.converged {
         cached_inner
             .cycles
@@ -612,6 +623,6 @@ pub(crate) fn update_custom_outer_inner_cap_from_warm_start(
                 .saturating_add(CUSTOM_OUTER_INNER_CAP_MARGIN),
         )
     }
-    .clamp(1, full_budget);
+    .clamp(cap_floor, full_budget);
     outer_cap.store(next_cap, Ordering::Relaxed);
 }

--- a/crates/gam-custom-family/src/fit.rs
+++ b/crates/gam-custom-family/src/fit.rs
@@ -502,6 +502,20 @@ pub(crate) fn effective_df_floor_rho_upper_bounds(
             if unit_weight_term_edf(&gammas, ceiling) >= EFFECTIVE_DF_FLOOR {
                 continue;
             }
+            // If the existing lower side of the box has already smoothed this
+            // term below the structural floor, the floor is not enforceable
+            // inside the optimizer's admissible domain. Do not manufacture an
+            // upper bound numerically indistinguishable from (or below, after
+            // the optimizer's strict bound-validation tolerance is applied)
+            // the lower bound: that turns a legitimate model into an invalid
+            // rho-box before the data likelihood is even evaluated. This case
+            // occurs for very weakly scaled range-space directions, including
+            // dispersion location-scale smooths whose unit-weight generalized
+            // eigenvalues can put the edf=1 crossing just outside the default
+            // [-10, 10] rho box.
+            if unit_weight_term_edf(&gammas, -ceiling) <= EFFECTIVE_DF_FLOOR {
+                continue;
+            }
             let mut lo = -ceiling;
             let mut hi = ceiling;
             for _ in 0..64 {
@@ -516,7 +530,7 @@ pub(crate) fn effective_df_floor_rho_upper_bounds(
             // Tied coordinates: take the tightest (smallest) bound across terms,
             // so every term sharing this λ retains at least the floor.
             let slot = &mut upper[outer];
-            if rho_star > -ceiling && rho_star < *slot {
+            if rho_star > -ceiling + 1e-6 && rho_star < *slot {
                 *slot = rho_star;
             }
         }


### PR DESCRIPTION
### Motivation
- The exact two-block spatial optimization for Negative-Binomial dispersion-location-scale was failing with a `custom-family invalid input` error because the computed per-term effective-DF upper bound could collapse onto (or below) the existing rho lower bound when the structural edf floor was not enforceable inside the optimizer domain, producing an invalid rho box before any likelihood evaluation.
- The adaptive outer-inner iteration cap (derived from a warm-start) was too aggressive in some cases, turning a performance budget into a mathematical gating constraint that prevented valid inner solves from reaching the KKT certificate and caused outer fallback exhaustion.

### Description
- In `crates/gam-custom-family/src/fit.rs` updated `effective_df_floor_rho_upper_bounds` to skip producing a tightening upper bound when the term is already below the edf floor at the lower rho box (`if unit_weight_term_edf(&gammas, -ceiling) <= EFFECTIVE_DF_FLOOR { continue; }`) and added a tiny epsilon (`1e-6`) when comparing the bisected `rho_star` against the lower box edge to avoid numerical equality cases.
- In `crates/gam-custom-family/src/custom_family_persistent_warm_start.rs` changed `update_custom_outer_inner_cap_from_warm_start` to treat the adaptive inner-iteration cap as a performance budget rather than a strict admissibility gate by introducing a small polishing floor (`cap_floor = full_budget.min(64)`) and clamping the next cap to at least that floor.
- Changes are focused, minimal and keep existing semantics while preventing spurious invalid-box and premature-cap rejections for legitimate dispersion-LS fits.

### Testing
- Ran the regression test that was failing: `cargo test --test regressions predict::dispersion_location_scale_generate_predict_variance_agreement::dispersion_location_scale_generate_matches_predict_variance_negbin -- --nocapture`, and it passed successfully.
- Verified the affected crates build and the regression test run produced the expected variance-agreement diagnostics and no `custom-family invalid input` failures.

---
🤖 Codex Cloud root-cause fix for #1843 (task `task_e_6a4574b7aac48324b7c78b2047d1395d`). **Unaudited** — review for reward-hacking before merge.

Closes #1843