### PR TITLE
Ensure Gaussian location-scale fits retain joint covariance

### DIFF
--- a/crates/gam-models/src/fit_orchestration/fit.rs
+++ b/crates/gam-models/src/fit_orchestration/fit.rs
@@ -1178,6 +1178,13 @@ pub(crate) fn fit_gaussian_location_scale_model(
             .mapv_inplace(|v| v / response_scale);
     }
 
+    // Gaussian location-scale prediction has two coupled linear predictors, so
+    // uncertainty on either response channel must be assembled from the joint
+    // `(β_μ, β_logσ)` Laplace posterior covariance. Request it
+    // unconditionally; otherwise predict-time delta-method SEs for the second
+    // predictor can only fall back to scalar/block-local approximations.
+    request.options.compute_covariance = true;
+
     let mut result =
         fit_location_scale_with_optional_wiggle::<GaussianLocationScaleWorkflow>(request)?;
 


### PR DESCRIPTION
### Motivation
- The Gaussian location-scale fit did not always assemble the joint `(β_μ, β_logσ)` posterior covariance, which caused the second linear predictor's response SE to fall back to a recycled scalar rather than a genuine per-row quadratic form.

### Description
- In `crates/gam-models/src/fit_orchestration/fit.rs` set `request.options.compute_covariance = true` inside `fit_gaussian_location_scale_model` so the shared location-scale workflow always computes the joint posterior covariance used for delta-method SEs.

### Testing
- Ran `cargo test --test quality families::mgcv_defect_gumbls_second_predictor_response_se::second_predictor_response_se_is_not_a_recycled_scalar`, and the test passed.

---
🤖 Codex Cloud root-cause fix for #1875 (task `task_e_6a45760373308324b5c3382b6e784216`). **Unaudited** — review for reward-hacking before merge.

Closes #1875