### PR TITLE
Fix SAS epsilon sign convention

### DIFF
--- a/crates/gam-solve/src/mixture_link.rs
+++ b/crates/gam-solve/src/mixture_link.rs
@@ -1,7 +1,7 @@
 use crate::estimate::EstimationError;
+use crate::quadrature::latent_cloglog_jet5;
 use gam_math::probability::{normal_cdf, normal_pdf};
 use gam_math::special::stable_polynomial_times_exp_neg as stable_nonnegative_poly_times_exp_neg;
-use crate::quadrature::latent_cloglog_jet5;
 use gam_problem::{
     InverseLink, LatentCLogLogState, LikelihoodSpec, LinkComponent, LinkFunction, MixtureLinkSpec,
     MixtureLinkState, ResponseFamily, SasLinkSpec, SasLinkState, StandardLink,
@@ -1224,7 +1224,7 @@ fn sas_inverse_link_mu_d1(eta: f64, epsilon: f64, log_delta: f64) -> (f64, f64) 
     let e = if eta.is_finite() { eta } else { 0.0 };
     let a = e.asinh();
     let delta = delta_id;
-    let u_raw = delta * a - epsilon;
+    let u_raw = delta * a + epsilon;
     let u = tanh_bound(u_raw, SAS_U_CLAMP);
     let g1 = tanh_bound_d1(u_raw, SAS_U_CLAMP);
     let s = u.sinh();
@@ -1373,7 +1373,6 @@ pub fn inverse_link_pdffourth_derivative_for_inverse_link(
 ) -> Result<f64, EstimationError> {
     inverse_link_pdf_derivative_for_inverse_link(link, eta, PdfDerivativeOrder::Fourth)
 }
-
 
 #[inline]
 fn royston_parmar_inverse_link_jet(eta: f64) -> InverseLinkJet {
@@ -1946,7 +1945,7 @@ pub fn beta_logistic_inverse_link_jetwith_param_partials(
 }
 
 /// SAS inverse-link jet for:
-///   mu(eta) = Phi(sinh(delta * asinh(eta) - epsilon)),
+///   mu(eta) = Phi(sinh(delta * asinh(eta) + epsilon)),
 ///   delta = exp(B * tanh(log_delta / B)), B = SAS_LOG_DELTA_BOUND.
 pub fn sas_inverse_link_jet(eta: f64, epsilon: f64, log_delta: f64) -> InverseLinkJet {
     let delta_id = sas_delta_from_raw_log_delta(log_delta);
@@ -1956,7 +1955,7 @@ pub fn sas_inverse_link_jet(eta: f64, epsilon: f64, log_delta: f64) -> InverseLi
     let e = if eta.is_finite() { eta } else { 0.0 };
     let a = e.asinh();
     let delta = delta_id;
-    let u_raw = delta * a - epsilon;
+    let u_raw = delta * a + epsilon;
     let u = tanh_bound(u_raw, SAS_U_CLAMP);
     let g1 = tanh_bound_d1(u_raw, SAS_U_CLAMP);
     let g2 = tanh_bound_d2(u_raw, SAS_U_CLAMP);
@@ -1986,7 +1985,7 @@ pub fn sas_inverse_link_pdfthird_derivative(eta: f64, epsilon: f64, log_delta: f
     // SAS link with bounded latent transform:
     //
     //   a  = asinh(eta),
-    //   u  = tanh_bound(delta * a - epsilon),
+    //   u  = tanh_bound(delta * a + epsilon),
     //   z  = sinh(u),
     //   mu = Phi(z).
     //
@@ -2021,7 +2020,7 @@ pub fn sas_inverse_link_pdfthird_derivative(eta: f64, epsilon: f64, log_delta: f
     let e = if eta.is_finite() { eta } else { 0.0 };
     let a = e.asinh();
     let delta = sas_delta_from_raw_log_delta(log_delta);
-    let u_raw = delta * a - epsilon;
+    let u_raw = delta * a + epsilon;
     let u = tanh_bound(u_raw, SAS_U_CLAMP);
     let g1 = tanh_bound_d1(u_raw, SAS_U_CLAMP);
     let g2 = tanh_bound_d2(u_raw, SAS_U_CLAMP);
@@ -2083,7 +2082,7 @@ pub fn sas_inverse_link_pdffourth_derivative(eta: f64, epsilon: f64, log_delta: 
     let e = if eta.is_finite() { eta } else { 0.0 };
     let a = e.asinh();
     let delta = sas_delta_from_raw_log_delta(log_delta);
-    let u_raw = delta * a - epsilon;
+    let u_raw = delta * a + epsilon;
     let u = tanh_bound(u_raw, SAS_U_CLAMP);
     let g1 = tanh_bound_d1(u_raw, SAS_U_CLAMP);
     let g2 = tanh_bound_d2(u_raw, SAS_U_CLAMP);
@@ -2167,7 +2166,7 @@ pub fn sas_inverse_link_jetwith_param_partials(
     let (ld_eff, dld_eff_draw) = sas_effective_log_delta(log_delta);
     let delta = ld_eff.exp();
     let ddelta_draw = delta * dld_eff_draw;
-    let u_raw = delta * a - epsilon;
+    let u_raw = delta * a + epsilon;
     let u = tanh_bound(u_raw, SAS_U_CLAMP);
     let g1 = tanh_bound_d1(u_raw, SAS_U_CLAMP);
     let g2 = tanh_bound_d2(u_raw, SAS_U_CLAMP);
@@ -2226,8 +2225,8 @@ pub fn sas_inverse_link_jetwith_param_partials(
         }
     };
 
-    // epsilon partials (raw_u_t = -1).
-    let rt_eps = -1.0;
+    // epsilon partials (raw_u_t = +1).
+    let rt_eps = 1.0;
     let r1t_eps = 0.0;
     let r2t_eps = 0.0;
     let r3t_eps = 0.0;

--- a/tests/quality/families/quality_vs_scipy_johnsonsu_sas_link_transform_math.rs
+++ b/tests/quality/families/quality_vs_scipy_johnsonsu_sas_link_transform_math.rs
@@ -8,7 +8,7 @@
 //! peer fitting tool whose noisy output we chase):
 //!
 //!   1. VALUE (mu): gam's mu(eta) equals the closed-form sinh-arcsinh CDF
-//!      `Phi(sinh(B*tanh((delta*asinh(eta)-eps)/B)))` to ~machine precision.
+//!      `Phi(sinh(B*tanh((delta*asinh(eta)+eps)/B)))` to ~machine precision.
 //!      scipy composes this from the elementary functions `norm.cdf`, `sinh`,
 //!      `tanh`, `arcsinh` — it does NOT reuse gam's internal jet, so agreement
 //!      is a genuine independent check that gam evaluates the right function.
@@ -32,7 +32,7 @@
 //!
 //! gam's SAS inverse link is, verbatim from `sas_inverse_link_jet`:
 //!
-//!   mu(eta) = Phi( sinh( B*tanh( (delta*asinh(eta) - epsilon) / B ) ) ),
+//!   mu(eta) = Phi( sinh( B*tanh( (delta*asinh(eta) + epsilon) / B ) ) ),
 //!   delta   = exp( B_d * tanh(log_delta / B_d) ),
 //!
 //! with `B = SAS_U_CLAMP = 50` and `B_d = SAS_LOG_DELTA_BOUND = 12`. This is the
@@ -142,7 +142,7 @@ def delta_of(ld):
 
 def cdf(e, ep, ld):
     # EXACT sinh-arcsinh CDF, built only from elementary functions:
-    #   mu = Phi(sinh(B*tanh((delta*asinh(eta)-eps)/B)))
+    #   mu = Phi(sinh(B*tanh((delta*asinh(eta)+eps)/B)))
     # gam takes a probit shortcut (latent z == eta) whenever eps==0 and
     # delta==1; replicate that shortcut elementwise so the differentiated
     # reference is the identical mathematical function gam evaluates there
@@ -151,7 +151,7 @@ def cdf(e, ep, ld):
     # derivative of a *different* function and fail for a bogus reason).
     d = delta_of(ld)
     a = np.arcsinh(e)
-    ur = d * a - ep
+    ur = d * a + ep
     z = np.sinh(B * np.tanh(ur / B))
     shortcut = (np.abs(ep) < 1e-12) & (np.abs(d - 1.0) < 1e-12)
     return Phi(np.where(shortcut, e, z))


### PR DESCRIPTION
### Motivation
- The SAS (sinh‑arcsinh) latent transform used `delta*asinh(eta) - epsilon` while the intended mathematical convention and downstream optimizer/use treat epsilon as an additive skew term, causing recovered epsilon to have inverted sign and wrong magnitude.
- The epsilon parameter partial path also used the opposite raw perturbation sign (`raw_u_t = -1`), which made analytic derivatives inconsistent with the corrected latent map.

### Description
- Switch the SAS latent argument from `delta * a - epsilon` to `delta * a + epsilon` across the SAS inverse‑link code, updating `sas_inverse_link_mu_d1`, `sas_inverse_link_jet`, `sas_inverse_link_pdfthird_derivative`, `sas_inverse_link_pdffourth_derivative`, and `sas_inverse_link_jetwith_param_partials`.
- Change the epsilon parameter partial sign from `rt_eps = -1.0` to `rt_eps = 1.0` so analytic `d/ d epsilon` partials match the corrected latent transform.
- Update the independent Python/scipy reference in `tests/quality/families/quality_vs_scipy_johnsonsu_sas_link_transform_math.rs` and in-code docstrings/comments to reflect the `+epsilon` convention.

### Testing
- Attempted to run `cargo test -q sas_param_partials_matchfd --lib -p gam-solve`, but workspace compilation of dependencies was still in progress and the test run did not complete within the session time window.
- Attempted to run `cargo test -q sas_fit_recovery_and_calibration_system --test misc`, but the test run similarly did not complete within the available session time.

---
🤖 Codex Cloud re-dispatch. **Unaudited** — review before merge.

Closes #1876