### PR TITLE
Use Gauss–Hermite quadrature for single-ρ̂ Lawley mean-shift (rho-variation)

### DIFF
--- a/crates/gam-terms/src/inference/lawley.rs
+++ b/crates/gam-terms/src/inference/lawley.rs
@@ -86,9 +86,9 @@
 
 use ndarray::{Array1, Array2, ArrayView2};
 
+use faer::Side;
 use gam_linalg::faer_ndarray::{FaerArrayView, factorize_symmetricwith_fallback};
 use gam_linalg::matrix::FactorizedSystem;
-use faer::Side;
 
 /// Order-2 jet (value, first, second η-derivative) product.
 #[inline]
@@ -502,7 +502,14 @@ const RHO_VARIATION_STEP: f64 = 0.05;
 ///   solver already maintains), passed as `rho_cov` (`m × m` for `m`
 ///   smoothing parameters). This is the sampling covariance of ρ̂.
 ///
-/// Returns the **total** mean shift `Δε(ρ̂) = Δε_conditional + ½·tr(HᵨᵨCov)`. The
+/// For a single smoothing parameter, returns the normal-reference expectation
+/// `E[Δε(ρ̂)]` directly by Gauss-Hermite quadrature. This avoids treating the
+/// second-order delta term as the target when the REML/LAML log-λ uncertainty is
+/// large enough for higher even derivatives of `Δε(ρ)` to be visible in the LR
+/// first moment. For multi-parameter smooths the function retains the
+/// curvature/covariance delta assembly below.
+///
+/// Returns the **total** mean shift `Δε(ρ̂)`. The
 /// caller forms the Bartlett factor `c = 1 + Δε(ρ̂)/d` exactly as for the
 /// conditional shift; the difference from the conditional factor is the size
 /// correction attributable specifically to ρ̂-variation.
@@ -584,6 +591,69 @@ pub fn lawley_lr_mean_shift_with_rho_variation(
         }
         lawley_lr_mean_shift(x, kappas, Some(s.view()), tested.clone())
     };
+
+    if m == 1 {
+        let var = rho_cov[[0, 0]];
+        if var < -1e-14 {
+            return Err(format!(
+                "lawley_lr_mean_shift_with_rho_variation: rho_cov[0,0] must be non-negative; got {var}"
+            ));
+        }
+        if var <= 1e-14 {
+            return Ok(conditional);
+        }
+        // 15-point Gauss-Hermite rule for
+        // E[f(ρ + Z)] = π^{-1/2} Σ w_i f(ρ + √(2 Var) x_i), Z ~ N(0, Var).
+        // The conditional anchor is at ρ, so the quadrature abscissa is the
+        // perturbation t = √(2 Var) x_i passed to `shift_at`.
+        const GH15_X: [f64; 15] = [
+            -4.499990707309391,
+            -3.669950373404453,
+            -2.967166927905603,
+            -2.325732486173858,
+            -1.719992575186489,
+            -1.136115585210921,
+            -0.565069583255576,
+            0.0,
+            0.565069583255576,
+            1.136115585210921,
+            1.719992575186489,
+            2.325732486173858,
+            2.967166927905603,
+            3.669950373404453,
+            4.499990707309391,
+        ];
+        const GH15_W: [f64; 15] = [
+            1.522475804253517e-9,
+            1.059115547711067e-6,
+            0.0001000044412324999,
+            0.002778068842912776,
+            0.03078003387254608,
+            0.1584889157959357,
+            0.4120286874988986,
+            0.5641003087264175,
+            0.4120286874988986,
+            0.1584889157959357,
+            0.03078003387254608,
+            0.002778068842912776,
+            0.0001000044412324999,
+            1.059115547711067e-6,
+            1.522475804253517e-9,
+        ];
+        let scale = (2.0 * var).sqrt();
+        let mut total = 0.0;
+        for (&x_i, &w_i) in GH15_X.iter().zip(GH15_W.iter()) {
+            total += w_i * shift_at(&[(0, scale * x_i)])?;
+        }
+        let total = total / std::f64::consts::PI.sqrt();
+        if !total.is_finite() {
+            return Err(
+                "lawley_lr_mean_shift_with_rho_variation: non-finite quadrature total shift"
+                    .to_string(),
+            );
+        }
+        return Ok(total);
+    }
 
     let h = RHO_VARIATION_STEP;
     // Hessian of Δε in ρ by symmetric finite differences of the deterministic


### PR DESCRIPTION
### Motivation

- The assembled ρ̂-variation term did not reproduce the simulated LR mean for Poisson smooths because the delta-method curvature assembly (½·tr(H·Cov)) can miss higher even-derivative contributions when log-λ uncertainty is appreciable.  
- For the single-smoothing-parameter case the correct target is the unconditional expectation `E[Δε(ρ̂)]` over ρ̂, not just the second-order delta correction, so the implementation must evaluate that expectation directly.

### Description

- Added a direct Gauss–Hermite quadrature path for the single-parameter case in `lawley_lr_mean_shift_with_rho_variation` to compute `E[Δε(ρ̂)]` with a 15-point rule and return that total mean shift.  
- Preserved the existing behaviour for `Var(ρ̂)` ≈ 0 by returning the conditional `Δε` and retained the multi-parameter fallback that assembles `½·Σ H_{bb'} Cov_{bb'}` for `m > 1`.  
- Added a small validation on the single-entry `rho_cov` to reject slight negative variances and a non-finite-quadrature error message, and kept the `shift_at` central-difference helper unchanged.  
- Change is localized to `crates/gam-terms/src/inference/lawley.rs` and keeps surrounding conventions and documentation intact.

### Testing

- Ran `rustfmt --check crates/gam-terms/src/inference/lawley.rs`, which succeeded.  
- Ran `git diff --check`, which reported no whitespace/merge issues.  
- Attempted targeted unit tests: `cargo test -p gam-terms inference::lawley::tests::rho_variation_correction_matches_curvature_times_variance -- --nocapture` and `cargo test -p gam tests::basis_smooth::smooths::smooth_term_lr_bartlett_calibration::rho_variation_assembly_matches_simulated_expectation_over_rho_hat -- --nocapture`; compilation initially failed due to a full filesystem, `target` was cleaned and compilation progressed, but the test processes did not finish within the session time available here (compilation progressed through many crates).  

If desired I can re-run the focused test executions in CI or on a machine with sufficient build resources to confirm the previously failing tests now pass end-to-end.

---
🤖 Codex Cloud root-cause fix for #1873 (task `task_e_6a4575f1238c8324a66993adc76b73a7`). **Unaudited** — review for reward-hacking before merge.

Closes #1873