### PR TITLE
Fix SAE #1026 fit helper timeout contract

### DIFF
--- a/examples/sae_ev_vs_k_olmo.py
+++ b/examples/sae_ev_vs_k_olmo.py
@@ -193,7 +193,11 @@ def _fit_ev(
     n_iter: int,
     max_fit_seconds: float,
     max_reconstruct_seconds: float,
-) -> tuple[float, float, float, dict | None, list[str], bool]:
+    *,
+    include_timeout: bool = False,
+) -> tuple[float, float, float, dict | None, list[str]] | tuple[
+    float, float, float, dict | None, list[str], bool
+]:
     """Fit one dictionary through the production engine; return HELD-OUT EV.
 
     The real guard is a HARD subprocess timeout: the fit + reconstruct run in a
@@ -223,7 +227,8 @@ def _fit_ev(
             f"reporting NaN EV and flagging timeout.",
             flush=True,
         )
-        return (float("nan"), float("nan"), float("nan"), None, [], True)
+        timed_out_result = (float("nan"), float("nan"), float("nan"), None, [])
+        return (*timed_out_result, True) if include_timeout else timed_out_result
     else:
         executor.shutdown(wait=False)
 
@@ -251,14 +256,14 @@ def _fit_ev(
         f"held_out_EV={result['test_ev']:.4f}",
         flush=True,
     )
-    return (
+    ok_result = (
         result["test_ev"],
         fit_seconds,
         reconstruct_seconds,
         result["hybrid_split"],
         result["atom_topologies"],
-        False,
     )
+    return (*ok_result, False) if include_timeout else ok_result
 
 
 def _parse_ladder(value: str) -> list[int]:
@@ -464,6 +469,7 @@ def main() -> None:
             args.n_iter,
             k_max_fit_seconds,
             args.max_reconstruct_seconds,
+            include_timeout=True,
         )
         # The pure-linear comparison arm rides a separate basis lane whose OOS /
         # basis_with_jet plumbing can error independently of the curved arm (e.g.
@@ -480,6 +486,7 @@ def main() -> None:
                 args.n_iter,
                 k_max_fit_seconds,
                 args.max_reconstruct_seconds,
+                include_timeout=True,
             )
         except Exception as exc:  # noqa: BLE001 — arm-isolated, reported honestly
             print(f"[linear K={k}] arm failed, reporting NaN: {exc}", flush=True)


### PR DESCRIPTION
### Motivation
- The `_fit_ev` helper used by the #1026 EV-vs-K driver needed to preserve its legacy five-value return shape for tests and callers while allowing the CLI path to receive a sixth `timed_out` flag for honest timeout reporting.

### Description
- Introduce a keyword-only `include_timeout: bool = False` parameter to `
  _fit_ev` so callers can opt into receiving a sixth `timed_out` boolean while keeping the default five-value return for compatibility.
- On subprocess hard-timeout the helper still produces NaN EV diagnostics, and the `timed_out` flag is conditionally returned only when `include_timeout=True`.
- Update the CLI ladder path in `examples/sae_ev_vs_k_olmo.py` to call `_fit_ev(..., include_timeout=True)` for both curved/hybrid and linear arms so the driver can report timeouts without breaking existing test callers.

### Testing
- Successfully type-checked/compiled the modified script with `python3 -m py_compile examples/sae_ev_vs_k_olmo.py`.
- Verified the file parses as valid Python using `ast.parse(...)` in a smoke check.
- Attempted `pytest -q tests/test_sae_1026_acceptance_contract.py` but it could not run in this environment due to a missing `numpy` dependency (test run blocked, not a code failure).

---
🤖 Codex Cloud re-dispatch. **Unaudited** — review before merge.

Closes #1026