### PR TITLE
Return last certified cascade when refinement hits center cap

### DIFF
--- a/crates/gam-solve/src/residual_cascade.rs
+++ b/crates/gam-solve/src/residual_cascade.rs
@@ -2176,8 +2176,21 @@ pub fn fit_residual_cascade(
     sobolev_s: f64,
 ) -> Result<ResidualCascadeFit, String> {
     let mut levels = INITIAL_LEVELS;
+    let mut capped_fit: Option<ResidualCascadeFit> = None;
     loop {
-        let design = ResidualCascadeDesign::build(xs, y, w, metric, sobolev_s, levels)?;
+        let design = match ResidualCascadeDesign::build(xs, y, w, metric, sobolev_s, levels) {
+            Ok(design) => design,
+            Err(err)
+                if levels > INITIAL_LEVELS
+                    && err.contains(&format!("center cap {MAX_CENTERS} exceeded")) =>
+            {
+                if let Some(fit) = capped_fit {
+                    return Ok(fit);
+                }
+                return Err(err);
+            }
+            Err(err) => return Err(err),
+        };
         // Quasi-uniformity guard (issue #1032, caveat 2): if the metric has
         // collapsed the cloud onto a near-degenerate sheet in scaled
         // coordinates, the BPX iteration bound no longer holds. Refuse the
@@ -2225,7 +2238,15 @@ pub fn fit_residual_cascade(
                 });
                 return Ok(fit);
             }
-            Some(_) => {
+            Some(bound) => {
+                capped_fit = Some({
+                    fit.refinement = Some(RefinementCertificate {
+                        next_level_gain_bound: bound,
+                        tolerance,
+                        exhausted: true,
+                    });
+                    fit
+                });
                 levels += 1;
             }
         }


### PR DESCRIPTION
### Motivation
- When a deeper refinement level fails because the cascade exceeds the center cap, the design build surfaced an error and bubbled out instead of returning the last certified fit, which causes the auto-route to fall back or hide diagnostics; the fix preserves the most recent successful fit as a valid exhausted certificate so the caller still receives a certified `ResidualCascadeFit`.

### Description
- Add a `capped_fit: Option<ResidualCascadeFit>` in `fit_residual_cascade` to retain the most recent successful fit before attempting the next level.
- Treat an `Err` from `ResidualCascadeDesign::build` that contains `"center cap {MAX_CENTERS} exceeded"` (and occurs past `INITIAL_LEVELS`) as a signal to return the preserved `capped_fit` instead of propagating the error.
- When the `next_level_gain_bound` path decides to attempt another level, stash the current `fit` with `refinement.exhausted = true` into `capped_fit` before incrementing `levels` so it can be returned if a subsequent build fails.
- No other control flow or numerical logic was altered; existing certificates and error paths remain unchanged.

### Testing
- Ran `git diff --check` which completed with no introduced issues; this succeeded.
- Ran `rustfmt` on the modified file which completed successfully.
- Ran `cargo fmt --check`, which reported pre-existing unrelated formatting diffs outside this change; this is an external formatting warning, not caused by this patch.
- Attempted `cargo check -p gam-solve` and targeted `cargo test` runs in the environment but they timed out before completing, so full integration/test execution could not be completed here.

---
🤖 Codex Cloud root-cause fix for #1853 (task `task_e_6a457504948083248e8818f072c38d8e`). **Unaudited** — review for reward-hacking before merge.

Closes #1853