### PR TITLE
Fix logit posterior variance regression

### DIFF
--- a/crates/gam-solve/src/quadrature.rs
+++ b/crates/gam-solve/src/quadrature.rs
@@ -4093,12 +4093,12 @@ pub fn probit_posterior_mean(eta: f64, se_eta: f64) -> f64 {
 
 #[inline]
 pub fn logit_posterior_meanvariance(ctx: &QuadratureContext, eta: f64, se_eta: f64) -> (f64, f64) {
-    let m1 = integrate_normal_ghq_adaptive(ctx, eta, se_eta, sigmoid);
-    let m2 = integrate_normal_ghq_adaptive(ctx, eta, se_eta, |x| {
+    let (m1, m2) = integrate_normal_ghq_adaptive(ctx, eta, se_eta, |x| {
         let p = sigmoid(x);
-        p * p
-    })
-    .clamp(0.0, 1.0);
+        (p, p * p)
+    });
+    let m1 = m1.clamp(0.0, 1.0);
+    let m2 = m2.clamp(0.0, 1.0);
     (m1, (m2 - m1 * m1).max(0.0))
 }
 
@@ -5528,7 +5528,11 @@ mod tests {
         let s = (1.0 + sigma * sigma).sqrt();
         let z = mu / s;
         let pdf = gam_math::probability::normal_pdf(z);
-        assert_relative_eq!(out.mean, gam_math::probability::normal_cdf(z), epsilon = 1e-12);
+        assert_relative_eq!(
+            out.mean,
+            gam_math::probability::normal_cdf(z),
+            epsilon = 1e-12
+        );
         assert_relative_eq!(out.d1, pdf / s, epsilon = 1e-12);
         assert_relative_eq!(out.d2, -z * pdf / (s * s), epsilon = 1e-12);
         assert_relative_eq!(out.d3, (z * z - 1.0) * pdf / (s * s * s), epsilon = 1e-12);

--- a/tests/regressions/predict/predict_2_2.rs
+++ b/tests/regressions/predict/predict_2_2.rs
@@ -126,9 +126,12 @@ fn delta_method_variance_matches_posterior_simulation_for_small_logit_problem() 
     let l21 = cov[[1, 0]] / l11;
     let l22 = (cov[[1, 1]] - l21 * l21).sqrt();
     let mut vals = Vec::new();
-    for k in 0..20000 {
-        let u1 = ((k * 48271 % 2147483647) as f64) / 2147483647.0;
-        let u2 = ((k * 69621 % 2147483647) as f64) / 2147483647.0;
+    let mut state = 1_u64;
+    for _ in 0..20000 {
+        state = (state * 48271) % 2147483647;
+        let u1 = (state as f64) / 2147483647.0;
+        state = (state * 48271) % 2147483647;
+        let u2 = (state as f64) / 2147483647.0;
         let r = (-2.0 * u1.max(1e-12).ln()).sqrt();
         let z1 = r * (2.0 * std::f64::consts::PI * u2).cos();
         let z2 = r * (2.0 * std::f64::consts::PI * u2).sin();


### PR DESCRIPTION
### Motivation
- The delta-method predictive variance on the logit link disagreed with dense posterior simulation because the logit response second-moment used a separate quadrature pass (different nodes/weights) and the regression RNG produced correlated Box–Muller uniforms, introducing a test artifact.

### Description
- Compute both logistic-normal moments in a single adaptive GHQ evaluation by returning `(E[p], E[p^2])` from `integrate_normal_ghq_adaptive` and then form `Var(μ)=E[p^2]−E[p]^2`, clamping moments into `[0,1]` before differencing (`crates/gam-solve/src/quadrature.rs`).
- Repair the regression fixture RNG so Box–Muller consumes two sequential draws from one Park–Miller stream (removes unintended correlation between the paired uniforms) (`tests/regressions/predict/predict_2_2.rs`).

### Testing
- Ran the targeted regression: `cargo test --test regressions predict::predict_2_2::delta_method_variance_matches_posterior_simulation_for_small_logit_problem -- --nocapture`, which passed.
- Ran formatting checks on the modified files with `rustfmt --check crates/gam-solve/src/quadrature.rs tests/regressions/predict/predict_2_2.rs`, which succeeded for those files.

---
🤖 Codex Cloud root-cause fix for #1878 (task `task_e_6a457645d9408324ae550e95b95a8003`). **Unaudited** — review for reward-hacking before merge.

Closes #1878