### PR TITLE
Improve measure-jet gap basis coverage by boosting representer range for explicit finite bands

### DIFF
--- a/crates/gam-terms/src/basis/measure_jet_smooth.rs
+++ b/crates/gam-terms/src/basis/measure_jet_smooth.rs
@@ -168,6 +168,10 @@ pub(crate) const MEASURE_JET_MAX_AUTO_SCALES: usize = 8;
 /// both at the root without touching the energy penalty or the dials.
 pub(crate) const MEASURE_JET_AUTO_LENGTH_SCALE_FACTOR: f64 = 1.0;
 
+/// Modest extra Gaussian overlap for explicit finite scale bands, so the
+/// representer span covers support gaps the jet penalty is asked to bridge.
+pub(crate) const MEASURE_JET_EXPLICIT_SCALES_LENGTH_SCALE_FACTOR: f64 = 1.32;
+
 /// Single-scale fused-mode weight of the affine-preserving nullspace ridge,
 /// as a fraction of the primary energy penalty's Frobenius scale (#1116). The
 /// ridge's role is identifiability — flooring the fused energy's near-nullspace
@@ -255,6 +259,9 @@ pub struct MeasureJetBasisSpec {
     pub tau0: f64,
     /// Number of scale nodes; `0` sentinel = auto dyadic band.
     pub num_scales: usize,
+    /// True only when the formula supplied `scales=` explicitly.
+    #[serde(default)]
+    pub explicit_num_scales: bool,
     /// Representer (Gaussian RBF) range ℓ; `0.0` sentinel = auto
     /// (median nearest-center spacing × [`MEASURE_JET_AUTO_LENGTH_SCALE_FACTOR`]).
     pub length_scale: f64,
@@ -307,6 +314,7 @@ impl Default for MeasureJetBasisSpec {
             alpha: 1.0,
             tau0: 1e-3,
             num_scales: 0,
+            explicit_num_scales: false,
             length_scale: 0.0,
             double_penalty: true,
             learn_length_scale: false,
@@ -1319,7 +1327,10 @@ pub(crate) fn realize_measure_jet_geometry(
             (nodes, masses, band.eps, band.log_step)
         }
     };
-    let length_scale = realized_measure_jet_length_scale(centers.view(), spec.length_scale)?;
+    let mut length_scale = realized_measure_jet_length_scale(centers.view(), spec.length_scale)?;
+    if spec.length_scale == 0.0 && spec.explicit_num_scales && spec.frozen_quadrature.is_none() {
+        length_scale *= MEASURE_JET_EXPLICIT_SCALES_LENGTH_SCALE_FACTOR;
+    }
     // Realized-design constraint transform: uniform coefficient sum-to-zero
     // at fit time; the frozen composed `z · z_parametric` at predict time
     // (#532 pattern — see MeasureJetIdentifiability).

--- a/crates/gam-terms/src/term_builder.rs
+++ b/crates/gam-terms/src/term_builder.rs
@@ -2712,6 +2712,7 @@ pub fn build_smooth_basis(
                     "measurejet smooth tau must be finite and nonnegative; got {tau0}"
                 ));
             }
+            let explicit_num_scales = options.contains_key("scales");
             let num_scales = option_usize(options, "scales").unwrap_or(0);
             let length_scale = option_f64(options, "length_scale").unwrap_or(0.0);
             if !length_scale.is_finite() || length_scale < 0.0 {
@@ -2746,6 +2747,7 @@ pub fn build_smooth_basis(
                     alpha,
                     tau0,
                     num_scales,
+                    explicit_num_scales,
                     // 0.0 sentinel = auto initialization in the basis builder
                     // (median nearest-center spacing).
                     length_scale,


### PR DESCRIPTION
### Motivation
- The measure-jet predict path was reverting to the global training mean in finite support gaps because the Gaussian representer span was too local and left no active basis inside user-requested finite `scales=` bands.  
- Make the representer span more overlap-friendly when the user explicitly requests a finite scale band so the jet penalty has basis coverage to continue the local affine trend across gaps.

### Description
- Add a boolean `explicit_num_scales` to `MeasureJetBasisSpec` to record whether the formula supplied `scales=` (field `explicit_num_scales`, default `false`).  
- Add `MEASURE_JET_EXPLICIT_SCALES_LENGTH_SCALE_FACTOR` and, when the spec uses auto `length_scale` (spec.length_scale == 0.0) and the formula explicitly requested finite `scales` (and no `frozen_quadrature`), multiply the realized auto `length_scale` by that modest factor so Gaussian representers overlap more across finite-band gaps.  
- Plumb the `explicit_num_scales` flag through the term parser (`term_builder`) so that the basis builder knows formula provenance and applies the boosted auto length-scale only for user-requested finite bands.

### Testing
- Ran the basis unit test that verifies replay/roundtrip (`measure_jet_smooth::tests::build_replay_roundtrip_reproduces_design_and_penalty`) which passed.  
- Ran the integrated web-quality gate (`cargo test -p gam --test measure_jet measure_jet_web_quality_contracts -- --nocapture`), which moved the failure mode (the in-gap collapse assertion was addressed) but the test still fails later on interval-coverage (empirical 95% coverage fell outside the expected window).  
- Ran the parity accuracy test (`cargo test -p gam --test measure_jet measure_jet_single_scale_mode_accuracy_parity -- --nocapture`) which still fails the parity threshold (mjs accuracy remains worse than reference), so further tuning/analysis is required.

---
🤖 Codex Cloud fix for #1845 (task `task_e_6a4574c6d79083249688123c15646e2a`). **Unaudited** — review before merge.

Closes #1845