### PR TITLE
Synchronize stateful SAS metadata from unified fit payloads

### DIFF
--- a/crates/gam-models/src/inference/model.rs
+++ b/crates/gam-models/src/inference/model.rs
@@ -2613,7 +2613,7 @@ impl FittedModel {
             .or(payload.unified.as_ref())
             .is_some_and(|fit| fit.used_device);
         payload.synchronize_empty_feature_contract();
-        let Some(fit) = payload.fit_result.as_ref() else {
+        let Some(fit) = payload.fit_result.as_ref().or(payload.unified.as_ref()) else {
             return;
         };
         match (&mut payload.family_state, &fit.fitted_link) {

--- a/tests/pyffi/misc/stateful_saved_model_sync.rs
+++ b/tests/pyffi/misc/stateful_saved_model_sync.rs
@@ -352,6 +352,68 @@ fn save_and_load_syncs_standard_sas_state_from_fit_result() {
 }
 
 #[test]
+fn save_and_load_syncs_standard_sas_state_from_unified_fit_result() {
+    let log_delta = -0.4;
+    let sas_state =
+        gam::mixture_link::sas_link_state_from_raw(0.25, log_delta).expect("valid sas state");
+    let covariance =
+        Array2::from_shape_vec((2, 2), vec![0.1, 0.02, 0.02, 0.2]).expect("2x2 covariance");
+    let mut payload = FittedModelPayload::new(
+        MODEL_PAYLOAD_VERSION,
+        "y ~ x".to_string(),
+        ModelKind::Standard,
+        FittedFamily::Standard {
+            likelihood: LikelihoodSpec::new(ResponseFamily::Binomial, InverseLink::Sas(sas_state)),
+            link: None,
+            latent_cloglog_state: None,
+            mixture_state: None,
+            sas_state: None,
+        },
+        "binomial-sas".to_string(),
+    );
+    payload.unified = Some(minimal_fit_result(FittedLinkState::Sas {
+        state: sas_state,
+        covariance: Some(covariance.clone()),
+    }));
+    payload.data_schema = Some(gam::inference::model::DataSchema { columns: vec![] });
+    payload.resolved_termspec = Some(gam::terms::smooth::TermCollectionSpec {
+        linear_terms: vec![],
+        smooth_terms: vec![],
+        random_effect_terms: vec![],
+    });
+
+    let model = FittedModel::from_payload(payload);
+    let saved_state = model
+        .saved_sas_state()
+        .expect("saved sas state")
+        .expect("expected synchronized sas state from unified fit");
+    assert_eq!(saved_state, sas_state);
+
+    let dir = tempdir().expect("temp dir");
+    let path = dir.path().join("unified-model.json");
+    model.save_to_path(&path).expect("save model");
+
+    let saved = read_saved_model_json(&path);
+    let family_state = standard_family_state(&saved);
+    assert_eq!(
+        family_state.get("sas_state"),
+        Some(&serde_json::to_value(sas_state).expect("sas state json")),
+        "serialized model should include synchronized family_state.sas_state from unified fit"
+    );
+    assert_eq!(
+        saved_model_payload(&saved).get("sas_param_covariance"),
+        Some(&serde_json::json!([[0.1, 0.02], [0.02, 0.2]]))
+    );
+
+    let loaded = FittedModel::load_from_path(&path).expect("load model");
+    let loaded_state = loaded
+        .saved_sas_state()
+        .expect("loaded sas state")
+        .expect("expected loaded sas state");
+    assert_eq!(loaded_state, sas_state);
+}
+
+#[test]
 fn save_and_load_syncs_standard_latent_cloglog_state_from_fit_result() {
     let latent_state = LatentCLogLogState::new(0.65).expect("valid latent state");
     let mut payload = FittedModelPayload::new(


### PR DESCRIPTION
### Motivation
- The persisted standard-SAS saved-model payload could diverge when the stateful link fit lived in `payload.unified` rather than legacy `payload.fit_result`, causing saved `sas_state` and `sas_param_covariance` to be omitted during save.
- The intent is to make stateful-link synchronization use the canonical fit container so saved models always include synchronized SAS state regardless of whether the fit was written into `fit_result` or `unified`.

### Description
- Use the canonical fit payload from either `fit_result` or `unified` when synchronizing stateful link metadata by changing the early-exit to `payload.fit_result.as_ref().or(payload.unified.as_ref())` in `synchronize_stateful_link_metadata` (in `crates/gam-models/src/inference/model.rs`).
- Persist SAS covariance when the fit state is present in `unified` by reusing the existing branch that writes `payload.sas_param_covariance` from the fit covariance.
- Add a regression test `save_and_load_syncs_standard_sas_state_from_unified_fit_result` in `tests/pyffi/misc/stateful_saved_model_sync.rs` which constructs a `FittedModelPayload` with a `unified` `FittedLinkState::Sas` and asserts `family_state.sas_state`, `sas_param_covariance`, and the loaded SAS state round-trip.

### Testing
- Ran `cargo check -p gam-models --lib` which completed successfully, verifying the `gam-models` changes compile.
- Added and formatted code with `rustfmt` and ensured `git diff --check` shows no whitespace issues.
- Attempted to run the saved-model sync test via `cargo test` for the top-level `gam` test selection, but the full test invocation was blocked by an existing repository build gate (the ban-scanner line-count violation in `crates/gam-sae/src/manifold/tests.rs`), so the targeted runtime test could not be executed in this environment. The new test is present and will run in CI where the repository line-count gate is satisfied.

---
🤖 Codex Cloud root-cause fix for #1877 (task `task_e_6a4576226f808324b4ad109c93e441fc`). **Unaudited** — review for reward-hacking before merge.

Closes #1877