### PR TITLE
Move softmax_topk torch math to Rust kernels

### DIFF
--- a/crates/gam-pyffi/src/manifold/geometry_ffi.rs
+++ b/crates/gam-pyffi/src/manifold/geometry_ffi.rs
@@ -30,6 +30,120 @@ fn sae_set_ibp_alpha(alpha: f64) {
     gam::terms::sae::assignment::set_ibp_alpha_override(alpha);
 }
 
+#[pyfunction(signature = (centers_1d, d))]
+fn sae_duchon_centers_nd<'py>(
+    py: Python<'py>,
+    centers_1d: PyReadonlyArray1<'py, f64>,
+    d: usize,
+) -> PyResult<Py<PyArray2<f64>>> {
+    let base = centers_1d.as_array();
+    let k = base.len();
+    let mut out = Array2::<f64>::zeros((k, d.max(1)));
+    if k == 0 {
+        return Ok(out.into_pyarray(py).unbind());
+    }
+    for i in 0..k {
+        out[(i, 0)] = base[i];
+    }
+    if d <= 1 {
+        return Ok(out.into_pyarray(py).unbind());
+    }
+    let mut phi = 2.0_f64;
+    for _ in 0..32 {
+        phi = (1.0 + phi).powf(1.0 / d as f64);
+    }
+    for j in 0..(d - 1) {
+        let alpha = (1.0 / phi).powi((j + 1) as i32).rem_euclid(1.0);
+        for i in 0..k {
+            out[(i, j + 1)] = (((i + 1) as f64) * alpha + 0.5).rem_euclid(1.0);
+        }
+    }
+    Ok(out.into_pyarray(py).unbind())
+}
+
+#[pyfunction(signature = (log_scores, iters = 12))]
+fn sae_sinkhorn_balance<'py>(
+    py: Python<'py>,
+    log_scores: PyReadonlyArray2<'py, f64>,
+    iters: usize,
+) -> PyResult<Py<PyArray2<f64>>> {
+    let scores = log_scores.as_array();
+    let (n, f) = scores.dim();
+    if f < 2 || n == 0 {
+        return Ok(scores.to_owned().into_pyarray(py).unbind());
+    }
+    let mut bias = vec![0.0_f64; f];
+    let target = (1.0 / f as f64).ln();
+    for _ in 0..iters {
+        let mut usage = vec![0.0_f64; f];
+        for i in 0..n {
+            let mut max_v = f64::NEG_INFINITY;
+            for k in 0..f {
+                max_v = max_v.max(scores[(i, k)] + bias[k]);
+            }
+            let mut sum = 0.0;
+            for k in 0..f {
+                sum += (scores[(i, k)] + bias[k] - max_v).exp();
+            }
+            for k in 0..f {
+                usage[k] += (scores[(i, k)] + bias[k] - max_v).exp() / sum;
+            }
+        }
+        for u in &mut usage {
+            *u = (*u / n as f64).max(1.0e-12);
+        }
+        for k in 0..f {
+            bias[k] += target - usage[k].ln();
+        }
+        let mean = bias.iter().sum::<f64>() / f as f64;
+        for b in &mut bias {
+            *b -= mean;
+        }
+    }
+    let mut out = scores.to_owned();
+    for i in 0..n {
+        for k in 0..f {
+            out[(i, k)] += bias[k];
+        }
+    }
+    Ok(out.into_pyarray(py).unbind())
+}
+
+#[pyfunction(signature = (logits, temperature))]
+fn sae_topk_activation_value_grad<'py>(
+    py: Python<'py>,
+    logits: PyReadonlyArray2<'py, f64>,
+    temperature: f64,
+) -> PyResult<(Py<PyArray2<f64>>, Py<PyArray2<f64>>)> {
+    if !(temperature.is_finite() && temperature > 0.0) {
+        return Err(py_value_error(format!(
+            "sae_topk_activation_value_grad requires temperature > 0, got {temperature}"
+        )));
+    }
+    let x = logits.as_array();
+    let mut value = Array2::<f64>::zeros(x.dim());
+    let mut grad = Array2::<f64>::zeros(x.dim());
+    for ((i, k), &l) in x.indexed_iter() {
+        let z = l / temperature;
+        let sp = if z > 0.0 {
+            z + (-z).exp().ln_1p()
+        } else {
+            z.exp().ln_1p()
+        };
+        value[(i, k)] = temperature * sp;
+        grad[(i, k)] = if z >= 0.0 {
+            1.0 / (1.0 + (-z).exp())
+        } else {
+            let ez = z.exp();
+            ez / (1.0 + ez)
+        };
+    }
+    Ok((
+        value.into_pyarray(py).unbind(),
+        grad.into_pyarray(py).unbind(),
+    ))
+}
+
 #[pyfunction(signature = (points, mode = "kneedle", knee_slope_fraction = 0.10, complexity_penalty = 0.05, flat_span_tol = 1.0e-6))]
 fn sae_select_k(
     py: Python<'_>,
@@ -4136,6 +4250,9 @@ fn rust_extension(module: &Bound<'_, PyModule>) -> PyResult<()> {
     module.add_function(wrap_pyfunction!(analytic_penalty_value_grad, module)?)?;
     module.add_function(wrap_pyfunction!(analytic_penalty_hvp, module)?)?;
     module.add_function(wrap_pyfunction!(gumbel_schedule_tau, module)?)?;
+    module.add_function(wrap_pyfunction!(sae_duchon_centers_nd, module)?)?;
+    module.add_function(wrap_pyfunction!(sae_sinkhorn_balance, module)?)?;
+    module.add_function(wrap_pyfunction!(sae_topk_activation_value_grad, module)?)?;
     module.add_function(wrap_pyfunction!(sae_ibp_map_value_grad, module)?)?;
     module.add_function(wrap_pyfunction!(sae_jumprelu_row_value_grad, module)?)?;
     module.add_function(wrap_pyfunction!(sae_jumprelu_batch_value_grad, module)?)?;

--- a/gamfit/torch/manifold_sae.py
+++ b/gamfit/torch/manifold_sae.py
@@ -48,7 +48,6 @@ from typing import Any, Callable, Literal, Mapping, cast
 
 import numpy as np
 import torch
-import torch.nn.functional as F_torch
 from torch import nn
 
 from .._binding import rust_module
@@ -556,35 +555,29 @@ def _basis_rust(
 
 
 def _duchon_centers_nd(centers_1d: torch.Tensor, d: int) -> torch.Tensor:
-    """Lift the ``(K,)`` 1-D Duchon centers to a ``(K, d)`` cloud in ``[0, 1]^d``.
+    """Lift 1-D Duchon centers through the Rust generalized-golden-ratio kernel."""
+    out = rust_module().sae_duchon_centers_nd(
+        np.ascontiguousarray(to_numpy_f64(centers_1d).reshape(-1)), int(d)
+    )
+    return from_numpy_like(np.asarray(out, dtype=np.float64), centers_1d)
 
-    Axis 0 keeps the caller's 1-D centers (so the periodic/leading coordinate of
-    a cylinder or product patch is seeded exactly as in the 1-D case). The
-    remaining ``d - 1`` axes are filled by an additive-recurrence (Kronecker /
-    generalized-golden-ratio) low-discrepancy sequence keyed only to ``(K, d)``:
-    deterministic, buffer-free, and non-degenerate (the centers do not collapse
-    onto a diagonal, so the multi-axis Duchon kernel is well-conditioned). The
-    centers are a *fixed* design the decoder learns against, so any deterministic
-    well-spread placement is admissible; this one is reproducible and stable
-    across forward calls without enlarging the serialized state.
-    """
-    base = centers_1d.reshape(-1, 1)
-    k = int(base.shape[0])
-    dtype = base.dtype
-    device = base.device
-    if d <= 1 or k == 0:
-        return base
-    # Generalized golden ratio phi_d: the real root of x^{d} = x + 1; its
-    # reciprocal powers give the canonical R_d low-discrepancy generators.
-    phi = 2.0
-    for _ in range(32):
-        phi = (1.0 + phi) ** (1.0 / float(d))
-    alphas = [((1.0 / phi) ** (j + 1)) % 1.0 for j in range(d - 1)]
-    idx = torch.arange(1, k + 1, dtype=dtype, device=device).reshape(-1, 1)
-    extra = torch.empty((k, d - 1), dtype=dtype, device=device)
-    for j, a in enumerate(alphas):
-        extra[:, j] = torch.remainder(idx[:, 0] * float(a) + 0.5, 1.0)
-    return torch.cat([base, extra], dim=-1)
+
+class _TopKActivationFn(torch.autograd.Function):
+    """``tau * softplus(logits / tau)`` with Rust value and diagonal VJP."""
+
+    @staticmethod
+    def forward(ctx: Any, logits: torch.Tensor, temperature: float) -> torch.Tensor:
+        rows = to_numpy_f64(logits).reshape(logits.shape[0], -1)
+        value, grad = rust_module().sae_topk_activation_value_grad(
+            np.ascontiguousarray(rows), float(temperature)
+        )
+        ctx.save_for_backward(from_numpy_like(grad, logits).reshape_as(logits))
+        return from_numpy_like(value, logits).reshape_as(logits)
+
+    @staticmethod
+    def backward(ctx: Any, grad_output: torch.Tensor) -> tuple[torch.Tensor, None]:
+        (jac_diag,) = ctx.saved_tensors
+        return grad_output * jac_diag, None
 
 
 def _eval_basis_on_manifold(
@@ -774,7 +767,8 @@ class _SparsityLayer(nn.Module):
 
     def _topk_activation(self, logits: torch.Tensor) -> torch.Tensor:
         tau = max(float(self.tau.item()), 1e-6)
-        return tau * F_torch.softplus(logits / tau)
+        apply = cast(Callable[..., torch.Tensor], _TopKActivationFn.apply)
+        return apply(logits, tau)
 
     def _topk_mask(self, scores: torch.Tensor) -> torch.Tensor:
         k = min(self.target_k, scores.shape[-1])
@@ -1398,42 +1392,15 @@ class _SparsityLayer(nn.Module):
     def _sinkhorn_balance(
         log_scores: torch.Tensor, *, iters: int = 12
     ) -> torch.Tensor:
-        """Add per-atom log-bias potentials so atom usage is balanced.
-
-        ``log_scores[n, k]`` are the unnormalized log-responsibilities of row
-        ``n`` for atom ``k`` (already temperature-scaled). We add a per-column
-        (per-atom) potential ``b_k`` and renormalize each row so the resulting
-        responsibilities ``softmax_k(log_scores + b)`` have equal column sums
-        (each atom claims ``N/F`` of the total assignment mass). This is the
-        Sinkhorn projection of the row-stochastic responsibility matrix onto the
-        doubly-balanced transport polytope with a uniform atom marginal; a few
-        fixed-point sweeps converge it. The potentials are computed under
-        ``no_grad`` and treated as constants in the M-step — they only steer the
-        *assignment*, the reconstruction gradient still flows through the
-        residual-driven ``log_scores``.
-        """
-        n_atoms = log_scores.shape[-1]
-        if n_atoms < 2:
+        """Add Rust-computed per-atom log-bias potentials for balanced usage."""
+        if log_scores.shape[-1] < 2:
             return log_scores
         with torch.no_grad():
-            bias = torch.zeros(
-                n_atoms, dtype=log_scores.dtype, device=log_scores.device
+            out = rust_module().sae_sinkhorn_balance(
+                np.ascontiguousarray(to_numpy_f64(log_scores).reshape(log_scores.shape[0], -1)),
+                int(iters),
             )
-            target = torch.log(
-                torch.tensor(
-                    1.0 / float(n_atoms),
-                    dtype=log_scores.dtype,
-                    device=log_scores.device,
-                )
-            )
-            for _ in range(iters):
-                resp = torch.softmax(log_scores + bias, dim=-1)
-                # Mean assignment mass per atom (row-marginal already 1).
-                usage = resp.mean(dim=0).clamp_min(1e-12)
-                # Multiplicative Sinkhorn update toward the uniform marginal.
-                bias = bias + (target - torch.log(usage))
-                bias = bias - bias.mean()
-        return log_scores + bias
+        return from_numpy_like(np.asarray(out, dtype=np.float64), log_scores).reshape_as(log_scores)
 
     def penalty(self, logits: torch.Tensor) -> torch.Tensor:
         """Rust-backed scalar penalty value at ``logits``."""


### PR DESCRIPTION
### Motivation
- Migrate remaining Python numerical math in the `softmax_topk` routing stack into Rust kernels so Python acts only as a thin marshaller and tape glue per the project SPEC. 
- Replace fragile/duplicated Python numeric implementations (Duchon center lifting, Sinkhorn balancing, softplus top-k activation value+grad) with Rust single-source-of-truth kernels to ensure bit-consistent behavior with closed-form code paths and better performance.

### Description
- Added PyO3 kernels in `crates/gam-pyffi/src/manifold/geometry_ffi.rs`: `sae_duchon_centers_nd`, `sae_sinkhorn_balance`, and `sae_topk_activation_value_grad`, and registered them on the Python extension module. 
- Replaced Python `manifold_sae._duchon_centers_nd` with a thin call into `rust_module().sae_duchon_centers_nd` that marshals arrays via `to_numpy_f64` / `from_numpy_like`.
- Replaced Python `_sinkhorn_balance` with a no-grad wrapper that calls `rust_module().sae_sinkhorn_balance` and rewraps the result as a torch tensor.
- Implemented an autograd shim `_TopKActivationFn` that calls `sae_topk_activation_value_grad` in forward and uses the returned diagonal VJP in backward, and updated `_topk_activation` to use that shim so value+grad are Rust-sourced while keeping torch tape continuity.
- Removed the Python inline implementations and a now-unused import, keeping Python responsible only for shape plumbing and autograd tape glue.

### Testing
- Ran `python -m py_compile gamfit/torch/manifold_sae.py` and it succeeded. 
- Ran `git diff --check` to ensure no whitespace or trivial diff errors and it succeeded. 
- Attempted `cargo check -p gam-pyffi`, but the repo-level `build.rs` contains an authorship guard that aborts the root build script early; the guard prevented a full crate build in this environment (no changes to the guard were made here).

---
🤖 Codex Cloud re-dispatch. **Unaudited** — review before merge.

Closes #2011