### PR TITLE
Fix response-scale sigma floor reconstruction API

### DIFF
--- a/crates/gam-models/src/gamlss/builders.rs
+++ b/crates/gam-models/src/gamlss/builders.rs
@@ -1166,6 +1166,31 @@ pub struct GaussianLocationScaleFitResult {
     pub response_scale: f64,
 }
 
+impl GaussianLocationScaleFitResult {
+    /// Additive σ floor in raw response units for reconstructing the returned
+    /// log-σ coefficients.
+    ///
+    /// Gaussian location-scale fits are solved after standardizing `y` by
+    /// [`Self::response_scale`]. Mapping coefficients back to raw units shifts
+    /// the log-σ intercept by `ln(response_scale)`, which scales only the
+    /// `exp(η)` part of `σ = b + exp(η)`. The additive floor must therefore be
+    /// carried separately as `response_scale * b`; otherwise response rescaling
+    /// `y -> c*y` leaves a raw `b` behind and breaks equivariance.
+    #[inline]
+    pub fn sigma_floor_response_units(&self) -> f64 {
+        self.response_scale * crate::sigma_link::LOGB_SIGMA_FLOOR
+    }
+
+    /// Reconstruct raw-response σ from a returned raw-unit log-σ predictor.
+    #[inline]
+    pub fn sigma_from_raw_eta(&self, eta: f64) -> f64 {
+        crate::sigma_link::logb_sigma_from_eta_with_floor_scalar(
+            self.sigma_floor_response_units(),
+            eta,
+        )
+    }
+}
+
 /// Fit the binomial mean link-wiggle model. Returns the γ-space fit and, when
 /// the frozen-basis de-aliasing engaged (#1596), the standard-basis warp
 /// coefficients `β_w = Z·γ` for the saved-model predict runtime.


### PR DESCRIPTION
### Motivation
- The Gaussian location-scale σ floor (LOGB_SIGMA_FLOOR) was being reconstructed as an absolute additive value in raw units, breaking equivariance under a global response rescale `y → c·y` when the fitted σ is comparable to the floor.

### Description
- Add `GaussianLocationScaleFitResult::sigma_floor_response_units()` and `GaussianLocationScaleFitResult::sigma_from_raw_eta()` in `crates/gam-models/src/gamlss/builders.rs` to centralize and apply the response-scale-relative additive floor (`response_scale * LOGB_SIGMA_FLOOR`) when reconstructing raw σ from persisted log-σ predictors.

### Testing
- Ran the regression test `cargo test --test regressions location_scale_noise_is_response_scale_equivariant -- --nocapture`, which now passes and verifies that σ reconstruction is response-scale-equivariant.

---
🤖 Codex Cloud root-cause fix for #1874 (task `task_e_6a4575fb80f483248e8f6114448c686f`). **Unaudited** — review for reward-hacking before merge.

Closes #1874