### PR TITLE
Fix marginal-slope wall-clock deadline arming

### DIFF
--- a/crates/gam-models/src/bms/block_specs.rs
+++ b/crates/gam-models/src/bms/block_specs.rs
@@ -1743,6 +1743,31 @@ pub fn fit_bernoulli_marginal_slope_terms(
     kappa_options: &SpatialLengthScaleOptimizationOptions,
     policy: &gam_runtime::resource::ResourcePolicy,
 ) -> Result<BernoulliMarginalSlopeFitResult, String> {
+    // gam#1794: Bernoulli/flex marginal-slope runs through the same coupled
+    // exact-joint inner solves as survival marginal-slope, so it needs the same
+    // fit-level fuse. Without it, non-certification in startup validation or
+    // flex PIRLS scaling probes can spin until the harness hard-timeouts.
+    crate::marginal_slope_shared::arm_marginal_slope_outer_wall_clock_deadline(
+        kappa_options.outer_wall_clock_budget_secs,
+    );
+    let result = fit_bernoulli_marginal_slope_terms_impl(
+        data,
+        spec,
+        options,
+        kappa_options,
+        policy,
+    );
+    gam_solve::rho_optimizer::clear_outer_wall_clock_deadline();
+    result
+}
+
+fn fit_bernoulli_marginal_slope_terms_impl(
+    data: ArrayView2<'_, f64>,
+    spec: BernoulliMarginalSlopeTermSpec,
+    options: &BlockwiseFitOptions,
+    kappa_options: &SpatialLengthScaleOptimizationOptions,
+    policy: &gam_runtime::resource::ResourcePolicy,
+) -> Result<BernoulliMarginalSlopeFitResult, String> {
     let mut spec = spec;
     let data_view = data;
     validate_spec(data_view, &spec)?;

--- a/crates/gam-models/src/fit_orchestration/request.rs
+++ b/crates/gam-models/src/fit_orchestration/request.rs
@@ -437,11 +437,11 @@ pub struct FitConfig {
     /// standard formula fits. `None` uses the production default.
     pub outer_max_iter: Option<usize>,
     /// Optional wall-clock budget (seconds) for the outer smoothing search
-    /// (gam#979). Threaded to the survival marginal-slope fit, whose constrained
+    /// (gam#979/#1794). Threaded to marginal-slope fits whose constrained
     /// joint-Newton can fail to certify convergence and otherwise grind without
     /// bound; with this set the fit returns its best-so-far iterate (or a
-    /// catchable error) within the budget instead of hanging. `None` keeps the
-    /// generous built-in default for that path and is unbounded elsewhere.
+    /// catchable error) within the budget instead of hanging. `None` uses the
+    /// bounded built-in marginal-slope default.
     pub outer_wall_clock_budget_secs: Option<f64>,
 
     /// GPU backend selection policy. `Auto` uses supported device kernels for

--- a/crates/gam-models/src/marginal_slope_shared.rs
+++ b/crates/gam-models/src/marginal_slope_shared.rs
@@ -37,6 +37,25 @@ use ndarray::{Array1, Array2, Axis};
 use std::ops::Range;
 use std::sync::Arc;
 
+/// Default whole-fit wall-clock budget for marginal-slope families.
+///
+/// This is a defensive fuse, not a convergence criterion: it bounds known
+/// joint-Newton non-certification paths so callers get a catchable error before
+/// common test/CI harnesses kill the process. Explicit caller budgets still win.
+pub(crate) const DEFAULT_MARGINAL_SLOPE_OUTER_WALL_CLOCK_BUDGET_SECS: f64 = 30.0;
+
+/// Arms the shared fit-level deadline used by marginal-slope fits and returns
+/// the budget that was installed. Callers must clear the deadline on every exit.
+pub(crate) fn arm_marginal_slope_outer_wall_clock_deadline(budget_secs: Option<f64>) -> f64 {
+    let budget_secs = budget_secs
+        .unwrap_or(DEFAULT_MARGINAL_SLOPE_OUTER_WALL_CLOCK_BUDGET_SECS)
+        .max(1.0);
+    gam_solve::rho_optimizer::arm_outer_wall_clock_deadline(
+        std::time::Instant::now() + std::time::Duration::from_secs_f64(budget_secs),
+    );
+    budget_secs
+}
+
 /// Canonical inner-cache `beta_seed` validator passed to the generic
 /// outer-engine (`optimize_spatial_length_scale_exact_joint`).
 ///
@@ -2146,5 +2165,30 @@ mod tests {
             "weight_scale {} not near 5.0",
             scale
         );
+    }
+}
+
+#[cfg(test)]
+mod deadline_tests {
+    use super::*;
+
+    #[test]
+    fn marginal_slope_deadline_helper_uses_bounded_default_and_honors_override() {
+        gam_solve::rho_optimizer::clear_outer_wall_clock_deadline();
+
+        let default_budget = arm_marginal_slope_outer_wall_clock_deadline(None);
+        assert_eq!(
+            default_budget, DEFAULT_MARGINAL_SLOPE_OUTER_WALL_CLOCK_BUDGET_SECS,
+            "None should install the shared bounded marginal-slope default, not the old 300s survival-only budget"
+        );
+        assert!(
+            !gam_solve::rho_optimizer::outer_wall_clock_deadline_exceeded(),
+            "freshly armed default budget should not already be expired"
+        );
+        gam_solve::rho_optimizer::clear_outer_wall_clock_deadline();
+
+        let explicit_budget = arm_marginal_slope_outer_wall_clock_deadline(Some(0.25));
+        assert_eq!(explicit_budget, 1.0, "explicit tiny budgets are floored");
+        gam_solve::rho_optimizer::clear_outer_wall_clock_deadline();
     }
 }

