### PR TITLE
Ensure Matérn basis has sufficient centers for exact adaptive regularization

### DIFF
--- a/crates/gam-models/src/fit_orchestration/drivers/design_construction.rs
+++ b/crates/gam-models/src/fit_orchestration/drivers/design_construction.rs
@@ -216,17 +216,61 @@ fn fit_term_collection_forspecwith_heuristic_lambdas(
     family: LikelihoodSpec,
     options: &FitOptions,
 ) -> Result<FittedTermCollection, EstimationError> {
-    let base_design = build_term_collection_design(data, spec)?;
+    let adaptive_opts = options.adaptive_regularization.clone().unwrap_or_default();
+    let resolved_spec;
+    let design_spec = if adaptive_opts.enabled {
+        resolved_spec = ensure_matern_adaptive_center_resolution(spec, data.nrows());
+        &resolved_spec
+    } else {
+        spec
+    };
+    let base_design = build_term_collection_design(data, design_spec)?;
     fit_term_collection_on_realized_design(
         y,
         weights,
         offset,
-        spec,
+        design_spec,
         &base_design,
         heuristic_lambdas,
         family,
         options,
     )
+}
+
+fn ensure_matern_adaptive_center_resolution(
+    spec: &TermCollectionSpec,
+    n_rows: usize,
+) -> TermCollectionSpec {
+    let mut out = spec.clone();
+    for term in &mut out.smooth_terms {
+        let gam_terms::smooth::SmoothBasisSpec::Matern {
+            feature_cols,
+            spec: matern,
+            ..
+        } = &mut term.basis
+        else {
+            continue;
+        };
+        if let gam_terms::basis::CenterStrategy::FarthestPoint { num_centers } =
+            &mut matern.center_strategy
+        {
+            // Exact spatial-adaptive regularization estimates three operator
+            // weights from the fitted Matérn field and its first/second
+            // collocation derivatives.  That is a richer hyperproblem than the
+            // ordinary quadratic Matérn fit: with fewer centers than the
+            // coordinate dimension's linear scale, the radial span cannot carry
+            // even low-order directional structure, so REML can only explain the
+            // signal by pushing the adaptive operator weights into the
+            // over-smoothed mean basin.  Treat user-supplied FarthestPoint counts
+            // as a lower bound for this exact-adaptive path and ensure a modest
+            // O(d) collocation resolution.  Existing larger bases are left
+            // untouched, and the cap at n_rows preserves the reduced-rank
+            // contract.
+            let min_centers = (4 * feature_cols.len()).min(n_rows).max(*num_centers);
+            *num_centers = min_centers;
+        }
+    }
+    out
 }
 
 fn has_bounded_linear_terms(spec: &TermCollectionSpec) -> bool {


### PR DESCRIPTION
### Motivation
- Adaptive Charbonnier/Matérn hyperfit was over-smoothing toward the mean because the exact adaptive overlay was operating on under-resolved radial bases, leaving no directional collocation information for the operator-weight hyperfit to use.
- The root cause is under-sized Matérn center counts (user `FarthestPoint` values) that are fine for the quadratic baseline fit but too small for the richer exact adaptive problem.

### Description
- Add `ensure_matern_adaptive_center_resolution` which clones the incoming `TermCollectionSpec` and, for every `Matern` term using `FarthestPoint`, raises `num_centers` to at least `min_centers = (4 * d).min(n_rows).max(current)` where `d` is the number of feature columns, leaving larger bases unchanged and capping by `n_rows`.
- Wire this step into `fit_term_collection_forspecwith_heuristic_lambdas` so the pre-build spec passed to `build_term_collection_design` is the resolved one when `adaptive_regularization` is enabled, and leave non-adaptive fits untouched.
- Document reasoning inline: the exact adaptive overlay estimates three operator weights from field + derivative collocations, so a modest O(d) collocation resolution is required to expose directional structure.

### Testing
- Ran the targeted failing test `tests/basis_smooth/smooths::matern_integration::matern_fit_term_collection_gaussian_simulated_10dwith_exact_adaptive_regularization` which now passes.
- Ran the whole `tests/basis_smooth/smooths::matern_integration` suite (3 tests) which all pass.
- Performed `cargo check -p gam-models` to ensure the crate remains build-clean; it succeeded.

---
🤖 Codex Cloud fix for #1864 (task `task_e_6a457572cc2083248b0db476b45467d8`). **Unaudited** — review before merge.

Closes #1864