### PR TITLE
SPEC: grid search is never allowed

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -14,3 +14,4 @@
 - Large, massive changes must be made if that would improve the code--it's not something to be avoided.
 - XFAIL pattern on tests is never allowed. A failing test should always indicate problematic behavior.
 - The goal of this project is never to copy existing reference implementations.
+- Grid search is never allowed.


### PR DESCRIPTION
Adds the invariant that grid search is never allowed (per direct instruction). Note: this bans grid-multistart solver fallbacks.