--- a/crates/gam-models/src/survival/marginal_slope/fit_entry.rs
+++ b/crates/gam-models/src/survival/marginal_slope/fit_entry.rs
@@ -8,16 +8,14 @@ pub fn fit_survival_marginal_slope_terms(
     options: &BlockwiseFitOptions,
     kappa_options: &SpatialLengthScaleOptimizationOptions,
 ) -> Result<SurvivalMarginalSlopeFitResult, String> {
-    // gam#979: bound the whole fit so the survival marginal-slope outer search —
-    // whose constrained joint-Newton cannot certify convergence on the
-    // monotonicity-pinned baseline, so seed screening escalates to an uncapped
-    // cycle budget while every seed rejects — returns its best-so-far iterate
-    // (or a catchable error) in bounded time instead of hanging. Configurable
-    // via kappa_options; generous default. Cleared on EVERY exit path so a stale
-    // deadline never leaks to a later fit.
-    let budget_secs = kappa_options.outer_wall_clock_budget_secs.unwrap_or(300.0);
-    gam_solve::rho_optimizer::arm_outer_wall_clock_deadline(
-        std::time::Instant::now() + std::time::Duration::from_secs_f64(budget_secs.max(1.0)),
+    // gam#979/#1794: bound the whole fit so marginal-slope outer searches whose
+    // joint-Newton inner solves cannot certify convergence return a catchable
+    // error in bounded time instead of spinning until an external harness kills
+    // the process. The default is intentionally below common per-test timeouts;
+    // explicit kappa_options still override it. Cleared on EVERY exit path so a
+    // stale deadline never leaks to a later fit.
+    crate::marginal_slope_shared::arm_marginal_slope_outer_wall_clock_deadline(
+        kappa_options.outer_wall_clock_budget_secs,
     );
     let result = fit_survival_marginal_slope_terms_impl(data, spec, options, kappa_options);
     gam_solve::rho_optimizer::clear_outer_wall_clock_deadline();

--- a/crates/gam-terms/src/smooth/term_specs.rs
+++ b/crates/gam-terms/src/smooth/term_specs.rs
@@ -3926,11 +3926,9 @@ pub struct SpatialLengthScaleOptimizationOptions {
     pub pilot_subsample_threshold: usize,
     /// Optional wall-clock budget (seconds) for the whole outer smoothing search
     /// (gam#979). When a family arms the global deadline from this, an outer
-    /// search that cannot certify convergence (survival marginal-slope's
-    /// monotonicity-pinned constrained joint-Newton) returns its best-so-far
-    /// iterate (or a catchable error) within the budget instead of hanging.
-    /// `None` keeps the legacy unbounded behavior; the survival marginal-slope
-    /// path applies a generous default when this is `None`.
+    /// search that cannot certify convergence returns its best-so-far iterate
+    /// (or a catchable error) within the budget instead of hanging. `None` lets
+    /// marginal-slope fit entries apply their bounded built-in default.
     pub outer_wall_clock_budget_secs: Option<f64>,
 }
 


### PR DESCRIPTION
### Motivation
- The marginal-slope fit-level wall-clock deadline was only armed on the survival entry and used a generous 300s fallback, causing CI tests to TIMEOUT and leaving the BMS/flex paths unbounded when inner joint-Newton non-certification stalls.  
- Provide a consistent, conservative safety fuse for all marginal-slope families so non-convergent inner solves return a catchable error rather than spinning until external harness timeouts.

### Description
- Add a shared helper and bounded default: introduce `DEFAULT_MARGINAL_SLOPE_OUTER_WALL_CLOCK_BUDGET_SECS = 30.0` and `arm_marginal_slope_outer_wall_clock_deadline` in `crates/gam-models/src/marginal_slope_shared.rs`, which arms `gam_solve::rho_optimizer::arm_outer_wall_clock_deadline` and floors tiny budgets to `1.0` second.  
- Use the helper from both marginal-slope entry points: replace the ad-hoc 300s behavior in `crates/gam-models/src/survival/marginal_slope/fit_entry.rs` and arm/clear the deadline around the Bernoulli/flex entry in `crates/gam-models/src/bms/block_specs.rs` so both survival and BMS/flex paths install the same deadline.  
- Update option documentation to reflect that marginal-slope fits apply a bounded built-in default when `outer_wall_clock_budget_secs` is `None` in `crates/gam-models/src/fit_orchestration/request.rs` and `crates/gam-terms/src/smooth/term_specs.rs`.  
- Add a unit test `marginal_slope_deadline_helper_uses_bounded_default_and_honors_override` in `crates/gam-models/src/marginal_slope_shared.rs` to assert the helper uses the bounded default and that tiny explicit budgets are floored.

### Testing
- Ran `cargo check -p gam-models --lib`, which completed successfully.  
- Ran `git diff --check`, which reported no issues.  
- Attempted the targeted unit test `cargo test -p gam-models marginal_slope_deadline_helper_uses_bounded_default_and_honors_override`, but the test-harness build did not finish within the available execution window; the helper is covered by the added unit test and the library build passed.

---
🤖 Codex Cloud fix for #1794 (task `task_e_6a45734897b88324a47eb23c92f0938c`). **Unaudited** — review before merge.

Closes #1794