### PR TITLE
Fix orphaned-lineage API skew in tests

### DIFF
--- a/gamfit/torch/manifold_sae.py
+++ b/gamfit/torch/manifold_sae.py
@@ -1765,6 +1765,7 @@ class ManifoldSAE(nn.Module):
         x: torch.Tensor,
         *,
         max_iter: int | None = None,
+        n_iter: int | None = None,
         random_state: int = 0,
         learning_rate: float | None = None,
     ) -> _ClosedFormManifoldSAE:
@@ -1804,6 +1805,12 @@ class ManifoldSAE(nn.Module):
         the closed-form decoder. Build a fresh, unfitted module for gradient
         training.
         """
+        if max_iter is not None and n_iter is not None and int(max_iter) != int(n_iter):
+            raise ValueError(
+                f"ManifoldSAE.fit: max_iter={max_iter} and n_iter={n_iter} "
+                "are aliases and must agree when both are given"
+            )
+        resolved_iter = max_iter if max_iter is not None else n_iter
         if not isinstance(x, torch.Tensor):
             raise TypeError("ManifoldSAE.fit expects a torch.Tensor")
         if x.dim() != 2 or x.shape[1] != self.cfg.input_dim:
@@ -1857,13 +1864,44 @@ class ManifoldSAE(nn.Module):
             atom_basis=cfg.closed_form_basis_kind(),
             assignment=cfg.closed_form_assignment(),
             schedule=cfg.sparsity.gumbel_schedule(),
-            n_iter=int(max_iter or cfg.reml.max_iter),
+            n_iter=int(resolved_iter or cfg.reml.max_iter),
             random_state=int(random_state),
             **kwargs,
         )
+        self._pad_fit_decoder_blocks_for_config(fit)
         self._last_fit = fit
         self._copy_fit_into_params(fit)
         return fit
+
+    def _pad_fit_decoder_blocks_for_config(self, fit: _ClosedFormManifoldSAE) -> None:
+        """Expose closed-form decoder blocks at the module config width.
+
+        Rust atoms can legitimately solve with narrower basis blocks than the
+        torch wrapper's fixed ``n_basis_per_atom`` (for example periodic bases
+        have width ``2H+1``).  The torch module has a rectangular
+        ``(F, K, D)`` decoder parameter and the public torch ``fit()`` contract
+        mirrors that rectangular config surface, so pad missing rows/columns
+        with zeros before returning the fit object.  This is representation-only:
+        it never alters fitted values, because padded coefficients multiply
+        basis columns that are absent/zero-padded on the torch side.
+        """
+        F = int(self.cfg.n_atoms)
+        K = int(self.cfg.n_basis_per_atom)
+        D = int(self.cfg.input_dim)
+        padded: list[np.ndarray] = []
+        for block in fit.decoder_blocks[:F]:
+            arr = np.asarray(block, dtype=np.float64)
+            out = np.zeros((K, D), dtype=np.float64)
+            if arr.ndim == 2:
+                m_i = min(int(arr.shape[0]), K)
+                d_i = min(int(arr.shape[1]), D)
+                out[:m_i, :d_i] = arr[:m_i, :d_i]
+            padded.append(out)
+        if len(padded) < F:
+            padded.extend(
+                np.zeros((K, D), dtype=np.float64) for _ in range(F - len(padded))
+            )
+        fit.decoder_blocks = padded
 
     @torch.no_grad()
     def _copy_fit_into_params(self, fit: _ClosedFormManifoldSAE) -> None:

--- a/gamfit/torch/penalties.py
+++ b/gamfit/torch/penalties.py
@@ -15,6 +15,7 @@ from torch.optim import Optimizer
 from .._binding import rust_module
 from .._penalty_bridge import (
     GumbelTemperatureSchedule,
+    fixed_weight_schedule as _fixed_weight_schedule,
     ard_descriptor,
     block_orthogonality_descriptor,
     call_rust_value_grad as _call_rust_value_grad,

--- a/tests/torch/test_manifold_sae_parity.py
+++ b/tests/torch/test_manifold_sae_parity.py
@@ -82,6 +82,7 @@ def test_forward_output_shapes_and_finite():
         atom_manifold="circle",
         atom_basis="fourier",
         n_basis_per_atom=5,
+        dtype=torch.float32,
     )
     sae = gt.ManifoldSAE(cfg)
     x = torch.randn(7, 8, dtype=torch.float32)
@@ -153,20 +154,19 @@ def test_decoder_monotonicity_routes_through_rust():
     assert sae0.decoder_monotonicity_penalty().item() == 0.0
 
 
-def test_bspline_basis_routes_through_rust():
-    # Cylinder + bspline now reaches the Rust bspline arm of basis_with_jet
-    # (open uniform). Forward and backward must both succeed without falling
-    # back to the Duchon path.
+def test_bspline_basis_refuses_dead_multid_coordinates():
+    # The Rust B-spline basis_with_jet kernel is one-dimensional.  A rank-2
+    # cylinder + bspline config would silently ignore the second intrinsic
+    # coordinate, so the module must refuse it instead of routing through a
+    # mathematically wrong basis.
     cfg = gt.ManifoldSAEConfig(
         input_dim=5, K=2, intrinsic_rank=2, atom_manifold="cylinder",
         atom_basis="bspline", basis_order=2, n_basis_per_atom=6,
     )
     sae = gt.ManifoldSAE(cfg)
     x = torch.randn(3, 5, dtype=torch.float64, requires_grad=True)
-    out = sae(x)
-    assert torch.isfinite(out.x_hat).all()
-    out.x_hat.sum().backward()
-    assert x.grad is not None and torch.isfinite(x.grad).all()
+    with pytest.raises(NotImplementedError, match="bspline.*intrinsically 1-D"):
+        sae(x)
 
 
 def test_basis_eval_matches_rust_basis_with_jet():


### PR DESCRIPTION
Fix orphaned-lineage API skew in tests

Converted from a completed Codex Cloud task: https://chatgpt.com/codex/tasks/task_e_6a45e0463de88324aadcdad75acb2c95

**Unaudited** — review before merge.
