### PR TITLE
Recover spatial-κ optimizer from NaN frequentist covariance (treat as infeasible trial point)

### DIFF
--- a/crates/gam-models/src/fit_orchestration/drivers/design_construction.rs
+++ b/crates/gam-models/src/fit_orchestration/drivers/design_construction.rs
@@ -6353,11 +6353,59 @@ fn fit_score(fit: &UnifiedFitResult) -> f64 {
 /// trust-region solver retreats, rather than aborting the entire REML fit.
 ///
 /// A `BasisError` is exactly this class: it means "the basis/design cannot be
-/// built at this hyperparameter". Everything else (PIRLS divergence wired to a
-/// distinct variant, layout/topology invariants, over-parameterization) stays
-/// fatal so genuine bugs are never masked.
+/// built at this hyperparameter". The same retreat semantics also apply when a
+/// trial reaches the inner solve but produces a singular/unstable curvature:
+/// those cases are reported by the shared inner-solve retreat classifier, or
+/// by the final fit validator when an inference-only matrix derived from
+/// `H⁻¹` (not the fitted mean coefficients themselves) becomes non-finite.
+/// Everything else (layout/topology invariants, over-parameterization, and
+/// arbitrary invalid inputs) stays fatal so genuine bugs are never masked.
 fn is_recoverable_trial_point_error(err: &EstimationError) -> bool {
     matches!(err, EstimationError::BasisError(_))
+        || err.is_inner_solve_retreat()
+        || is_recoverable_fit_inference_finiteness_error(err)
+}
+
+fn is_recoverable_fit_inference_finiteness_error(err: &EstimationError) -> bool {
+    let EstimationError::InvalidInput(message) = err else {
+        return false;
+    };
+
+    message.contains("must be finite")
+        && [
+            "fit_result.beta_covariance_frequentist",
+            "fit_result.coefficient_influence",
+            "fit_result.weighted_gram",
+        ]
+        .iter()
+        .any(|field| message.contains(field))
+}
+
+#[cfg(test)]
+mod spatial_trial_recovery_tests {
+    use super::*;
+
+    #[test]
+    fn nonfinite_frequentist_covariance_is_recoverable_trial_point() {
+        let err = EstimationError::InvalidInput(
+            "fit_result.beta_covariance_frequentist[0] must be finite, got NaN".to_string(),
+        );
+
+        assert!(
+            is_recoverable_trial_point_error(&err),
+            "singular trial-point curvature should make spatial κ retreat, not abort"
+        );
+    }
+
+    #[test]
+    fn arbitrary_invalid_input_remains_fatal_trial_point_error() {
+        let err = EstimationError::InvalidInput("outer rho bounds are invalid".to_string());
+
+        assert!(
+            !is_recoverable_trial_point_error(&err),
+            "the spatial κ recovery gate must not mask unrelated invalid inputs"
+        );
+    }
 }
 
 fn require_successful_spatial_optimization_result<T>(


### PR DESCRIPTION
### Motivation
- Fix the spatial κ optimizer aborting when a trial point produced a NaN frequentist covariance (e.g. `Ve = F·H⁻¹` when `H` is near-singular) instead of retreating with objective +∞ as intended.  
- Root cause: the recovery gate `is_recoverable_trial_point_error` only accepted `BasisError` and therefore treated other recoverable diagnostics (inner-solve retreats and inference-only non-finiteness reported as `InvalidInput`) as fatal.  

### Description
- Broaden `is_recoverable_trial_point_error` in `crates/gam-models/src/fit_orchestration/drivers/design_construction.rs` to also accept `err.is_inner_solve_retreat()` and a new helper `is_recoverable_fit_inference_finiteness_error(err)` that recognizes `EstimationError::InvalidInput` messages that indicate non-finite inference matrices (checks for `"must be finite"` and fields like `fit_result.beta_covariance_frequentist`, `fit_result.coefficient_influence`, `fit_result.weighted_gram`).  
- Added the helper function `is_recoverable_fit_inference_finiteness_error` that safely classifies those `InvalidInput` messages as recoverable trial-point infeasibilities.  
- Preserved fatal behavior for unrelated `InvalidInput` messages so unrelated configuration/layout errors remain hard failures.  
- Added unit tests (`spatial_trial_recovery_tests`) that assert a NaN frequentist covariance `InvalidInput` is treated recoverable and that an unrelated `InvalidInput` stays fatal.  

### Testing
- Ran `cargo test -p gam-models spatial_trial_recovery_tests --lib` and the two new tests passed (2 passed, 0 failed).  
- Attempted a larger targeted test (`cargo test -p gam families::narrow_gaussian_bump_quality::narrow_gaussian_bump_peak_and_baseline`) but the compilation/test invocation stalled on the CI artifact lock in this environment and could not be completed here.

---
🤖 Codex Cloud fix for #1827 (task `task_e_6a45743dc05083248bd33b85a6d42433`). **Unaudited** — review before merge.

Closes #1827