### PR TITLE
Protect marginal-slope absorber from over-orthogonalization and scale absorber ridge with n

### DIFF
--- a/crates/gam-models/src/bms/block_specs.rs
+++ b/crates/gam-models/src/bms/block_specs.rs
@@ -4,7 +4,7 @@ use super::hessian_paths::{new_cell_moment_cache_stats, new_cell_moment_lru_cach
 use super::install_flex::validate_spec;
 use super::*;
 use gam_linalg::faer_ndarray::{FaerEigh, fast_ab, fast_atb, fast_xt_diag_x};
-use crate::marginal_slope_orthogonal::INFLUENCE_ABSORBER_FIXED_LOG_LAMBDA;
+use crate::marginal_slope_orthogonal::influence_absorber_log_lambda;
 use faer::Side;
 
 /// Sup-norm of the FITTED marginal linear predictor `η = X·β` at which the
@@ -1986,45 +1986,57 @@ pub fn fit_bernoulli_marginal_slope_terms(
     // Absorbed Stage-1 influence columns (#461, design §3). When the workflow
     // chained a CTN Stage-1 into this marginal-slope fit, `spec.score_influence_
     // jacobian` carries the out-of-fold `J = ∂z/∂θ₁`; the realized leakage
-    // directions `Z_infl = diag(s_f·β̂₀)·J` are residualised against the
-    // marginal span (logslope-aligned component retained) and appended to the
-    // additive marginal-index block as a fixed-ridge absorber, so the joint
-    // penalised solve makes the (α,β) score orthogonal to span(Z_infl) — the
-    // x-dependent realisation of `ψ − Π_η[ψ]`. `None` ⇒ raw z, and the free
-    // score_warp spline below is the x-free-column fallback. β̂₀(x_i) is the
-    // rigid-pilot logslope `baseline.1 + logslope_offset[i]`; s_f = probit_scale.
+    // directions `Z_infl = diag(s_f·β̂₀)·J` are residualised against the fitted
+    // marginal+logslope target span and appended to the additive marginal-index
+    // block as a fixed-ridge absorber, so the joint penalised solve makes the
+    // (α,β) score orthogonal to the remaining nuisance span without letting the
+    // absorber compete for identifiable β(x) signal. `None` ⇒ raw z, and the
+    // free score_warp spline below is the x-free-column fallback. β̂₀(x_i) is
+    // the rigid-pilot logslope `baseline.1 + logslope_offset[i]`; s_f =
+    // probit_scale.
     let influence_columns = if let Some(jac) = spec
         .score_influence_jacobian
         .as_ref()
         .filter(|j| j.ncols() > 0)
     {
-        let marginal_dense_for_proj = marginal_design
-            .design
-            .try_to_dense_arc("bernoulli marginal-slope influence-block marginal projection")?;
-        let marginal_dense = marginal_dense_for_proj.as_ref();
-        if jac.nrows() != marginal_dense.nrows() {
+        let protected_design = DesignMatrix::hstack(vec![
+            marginal_design.design.clone(),
+            logslope_design.design.clone(),
+        ])
+        .map_err(|e| {
+            format!(
+                "bernoulli marginal-slope influence-block protected projection stack failed to concatenate marginal + logslope design: {e}"
+            )
+        })?;
+        let protected_dense_for_proj = protected_design
+            .try_to_dense_arc("bernoulli marginal-slope influence-block protected projection")?;
+        let protected_dense = protected_dense_for_proj.as_ref();
+        if jac.nrows() != protected_dense.nrows() {
             return Err(format!(
-                "influence block: Jacobian has {} rows, marginal design has {}",
+                "influence block: Jacobian has {} rows, protected design has {}",
                 jac.nrows(),
-                marginal_dense.nrows()
+                protected_dense.nrows()
             ));
         }
-        // Z̃ = residualize(diag(s_f·β̂₀)·J) against the marginal span in the
-        // rigid-pilot W-metric, via the SHARED core entry point (single source
-        // of truth across bms + survival; the two families differ ONLY in how
-        // they install the returned Z̃ — bms widens [M | Z̃], survival adds a
-        // dedicated η₁ channel). β̂₀(x_i) = baseline.1 + logslope_offset[i];
-        // s_f = probit_scale; W = the rigid-pilot PIRLS row metric.
+        // Z̃ = residualize(diag(s_f·β̂₀)·J) against the fitted target span in
+        // the rigid-pilot W-metric.  For BMS the absorbed columns are installed
+        // in the same additive predictor as the marginal surface; if we protect
+        // only M, any component of Z_infl aligned with the logslope design G can
+        // be assigned to the fixed-ridge absorber by the joint solve, erasing
+        // genuine β(x) heterogeneity.  Projecting out [M | G] keeps the nuisance
+        // absorber orthogonal to both parametric target surfaces while still
+        // absorbing Stage-1 leakage directions outside that identifiable target
+        // span. β̂₀(x_i) = baseline.1 + logslope_offset[i]; s_f = probit_scale;
+        // W = the rigid-pilot PIRLS row metric.
         let rigid_logslope_at_rows = &spec.logslope_offset + baseline.1;
-        let residualized =
-            crate::marginal_slope_orthogonal::residualized_influence_block(
-                jac,
-                z_train,
-                &rigid_logslope_at_rows,
-                probit_scale,
-                marginal_dense.view(),
-                &cross_block_pilot_w_score_warp,
-            )?;
+        let residualized = crate::marginal_slope_orthogonal::residualized_influence_block(
+            jac,
+            z_train,
+            &rigid_logslope_at_rows,
+            probit_scale,
+            protected_dense.view(),
+            &cross_block_pilot_w_score_warp,
+        )?;
         Some(residualized)
     } else {
         None
@@ -2310,7 +2322,7 @@ pub fn fit_bernoulli_marginal_slope_terms(
                 baseline.1,
                 p_m,
                 influence_columns.as_ref(),
-                INFLUENCE_ABSORBER_FIXED_LOG_LAMBDA,
+                influence_absorber_log_lambda(spec.z.len()),
             )?,
             build_logslope_blockspec_bms(
                 logslope_design,

--- a/crates/gam-models/src/marginal_slope_orthogonal.rs
+++ b/crates/gam-models/src/marginal_slope_orthogonal.rs
@@ -32,30 +32,43 @@
 //! `k = 0` is the unconstrained location block `b(x)`; rows `k ≥ 1` are the
 //! squared SCOP shape blocks for `γ_k(x)`.
 
-use gam_linalg::faer_ndarray::{
-    FaerArrayView, factorize_symmetricwith_fallback, fast_ab, fast_abt, fast_xt_diag_x,
-    fast_xt_diag_y,
+use crate::inference::model::TRANSFORMATION_SCORE_PIT_CLIP_EPS;
+use crate::probability::{
+    log1mexp_positive, normal_cdf, normal_logcdf, normal_pdf, standard_normal_quantile,
 };
 use crate::transformation_normal::{
     TRANSFORMATION_MONOTONICITY_EPS, TransformationNormalFitResult, transformation_normal_pit_score,
 };
-use crate::inference::model::TRANSFORMATION_SCORE_PIT_CLIP_EPS;
-use gam_linalg::matrix::FactorizedSystem;
-use crate::probability::{
-    log1mexp_positive, normal_cdf, normal_logcdf, normal_pdf, standard_normal_quantile,
-};
-use gam_terms::smooth::build_term_collection_design;
 use faer::Side;
+use gam_linalg::faer_ndarray::{
+    FaerArrayView, factorize_symmetricwith_fallback, fast_ab, fast_abt, fast_xt_diag_x,
+    fast_xt_diag_y,
+};
+use gam_linalg::matrix::FactorizedSystem;
+use gam_terms::smooth::build_term_collection_design;
 use ndarray::{Array1, Array2, ArrayView2};
 
-/// Fixed (NOT REML-learned) log-λ for the influence-absorber block's ridge.
+/// Baseline fixed (NOT REML-learned) log-λ for the influence-absorber block's
+/// ridge.
 ///
-/// The §3 absorbed block `+Z_infl·γ` carries a small fixed ridge `½·ρ·‖γ‖²`
-/// (`ρ = exp(log_λ)`) so the joint solve soaks the `span(Z_infl)` component of
-/// the η-residual into `γ` without that block being treated as a smooth/REML
-/// surface. `log_λ = 0` ⇒ `ρ = 1`: enough to keep `γ` finite and bounded while
-/// the much larger marginal/logslope likelihood curvature dominates the fit.
+/// The §3 absorbed block `+Z_infl·γ` is an estimating-equation correction, not a
+/// new outcome surface. Its ridge therefore has to live on the same O(n) scale as
+/// the likelihood curvature; otherwise, as n grows, an O(1) ridge makes the
+/// absorber effectively unpenalized and it can fit genuine β(x) signal.  Keep the
+/// historical constant as the lower bound and use [`influence_absorber_log_lambda`]
+/// at call sites that know the training-row count.
 pub(crate) const INFLUENCE_ABSORBER_FIXED_LOG_LAMBDA: f64 = 0.0;
+
+/// Fixed absorber ridge for `n_rows` observations.
+///
+/// Penalizing γ by roughly one unit per observation keeps the absorber a nuisance
+/// leakage correction rather than a competing flexible target surface, while the
+/// residualized columns still contribute when their score improvement is O(n).
+pub(crate) fn influence_absorber_log_lambda(n_rows: usize) -> f64 {
+    (n_rows.max(1) as f64)
+        .ln()
+        .max(INFLUENCE_ABSORBER_FIXED_LOG_LAMBDA)
+}
 
 /// Per-row, per-θ₁ score-influence Jacobian `∂z/∂θ₁` for a fitted CTN, plus the
 /// latent score `z` itself on the same rows.


### PR DESCRIPTION
### Motivation
- The marginal-slope Neyman-orthogonal absorber was overreaching: `Z_infl` was being residualized only against the marginal design `M`, which allowed the absorber to claim components aligned with the logslope design `G` and thereby erase genuine β(x) heterogeneity (Sim B power loss).
- The absorber used a constant O(1) fixed ridge, which can become effectively unpenalized as sample size grows and let the absorber compete with identifiable target surfaces.

### Description
- Residualize influence columns against the combined marginal+logslope target span rather than marginal alone by building a protected design `hstack([M, G])` and passing its dense view into `residualized_influence_block` (`crates/gam-models/src/bms/block_specs.rs`).
- Add `influence_absorber_log_lambda(n_rows: usize)` in `marginal_slope_orthogonal.rs` which returns `ln(n_rows)` floored at the existing historical constant, and use it at fit-time so the absorber ridge scales with the training row count instead of remaining an absolute O(1) constant.
- Update imports and inline documentation/comments to explain the protection and ridge-scaling rationale; keep the historical constant as a lower bound so behaviour is backward-compatible when `n=1`.
- Keep the change focused to the marginal-slope orthogonalization path (BMS fit wiring) and the absorber-ridge helper; no tests were weakened or removed.

### Testing
- Ran the focused acceptance test `cargo test -p gam --test inference misc::marginal_slope_neyman_orthogonal_reference::sim_b_orthogonalization_preserves_real_heterogeneity_signal -- --exact --nocapture`, which passed after the change (orthogonalization no longer eats the real β(x) signal).
- Ran `cargo test -p gam --test inference misc::marginal_slope_neyman_orthogonal_reference::sim_a_false_heterogeneity_is_controlled_by_orthogonalization -- --exact --nocapture`; this still failed earlier during the full-data CTN Stage-1 outer solve (pre-existing Stage-1 convergence issue) and did not exercise the BMS absorber change.
- `cargo fmt --check` reported unrelated pre-existing formatting diffs in other files (outside this patch); `git diff --check` produced no new problems introduced by this change.

---
🤖 Codex Cloud fix for #1865 (task `task_e_6a4575a268ec83248422c8da7559b0e9`). **Unaudited** — review before merge.

Closes #1865