### PR TITLE
Fix random-effect BLUP recovery

### DIFF
--- a/crates/gam-data/src/lib.rs
+++ b/crates/gam-data/src/lib.rs
@@ -2,9 +2,53 @@ use csv::{ReaderBuilder, StringRecord};
 use ndarray::{Array2, Axis};
 use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
+use std::cmp::Ordering;
 use std::collections::{HashMap, HashSet};
 use std::fmt;
 use std::path::Path;
+
+fn natural_level_cmp(a: &str, b: &str) -> Ordering {
+    let mut ia = 0;
+    let mut ib = 0;
+    let ba = a.as_bytes();
+    let bb = b.as_bytes();
+    while ia < ba.len() && ib < bb.len() {
+        if ba[ia].is_ascii_digit() && bb[ib].is_ascii_digit() {
+            let sa = ia;
+            let sb = ib;
+            while ia < ba.len() && ba[ia].is_ascii_digit() {
+                ia += 1;
+            }
+            while ib < bb.len() && bb[ib].is_ascii_digit() {
+                ib += 1;
+            }
+            let da = &a[sa..ia];
+            let db = &b[sb..ib];
+            let ta = da.trim_start_matches('0');
+            let tb = db.trim_start_matches('0');
+            let ta = if ta.is_empty() { "0" } else { ta };
+            let tb = if tb.is_empty() { "0" } else { tb };
+            match ta.len().cmp(&tb.len()).then_with(|| ta.cmp(tb)) {
+                Ordering::Equal if da.len() != db.len() => return da.len().cmp(&db.len()),
+                Ordering::Equal => {}
+                ord => return ord,
+            }
+        } else {
+            match ba[ia].cmp(&bb[ib]) {
+                Ordering::Equal => {
+                    ia += 1;
+                    ib += 1;
+                }
+                ord => return ord,
+            }
+        }
+    }
+    ba.len().cmp(&bb.len())
+}
+
+fn sort_levels_canonical(levels: &mut [String]) {
+    levels.sort_by(|a, b| natural_level_cmp(a, b));
+}
 
 // ---------------------------------------------------------------------------
 // Typed error
@@ -781,7 +825,7 @@ fn infer_delimited_column(
                 new_idx
             });
         }
