### PR TITLE
Compute ALO sandwich SE from frozen-curvature meat (X' W X)

### DIFF
--- a/crates/gam-solve/src/inference/alo.rs
+++ b/crates/gam-solve/src/inference/alo.rs
@@ -1,14 +1,14 @@
 use crate::estimate::EstimationError;
 use crate::estimate::{FitGeometry, UnifiedFitResult};
 use crate::pirls;
-use gam_linalg::faer_ndarray::{FaerArrayView, FaerCholesky};
-use gam_linalg::matrix::{PsdWeightsView, SignedWeightsView};
-use gam_linalg::utils::StableSolver;
-use gam_problem::LinkFunction;
 use faer::Mat as FaerMat;
 use faer::linalg::matmul::matmul;
 use faer::prelude::ReborrowMut;
 use faer::{Accum, Par};
+use gam_linalg::faer_ndarray::{FaerArrayView, FaerCholesky};
+use gam_linalg::matrix::{PsdWeightsView, SignedWeightsView};
+use gam_linalg::utils::StableSolver;
+use gam_problem::LinkFunction;
 use ndarray::{Array1, Array2, ArrayView1, ShapeBuilder, s};
 use std::fmt;
 
@@ -316,11 +316,8 @@ fn bayesvar_eta(phi: f64, x_hinv_x: f64) -> f64 {
 }
 
 #[inline]
-fn sandwichvar_eta(phi: f64, x_hinv_x: f64, es_norm2: f64, ridge: f64, s_norm2: f64) -> f64 {
-    // With H = X'WX + S + ridge*I and t = H^{-1}x_i:
-    // t'X'WXt = t'Ht - t'St - ridge*||t||^2
-    //         = x_i't - ||E t||^2 - ridge*||t||^2.
-    phi * (x_hinv_x - es_norm2 - ridge * s_norm2)
+fn sandwichvar_eta_from_meat(phi: f64, meat_quad: f64) -> f64 {
+    phi * meat_quad
 }
 
 #[inline]
@@ -804,9 +801,6 @@ fn compute_alo_from_input_inner(input: &AloInput) -> Result<AloDiagnostics, AloE
 
     let xt = x_dense.t();
     let phi = input.phi;
-    let ridge = input.ridge;
-
-    let e_rank = input.penalty_root.map(|e| e.nrows()).unwrap_or(0);
 
     let mut aii = Array1::<f64>::zeros(n);
     let mut x_hinv_x_diag = Array1::<f64>::zeros(n);
@@ -819,14 +813,14 @@ fn compute_alo_from_input_inner(input: &AloInput) -> Result<AloDiagnostics, AloE
     // This removes redundant `xrow = x_dense.row(obs)` indirection inside the
     // per-observation loop: rhs_chunk_buf already holds X^T at the right cols.
     let mut rhs_chunk_buf = Array2::<f64>::zeros((p, block_cols).f());
-    // Reusable faer column-major buffer for the E*S product. Building this
-    // once per chunk lets the inner loop read contiguous columns directly via
-    // `col_as_slice`, which is just a borrow into the existing storage.
-    let mut es_chunk_storage = if e_rank > 0 {
-        FaerMat::<f64>::zeros(e_rank, block_cols)
-    } else {
-        FaerMat::<f64>::zeros(0, 0)
-    };
+    // Reusable faer column-major buffer for X*S, where S = H^{-1}X_i for the
+    // current RHS chunk.  The sandwich SE must use the same frozen-curvature
+    // meat as the exact LOO reference, `X' W X`, directly; reconstructing it as
+    // `H - S_penalty - ridge*I` is brittle because the exported stabilized
+    // Hessian may include curvature/stabilization details that are not exactly
+    // represented by the penalty root plus public ridge scalar.
+    let mut xs_chunk_storage = FaerMat::<f64>::zeros(n, block_cols);
+    let x_dense_view = FaerArrayView::new(x_dense);
 
     for chunk_start in (0..n).step_by(block_cols) {
         let chunk_end = (chunk_start + block_cols).min(n);
@@ -843,22 +837,15 @@ fn compute_alo_from_input_inner(input: &AloInput) -> Result<AloDiagnostics, AloE
         // materialize a parallel ndarray copy.
         let s_chunk = factor.solve(rhs_chunk.as_ref());
 
-        if e_rank > 0
-            && let Some(e) = input.penalty_root
-        {
-            let eview = FaerArrayView::new(e);
-            // Compute only the leading `width` columns; `col_as_slice` will
-            // index into the full-width buffer up to `width` below.
-            let mut es_target = es_chunk_storage.as_mut().subcols_mut(0, width);
-            matmul(
-                es_target.rb_mut(),
-                Accum::Replace,
-                eview.as_ref(),
-                s_chunk.as_ref(),
-                1.0,
-                Par::Seq,
-            );
-        }
+        let mut xs_target = xs_chunk_storage.as_mut().subcols_mut(0, width);
+        matmul(
+            xs_target.rb_mut(),
+            Accum::Replace,
+            x_dense_view.as_ref(),
+            s_chunk.as_ref(),
+            1.0,
+            Par::Seq,
+        );
 
         let rhs_view = rhs_chunk_buf.slice(s![.., ..width]);
 
@@ -872,32 +859,24 @@ fn compute_alo_from_input_inner(input: &AloInput) -> Result<AloDiagnostics, AloE
             let s_slice = s_chunk.col_as_slice(local_col);
 
             let mut x_hinv_x = 0.0f64;
-            let mut s_norm2 = 0.0f64;
-            // Fused dot products over the same column: one cache-friendly pass.
+            // Fused dot product over the current solve column.
             for k in 0..p {
                 let sval = s_slice[k];
                 let xval = rhs_slice[k];
                 x_hinv_x = sval.mul_add(xval, x_hinv_x);
-                s_norm2 = sval.mul_add(sval, s_norm2);
             }
             let ai = w_h[obs].max(0.0) * x_hinv_x;
-            let mut es_norm2 = 0.0f64;
-            if e_rank > 0 {
-                let es_slice = es_chunk_storage.col_as_slice(local_col);
-                for r in 0..e_rank {
-                    let v = es_slice[r];
-                    es_norm2 = v.mul_add(v, es_norm2);
-                }
-            }
             aii[obs] = ai;
             x_hinv_x_diag[obs] = x_hinv_x;
 
             let var_bayes = bayesvar_eta(phi, x_hinv_x);
-            let var_sandwich = if e_rank > 0 {
-                sandwichvar_eta(phi, x_hinv_x, es_norm2, ridge, s_norm2)
-            } else {
-                var_bayes
-            };
+            let xs_slice = xs_chunk_storage.col_as_slice(local_col);
+            let mut meat_quad = 0.0f64;
+            for row in 0..n {
+                let xs = xs_slice[row];
+                meat_quad += w_h[row] * xs * xs;
+            }
+            let var_sandwich = sandwichvar_eta_from_meat(phi, meat_quad);
 
             if !var_bayes.is_finite() || !var_sandwich.is_finite() {
                 return Err(AloError::LooComputationFailed {
@@ -914,17 +893,14 @@ fn compute_alo_from_input_inner(input: &AloInput) -> Result<AloDiagnostics, AloE
                     ),
                 });
             }
-            if e_rank > 0 {
-                let sandwich_scale =
-                    phi * (x_hinv_x.abs() + es_norm2.abs() + (ridge * s_norm2).abs());
-                let sandwich_tol = variance_negative_tolerance(sandwich_scale);
-                if var_sandwich < -sandwich_tol {
-                    return Err(AloError::LooComputationFailed {
-                        reason: format!(
-                            "ALO sandwich variance is materially negative at row {obs}: var={var_sandwich:.6e}, tol={sandwich_tol:.6e}"
-                        ),
-                    });
-                }
+            let sandwich_scale = phi * meat_quad.abs().max(x_hinv_x.abs());
+            let sandwich_tol = variance_negative_tolerance(sandwich_scale);
+            if var_sandwich < -sandwich_tol {
+                return Err(AloError::LooComputationFailed {
+                    reason: format!(
+                        "ALO sandwich variance is materially negative at row {obs}: var={var_sandwich:.6e}, tol={sandwich_tol:.6e}"
+                    ),
+                });
             }
 
             se_bayes[obs] = var_bayes.max(0.0).sqrt();
@@ -1948,7 +1924,7 @@ mod tests {
     use super::{
         ALO_EXACT_SCALAR_MAX_ITERS, AloExactScalarError, AloInput, alo_eta_exact_frozen_curvature,
         alo_eta_updatewith_offset, bayesvar_eta, compute_alo_from_input_inner,
-        percentile_from_sorted, percentile_index, sandwichvar_eta,
+        percentile_from_sorted, percentile_index, sandwichvar_eta_from_meat,
     };
     use gam_linalg::matrix::{PsdWeightsView, SignedWeightsView};
     use gam_problem::LinkFunction;
@@ -2089,30 +2065,22 @@ mod tests {
     }
 
     #[test]
-    fn gaussian_unpenalized_sandwich_equals_bayes() {
-        // In Gaussian linear model with S=0 and ridge=0:
-        // H = X'WX, so sandwich and bayes eta variances are identical.
+    fn gaussian_unpenalized_direct_sandwich_equals_bayes() {
+        // In a Gaussian linear model with H = X'WX, direct meat
+        // x_i'H^{-1}X'WXH^{-1}x_i equals x_i'H^{-1}x_i.
         let phi = 2.5;
         let x_hinv_x = 0.3;
-        let es_norm2 = 0.0;
-        let ridge = 0.0;
-        let s_norm2 = 0.0;
         let vb = bayesvar_eta(phi, x_hinv_x);
-        let vs = sandwichvar_eta(phi, x_hinv_x, es_norm2, ridge, s_norm2);
+        let vs = sandwichvar_eta_from_meat(phi, x_hinv_x);
         assert!((vb - vs).abs() < 1e-12);
     }
 
     #[test]
-    fn sandwich_matches_direct_linear_gaussian_formula() {
-        // Small brute-force linear Gaussian check:
-        // var_sandwich(eta_i) = phi * x_i^T H^{-1} X'WX H^{-1} x_i.
+    fn sandwich_from_direct_meat_scales_by_phi() {
         let phi = 1.7;
-        let x_hinv_x = 0.41;
-        let es_norm2 = 0.05;
-        let ridge = 1e-3;
-        let s_norm2 = 2.0;
-        let got = sandwichvar_eta(phi, x_hinv_x, es_norm2, ridge, s_norm2);
-        let expected = phi * (x_hinv_x - es_norm2 - ridge * s_norm2);
+        let meat_quad = 0.358;
+        let got = sandwichvar_eta_from_meat(phi, meat_quad);
+        let expected = phi * meat_quad;
         assert!((got - expected).abs() < 1e-12);
     }
 


### PR DESCRIPTION
### Motivation
- The ALO frequentist sandwich standard errors used a brittle reconstruction of the sandwich "meat" from the stabilized Hessian minus penalty/ridge pieces which produced a small but systematic mismatch with the exact frozen-curvature LOO reference.  
- The reference frozen-curvature LOO uses the direct curvature `X' W X` (the meat) and the ALO path must use the same frozen-curvature meat to agree numerically.  
- A principled fix is to compute the sandwich SE from the direct frozen-curvature meat rather than algebraically reconstructing it from Hessian/penalty pieces, preserving mathematical equivalence to the LOO reference.  

### Description
- Replace the indirect Hessian-minus-penalty sandwich assembly with a direct chunked computation of the frozen-curvature meat by forming `X * (H^{-1} X_i)` for RHS chunks and accumulating the weighted quadratic form `phi * (X' W X)_ii` per row. (changed in `crates/gam-solve/src/inference/alo.rs`).  
- Introduced a small helper `sandwichvar_eta_from_meat(phi, meat_quad)` and a reusable faer buffer `xs_chunk_storage` so the blocked multi-RHS solve remains BLAS-3 friendly while producing the exact frozen-curvature meat used by the tests.  
- Removed the brittle path that attempted to reconstruct the meat from penalty-root / ridge / norm quantities and updated the local unit checks to use the direct-meat helper to keep test coverage aligned with the new computation.  

### Testing
- Ran `cargo test -p gam --test inference alo_se_calculation_correct` and the test passed.  
- Ran `cargo test -p gam --test inference alo_matches_exact_frozen_curvature_loo_small_n_binomial` and the test passed.  
- The two targeted ALO diagnostics tests now match the exact frozen-curvature LOO reference within the original tolerances.

---
🤖 Codex Cloud root-cause fix for #1869 (task `task_e_6a4575cd95388324a2ca7cbb5d9198c4`). **Unaudited** — review for reward-hacking before merge.

Closes #1869