### PR TITLE
Clamp residual cascade condition estimate at one

### DIFF
--- a/tests/misc/misc/residual_cascade_certification.rs
+++ b/tests/misc/misc/residual_cascade_certification.rs
@@ -676,7 +676,12 @@ fn coarse_space_preconditioner_conditions_uniformly_in_depth() {
                 u[j] = s[j] / inv_norm;
             }
         }
-        lam_max * inv_norm
+        // The spectral condition number of an SPD matrix is mathematically
+        // bounded below by one.  For identity-like matrices the two iterative
+        // estimates can straddle one by a few ulps after whitening/Cholesky
+        // roundoff, so enforce the invariant at the numerical boundary rather
+        // than reporting an impossible sub-unit condition number.
+        (lam_max * inv_norm).max(1.0)
     }
 
     let mut conds = Vec::new();


### PR DESCRIPTION
### Motivation
- The iterative `cond_sym` helper in the residual-cascade tests can produce a value just below 1.0 for identity-like whitened operators due to floating-point roundoff, which tripped an assertion that had no numerical slack.

### Description
- Enforce the mathematical lower bound by returning `(lam_max * inv_norm).max(1.0)` from the `cond_sym` helper and document the rationale in a comment so identity-like SPD matrices cannot report impossible sub-unit condition estimates.

### Testing
- Ran the targeted test `cargo test --test misc misc::residual_cascade_certification::coarse_space_preconditioner_conditions_uniformly_in_depth`, which passed.
- Verified formatting for the modified file with `rustfmt --check tests/misc/misc/residual_cascade_certification.rs`, which passed.

---
🤖 Codex Cloud root-cause fix for #1851 (task `task_e_6a4574f5b1708324b11a2e362dbe62eb`). **Unaudited** — review for reward-hacking before merge.

Closes #1851