-        levels.sort();
+        sort_levels_canonical(&mut levels);
         level_index.clear();
         for (idx, level) in levels.iter().enumerate() {
             level_index.insert(level.clone(), idx);
@@ -2036,11 +2080,12 @@ fn infer_schema_column(
     } else {
         ColumnKindTag::Categorical
     };
-    // Canonical (sorted) level order — see `infer_and_encode_column_major`. The
+    // Canonical natural-sorted level order — see `infer_and_encode_column_major`. The
     // record-driven and column-major inference paths must produce byte-identical
-    // schemas, so both sort the level set lexicographically (#1319).
+    // schemas, so both sort the level set with the same natural comparator
+    // (#1319).
     if matches!(kind, ColumnKindTag::Categorical) {
-        levels.sort();
+        sort_levels_canonical(&mut levels);
     }
     Ok(SchemaColumn {
         name: name.to_string(),
@@ -2152,9 +2197,10 @@ pub fn infer_and_encode_column_major(
     // row-shuffle would permute the output) instead of on the class labels
     // (#1319). Sorting makes the encoding a deterministic function of the label
     // *set*, independent of row order, and matches the factor convention so
-    // column `k` of a multinomial prediction is class `levels[k]`.
+    // column `k` of a multinomial prediction is class `levels[k]`. Use natural
+    // ordering so generated labels like g2 stay before g10.
     if matches!(kind, ColumnKindTag::Categorical) {
-        levels.sort();
+        sort_levels_canonical(&mut levels);
     }
     let schema = SchemaColumn {
         name: name.to_string(),

--- a/crates/gam-terms/src/smooth/term_specs.rs
+++ b/crates/gam-terms/src/smooth/term_specs.rs
@@ -5731,14 +5731,17 @@ pub fn build_random_effect_block(
         }
         levels.clone()
     } else {
-        let mut levels_set = BTreeSet::<u64>::new();
+        let mut seen = BTreeSet::<u64>::new();
+        let mut levels = Vec::<u64>::new();
         for &v in col {
-            levels_set.insert(v.to_bits());
+            let bits = v.to_bits();
+            if seen.insert(bits) {
+                levels.push(bits);
+            }
         }
-        if levels_set.is_empty() {
+        if levels.is_empty() {
             crate::bail_invalid_basis!("random-effect term '{}' has no observed levels", spec.name);
         }
-        let levels: Vec<u64> = levels_set.into_iter().collect();
         let start_idx = if spec.drop_first_level && levels.len() > 1 {
             1usize
         } else {
@@ -6715,10 +6718,32 @@ pub fn build_factor_smooth(
         joint_null_rotation: None,
     };
     let inner = build_single_local_smooth_term(data, &inner_term, workspace)?;
-    let base = inner
+    let mut base = inner
         .design
         .try_to_dense_by_chunks("factor smooth marginal")
         .map_err(BasisError::InvalidInput)?;
+    if matches!(spec.flavour, FactorSmoothFlavour::Re) {
+        // `bs="re"` is a parametric random intercept+slope, not a B-spline
+        // smooth evaluated through clamped knot support.  A degree-1 B-spline
+        // with no internal knots spans the training rows, but outside the
+        // boundary knots its basis is not the model matrix for `(1 + x | g)`;
+        // held-out extrapolation then loses the random slope contribution.
+        // Build the random-effect marginal directly as `[1, x - c]`, centered
+        // at the frozen marginal domain, so fit-time and replay-time rows use
+        // the same well-conditioned parametric columns on and off the training
+        // interval.
+        let center = match &inner.metadata {
+            BasisMetadata::BSpline1D { knots, .. } if !knots.is_empty() => {
+                0.5 * (knots[0] + knots[knots.len() - 1])
+            }
+            _ => 0.0,
+        };
+        let mut linear = Array2::<f64>::ones((data.nrows(), 2));
+        linear
+            .column_mut(1)
+            .assign(&data.column(feature_col).mapv(|x| x - center));
+        base = linear;
+    }
     let n = base.nrows();
     let p = base.ncols();
     let q = p * n_levels;
@@ -6743,25 +6768,33 @@ pub fn build_factor_smooth(
     // Penalties: replicate each marginal penalty into a block-diagonal
     // `I_L ⊗ S_j` so every level shares the same smoothing parameter λ_j (one
     // λ per marginal penalty), the defining feature of a factor smooth. For
-    // `Re` the marginal penalty is replaced by an identity ridge so each
-    // per-level coefficient is an iid Gaussian random effect.
+    // `Re` the marginal penalty is replaced by one ridge per parametric
+    // coordinate so intercept and slope variances can be learned separately.
     let marginal_penalties: Vec<Array2<f64>> = if matches!(spec.flavour, FactorSmoothFlavour::Re) {
-        vec![Array2::<f64>::eye(p)]
+        (0..p)
+            .map(|j| {
+                let mut s = Array2::<f64>::zeros((p, p));
+                s[[j, j]] = 1.0;
+                s
+            })
+            .collect()
     } else {
         inner.penalties.clone()
     };
     let marginal_penaltyinfo: Vec<PenaltyInfo> = if matches!(spec.flavour, FactorSmoothFlavour::Re)
     {
-        vec![PenaltyInfo {
-            source: PenaltySource::Primary,
-            original_index: 0,
-            active: true,
-            effective_rank: p,
-            dropped_reason: None,
-            nullspace_dim_hint: 0,
-            normalization_scale: 1.0,
-            kronecker_factors: None,
-        }]
+        (0..p)
+            .map(|j| PenaltyInfo {
+                source: PenaltySource::Primary,
+                original_index: j,
+                active: true,
+                effective_rank: 1,
+                dropped_reason: None,
+                nullspace_dim_hint: p.saturating_sub(1),
+                normalization_scale: 1.0,
+                kronecker_factors: None,
+            })
+            .collect()
     } else {
         inner.penaltyinfo.clone()
     };
@@ -6795,7 +6828,7 @@ pub fn build_factor_smooth(
     }
 
     let mut nullspaces: Vec<usize> = if matches!(spec.flavour, FactorSmoothFlavour::Re) {
-        vec![0]
+        vec![q.saturating_sub(n_levels); p]
     } else {
         inner
             .nullspaces


### PR DESCRIPTION
### Motivation
- Random-effect BLUP / partial pooling produced garbage per-group estimates because group-level encoding and the `bs="re"` marginal construction did not match the parametric random-intercept+slope semantics, breaking BLUP ordering and shrinkage.
- The defect affected both the `group()` random-intercept path (ordering / level mapping) and the `bs="re"` random-slope path (marginal basis and penalty topology), so a single coordinated fix was required in basis construction and categorical-level handling.

### Description
- Preserve first-observed level ordering when building unfrozen `group()` random-effect blocks so coefficient indices align with the encoded group ids used by BLUP extraction, implemented in `crates/gam-terms/src/smooth/term_specs.rs`.
- Make `bs="re"` factor-smooth marginal a centered parametric design `[1, x - c]` (center `c` from the frozen marginal domain) instead of relying on clamped B-spline columns so fit-time and replay-time rows use the same parametric columns on/off the training interval, implemented in `crates/gam-terms/src/smooth/term_specs.rs`.
- Replace the single identity ridge for `bs="re"` with one ridge (separate penalty coordinate) per parametric coordinate (intercept and slope) so REML can learn distinct partial-pooling strengths, implemented in `crates/gam-terms/src/smooth/term_specs.rs` (penalty and `PenaltyInfo` construction updated).
- Make categorical-level ordering deterministic and natural-sorted across record-driven and column-major encoders (so labels like `g2` come before `g10`) by adding a natural comparator and canonical sort in `crates/gam-data/src/lib.rs` so encoded-level alignment is stable across code paths.

### Testing
- Ran the targeted randomized/behavioral regression and quality tests: `cargo test -p gam --test quality re_random_slope_partial_pools_toward_population -- --nocapture` and `cargo test -p gam --test regressions group_random_intercept -- --nocapture`, and both suites passed (the formerly failing `re_random_slope_partial_pools_toward_population`, `group_random_intercept_fits_above_sparse_exact_threshold`, and `group_random_intercept_just_below_threshold_still_fits` now succeed).
- Ran a smoke `cargo test -p gam --test regressions` selection to confirm the sparse-exact smoothing-correction path also materializes the corrected covariance; tests passed.
- Ran `cargo fmt --check` (noted existing unrelated formatting diffs in the tree prior to this PR); the functional changes were kept minimal and idiomatic and all targeted tests passed.

---
🤖 Codex Cloud fix for #1886 (task `task_e_6a4576a46f388324acc52d700fc659a8`). **Unaudited** — review before merge.

Closes #1886