### PR TITLE
Fix by-factor / bs="sz" SmoothBasisSpec construction

### DIFF
--- a/crates/gam-terms/src/term_builder.rs
+++ b/crates/gam-terms/src/term_builder.rs
@@ -25,13 +25,13 @@ use crate::inference::formula_dsl::{
     option_usize_any, option_usize_any_strict, option_usize_strict, strip_quotes,
 };
 use crate::smooth::{
-    ByVarKind, FactorSmoothFlavour, FactorSmoothSpec, LinearCoefficientGeometry, LinearTermSpec,
-    RandomEffectTermSpec, ShapeConstraint, SmoothBasisSpec, SmoothTermSpec,
-    TensorBSplineIdentifiability, TensorBSplinePenaltyDecomposition, TensorBSplineSpec,
-    TermCollectionSpec,
+    BySmoothKind, ByVarKind, ByVariableSpec, FactorSmoothFlavour, FactorSmoothSpec,
+    LinearCoefficientGeometry, LinearTermSpec, RandomEffectTermSpec, ShapeConstraint,
+    SmoothBasisSpec, SmoothTermSpec, TensorBSplineIdentifiability,
+    TensorBSplinePenaltyDecomposition, TensorBSplineSpec, TermCollectionSpec,
 };
-use gam_problem::types::ColIdx;
 use gam_data::{ColumnKindTag, DataError, EncodedDataset as Dataset};
+use gam_problem::types::ColIdx;
 use gam_runtime::resource::ResourcePolicy;
 
 /// Default B-spline degree when a smooth's `degree=` option is absent. Cubic
@@ -474,6 +474,39 @@ pub fn build_termspec(
                     policy,
                     smooth_coordinate_count,
                 )?;
+                let inner_basis = match inner_basis {
+                    SmoothBasisSpec::FactorSmooth {
+                        spec:
+                            FactorSmoothSpec {
+                                continuous_cols,
+                                group_col,
+                                marginal,
+                                flavour: FactorSmoothFlavour::Sz,
+                                frozen_global_orthogonality,
+                                ..
+                            },
+                    } => {
+                        if continuous_cols.len() != 1 {
+                            return Err(TermBuilderError::incompatible_config(format!(
+                                "sz factor-smooth currently expects exactly one continuous covariate, found {}",
+                                continuous_cols.len()
+                            )));
+                        }
+                        SmoothBasisSpec::FactorSumToZero {
+                            inner: Box::new(SmoothBasisSpec::BSpline1D {
+                                feature_col: continuous_cols[0],
+                                spec: marginal,
+                            }),
+                            by_col: group_col,
+                            levels: encoded_levels_for_column(ds, ColIdx::new(group_col))
+                                .into_iter()
+                                .map(|(bits, _)| bits)
+                                .collect(),
+                            frozen_global_orthogonality,
+                        }
+                    }
+                    other => other,
+                };
                 if let Some(by_name) = by_name {
                     let by_col = resolve_col(col_map, &by_name)?;
                     match ds.column_kinds.get(by_col).copied().ok_or_else(|| {
@@ -528,34 +561,37 @@ pub fn build_termspec(
                                     frozen_levels: None,
                                 });
                             }
-                            // Route to a single BySmooth::Factor term with
-                            // frozen levels pre-populated from the training data.
-                            // Design building later gates each level into its own
-                            // column block (see build_by_smooth_local in term_specs).
-                            let frozen_levels: Vec<u64> =
-                                levels.iter().map(|(bits, _)| *bits).collect();
-                            smooth_terms.push(SmoothTermSpec {
-                                name: label.clone(),
-                                basis: SmoothBasisSpec::BySmooth {
-                                    smooth: Box::new(inner_basis),
-                                    by_kind: ByVarKind::Factor {
-                                        feature_col: by_col,
-                                        ordered: option_bool(options, "ordered").unwrap_or(false),
-                                        frozen_levels: Some(frozen_levels),
+                            // Unordered factor-by smooths are independent
+                            // level-specific smooths. Preserve that
+                            // term-spec structure explicitly so later
+                            // hierarchy/identifiability passes can see the
+                            // per-level ownership rather than a generic
+                            // BySmooth envelope.
+                            for (level_bits, level_label) in levels {
+                                smooth_terms.push(SmoothTermSpec {
+                                    name: format!("{label}:by={by_name}[{level_label}]"),
+                                    basis: SmoothBasisSpec::ByVariable {
+                                        inner: Box::new(inner_basis.clone()),
+                                        by_col,
+                                        kind: BySmoothKind::Level { level_bits },
+                                        by: ByVariableSpec::Level {
+                                            value_bits: level_bits,
+                                            label: level_label,
+                                        },
                                     },
-                                },
-                                shape,
-                                joint_null_rotation: None,
-                            });
+                                    shape: shape.clone(),
+                                    joint_null_rotation: None,
+                                });
+                            }
                         }
                         ColumnKindTag::Binary | ColumnKindTag::Continuous => {
                             smooth_terms.push(SmoothTermSpec {
                                 name: label.clone(),
-                                basis: SmoothBasisSpec::BySmooth {
-                                    smooth: Box::new(inner_basis),
-                                    by_kind: ByVarKind::Numeric {
-                                        feature_col: by_col,
-                                    },
+                                basis: SmoothBasisSpec::ByVariable {
+                                    inner: Box::new(inner_basis),
+                                    by_col,
+                                    kind: BySmoothKind::Numeric,
+                                    by: ByVariableSpec::Numeric,
                                 },
                                 shape,
                                 joint_null_rotation: None,


### PR DESCRIPTION
### Motivation
- `build_termspec` was emitting incorrect `SmoothBasisSpec` variants for `by=` factor and `bs="sz"` factor-smooths, causing higher-level code and tests to observe the wrong envelope/kind. 
- This manifested as two failing tests that expect unordered factor `by=` to expand to per-level `ByVariable`-Level terms and binary `by=` / `bs=sz` to produce the specialized `ByVariable::Numeric` and `FactorSumToZero` specs respectively.

### Description
- Added the missing imports (`BySmoothKind`, `ByVariableSpec`) and updated `crates/gam-terms/src/term_builder.rs` to construct the correct variants.
- When `build_smooth_basis` returns a `FactorSmooth` with flavour `Sz`, convert it into a `SmoothBasisSpec::FactorSumToZero` carrying the shared B-spline marginal, `by_col`, frozen `levels`, and any `frozen_global_orthogonality` metadata for correct replay at predict-time.
- For categorical `by=` columns, expand into one `SmoothBasisSpec::ByVariable { kind: BySmoothKind::Level, .. }` smooth per training level (preserving per-level ownership) and keep the logic that conditionally adds an unpenalized fixed main effect when no penalized group owner is present.
- For binary/continuous `by=` columns, emit `SmoothBasisSpec::ByVariable { kind: BySmoothKind::Numeric, by: ByVariableSpec::Numeric, .. }` wrapping the inner basis.

### Testing
- Ran `cargo test -p gam --test basis_smooth difference_smooth_formula -- --nocapture`, and both targeted tests passed (`unordered_by_factor_expands_to_level_smooths_and_fixed_main_effect` and `binary_by_and_sz_parse_to_specialized_basis_specs`).
- Ran `git diff --check` to catch whitespace / conflict issues and committed the focused changes; `cargo fmt --check` reported unrelated repository rustfmt drift outside the edited region but did not affect the functional fix.

---
🤖 Codex Cloud root-cause fix for #1887 (task `task_e_6a4576ac40e8832488d3c1a8ee2cb9ad`). **Unaudited** — review for reward-hacking before merge.

Closes #1887