### PR TITLE
Apply bias-correction linearization to smoothing-corrected beta covariance

### DIFF
--- a/crates/gam-solve/src/estimate/optimizer.rs
+++ b/crates/gam-solve/src/estimate/optimizer.rs
@@ -2251,6 +2251,7 @@ where
     let mut beta_covariance_frequentist = None;
     let mut coefficient_influence = None;
     let mut weighted_gram = None;
+    let mut bias_correction_jacobian = None;
     // Factorization of stabilized Hessian in transformed basis, reused for
     // SE computation via solve-on-demand after dispersion is determined.
     let mut edf_factor: Option<Box<dyn FactorizedSystem>> = None;
@@ -2701,6 +2702,18 @@ where
             }
             let mut s_mat = qs.dot(&s_t).dot(&qs.t());
             gam_linalg::matrix::symmetrize_in_place(&mut s_mat);
+
+            // The frequentist bias-corrected coefficient used by prediction is
+            // β_BC = β̂ + b̂ with b̂ = H⁻¹S(β̂ - μ) at fixed smoothing
+            // parameters. Its fixed-ρ linearization with respect to β̂ is
+            // A = I + H⁻¹S. Credible bands centered at β_BC must use the
+            // covariance of that same estimator, A V Aᵀ; otherwise the center is
+            // debiased but the reported uncertainty remains for the shrunken
+            // penalized mode β̂, producing severely over-narrow bands on heavily
+            // smoothed large-scale Duchon fits (#1870).
+            let mut bc_jac = Array2::<f64>::eye(p_cov);
+            bc_jac += &h_inv.dot(&s_mat);
+            bias_correction_jacobian = Some(bc_jac);
             // Influence matrix F = I − H⁻¹·S(λ) = H⁻¹·X'WX. This is a product
             // of two symmetric matrices and is therefore generally NOT
             // symmetric; it must not be symmetrized — `gam_linalg::matrix::symmetrize_in_place(F)`
@@ -2843,6 +2856,11 @@ where
             (Some(base_cov), Some(corr)) if base_cov.as_array().dim() == corr.dim() => {
                 let mut corrected = base_cov.as_array().clone();
                 corrected += corr;
+                if let Some(a_bc) = bias_correction_jacobian.as_ref()
+                    && a_bc.dim() == corrected.dim()
+                {
+                    corrected = a_bc.dot(&corrected).dot(&a_bc.t());
+                }
                 gam_linalg::matrix::symmetrize_in_place(&mut corrected);
                 Some(corrected)
             }


### PR DESCRIPTION
### Motivation
- Large-scale Duchon REML credible bands were collapsing because the bias-corrected estimator `β_BC = β̂ + H⁻¹S(β̂ − μ)` was used as the interval center while the stored covariance still described the penalized mode `β̂`, producing over-narrow intervals (#1870).

### Description
- Compute and retain the fixed-ρ bias-correction Jacobian `A = I + H⁻¹ S` during inference assembly as `bias_correction_jacobian` in `optimizer.rs`.
- When forming the smoothing-corrected coefficient covariance, propagate the bias-correction linearization by replacing `Vp = Vb + J V_ρ Jᵀ` with `A Vp Aᵀ` (applied only when dimensions match), so credible bands are centered and scaled consistently with `β_BC`.
- Preserve existing smoothing-correction addition and symmetrization flow and fall back to the prior behavior when the Jacobian is unavailable or dimension-mismatched.

### Testing
- Ran code formatting with `cargo fmt` for the changed package (`gam-solve`).
- Ran `cargo check -p gam-solve`, which completed successfully in the development profile.
- Attempted `cargo test --release large_scale_reml_stress_coverage -- --nocapture`, but the release test run was blocked by an existing repository build-time ban-scanner failure unrelated to this change (tracked file length exceeded the workspace gate), so the full release stress test could not complete in this environment.

---
🤖 Codex Cloud root-cause fix for #1870 (task `task_e_6a4575d6e2708324a6229a865ec1c410`). **Unaudited** — review for reward-hacking before merge.

Closes #1870