### PR TITLE
Use SAS bounded transform for Beta-Logistic state's derived delta

### DIFF
--- a/crates/gam-solve/src/mixture_link.rs
+++ b/crates/gam-solve/src/mixture_link.rs
@@ -638,14 +638,15 @@ pub fn state_from_beta_logisticspec(spec: SasLinkSpec) -> Result<SasLinkState, S
         return Err("Beta-Logistic link parameters must be finite".to_string());
     }
     // For Beta-Logistic, `log_delta` is the unconstrained log geometric-mean beta
-    // shape (the kernels' `log_shape_center`); the derived `delta = exp(log_delta)`
-    // is the positive geometric-mean shape `sqrt(a*b)`. Evaluation consumes
-    // `log_delta`, never `delta`.
+    // shape (the kernels' `log_shape_center`). Evaluation consumes `log_delta`,
+    // never `delta`, but keep the shared `SasLinkState::delta` field on the same
+    // bounded SAS parameterization used by `state_from_sasspec` so constructing a
+    // state from a large finite raw log-delta cannot overflow this derived field.
     let log_shape_center = spec.initial_log_delta;
     Ok(SasLinkState {
         epsilon: spec.initial_epsilon,
         log_delta: log_shape_center,
-        delta: log_shape_center.exp(),
+        delta: sas_delta_from_raw_log_delta(log_shape_center),
     })
 }
 


### PR DESCRIPTION
### Motivation
- The Beta-Logistic state construction computed the derived `SasLinkState::delta` as `exp(log_delta)`, which overflows for large `log_delta` values while the SAS parameterisation uses a bounded `delta = exp(B * tanh(log_delta / B))` (`SAS_LOG_DELTA_BOUND`), and the regression test asserts both should share the same bounded behaviour.

### Description
- In `state_from_beta_logisticspec` replaced the unbounded `delta: log_shape_center.exp()` with the shared `delta: sas_delta_from_raw_log_delta(log_shape_center)` so the derived `SasLinkState::delta` uses the same bounded SAS transform while preserving the raw `log_delta` used by Beta-Logistic evaluation.

### Testing
- Ran the targeted regression test `tests::regressions::families::solver_links_and_topology::beta_logistic_state_fromspec_uses_same_bounded_delta_parameterization_as_sas` via `cargo test -p gam --test regressions beta_logistic_state_fromspec_uses_same_bounded_delta_parameterization_as_sas`, and it passed.

---
🤖 Codex Cloud fix for #1807 (task `task_e_6a4573aa1d9c8324a2942ee5ab54eda7`). **Unaudited** — review before merge.

Closes #1807