### PR TITLE
Fix rho-variance cubature gate for smooth credible bands

### DIFF
--- a/crates/gam-solve/src/reml/eval.rs
+++ b/crates/gam-solve/src/reml/eval.rs
@@ -743,13 +743,12 @@ impl<'a> RemlState<'a> {
         const HIGHGRAD_REL_TOL: f64 = 1e-3;
         let cost_scale = 1.0 + final_fit.deviance.abs();
         let highgrad = grad_norm > HIGHGRAD_REL_TOL * cost_scale;
-        if !near_boundary && !highgrad {
-            // Keep the hot path cheap when the local linearization is likely sufficient.
-            return self.finalize_smoothing_outcome(first_order_routine(
-                first_order_correction,
-                "linearization sufficient: not near boundary and outer gradient is small",
-            ));
-        }
+        // Do not decide the cubature gate from boundary/gradient alone.  A fit can
+        // be perfectly interior and converged while the REML surface is still broad
+        // in rho; then the missing `E_rho[H(rho)^-1] - H(rho_hat)^-1` curvature
+        // component materially narrows posterior smooth bands.  Continue to the
+        // rho-Hessian inversion below so `max_rhovar` can trigger cubature for
+        // those broad-but-well-converged posteriors.
 
         // If the first-order path used a rank-deficient pseudo-inverse, the
         // ρ-Hessian was indefinite or near-singular and the matrix-free ridged
@@ -2483,7 +2482,6 @@ mod smoothing_correction_outcome_tests {
             "n_rho == 0: unified corrected covariance equals H^{-1}",
             "n_rho exceeds AUTO_CUBATURE_MAX_RHO_DIM: cubature cost prohibitive",
             "beta dimension exceeds AUTO_CUBATURE_MAX_BETA_DIM: cubature cost prohibitive",
-            "linearization sufficient: not near boundary and outer gradient is small",
             "first-order V_rho rank-deficient: cubature would impute spurious variance",
             "post-inversion rho posterior variance below trigger threshold",
             "no base covariance supplied: nothing for cubature to upgrade",


### PR DESCRIPTION
### Motivation
- Posterior credible bands were under-covering because the smoothing-correction auto path could short-circuit to the first-order linearization for interior, apparently-converged fits, skipping the rho-Hessian inversion and therefore the sigma-point cubature that supplies the missing curvature term `E_rho[H(ρ)⁻¹] − H(ρ̂)⁻¹` that inflates posterior SDs.

### Description
- Remove the early-return gate that exited when `!near_boundary && !highgrad` so the code always proceeds to build and inspect the rho Hessian (allowing `max_rhovar` to trigger cubature for broad-but-converged rho posteriors) in `crates/gam-solve/src/reml/eval.rs`.
- Add an explanatory comment documenting why the boundary/gradient-only decision was unsafe for credible-band calibration and should not bypass the rho-Hessian inversion.
- Remove the now-obsolete routine reason string from the smoothing-correction outcome test registry so the classification reasons remain consistent with the new gate logic.

### Testing
- Ran `git diff --check` to validate the working tree diff for obvious issues and it reported no check failures.
- Ran `rustfmt --check crates/gam-solve/src/reml/eval.rs`, which reported pre-existing formatting diffs elsewhere in the file (unrelated to the logic change) and therefore flagged formatting, not functional regressions.
- Attempted to run the focused unit test `cargo test -p gam-solve smoothing_correction_outcome_tests::classification_reason_strings_are_nonempty_and_distinct`; compilation proceeded but was not completed to test termination within this environment due to long build time (no runtime test failures observed during incremental compilation steps seen here).

---
🤖 Codex Cloud root-cause fix for #1871 (task `task_e_6a4575dff5f48324aa11ab9e5115e66d`). **Unaudited** — review for reward-hacking before merge.

Closes #1871