### PR TITLE
Route cr (cubic-regression) bases to standard dense fit and add `ds` duchon alias

### DIFF
--- a/crates/gam-models/src/fit_orchestration/entry.rs
+++ b/crates/gam-models/src/fit_orchestration/entry.rs
@@ -652,7 +652,9 @@ fn fit_expectile_laws(
 ///   through the scan would silently drop that penalty and select λ from the
 ///   bending penalty alone, which is exactly the EDF inflation #1266 reports.
 ///   Those fits fall through to the dense two-rho path, which owns both penalties
-///   jointly;
+///   jointly. Natural cubic regression (`bs="cr"`/`"cs"`) terms also fall
+///   through: their knot-value parameterization is a finite-rank regression
+///   spline, not the scan's full smoothing-spline state-space posterior;
 /// - the offset is identically zero and every weight is finite and positive;
 /// - at least 3 distinct finite abscissae (the scan's diffuse rank plus one).
 ///
@@ -748,6 +750,7 @@ pub fn spline_scan_fast_path(request: &StandardFitRequest<'_>) -> Option<SplineS
         || matches!(
             bspec.knotspec,
             gam_terms::basis::BSplineKnotSpec::PeriodicUniform { .. }
+                | gam_terms::basis::BSplineKnotSpec::NaturalCubicRegression { .. }
         )
     {
         return None;

--- a/crates/gam-terms/src/term_builder.rs
+++ b/crates/gam-terms/src/term_builder.rs
@@ -2866,7 +2866,7 @@ pub fn build_smooth_basis(
                 input_scales: None,
             })
         }
-        "duchon" => {
+        "duchon" | "ds" => {
             validate_known_options(
                 "duchon",
                 options,


### PR DESCRIPTION
### Motivation
- The predict-at-training design-replay sweep expected a `Standard` fit for `s(x, bs="cr", k=10)`, but `cr` (natural cubic regression) bases were being treated as scan-eligible and did not return the standard `FitResult` variant, causing the test to fail.
- The basis sweep also exercised a Duchon shorthand `bs="ds"` which was not recognized and caused an unsupported-smooth error in the sweep.

### Description
- Exclude natural cubic regression knot-value bases from the spline-scan fast-path by treating `BSplineKnotSpec::NaturalCubicRegression { .. }` as ineligible so `cr` / `cs` fits fall through to the dense standard fit path (`crates/gam-models/src/fit_orchestration/entry.rs`).
- Document the reason in the fast-path comment clarifying that `cr`/`cs` are finite-rank knot-value parameterizations and must not use the scan.
- Add the mgcv shorthand alias `"ds"` for the Duchon builder so `bs="ds"` routes to the existing Duchon smooth branch instead of returning `unsupported smooth type` (`crates/gam-terms/src/term_builder.rs`).

### Testing
- Ran the reproduce test `cargo test -p gam --test prediction predict_at_training_matches_fitted_across_1d_bases -- --nocapture`, which passed (the `cr` case now returns a `Standard` fit and the full 1-D basis sweep succeeded).
- Verified `git diff --check` to ensure no whitespace/errors introduced by the change.

---
🤖 Codex Cloud root-cause fix for #1844 (task `task_e_6a4574bf337c83248f35ed2bec9b5a79`). **Unaudited** — review for reward-hacking before merge.

Closes #1844