### PR TITLE
Fix cell moment scratch resize reuse

### DIFF
--- a/crates/gam-model-kernels/src/cubic_cell_kernel.rs
+++ b/crates/gam-model-kernels/src/cubic_cell_kernel.rs
@@ -1530,9 +1530,15 @@ impl CellMomentScratch {
             CELL_MOMENT_REALLOCS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
             self.moments.reserve(len - self.moments.capacity());
         }
-        self.moments.resize(len, 0.0);
-        self.moments.fill(0.0);
-        &mut self.moments
+        // Grow monotonically: shorter requests should not truncate the backing
+        // storage and then zero the old tail when a later request grows again.
+        // Only the active prefix is scratch for this evaluation.
+        if self.moments.len() < len {
+            self.moments.resize(len, 0.0);
+        }
+        let out = &mut self.moments[..len];
+        out.fill(0.0);
+        out
     }
 }
 

--- a/tests/regressions/misc/cubic_cell_kernel_bug_hunt.rs
+++ b/tests/regressions/misc/cubic_cell_kernel_bug_hunt.rs
@@ -223,8 +223,9 @@ fn bug_cell_moment_scratch_resize_corrupts_existing_entries() {
             "Expected scratch resize reuse to preserve earlier written values exactly after changing output length; mismatch at index {i}"
         );
     }
-    assert!(
-        (snap[0] - fresh.moments[0]).abs() < 0.0,
+    assert_eq!(
+        snap[0].to_bits(),
+        fresh.moments[0].to_bits(),
         "Expected scratch-backed moment storage to remain untouched after a second call with a different requested length"
     );
 }


### PR DESCRIPTION
### Motivation
- `CellMomentScratch::prepare_moments` previously called `Vec::resize(len, 0.0)` unconditionally which truncated the backing buffer on shorter requests and caused later growth to zero out previously stored tail entries, corrupting scratch-backed moment storage.
- The regression test asserted an impossible negative tolerance; the sentinel should check exact preservation of bitwise equality for the stored moment.

### Description
- Change `CellMomentScratch::prepare_moments` to only `resize` when `self.moments.len() < len`, return the active prefix `&mut self.moments[..len]`, and zero only that prefix via `out.fill(0.0)`, preserving the backing tail.
- Add a clarifying comment explaining the monotonic-growth intent of the buffer.
- Update the regression assertion to `assert_eq!(snap[0].to_bits(), fresh.moments[0].to_bits(), ...)` to test exact bit preservation.
- Modified files: `crates/gam-model-kernels/src/cubic_cell_kernel.rs` and `tests/regressions/misc/cubic_cell_kernel_bug_hunt.rs`.

### Testing
- Ran `cargo test bug_cell_moment_scratch_resize_corrupts_existing_entries --test regressions` and the test passed (`ok`).
- Ran `cargo check -p gam-model-kernels` and the package checked successfully.

---
🤖 Codex Cloud fix for #1838 (task `task_e_6a457491d4d88324887f94c7c6d60118`). **Unaudited** — review before merge.

Closes #1838