### PR TITLE
Add chart-interp and dose–response metrics; expose SAE coordinate posteriors

### DIFF
--- a/bench/_synth_sae_metrics.py
+++ b/bench/_synth_sae_metrics.py
@@ -41,6 +41,7 @@ quality metric must not depend on it.
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import Any
 
 import numpy as np
 
@@ -253,3 +254,145 @@ def recovery_scores(
     return RecoveryScores(
         mcc, precision, recall, f1, jaccard, ceiling, rows, cols, method
     )
+
+
+def _rankdata_average(x: np.ndarray) -> np.ndarray:
+    """Average ranks with deterministic tie handling (SciPy-free)."""
+    x = np.asarray(x, dtype=float).reshape(-1)
+    order = np.argsort(x, kind="mergesort")
+    ranks = np.empty(x.shape[0], dtype=float)
+    i = 0
+    while i < order.size:
+        j = i + 1
+        while j < order.size and x[order[j]] == x[order[i]]:
+            j += 1
+        ranks[order[i:j]] = 0.5 * (i + j - 1) + 1.0
+        i = j
+    return ranks
+
+
+def _pearson(x: np.ndarray, y: np.ndarray) -> float:
+    x = np.asarray(x, dtype=float).reshape(-1)
+    y = np.asarray(y, dtype=float).reshape(-1)
+    mask = np.isfinite(x) & np.isfinite(y)
+    if mask.sum() < 2:
+        return 0.0
+    xc = x[mask] - float(np.mean(x[mask]))
+    yc = y[mask] - float(np.mean(y[mask]))
+    denom = float(np.linalg.norm(xc) * np.linalg.norm(yc))
+    return 0.0 if denom <= 0.0 else float(np.dot(xc, yc) / denom)
+
+
+def spearman_rank_correlation(recovered: np.ndarray, labels: np.ndarray) -> float:
+    """Spearman correlation for non-cyclic chart coordinates."""
+    return _pearson(
+        _rankdata_average(np.asarray(recovered)),
+        _rankdata_average(np.asarray(labels)),
+    )
+
+
+def circular_rank_correlation(
+    recovered: np.ndarray, cyclic_labels: np.ndarray, period: float = 1.0
+) -> float:
+    """Rotation-invariant circular/rank association for 1-D chart coordinates.
+
+    The recovered coordinate is rank-normalized onto a circle, then compared to
+    ground-truth cyclic labels by the magnitude of the first circular moment
+    ``E[exp(i(theta_hat - theta_true))]``. This scores coordinate identity
+    without requiring an arbitrary chart origin or orientation.
+    """
+    rec = np.asarray(recovered, dtype=float).reshape(-1)
+    lab = np.asarray(cyclic_labels, dtype=float).reshape(-1)
+    if rec.size != lab.size:
+        raise ValueError("recovered and cyclic_labels must have the same length")
+    mask = np.isfinite(rec) & np.isfinite(lab)
+    if mask.sum() < 2:
+        return 0.0
+    ranks = (_rankdata_average(rec[mask]) - 0.5) / float(mask.sum())
+    theta_hat = 2.0 * np.pi * ranks
+    theta_true = 2.0 * np.pi * (np.mod(lab[mask], period) / period)
+    return float(abs(np.mean(np.exp(1j * (theta_hat - theta_true)))))
+
+
+def chart_interp_score(
+    recovered_t: np.ndarray,
+    ground_truth_labels: np.ndarray,
+    *,
+    cyclic: bool = True,
+    period: float = 1.0,
+    weights: np.ndarray | None = None,
+) -> dict[str, Any]:
+    """Manifold-native chart-interpretability score for coordinate identity.
+
+    ``recovered_t`` is the scalar coordinate inferred for rows/tokens and
+    ``ground_truth_labels`` is the known concept order/phase. For cyclic charts
+    the headline is the rotation-invariant circular rank correlation; otherwise
+    it is Spearman rank correlation. Optional posterior weights (for example
+    inverse coordinate variance from the row-Hessian solve) select reliable rows
+    but do not change the estimand.
+    """
+    t = np.asarray(recovered_t, dtype=float).reshape(-1)
+    y = np.asarray(ground_truth_labels, dtype=float).reshape(-1)
+    if t.size != y.size:
+        raise ValueError("recovered_t and ground_truth_labels must have the same length")
+    mask = np.isfinite(t) & np.isfinite(y)
+    if weights is not None:
+        w = np.asarray(weights, dtype=float).reshape(-1)
+        if w.size != t.size:
+            raise ValueError("weights must have the same length as recovered_t")
+        mask &= np.isfinite(w) & (w > 0.0)
+    if mask.sum() < 2:
+        score = 0.0
+    elif cyclic:
+        score = circular_rank_correlation(t[mask], y[mask], period=period)
+    else:
+        score = abs(spearman_rank_correlation(t[mask], y[mask]))
+    return {"score": float(score), "n": int(mask.sum()), "cyclic": bool(cyclic)}
+
+
+def dose_response_calibration(
+    predicted_nats: np.ndarray, measured_kl: np.ndarray
+) -> dict[str, float]:
+    """Calibrate predicted steering dose (nats) against measured KL.
+
+    Returns slope-through-origin, intercept/slope linear fit, Pearson
+    correlation, RMSE, MAE, and sample count. The slope-through-origin is the
+    key calibration number: 1.0 means the output-Fisher dose predicts measured
+    KL in natural units.
+    """
+    pred = np.asarray(predicted_nats, dtype=float).reshape(-1)
+    meas = np.asarray(measured_kl, dtype=float).reshape(-1)
+    if pred.size != meas.size:
+        raise ValueError("predicted_nats and measured_kl must have the same length")
+    mask = np.isfinite(pred) & np.isfinite(meas) & (pred >= 0.0) & (meas >= 0.0)
+    if mask.sum() == 0:
+        return {
+            "n": 0,
+            "slope": 0.0,
+            "intercept": 0.0,
+            "linear_slope": 0.0,
+            "pearson": 0.0,
+            "rmse": 0.0,
+            "mae": 0.0,
+        }
+    x = pred[mask]
+    y = meas[mask]
+    denom = float(np.dot(x, x))
+    slope = 0.0 if denom <= 0.0 else float(np.dot(x, y) / denom)
+    if x.size >= 2 and float(np.var(x)) > 0.0:
+        linear_slope, intercept = np.polyfit(x, y, 1)
+        linear_slope = float(linear_slope)
+        intercept = float(intercept)
+    else:
+        linear_slope = slope
+        intercept = 0.0
+    err = y - slope * x
+    return {
+        "n": int(x.size),
+        "slope": float(slope),
+        "intercept": float(intercept),
+        "linear_slope": float(linear_slope),
+        "pearson": _pearson(x, y),
+        "rmse": float(np.sqrt(np.mean(err * err))),
+        "mae": float(np.mean(np.abs(err))),
+    }

--- a/gamfit/_sae_manifold.py
+++ b/gamfit/_sae_manifold.py
@@ -516,6 +516,11 @@ class ManifoldSAE:
     # rank-r subspace. ``None`` when no shard (or no mass_residual) was supplied.
     # Surfaced so a too-small rank ``r`` is visible, not silent.
     fisher_mass_residual: np.ndarray | None = None
+    # Optional per-row, per-atom posterior covariance of the solved intrinsic
+    # coordinates, in the same units as ``coords``. Shape is a list of ``(N,d,d)``
+    # blocks. Fresh Rust payloads may expose this from the row-Hessian factors
+    # already built by the Arrow solve; legacy payloads leave it ``None``.
+    coordinate_posterior_covariance: list[np.ndarray] | None = None
     # Additive two-score per-atom lens (#980): for each atom, ``presence``
     # (representational, activation-side, Fisher-free), ``coupling`` (behavioral
     # output-Fisher mass; ``NaN`` under a Euclidean / no-harvest provenance), and
@@ -835,6 +840,14 @@ class ManifoldSAE:
                 None
                 if payload.get("fisher_mass_residual") is None
                 else np.asarray(payload["fisher_mass_residual"], dtype=float)
+            ),
+            coordinate_posterior_covariance=(
+                None
+                if payload.get("coordinate_posterior_covariance") is None
+                else [
+                    np.asarray(c, dtype=float)
+                    for c in payload["coordinate_posterior_covariance"]
+                ]
             ),
             # Additive post-fit diagnostics: the two-score per-atom lens,
             # residual-gauge certificate, and empirical incoherence inputs.
