### PR TITLE
Fix summary penalty cursor for unpenalized random-effect ranges

### DIFF
--- a/crates/gam-cli/src/main/run_sample_generate_report.rs
+++ b/crates/gam-cli/src/main/run_sample_generate_report.rs
@@ -729,7 +729,7 @@ pub(crate) fn run_report(args: ReportArgs) -> Result<(), String> {
                 // λ_raw = λ̃ / ||S_raw,ℓ||_F, before the arbitrary Mellin
                 // ε_ℓ^(-2s0)·log_step gauge is folded into the fit-time forms.
                 {
-                    let mut penalty_cursor = design.random_effect_ranges.len();
+                    let mut penalty_cursor = design.leading_penalty_blocks_before_smooth();
                     for term in &design.smooth.terms {
                         let k = term.penalties_local.len();
                         let term_penalty_start = penalty_cursor;

--- a/crates/gam-models/src/fit_orchestration/drivers/spatial_optimization.rs
+++ b/crates/gam-models/src/fit_orchestration/drivers/spatial_optimization.rs
@@ -9180,8 +9180,9 @@ pub fn smooth_term_lr_inference_forspec(
     let family_disp = lawley_dispersion_for_family(&family, &full.fit);
 
     // The penalty-block cursor walks the same block order the summary table
-    // uses: random-effect ranges first (skipped here), then smooth terms.
-    let mut penalty_cursor = full.design.random_effect_ranges.len();
+    // uses: any leading linear/random-effect penalty blocks first (skipped
+    // here), then smooth terms.
+    let mut penalty_cursor = full.design.leading_penalty_blocks_before_smooth();
     let mut out = Vec::<SmoothTermLrInference>::new();
     for (term_idx, design_term) in full.design.smooth.terms.iter().enumerate() {
         let k = design_term.penalties_local.len();

--- a/crates/gam-models/src/fit_orchestration/fit.rs
+++ b/crates/gam-models/src/fit_orchestration/fit.rs
@@ -237,10 +237,11 @@ fn guard_untrusted_edf_collapse(
         return;
     };
     edf_total_before = inference.edf_total;
-    // Penalty-block cursor walks the summary block order: random-effect ranges
-    // first, then smooth terms (mirrors `smooth_term_lr_inference_forspec` and the
+    // Penalty-block cursor walks the recorded global block order: any leading
+    // linear ridge and penalized random-effect ridge blocks first, then smooth
+    // terms (mirrors `smooth_term_lr_inference_forspec` and the
     // `build_model_summary` per-term EDF walk).
-    let mut penalty_cursor = design.random_effect_ranges.len();
+    let mut penalty_cursor = design.leading_penalty_blocks_before_smooth();
     // Running change to `Σ edf_by_block`. `edf_total` carries an additional
     // `mp = p − Σ rank_k` offset for the UNPENALIZED columns (e.g. the intercept),
     // so it is NOT `Σ edf_by_block`; applying the same delta preserves that offset.

--- a/crates/gam-terms/src/smooth/term_specs.rs
+++ b/crates/gam-terms/src/smooth/term_specs.rs
@@ -2345,6 +2345,27 @@ pub struct TermCollectionDesign {
 }
 
 impl TermCollectionDesign {
+    /// Number of global penalty blocks that precede the smooth-term penalty
+    /// blocks in the flat smoothing-parameter / EDF-trace layout.
+    ///
+    /// The prefix is not the same as `random_effect_ranges.len()`: unpenalized
+    /// (or empty) random-effect ranges contribute coefficient columns but no
+    /// penalty block. The authoritative layout is the recorded `penaltyinfo`
+    /// sequence assembled alongside `penalties`.
+    pub fn leading_penalty_blocks_before_smooth(&self) -> usize {
+        self.penaltyinfo
+            .iter()
+            .take_while(|info| {
+                matches!(
+                    &info.penalty.source,
+                    crate::basis::PenaltySource::Other(source)
+                        if source == "LinearTermRidge"
+                            || source.starts_with("RandomEffectRidge(")
+                )
+            })
+            .count()
+    }
+
     /// Convert blockwise penalties to `PenaltyMatrix::Blockwise` without
     /// expanding to `p_total × p_total`. This is the preferred path for
     /// family modules that accept `Vec<PenaltyMatrix>`.

--- a/tests/regressions/smooths/summary_penalty_cursor_skips_unpenalized_re.rs
+++ b/tests/regressions/smooths/summary_penalty_cursor_skips_unpenalized_re.rs
@@ -107,9 +107,12 @@ fn summary_penalty_cursor_matches_actual_penalty_layout() {
         })
         .count();
 
-    // What the summary cursor SKIPS before the first smooth: one slot per
-    // random-effect range, unconditionally (the buggy reconstruction).
-    let summary_cursor_skips = design.random_effect_ranges.len();
+    // What the summary cursor must skip before the first smooth: the actual
+    // leading non-smooth penalty blocks in the flat global penalty layout.
+    // This intentionally differs from the old buggy reconstruction, which
+    // advanced by one slot per random-effect range unconditionally.
+    let summary_cursor_skips = design.leading_penalty_blocks_before_smooth();
+    let buggy_cursor_skips = design.random_effect_ranges.len();
 
     // Sanity: the `by=g` factor really did introduce a random-effect range.
     assert!(
@@ -117,17 +120,22 @@ fn summary_penalty_cursor_matches_actual_penalty_layout() {
         "expected an unpenalized random-effect main effect for the by= factor; \
          random_effect_ranges was empty — formula plumbing changed"
     );
+    assert_ne!(
+        buggy_cursor_skips, leading_re_penalty_blocks,
+        "regression fixture no longer contains an unpenalized random-effect \
+         range; the old one-slot-per-range cursor would not desync"
+    );
 
     // The invariant the summary RELIES ON: the number of random-effect ranges it
-    // skips must equal the number of leading penalty blocks those ranges own.
-    // An unpenalized `by` factor breaks it (range present, no penalty block).
+    // skips must equal the number of leading penalty blocks those ranges own,
+    // not the number of random-effect coefficient ranges.
     assert_eq!(
         summary_cursor_skips, leading_re_penalty_blocks,
-        "summary penalty-cursor desync: the summary advances the penalty cursor \
-         by {summary_cursor_skips} (one per random-effect range) before the first \
-         smooth, but only {leading_re_penalty_blocks} leading penalty blocks \
-         actually belong to random effects. The first smooth's per_term_edf will \
-         read penalty_block_trace[{summary_cursor_skips}..] instead of \
+        "summary penalty-cursor desync: the summary advances the penalty cursor by \
+         {summary_cursor_skips} before the first smooth, but \
+         {leading_re_penalty_blocks} leading penalty blocks actually belong to \
+         random effects. The first smooth's per_term_edf will read \
+         penalty_block_trace[{summary_cursor_skips}..] instead of \
          [{leading_re_penalty_blocks}..], corrupting EDF / ref_df / p-value in the \
          influence-matrix-absent fallback path."
     );


### PR DESCRIPTION
### Motivation
- The model-summary penalty-cursor reconstruction assumed one penalty block per random-effect coefficient range, but unpenalized (or empty) random-effect ranges contribute columns but no penalty block, desyncing the cursor and corrupting per-term EDF / ref_df / p-value in the influence-matrix-absent fallback path.

### Description
- Add `TermCollectionDesign::leading_penalty_blocks_before_smooth()` which computes the number of leading non-smooth penalty blocks from the recorded `penaltyinfo` layout instead of counting `random_effect_ranges`.
- Seed the summary/EDF cursor with `leading_penalty_blocks_before_smooth()` (replacing uses of `random_effect_ranges.len()`) in the model summary, EDF-collapse guard, smooth-term LR inference, and report diagnostics so unpenalized or empty RE ranges do not advance the cursor.
- Update the regression `summary_penalty_cursor_skips_unpenalized_re` to assert the corrected cursor matches the actual leading penalty layout and to keep an explicit check that the old one-slot-per-range logic would have desynced the fixture.

### Testing
- Ran `cargo fmt` to normalize formatting across touched files successfully.
- Ran `cargo check -q -p gam-terms -p gam-models -p gam-cli` and the checked crates compiled cleanly.
- Attempted `cargo test -q summary_penalty_cursor_matches_actual_penalty_layout`; the test logic was updated, but a full test run in this environment was blocked by a pre-existing build-script ban-scanner failure unrelated to these changes (an oversized tracked test file), so CI should run the updated regression and validate the fix there.

---
🤖 Codex Cloud root-cause fix for #1883 (task `task_e_6a45768d31b883248bf81620265f8650`). **Unaudited** — review for reward-hacking before merge.

Closes #1883