### PR TITLE
Include lambda uncertainty in smooth LR reference df

### DIFF
--- a/crates/gam-models/src/fit_orchestration/drivers/spatial_optimization.rs
+++ b/crates/gam-models/src/fit_orchestration/drivers/spatial_optimization.rs
@@ -9286,9 +9286,16 @@ pub fn smooth_term_lr_inference_forspec(
         } else {
             0.0
         };
-        let ref_df = wood_reference_df(influence, &coeff_range)
+        let rho_uncertainty_df = wps_block_uncertainty_df(
+            full.fit.weighted_gram(),
+            full.fit.smoothing_correction(),
+            &coeff_range,
+            family_disp,
+        );
+        let ref_df = (wood_reference_df(influence, &coeff_range)
             .unwrap_or(0.0)
             .max(edf)
+            + rho_uncertainty_df)
             .max(null_dim as f64)
             .max(unconverged_dim_floor)
             .max(1.0);
@@ -9460,6 +9467,40 @@ fn lawley_dispersion_for_family(family: &LikelihoodSpec, fit: &UnifiedFitResult)
             }
         }
         _ => 1.0,
+    }
+}
+
+fn wps_block_uncertainty_df(
+    weighted_gram: Option<&Array2<f64>>,
+    smoothing_correction: Option<&Array2<f64>>,
+    coeff_range: &Range<usize>,
+    phi: f64,
+) -> f64 {
+    let (Some(xwx), Some(corr)) = (weighted_gram, smoothing_correction) else {
+        return 0.0;
+    };
+    let (start, end) = (coeff_range.start, coeff_range.end);
+    if start >= end
+        || end > xwx.nrows()
+        || end > xwx.ncols()
+        || end > corr.nrows()
+        || end > corr.ncols()
+        || !(phi.is_finite() && phi > 0.0)
+    {
+        return 0.0;
+    }
+
+    let mut trace = 0.0;
+    for i in start..end {
+        for j in start..end {
+            trace += xwx[[i, j]] * corr[[j, i]];
+        }
+    }
+    trace /= phi;
+    if trace.is_finite() && trace > 0.0 {
+        trace
+    } else {
+        0.0
     }
 }
 


### PR DESCRIPTION
### Motivation
- The post-selection likelihood-ratio test was anti-conservative at small n because the χ² reference degrees-of-freedom used for the LR did not account for sampling variation in the estimated smoothing parameters (λ̂), leaving the reference too tight when λ was chosen from the same data.

### Description
- Add a local Wood–Pya–Säfken smoothing-parameter uncertainty contribution for the tested coefficient block by introducing `wps_block_uncertainty_df` which computes the block trace `tr((X'WX)_jj Σ_{ρ,jj})/φ` from the fit's `weighted_gram` and `smoothing_correction` artifacts with shape and finiteness guards.
- Add the computed `rho_uncertainty_df` into the LR test `ref_df` (before applying the existing safety floors) so the per-term χ² reference accounts for λ-estimation uncertainty in addition to the coefficient-space Wood `edf1`.
- Keep the existing fallback and safety logic unchanged (positive/finiteness guards, unconverged-floor behavior, and the Bartlett/Lawley correction machinery remain intact).

### Testing
- Ran `cargo check -p gam-models` which completed successfully.
- Attempted the focused failing test `cargo test -p gam --test basis_smooth smooth_term_lr_size_calibration::null_simulation_size_is_calibrated_small_n -- --nocapture`, but compilation of the full dependency graph and linking in this environment exhausted resources and was stopped; no test result was produced for that full harness here.
- No tests were removed or loosened; the change is limited to adding the WPS block contribution and retains all existing guards so that the existing LR/Bartlett code paths exercise the new df automatically when `weighted_gram` and `smoothing_correction` are present.

---
🤖 Codex Cloud fix for #1872 (task `task_e_6a4575e7aeec8324b5f1d11e6e95398c`). **Unaudited** — review before merge.

Closes #1872