### PR TITLE
Treat Gamma(1,0) precision prior as equivalent to `Flat` for REML rho-prior policy

### DIFF
--- a/crates/gam-solve/src/reml/objective.rs
+++ b/crates/gam-solve/src/reml/objective.rs
@@ -3697,15 +3697,25 @@ mod tk_math_tests {
     pub(crate) fn firth_default_pc_prior_fills_flat_holes() {
         let pc = firth_default_pc_prior();
         let configured = RhoPrior::Normal { mean: 0.1, sd: 2.0 };
+        let flat_gamma = RhoPrior::GammaPrecision {
+            shape: 1.0,
+            rate: 0.0,
+        };
         // A whole `Flat` prior becomes the weak PC default.
         assert_eq!(*resolve_effective_rho_prior(&RhoPrior::Flat), pc);
+        // Gamma(1, 0) is the same flat MAP-in-λ prior and follows the same path.
+        assert_eq!(*resolve_effective_rho_prior(&flat_gamma), pc);
         // An explicitly-configured prior is honored unchanged (no override).
         assert_eq!(*resolve_effective_rho_prior(&configured), configured);
-        // Only the `Flat` coordinates of an Independent prior inherit the PC.
-        let indep = RhoPrior::Independent(vec![RhoPrior::Flat, configured.clone()]);
+        // Only flat coordinates of an Independent prior inherit the PC.
+        let indep = RhoPrior::Independent(vec![
+            RhoPrior::Flat,
+            configured.clone(),
+            flat_gamma.clone(),
+        ]);
         assert_eq!(
             *resolve_effective_rho_prior(&indep),
-            RhoPrior::Independent(vec![pc.clone(), configured.clone()])
+            RhoPrior::Independent(vec![pc.clone(), configured.clone(), pc.clone()])
         );
         // An Independent prior with no Flat holes is left untouched.
         let no_holes = RhoPrior::Independent(vec![configured.clone(), configured.clone()]);
@@ -3716,11 +3726,14 @@ mod tk_math_tests {
     pub(crate) fn firth_default_coord_mask_marks_only_flat_coordinates() {
         // Whole-Flat → every coordinate is a firth default.
         assert_eq!(firth_default_coord_mask(&RhoPrior::Flat, 3), vec![true; 3]);
-        // Independent → only the Flat holes are defaults.
+        // Independent → only mathematically flat holes are defaults.
         let indep = RhoPrior::Independent(vec![
             RhoPrior::Flat,
             RhoPrior::Normal { mean: 0.0, sd: 1.0 },
-            RhoPrior::Flat,
+            RhoPrior::GammaPrecision {
+                shape: 1.0,
+                rate: 0.0,
+            },
         ]);
         assert_eq!(firth_default_coord_mask(&indep, 3), vec![true, false, true]);
         // An explicitly-configured scalar prior defaults nothing.

--- a/crates/gam-solve/src/reml/state_caches.rs
+++ b/crates/gam-solve/src/reml/state_caches.rs
@@ -1723,17 +1723,38 @@ pub(crate) fn firth_default_pc_prior() -> RhoPrior {
     }
 }
 
+/// A Gamma prior on the physical precision `λ` with shape `1` and rate `0` has
+/// density proportional to a constant in `λ`. Under the deterministic
+/// MAP-in-`λ` REML convention used for [`RhoPrior::GammaPrecision`], its
+/// negative-log contribution is exactly zero (cost/gradient/Hessian all vanish),
+/// so it is semantically the same "unset/flat" coordinate as [`RhoPrior::Flat`].
+///
+/// Keep this equivalence explicit at the prior-policy boundary. Otherwise an
+/// `Independent([GammaPrecision { shape: 1, rate: 0 }])` is treated as an
+/// explicitly configured prior while `Flat` is treated as an unset coordinate,
+/// sending mathematically identical fits through different default-prior and
+/// seed-selection branches.
+#[inline]
+pub(crate) fn is_unset_flat_rho_prior(prior: &RhoPrior) -> bool {
+    match prior {
+        RhoPrior::Flat => true,
+        RhoPrior::GammaPrecision { shape, rate } => *shape == 1.0 && *rate == 0.0,
+        _ => false,
+    }
+}
+
 /// Per-coordinate `true` where the firth-general default barrier (rather than an
 /// explicitly-configured prior) governs that smoothing coordinate. A coordinate
-/// is a firth default exactly when the caller left it `Flat`: the whole prior is
-/// `Flat` (every coordinate defaulted) or it is an `Independent` with `Flat`
-/// holes. Returned per-`ρ`-coordinate so the runtime can override just those
-/// coordinates' objective contribution with the self-gated barrier.
+/// is a firth default exactly when the caller left it mathematically flat:
+/// `Flat`, or the equivalent `GammaPrecision { shape: 1, rate: 0 }`, either as a
+/// whole prior or as holes in an `Independent` prior. Returned per-`ρ`-coordinate
+/// so the runtime can override just those coordinates' objective contribution
+/// with the self-gated barrier.
 pub(crate) fn firth_default_coord_mask(configured: &RhoPrior, len: usize) -> Vec<bool> {
     match configured {
         RhoPrior::Flat => vec![true; len],
         RhoPrior::Independent(priors) if priors.len() == len => {
-            priors.iter().map(|p| matches!(p, RhoPrior::Flat)).collect()
+            priors.iter().map(is_unset_flat_rho_prior).collect()
         }
         _ => vec![false; len],
     }
@@ -1742,8 +1763,8 @@ pub(crate) fn firth_default_coord_mask(configured: &RhoPrior, len: usize) -> Vec
 /// Resolve the *effective* outer ρ prior under the (unconditional) firth-general
 /// default policy.
 ///
-/// An *unset* prior (the `Flat` sentinel — whole-prior, or any `Flat` coordinate
-/// of an `Independent`) is filled with the weakly-informative
+/// An *unset* prior (the `Flat` sentinel or equivalent Gamma(1, 0) flat prior —
+/// whole-prior, or any such coordinate of an `Independent`) is filled with the weakly-informative
 /// [`firth_default_pc_prior`]; any explicitly-configured prior is honored
 /// unchanged. Pulled out as a free function so the decision is unit-testable
 /// without constructing a full `RemlState`.
@@ -1751,13 +1772,18 @@ pub(crate) fn resolve_effective_rho_prior(configured: &RhoPrior) -> std::borrow:
     match configured {
         // Whole prior unset → fill every coordinate with the weak PC default.
         RhoPrior::Flat => std::borrow::Cow::Owned(firth_default_pc_prior()),
+        // Gamma(1, 0) is exactly flat in the deterministic MAP-in-λ convention,
+        // so route it through the same unset path as `Flat`.
+        RhoPrior::GammaPrecision { shape, rate } if *shape == 1.0 && *rate == 0.0 => {
+            std::borrow::Cow::Owned(firth_default_pc_prior())
+        }
         // Per-coordinate priors: only the `Flat` (unset) coordinates inherit the
         // PC default; explicitly configured coordinates are preserved.
-        RhoPrior::Independent(priors) if priors.iter().any(|p| matches!(p, RhoPrior::Flat)) => {
+        RhoPrior::Independent(priors) if priors.iter().any(is_unset_flat_rho_prior) => {
             let filled = priors
                 .iter()
                 .map(|p| match p {
-                    RhoPrior::Flat => firth_default_pc_prior(),
+                    p if is_unset_flat_rho_prior(p) => firth_default_pc_prior(),
                     other => other.clone(),
                 })
                 .collect();


### PR DESCRIPTION
### Motivation
- A Gamma precision prior with `shape = 1.0` and `rate = 0.0` is mathematically constant in the physical precision `λ` under the MAP-in-`λ` convention and should therefore be a bitwise no-op relative to the uninformed `Flat` prior, but the runtime treated it as an explicit prior and routed fits through different default-prior / seed-selection branches.
- This mismatch caused the flat block-gamma precision prior to perturb REML/MAP updates and fail the bitwise-identical comparison test.

### Description
- Add `is_unset_flat_rho_prior` to recognize `RhoPrior::Flat` and `RhoPrior::GammaPrecision { shape: 1.0, rate: 0.0 }` as mathematically unset/flat at the prior-policy boundary.
- Use `is_unset_flat_rho_prior` in `firth_default_coord_mask` so per-coordinate masking treats scalar `Gamma(1,0)` holes the same as `Flat` holes.
- Update `resolve_effective_rho_prior` to route whole-prior `Gamma(1,0)` and `Independent` coordinates matching the flat predicate into the same `firth_default_pc_prior` fill path as `Flat`.
- Extend existing tests in `reml::objective` to assert `Gamma(1,0)` equivalence for both scalar and `Independent`-hole cases and update related comments.

### Testing
- Ran `cargo check -q -p gam-solve` which completed successfully.
- Executed the targeted basis_smooth test `cargo test -q --test basis_smooth flat_gamma_precision_prior_matches_uninformed_fit_bitwise -- --nocapture` and it passed.
- Exercised the updated unit tests in `crates/gam-solve` covering `firth_default` behavior and the new `Gamma(1,0)` cases, which passed; an earlier broad `cargo test` attempt failed due to environment disk exhaustion but was unrelated to the code change and was resolved by a `cargo clean` before re-running the targeted tests.

---
🤖 Codex Cloud fix for #1882 (task `task_e_6a457669996c832493f6a821ebadd5a4`). **Unaudited** — review before merge.

Closes #1882