### PR TITLE
Seed thin-plate length-scale from center spacing to fix low-rank under-recovery

### DIFF
--- a/crates/gam-terms/src/smooth/term_specs.rs
+++ b/crates/gam-terms/src/smooth/term_specs.rs
@@ -4567,6 +4567,31 @@ pub fn auto_initial_length_scale_for_centers(
     spacing.max(AUTO_LENGTH_SCALE_FLOOR).min(max_range)
 }
 
+/// Low-rank radial-basis length-scale seed tied to the requested center spacing.
+///
+/// Thin-plate regression splines with `k << n` represent the surface through a
+/// compact set of centers; seeding the kernel at the observation fill distance
+/// (`max_range / sqrt(n)`) makes the center Gram nearly diagonal and turns the
+/// bending penalty into an ill-scaled ridge on the radial coefficients. REML then
+/// sees a weakly identified smoothing surface and can settle on under-recovered
+/// spatial fits. Seed at the center fill distance instead, so neighbouring
+/// centers interact at O(1) scale before REML tunes the smoothing parameter.
+pub fn auto_initial_length_scale_for_low_rank_centers(
+    data: ArrayView2<'_, f64>,
+    feature_cols: &[usize],
+    num_centers: usize,
+) -> f64 {
+    if data.nrows() == 0 || feature_cols.is_empty() {
+        return 1.0;
+    }
+    let Some(max_range) = feature_columns_max_range(data, feature_cols) else {
+        return 1.0;
+    };
+    let resolution_points = num_centers.max(1) as f64;
+    let spacing = max_range / resolution_points.sqrt();
+    spacing.max(AUTO_LENGTH_SCALE_FLOOR).min(max_range)
+}
+
 /// Requested center count encoded by a [`CenterStrategy`], if it carries an
 /// explicit count (used to make the Matérn auto length scale density-adaptive).
 fn center_strategy_requested_count(strategy: &CenterStrategy) -> Option<usize> {
@@ -4624,7 +4649,12 @@ pub fn auto_init_length_scale_in_basis(data: ArrayView2<'_, f64>, basis: &mut Sm
             feature_cols, spec, ..
         } => {
             if spec.length_scale == 0.0 {
-                spec.length_scale = auto_initial_length_scale(data, feature_cols);
+                spec.length_scale = match center_strategy_requested_count(&spec.center_strategy) {
+                    Some(k) => {
+                        auto_initial_length_scale_for_low_rank_centers(data, feature_cols, k)
+                    }
+                    None => auto_initial_length_scale(data, feature_cols),
+                };
             }
         }
         SmoothBasisSpec::ByVariable { inner, .. }


### PR DESCRIPTION
### Motivation
- Address a root cause of #1074 where low-rank thin-plate (`bs="tp"`) bases with `k << n` were seeded at the observation fill distance, producing a near-diagonal center Gram that weakly identified the bending penalty and led to poor REML smoothing (under-recovery of the true surface).

### Description
- Add `auto_initial_length_scale_for_low_rank_centers` to compute a length-scale seed tied to the requested center spacing so radial basis functions interact at O(1) scale for low-rank thin-plate bases (`crates/gam-terms/src/smooth/term_specs.rs`).
- Update `auto_init_length_scale_in_basis` so the `ThinPlate` branch uses the new center-spacing seed when the `CenterStrategy` carries an explicit center count, while preserving the existing data-derived fallback when no explicit center count is present.
- The change is a focused initializer adjustment only; it does not add user-facing knobs and leaves other basis/penalty assembly and REML selection logic intact.

### Testing
- Ran `cargo check -p gam-terms`, which completed successfully on the modified crate.
- Attempted the targeted regression test `cargo test --test bug_hunt_thin_plate_2d_recovers_truth_1074 -- --nocapture`, but the build was blocked before tests executed by the repository's `SPEC.md` HEAD-commit build gate; no test outcomes were produced as a result.

---
🤖 Codex Cloud re-dispatch. **Unaudited** — review before merge.

Closes #1074