### PR TITLE
Preserve SAE manifold reconstruction incumbent after final polish

### DIFF
--- a/crates/gam-sae/src/manifold/fit_drivers.rs
+++ b/crates/gam-sae/src/manifold/fit_drivers.rs
@@ -3731,6 +3731,11 @@ impl SaeManifoldTerm {
         // hint would always equal the cold LSQ decoder, never the seed). A freeze
         // is by definition not a convergence request, so there is no
         // under-converged decoder to rescue here.
+        let pre_polish_reconstruction_incumbent = self
+            .dictionary_reconstruction_ev(target, rho)
+            .ok()
+            .filter(|ev| ev.is_finite())
+            .map(|ev| (ev, self.snapshot_mutable_state()));
         if max_iter > 0 && !self.frames_active() {
             let mut best_objective =
                 self.penalized_objective_total(target, rho, analytic_penalties, 1.0)?;
@@ -3769,6 +3774,29 @@ impl SaeManifoldTerm {
                             break;
                         }
                     }
+                }
+            }
+        }
+        // The final decoder-LSQ / coordinate-reprojection polish is accepted by
+        // the penalized objective because that is the scalar consumed by the REML
+        // outer loop. Reconstruction EV is the user-facing fitted quantity,
+        // however, and the polish is allowed to trade data fit for smoothness.
+        // Keep the same #1026 invariant as the Newton loop: a bounded in-fit
+        // refinement may not return a materially worse reconstruction than the
+        // incumbent it started from. This preserves the evidence objective's
+        // monotone path during fitting while ensuring the delivered fitted state is
+        // the best reconstruction basin the inner solve already found, rather than
+        // a smoother-but-collapsed post-polish state.
+        if let Some((pre_polish_ev, pre_polish_state)) = pre_polish_reconstruction_incumbent {
+            if let Ok(final_ev) = self.dictionary_reconstruction_ev(target, rho) {
+                if final_ev.is_finite()
+                    && final_ev + SAE_FINAL_EV_DEGRADATION_TOL < pre_polish_ev
+                {
+                    log::warn!(
+                        "[#1026] restoring pre-polish reconstruction incumbent after final \
+                         polish degraded EV from {pre_polish_ev:.4} to {final_ev:.4}"
+                    );
+                    self.restore_mutable_state(&pre_polish_state);
                 }
             }
         }


### PR DESCRIPTION
### Motivation
- The final decoder-LSQ / coordinate-reprojection polish could accept a lower penalized objective while materially degrading reconstruction EV, returning a smoother but collapsed/underfitted fitted state and discarding a previously-reached good basin.
- This violates the inner-solve keep-best invariant (#1026) that the inner fit must not return a materially worse reconstruction than the best reconstruction basin it found.

### Description
- Capture the reconstruction EV and mutable-state snapshot immediately before the final decoder-LSQ / coordinate-reprojection polish (`pre_polish_reconstruction_incumbent`).
- After the polish rounds, compare the final dictionary reconstruction EV to the pre-polish EV and restore the pre-polish immutable state when the polish degraded EV by more than `SAE_FINAL_EV_DEGRADATION_TOL`, with a warning log message.
- Change is implemented in `crates/gam-sae/src/manifold/fit_drivers.rs` and maintains the existing penalized-objective gating while preserving the reconstruction-incumbent invariant.

### Testing
- Ran the targeted unit test: `cargo test -p gam-sae linear_span_anchor_reaches_pca_ceiling_at_dictionary_rank_1026 --lib`, which passed.
- Built and ran the `gam-sae` crate tests during development; the modified path compiles and the acceptance test above succeeded.

---
🤖 Codex Cloud re-dispatch. **Unaudited** — review before merge.

Closes #1911