### PR TITLE
Calibrate cross-class stacking with rank-aware evidence offsets

### DIFF
--- a/crates/gam-solve/src/topology_selector.rs
+++ b/crates/gam-solve/src/topology_selector.rs
@@ -35,13 +35,13 @@
 //! exist only during the race; it is not retained for the saved-model
 //! prediction path. That OOS-retention package is out of scope here.
 
-use crate::row_sampling_measure::CoresetCertificate;
 use crate::evidence::{
     GaussianMixtureConfig, StackingConfig, StackingWeights, TopologyScoreScale,
     UNION_STRUCTURE_LADDER, UnionStructure, UnionStructureFit, fit_gaussian_mixture,
     fit_union_ladder, fit_union_structure, solve_stacking_weights, union_per_point_log_density,
 };
 use crate::priority_selection::{PriorityCandidate, rank_priority_candidates};
+use crate::row_sampling_measure::CoresetCertificate;
 use ndarray::{Array2, ArrayView2};
 use serde_json::Value as JsonValue;
 use std::sync::Mutex;
@@ -1487,9 +1487,39 @@ pub fn adjudicate_cross_class_race(
     }
 
     // Cross-class: build the selection-time held-out density table and stack.
+    //
+    // The CV column is a plug-in predictive density: each fold refits the
+    // candidate and evaluates held-out rows at the fitted point estimate.  For
+    // flexible finite mixtures that plug-in score is optimistically sharp on
+    // smooth one-dimensional clouds (a handful of elongated Gaussian blobs can
+    // tile a ring), while the smooth S¹ candidate pays its parameter price in
+    // the evidence scalar only.  The race therefore has to put the two pieces
+    // on the same predictive scale before stacking: use the rank-aware Laplace
+    // negative log evidence as a per-observation model-prior offset.  This is
+    // the selection-time analogue of posterior predictive model comparison:
+    // holdout density supplies local predictive fit, and the marginal evidence
+    // supplies the Occam factor for candidate-class complexity.
+    let evidence_offsets: Vec<f64> = evidence
+        .iter()
+        .map(|&nle| {
+            if nle.is_finite() {
+                -nle / n.max(1) as f64
+            } else {
+                f64::NEG_INFINITY
+            }
+        })
+        .collect();
     let providers: Vec<HeldOutDensityProvider<'_>> =
         candidates.into_iter().map(|c| c.density_provider).collect();
-    let table = build_cv_log_density_table(n, folds, seed, &providers)?;
+    let mut table = build_cv_log_density_table(n, folds, seed, &providers)?;
+    for col in 0..table.ncols() {
+        let offset = evidence_offsets[col];
+        for row in 0..table.nrows() {
+            if table[[row, col]].is_finite() {
+                table[[row, col]] += offset;
+            }
+        }
+    }
     let stacking = solve_stacking_weights(table.view(), stacking_config)?;
     // Headline winner = max stacking weight (most predictive mass).
     let mut winner_index = 0usize;


### PR DESCRIPTION
### Motivation
- Cross-class shape races were over-crediting flexible finite mixtures (e.g. `mixture_k7`) on continuous circular data because the CV plug-in per-point log-densities and the marginal Laplace evidence lived on different effective scales.
- The selector must combine held-out predictive fit and the Occam/marginal-evidence penalty in a principled, per-observation way so smooth S¹ candidates are not unjustly displaced by optimistic plug-in mixture scores.

### Description
- Apply a per-candidate per-observation offset computed from the rank-aware Laplace negative-log-evidence rate before solving stacking weights: compute `evidence_offsets` as `-negative_log_evidence / n` and add this offset to every finite entry of the corresponding CV `table[[row, col]]`.
- Build the held-out CV table as before via `build_cv_log_density_table`, then mutate the table with the `evidence_offsets` prior to calling `solve_stacking_weights`, preserving the headline selection by maximum stacking weight.
- Small import/format tidying in `crates/gam-solve/src/topology_selector.rs` alongside the change.

### Testing
- Ran `cargo check -q -p gam-solve` which completed successfully.
- Verified `git diff --check -- crates/gam-solve/src/topology_selector.rs` (no spacing/check issues) and committed the change.
- Attempted the targeted integration test `circle_regime_gam_selects_smooth_circle_not_mixture_via_interpolated_holdout`, but the end-to-end test build repeatedly exceeded the session/compile time for the large test suite, so no runtime assertion result could be produced in this run.

---
🤖 Codex Cloud fix for #1849 (task `task_e_6a4574e501b083249262a606403424a4`). **Unaudited** — review before merge.

Closes #1849