@@ -1282,6 +1295,45 @@ class ManifoldSAE:
             "fitted": np.asarray(payload["fitted"], dtype=float),
         }
 
+    def coordinate_posteriors(self, X: Any | None = None) -> dict[str, Any]:
+        """Per-token coordinate posterior means and covariance blocks.
+
+        The posterior mean is always the converged coordinate ``t*``. When the
+        fitted payload includes row-Hessian coordinate covariance blocks, they
+        are returned as ``covariance`` and their inverse diagonal precision
+        weights are exposed for downstream manifold-native metrics (chart
+        interpretation and steering calibration). For out-of-sample ``X`` the
+        exact frozen-decoder coordinate solve supplies the means; covariance is
+        currently returned only for the training rows whose Hessian blocks were
+        factored during fitting.
+        """
+        x = None if X is None else _as_2d_float(X, "X")
+        means = self.per_atom_latent_for(self.training_data if x is None else x)
+        cov = (
+            self.coordinate_posterior_covariance
+            if (x is None or self._is_training_data(x))
+            else None
+        )
+        weights: list[np.ndarray] | None = None
+        if cov is not None:
+            weights = []
+            for block in cov:
+                arr = np.asarray(block, dtype=float)
+                if arr.ndim != 3 or arr.shape[1] != arr.shape[2]:
+                    raise ValueError(
+                        "coordinate posterior covariance blocks must have shape (N,d,d); "
+                        f"got {arr.shape}"
+                    )
+                diag = np.diagonal(arr, axis1=1, axis2=2)
+                weights.append(np.where(diag > 0.0, 1.0 / diag, 0.0))
+        return {
+            "mean": [m.copy() for m in means],
+            "covariance": (
+                None if cov is None else [np.asarray(c, dtype=float).copy() for c in cov]
+            ),
+            "precision_weight": weights,
+        }
+
     def project(self, X: Any, atom_k: int) -> np.ndarray:
         """Standalone per-atom projection ``project(x, atom_k) -> t`` (#357).
 
@@ -1617,6 +1669,14 @@ class ManifoldSAE:
             ),
             "metric_provenance": str(self.metric_provenance),
             "fisher_mass_residual": _optional_list(self.fisher_mass_residual),
+            "coordinate_posterior_covariance": (
+                None
+                if self.coordinate_posterior_covariance is None
+                else [
+                    np.asarray(c, dtype=float).tolist()
+                    for c in self.coordinate_posterior_covariance
+                ]
+            ),
         }
 
     def save(self, path: str | Path) -> None:
@@ -1793,6 +1853,14 @@ class ManifoldSAE:
                 None
                 if payload.get("fisher_mass_residual") is None
                 else np.asarray(payload["fisher_mass_residual"], dtype=float)
+            ),
+            coordinate_posterior_covariance=(
+                None
+                if payload.get("coordinate_posterior_covariance") is None
+                else [
+                    np.asarray(c, dtype=float)
+                    for c in payload["coordinate_posterior_covariance"]
+                ]
             ),
         )
 


### PR DESCRIPTION
### Motivation

- Provide manifold-native evaluation for SAEBench-style workflows: coordinate interpretability (chart-interp) and steering dose calibration (dose–response) are needed to measure coordinate identity and predicted-vs-measured KL. 
- Expose per-token coordinate posterior information so those metrics can weight/validate coordinates using the row-Hessian blocks the Arrow solver already factors.

### Description

- Added deterministic rank helpers and two new metrics in `bench/_synth_sae_metrics.py`: `chart_interp_score` (rotation-invariant circular rank / Spearman-based chart interpretability) and `dose_response_calibration` (slope-through-origin, linear fit, Pearson, RMSE, MAE). 
- Implemented small numeric helpers: `_rankdata_average`, `_pearson`, `spearman_rank_correlation`, and `circular_rank_correlation` used by `chart_interp_score`.
- Extended `ManifoldSAE` (in `gamfit/_sae_manifold.py`) with an optional `coordinate_posterior_covariance` field and round-trip support in `to_dict()` / `from_dict()` / `save()` / `load()` so fits that include row-Hessian coordinate covariance blocks retain the data.
- Added `ManifoldSAE.coordinate_posteriors()` which returns per-atom posterior means (`mean`), optional covariance blocks (`covariance`), and inverse-diagonal precision weights (`precision_weight`), validating block shapes and guarding OOS behavior (covariance currently available only for training rows when present in payload).

### Testing

- Ran unit tests for the synthetic SAE metrics: `python -m pytest bench/test_synth_sae_metrics.py` — 14 passed. 
- Performed smoke checks and static checks: `python -m py_compile gamfit/_sae_manifold.py bench/_synth_sae_metrics.py` and quick functional assertions on `chart_interp_score` and `dose_response_calibration` (both succeeded).
- Ran `tests/test_sae_manifold_fisher_shard_roundtrip.py`; it was executed but skipped in this environment because the Rust extension (`gamfit._rust`) is not built/available (skipped).

---
🤖 Codex Cloud re-dispatch. **Unaudited** — review before merge.

Closes #1942