### PR TITLE
Optimize sparse SAE Schur block GEMM

### DIFF
--- a/crates/gam-solve/src/arrow_schur/solve_options.rs
+++ b/crates/gam-solve/src/arrow_schur/solve_options.rs
@@ -636,19 +636,58 @@ impl BatchedBlockSolver for CpuBatchedBlockSolver {
         // strided reads of `left[[c, a]]` for every (a, b); reorder to
         // (c, a, b) so the inner `b`-loop is contiguous in `right` and
         // `left[[c, a]]` is hoisted out of the inner loop.
+        //
+        // Sparse SAE rows install a matrix-free `H_tβ` operator but the direct
+        // reduced-Schur path still asks `row_htbeta` for a dense `(d_i × K)`
+        // scratch matrix. Those rows have support on only the active atoms
+        // (`top_k · basis · p` columns), so blindly iterating the full `K × K`
+        // product made the Schur assembly compute-bound even though almost every
+        // entry multiplied by zero (#1995). Discover the non-zero column support
+        // of the two row factors once (`O(d_i·K)`) and multiply only the touched
+        // columns (`O(d_i·nnz_left·nnz_right)`). Dense callers still take the same
+        // arithmetic path with all columns active, while compact top-k rows scale
+        // with the active support rather than the global border width.
         let k = schur.nrows();
         let d = left.nrows();
         assert_eq!(left.ncols(), k);
+        assert_eq!(right.nrows(), d);
         assert_eq!(right.ncols(), k);
         assert_eq!(schur.ncols(), k);
+
+        let mut left_active = Vec::with_capacity(k);
+        let mut right_active = Vec::with_capacity(k);
+        for col in 0..k {
+            let mut left_nz = false;
+            let mut right_nz = false;
+            for row in 0..d {
+                left_nz |= left[[row, col]] != 0.0;
+                right_nz |= right[[row, col]] != 0.0;
+                if left_nz && right_nz {
+                    break;
+                }
+            }
+            if left_nz {
+                left_active.push(col);
+            }
+            if right_nz {
+                right_active.push(col);
+            }
+        }
+        if left_active.is_empty() || right_active.is_empty() {
+            return;
+        }
+
         for c in 0..d {
-            for a in 0..k {
+            for &a in &left_active {
                 let lca = left[[c, a]];
                 if lca == 0.0 {
                     continue;
                 }
-                for b in 0..k {
-                    schur[[a, b]] -= lca * right[[c, b]];
+                for &b in &right_active {
+                    let rcb = right[[c, b]];
+                    if rcb != 0.0 {
+                        schur[[a, b]] -= lca * rcb;
+                    }
                 }
             }
         }

--- a/crates/gam-solve/src/arrow_schur/tests.rs
+++ b/crates/gam-solve/src/arrow_schur/tests.rs
@@ -4,6 +4,54 @@ use super::*;
 use approx::assert_abs_diff_eq;
 use ndarray::array;
 
+/// #1995: compact SAE rows hand `block_gemm_subtract` dense scratch matrices
+/// whose nonzeros occupy only the active top-k beta columns. The CPU fallback
+/// must produce the same Schur update as a dense GEMM while doing work only on
+/// the discovered column support.
+#[test]
+pub(crate) fn block_gemm_subtract_matches_dense_on_sparse_column_support() {
+    let backend = CpuBatchedBlockSolver;
+    let d = 3usize;
+    let k = 12usize;
+    let mut left = Array2::<f64>::zeros((d, k));
+    let mut right = Array2::<f64>::zeros((d, k));
+    for (row, col, value) in [
+        (0, 1, 0.7),
+        (1, 1, -0.2),
+        (2, 7, 1.3),
+        (0, 10, -0.4),
+        (2, 10, 0.9),
+    ] {
+        left[[row, col]] = value;
+    }
+    for (row, col, value) in [
+        (0, 2, -1.1),
+        (2, 2, 0.5),
+        (1, 7, 0.8),
+        (0, 11, 0.25),
+        (2, 11, -0.6),
+    ] {
+        right[[row, col]] = value;
+    }
+
+    let mut actual = Array2::<f64>::zeros((k, k));
+    backend.block_gemm_subtract(&mut actual, &left, &right);
+
+    let mut expected = Array2::<f64>::zeros((k, k));
+    for c in 0..d {
+        for a in 0..k {
+            for b in 0..k {
+                expected[[a, b]] -= left[[c, a]] * right[[c, b]];
+            }
+        }
+    }
+    for a in 0..k {
+        for b in 0..k {
+            assert_eq!(actual[[a, b]], expected[[a, b]], "entry ({a}, {b})");
+        }
+    }
+}
+
 /// `SparseBlockKroneckerPenaltyOp` must reproduce the dense
 /// `KroneckerPenaltyOp { factor_a: G, factor_b: I_p }` on every interface
 /// (matvec, gradient, diagonal, to_dense) when the sparse block set covers


### PR DESCRIPTION
### Motivation

- The SAE manifold joint arrow‑Schur assembly was compute‑bound because the CPU fallback `block_gemm_subtract` iterated the full `K×K` column space even when per-row factors were support‑sparse (compact top‑k rows), causing pathological per‑iteration runtime at moderate `K` (#1995).

### Description

- Replace the dense-column triple loop in `CpuBatchedBlockSolver::block_gemm_subtract` with a short discovery pass that finds non‑zero column supports of the `left` and `right` factor matrices and then iterates only the touched columns, preserving the dense path semantics when all columns are active.
- The new path early-returns when no active columns exist and only performs `O(d · nnz_left · nnz_right)` work for sparse rows instead of `O(d · K²)`.
- Add a regression unit test `block_gemm_subtract_matches_dense_on_sparse_column_support` in `crates/gam-solve/src/arrow_schur/tests.rs` that builds sparse-column inputs and verifies the optimized update exactly matches the dense reference.

### Testing

- Ran `cargo test -p gam-solve block_gemm_subtract_matches_dense_on_sparse_column_support --lib` and it passed.
- Ran `cargo test -p gam-solve sparse_block_kronecker_matches_dense_kronecker --lib` and it passed to ensure no regressions in related arrow‑Schur tests.
- Ran `cargo check -p gam-solve` and it completed successfully.
- `cargo fmt --check` was attempted but the repository had unrelated formatting diffs outside this change (not introduced by this patch).

---
🤖 Codex Cloud re-dispatch. **Unaudited** — review before merge.

Closes #1995