### PR TITLE
Clarify external GLM response-support errors

### DIFF
--- a/crates/gam-solve/src/estimate/fit.rs
+++ b/crates/gam-solve/src/estimate/fit.rs
@@ -229,13 +229,16 @@ where
     // Per-family response-support validation, owned by the family type.
     // Gamma `y > 0`, Poisson / NegativeBinomial / Tweedie `y ≥ 0`, Beta
     // `y ∈ (0, 1)`. Centralising the rule on `ResponseFamily` means the
-    // external-design GLM path and the formula path produce identical
-    // user-facing messages for the same domain violation, and adding a new
-    // constrained family is a single edit on the type. The response column
-    // name is unknown on the external-design path (the caller passes a bare
+    // external-design GLM path and the formula path share the same
+    // family-owned domain rule, while this external path appends the routing
+    // context the formula path does not have. The response column name is
+    // unknown on the external-design path (the caller passes a bare
     // `y: ArrayView1<f64>`) so we surface it as the generic "y".
     if let Err(violation) = resolved_family.response.validate_response_support(y.view()) {
-        crate::bail_invalid_estim!("{}", violation);
+        crate::bail_invalid_estim!(
+            "{}; external-design GLM routing accepted the family/link, but the response values are outside that GLM family's support",
+            violation
+        );
     }
     validate_penalty_specs(&specs, x.ncols(), "fit_gam")?;
     let ext_opts = ExternalOptimOptions {


### PR DESCRIPTION
### Motivation
- Make the external-design Beta rejection message point users at the GLM routing path by clarifying that the family/link was accepted for GLM routing before the response-support check failed (fixes the missing “GLM” hint for Beta requests).

### Description
- Update the external-design response-support error in `crates/gam-solve/src/estimate/fit.rs` so the `validate_response_support` failure message appends routing context explaining that the external GLM route accepted the family/link but the response values are outside that GLM family's support, and adjust the adjacent comment to note the external path adds routing-specific context.

### Testing
- Ran the targeted regression: `cargo test -q --test regressions families::estimate_external_family_and_links::resolve_external_family_rejects_beta_response_with_clear_error -- --nocapture`, which passed.
- Ran `rustfmt --check crates/gam-solve/src/estimate/fit.rs`, which passed for the modified file. 
- Ran `git diff --check`, which reported no issues for the change; a repository-wide `cargo fmt --check` flags pre-existing formatting diffs outside this change and was not used to block this PR.

---
🤖 Codex Cloud root-cause fix for #1888 (task `task_e_6a4576b93170832494cab8093a79ba8c`). **Unaudited** — review for reward-hacking before merge.

Closes #1888