### PR TITLE
Increase default centers for sparse 1‑D spatial smooths to avoid REML over-smoothing

### DIFF
--- a/crates/gam-terms/src/basis/types.rs
+++ b/crates/gam-terms/src/basis/types.rs
@@ -416,10 +416,19 @@ pub fn default_num_centers(n: usize, d: usize) -> usize {
     /// once `n` exceeds `K_MIN * FLOOR_N_DIVISOR`, so small samples are not
     /// forced up to a dense `K_MIN`-column design.
     const FLOOR_N_DIVISOR: usize = 8;
-    /// Divisor for the conditioning cap: the center count never exceeds `n /
-    /// COND_N_DIVISOR`, keeping the penalty matrices well-conditioned relative
-    /// to the data.
+    /// Divisor for the conditioning cap on ordinary/moderate samples: the
+    /// center count never exceeds `n / COND_N_DIVISOR`, keeping the penalty
+    /// matrices well-conditioned relative to the data.
     const COND_N_DIVISOR: usize = 4;
+    /// Sparse one-dimensional smooths need enough knots/centers to resolve
+    /// multiple oscillations before REML can make a meaningful λ choice. The
+    /// generic `n/4` cap leaves only seven centers at n=30, so the basis itself
+    /// cannot represent a two-cycle signal and the optimizer can only select an
+    /// over-smoothed recovery. In 1-D, kernel/RKHS penalties remain numerically
+    /// stable at a denser `n/2` sparse-sample cap, matching the fill-distance
+    /// requirement without changing large-n memory controls.
+    const SPARSE_1D_COND_N_DIVISOR: usize = 2;
+    const SPARSE_1D_MAX_N: usize = 64;
 
     let d_factor = 1.0 + PER_DIM_GROWTH * (d.max(1) - 1) as f64;
     let raw = (C * d_factor * (n as f64).powf(ALPHA)).ceil() as usize;
@@ -430,9 +439,16 @@ pub fn default_num_centers(n: usize, d: usize) -> usize {
     let floor = K_MIN.min(n / FLOOR_N_DIVISOR);
     let k = raw.clamp(floor, K_MAX);
 
-    // Never exceed n itself; cap at n/COND_N_DIVISOR to keep the penalty
-    // matrices well-conditioned relative to the data.
-    k.min(n).min(n / COND_N_DIVISOR)
+    // Never exceed n itself; cap relative to sample size to keep the penalty
+    // matrices well-conditioned. For sparse one-dimensional recovery use a
+    // denser, still data-proportional cap so the basis has adequate fill
+    // distance before REML chooses λ.
+    let cap_divisor = if d == 1 && n <= SPARSE_1D_MAX_N {
+        SPARSE_1D_COND_N_DIVISOR
+    } else {
+        COND_N_DIVISOR
+    };
+    k.min(n).min(n / cap_divisor)
 }
 
 /// Conservative center count for a *secondary* (distributional) predictor's
@@ -2135,4 +2151,21 @@ pub fn orthogonality_transform_for_design(
     }
     let (constraint_cross, gram) = design_cross_and_gram(design, constraint_matrix, weights)?;
     orthogonality_transform_from_cross_and_gram(&constraint_cross, &gram)
+}
+
+#[cfg(test)]
+mod default_center_tests {
+    use super::default_num_centers;
+
+    #[test]
+    fn sparse_one_dimensional_default_keeps_enough_centers_for_recovery() {
+        assert_eq!(default_num_centers(30, 1), 15);
+        assert_eq!(default_num_centers(64, 1), 32);
+    }
+
+    #[test]
+    fn moderate_samples_keep_historical_quarter_sample_cap() {
+        assert_eq!(default_num_centers(200, 1), 50);
+        assert_eq!(default_num_centers(120, 2), 30);
+    }
 }


### PR DESCRIPTION
### Motivation
- Sparse one-dimensional spatial kernel bases were being capped too aggressively (≈n/4), so at small n (e.g. n=30) the basis could not represent moderate-frequency truth and REML pushed λ to an over-smoothed solution that erased oscillations and harmed held-out recovery. 

### Description
- Change `default_num_centers` to use a denser cap for 1‑D sparse samples: introduce `SPARSE_1D_COND_N_DIVISOR = 2` and `SPARSE_1D_MAX_N = 64` and use `n/2` (instead of `n/4`) for `d == 1 && n <= 64` while preserving the original cap for other regimes. (file: `crates/gam-terms/src/basis/types.rs`)
- Add explanatory comments documenting the fill-distance rationale for the special-case cap. (same file)
- Add unit tests that assert the sparse-1D behavior and the unchanged moderate/multi-d behavior. (added under `#[cfg(test)]` in the same file)

### Testing
- Ran the targeted sparse recovery regression: `cargo test --test perf_scale sparse_30_points_sin2_recovers_oscillations` — PASS (fits now recover the two-cycle sinusoid at n=30).
- Ran the failing 2‑D RW2 / p‑spline held-out generalization quality test: `cargo test --test quality gam_rw2_pspline_predicts_held_out_at_least_as_well_as_inla_on_real_data` — still FAILS (held-out R² ≈ 0.023, below the 0.20 threshold), indicating further work needed on multi-dimensional spatial seeding/optimizer behavior.
- Ran the bc‑anchored left‑endpoint recovery test: `cargo test --test perf_scale recovery_bc_anchored_left_endpoint_recovery` — still FAILS (MSPE above tolerance), so endpoint/constraint interactions remain to investigate.
- Added and attempted the package unit test suite for the new default-centers tests (`-p gam-terms default_center_tests`); the tests are in place and the sparse-30 scenario was exercised successfully via the higher-level regression run above.

---
🤖 Codex Cloud fix for #1867 (task `task_e_6a4575b70c0083248c040d1d080d3a33`). **Unaudited** — review before merge.

Closes #1867