### PR TITLE
Fix projected penalty-subspace trace to use canonical kernel for dense/operator drifts

### DIFF
--- a/crates/gam-solve/src/reml/reml_outer_engine/hyper_operator.rs
+++ b/crates/gam-solve/src/reml/reml_outer_engine/hyper_operator.rs
@@ -423,9 +423,22 @@ pub(crate) fn penalty_subspace_trace_drifts_batched(
     kernel: &PenaltySubspaceTrace,
     drifts: &[DriftDerivResult],
 ) -> Vec<f64> {
-    let factor = penalty_subspace_trace_factor(kernel);
-    let cache = ProjectedFactorCache::default();
-    trace_logdet_drifts_projected_factor_batched(drifts, &factor, &cache)
+    drifts
+        .iter()
+        .map(|drift| {
+            match drift {
+                // Use the canonical reduced-kernel contraction for dense drifts
+                // so the projected logdet value and its trace derivative share
+                // exactly the same eigenbasis/inverse. This is essential for
+                // composite drifts `B_i + D_βH[β_i]`: evaluating the dense
+                // component through a separately factorized square root can
+                // make the projected logdet value and gradient describe
+                // slightly different kernels.
+                DriftDerivResult::Dense(matrix) => kernel.trace_projected_logdet(matrix),
+                DriftDerivResult::Operator(op) => kernel.trace_operator(op.as_ref()),
+            }
+        })
+        .collect()
 }
 
 pub(crate) fn penalty_subspace_reduce_drifts_batched(


### PR DESCRIPTION
### Motivation
- The projected joint-penalty logdet path produced a value that matched `½ log|H|` but its trace-gradient omitted/mismatched the `D_βH[β_i]` mode-response coupling for coupled families because the batched projected-trace path mixed different kernel contractions for dense vs operator drifts, desynchronizing value and analytic gradient.

### Description
- Route the projected penalty-subspace trace batching so dense drifts use `PenaltySubspaceTrace::trace_projected_logdet` and operator drifts use `PenaltySubspaceTrace::trace_operator`, ensuring both value and trace-gradient use the same reduced spectral kernel and inverse for composite drifts such as `B_i + D_βH[β_i]`.
- Replace the previous factorized / mixed batched factor path with a single canonical per-drift contraction, keeping the implementation local to the RE-ML outer-engine hyper-operator batching logic (`penalty_subspace_trace_drifts_batched`).
- Change is minimal and focused to keep the projected logdet value and its derivative paired on the identical kernel/inverse.

### Testing
- Ran `cargo check -p gam-solve`, which completed successfully.
- Ran the targeted autodiff test `exact_joint_quadratic_lamlgradient_matches_three_autodiff_engines`; the test still fails locally with a small numeric discrepancy (`abs_err=1.802e-10` vs AD band `8.840e-11`) at `rho=-1.2`, indicating further numeric investigation may be required for tight AD agreement but the change closes the conceptual kernel mismatch between value and trace contraction.

---
🤖 Codex Cloud fix for #1820 (task `task_e_6a457407c53c83248a45ae60d5a35689`). **Unaudited** — review before merge.

Closes #1820