### PR TITLE
Fix pair-surface independent noise oracle

### DIFF
--- a/tests/perf_scale/misc/pair_surface_grid_consumer.rs
+++ b/tests/perf_scale/misc/pair_surface_grid_consumer.rs
@@ -202,6 +202,25 @@ fn noise(i: usize, amp: f64) -> f64 {
     ((i as f64 * 0.618_033_988_749_894_9).fract() - 0.5) * 2.0 * amp
 }
 
+/// Deterministic keyed noise stream in (−amp, amp).
+///
+/// A shifted Kronecker sequence is not an independent stream: for the fixed
+/// offset used by the large pair-surface oracle it has a sample covariance of
+/// about 0.024, which is exactly the residual off-diagonal the oracle is meant
+/// to rule out.  Use a keyed SplitMix64 permutation here so different response
+/// dimensions receive reproducible but decorrelated noise streams without
+/// depending on a runtime RNG.
+fn noise_stream(i: usize, stream: u64, amp: f64) -> f64 {
+    let mut z = (i as u64)
+        .wrapping_add(stream.wrapping_mul(0x9E37_79B9_7F4A_7C15))
+        .wrapping_add(0xBF58_476D_1CE4_E5B9);
+    z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+    z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+    z ^= z >> 31;
+    let u = ((z >> 11) as f64) * (1.0 / ((1_u64 << 53) as f64));
+    (u - 0.5) * 2.0 * amp
+}
+
 /// `nx × ny` lattice over the box — GRIDDED data, corners included.
 fn lattice(nx: usize, ny: usize, lo: [f64; 2], hi: [f64; 2]) -> (Vec<f64>, Vec<f64>) {
     let mut x1 = Vec::with_capacity(nx * ny);
@@ -542,8 +561,8 @@ fn pair_surface_large_gridded_n_recovers_truth_end_to_end() {
     let n = x1.len();
     let mut responses = Array2::<f64>::zeros((n, 2));
     for r in 0..n {
-        responses[[r, 0]] = truth0(x1[r], x2[r]) + noise(r, NOISE_AMP);
-        responses[[r, 1]] = truth1(x1[r], x2[r]) + noise(r + 13, NOISE_AMP);
+        responses[[r, 0]] = truth0(x1[r], x2[r]) + noise_stream(r, 0, NOISE_AMP);
+        responses[[r, 1]] = truth1(x1[r], x2[r]) + noise_stream(r, 1, NOISE_AMP);
     }
 
     let start = Instant::now();


### PR DESCRIPTION
### Motivation
- The large end-to-end pair-surface oracle test observed a spurious residual off-diagonal (~0.024) even though the two response dimensions were intended to carry independent noise; this was traced to the test's use of a shifted Kronecker (golden-ratio) sequence where a fixed offset produces a non-negligible sample covariance. 

### Description
- Add a deterministic, keyed SplitMix64-style generator `noise_stream(i, stream, amp)` and use distinct `stream` keys when planting noise into the two response dimensions so their noise streams are reproducibly decorrelated while keeping everything deterministic. 
- Replace the previous `noise(r)` / `noise(r+13)` pattern in `pair_surface_large_gridded_n_recovers_truth_end_to_end` with `noise_stream(r, 0, ...)` and `noise_stream(r, 1, ...)`, and document why the keyed stream is necessary; no production code was changed.

### Testing
- Ran `cargo test -p gam --test perf_scale misc::pair_surface_grid_consumer::pair_surface_large_gridded_n_recovers_truth_end_to_end -- --nocapture`, and the test passed. 
- Ran `cargo fmt --check`, which reported unrelated formatting diffs elsewhere in the repo (not introduced by this change).

---
🤖 Codex Cloud root-cause fix for #1858 (task `task_e_6a4575420d1c8324b9833e70d15a6790`). **Unaudited** — review for reward-hacking before merge.

Closes #1858