### PR TITLE
fix(survival): scope marginal-slope deadline guard

### DIFF
--- a/crates/gam-models/src/survival/marginal_slope/fit_entry.rs
+++ b/crates/gam-models/src/survival/marginal_slope/fit_entry.rs
@@ -2,6 +2,23 @@
 
 use super::*;
 
+struct OuterWallClockDeadlineGuard;
+
+impl OuterWallClockDeadlineGuard {
+    fn arm(budget_secs: f64) -> Self {
+        gam_solve::rho_optimizer::arm_outer_wall_clock_deadline(
+            std::time::Instant::now() + std::time::Duration::from_secs_f64(budget_secs.max(1.0)),
+        );
+        Self
+    }
+}
+
+impl Drop for OuterWallClockDeadlineGuard {
+    fn drop(&mut self) {
+        gam_solve::rho_optimizer::clear_outer_wall_clock_deadline();
+    }
+}
+
 pub fn fit_survival_marginal_slope_terms(
     data: ArrayView2<'_, f64>,
     spec: SurvivalMarginalSlopeTermSpec,
@@ -16,12 +33,8 @@ pub fn fit_survival_marginal_slope_terms(
     // via kappa_options; generous default. Cleared on EVERY exit path so a stale
     // deadline never leaks to a later fit.
     let budget_secs = kappa_options.outer_wall_clock_budget_secs.unwrap_or(300.0);
-    gam_solve::rho_optimizer::arm_outer_wall_clock_deadline(
-        std::time::Instant::now() + std::time::Duration::from_secs_f64(budget_secs.max(1.0)),
-    );
-    let result = fit_survival_marginal_slope_terms_impl(data, spec, options, kappa_options);
-    gam_solve::rho_optimizer::clear_outer_wall_clock_deadline();
-    result
+    let _deadline_guard = OuterWallClockDeadlineGuard::arm(budget_secs);
+    fit_survival_marginal_slope_terms_impl(data, spec, options, kappa_options)
 }
 
 pub(crate) fn fit_survival_marginal_slope_terms_impl(


### PR DESCRIPTION
### Motivation
- Ensure the process-global outer wall-clock deadline used to bound survival marginal-slope fits is always cleared on every exit path so stale deadlines cannot leak into later fits and make the deadline load-bearing (the #979 hang/bounded-return regression). 

### Description
- Introduce an RAII guard `OuterWallClockDeadlineGuard` that arms the deadline via `arm` and clears it in `Drop`, and use it in `fit_survival_marginal_slope_terms` (replacing the previous explicit `arm`/`clear` sequence) so the deadline is reliably cleared on early returns or unwinding (`crates/gam-models/src/survival/marginal_slope/fit_entry.rs`).

### Testing
- Ran `git diff --check`, `cargo fmt`, and `cargo check -p gam-models --lib` successfully, and began a longer `cargo test -p gam-solve --lib rho_optimizer::run_plan_tests:: -- --nocapture` run which was manually stopped during a clean rebuild with no test failures observed prior to interruption.

---
🤖 Codex Cloud re-dispatch. **Unaudited** — review before merge.

Closes #979