### PR TITLE
Fix existence and intensity in cone atoms

### DIFF
--- a/crates/gam-sae/src/assignment.rs
+++ b/crates/gam-sae/src/assignment.rs
@@ -3,13 +3,13 @@
 
 use ndarray::{Array1, Array2, ArrayView1, ArrayView2};
 
+use crate::manifold::SaeManifoldRho;
 use gam_solve::evidence::{HybridAtomCandidate, HybridAtomChoice, select_hybrid_atom};
 use gam_terms::analytic_penalties::{
     AnalyticPenalty, IBPAssignmentPenalty, IbpHessianDiagThirdChannels,
     SoftmaxAssignmentSparsityPenalty, resolve_learnable_weight,
 };
 use gam_terms::latent::{LatentCoordValues, LatentIdMode, LatentManifold};
-use crate::manifold::SaeManifoldRho;
 
 /// #976 Layer-1 guard: cap on one accepted iteration's assignment-logit
 /// update, in units of the gate temperature τ (the gate's natural length
@@ -259,19 +259,21 @@ impl AssignmentMode {
                 alpha,
                 learnable_alpha,
                 ..
-            } => Some(if let Some(over) = per_fit_override.or_else(ibp_alpha_override) {
-                // #1777 — the per-fit override (else the deprecated process-global
-                // one) flattens the ordered geometric prior π_k = (α/(α+1))^{k+1}
-                // so all K atoms can contribute to the reconstruction (the
-                // production α=1 gives a (0.5)^{k+1} schedule that structurally
-                // caps atoms 4..K → effective-K≈3). Forces the fixed value,
-                // bypassing the learnable schedule.
-                over
-            } else if learnable_alpha {
-                resolve_learnable_weight(alpha, rho.log_lambda_sparse)
-            } else {
-                alpha
-            }),
+            } => Some(
+                if let Some(over) = per_fit_override.or_else(ibp_alpha_override) {
+                    // #1777 — the per-fit override (else the deprecated process-global
+                    // one) flattens the ordered geometric prior π_k = (α/(α+1))^{k+1}
+                    // so all K atoms can contribute to the reconstruction (the
+                    // production α=1 gives a (0.5)^{k+1} schedule that structurally
+                    // caps atoms 4..K → effective-K≈3). Forces the fixed value,
+                    // bypassing the learnable schedule.
+                    over
+                } else if learnable_alpha {
+                    resolve_learnable_weight(alpha, rho.log_lambda_sparse)
+                } else {
+                    alpha
+                },
+            ),
             _ => None,
         }
     }
@@ -364,6 +366,8 @@ pub struct SaeAssignment {
     /// override is set). Read via [`Self::resolved_ibp_alpha`]; set from the FFI
     /// through the term's `set_fit_config`.
     pub ibp_alpha_override: Option<f64>,
+    /// Per-row positive cone amplitude stored as log s. Gates express existence; exp(log_amplitudes) expresses intensity.
+    pub log_amplitudes: Array2<f64>,
 }
 
 impl SaeAssignment {
@@ -412,6 +416,7 @@ impl SaeAssignment {
             ungated: vec![false; k],
             frozen_logits: None,
             ibp_alpha_override: None,
+            log_amplitudes: Array2::<f64>::zeros((n, k)),
         })
     }
 
@@ -610,6 +615,14 @@ impl SaeAssignment {
         self.coords.iter().map(|c| c.latent_dim()).sum()
     }
 
+    pub fn amplitude_coord_dim(&self) -> usize {
+        self.k_atoms()
+    }
+
+    pub fn amplitude_offset(&self) -> usize {
+        self.assignment_coord_dim()
+    }
+
     pub fn assignment_coord_dim(&self) -> usize {
         match self.mode {
             AssignmentMode::Softmax { .. } => self.k_atoms().saturating_sub(1),
@@ -618,12 +631,12 @@ impl SaeAssignment {
     }
 
     pub fn row_block_dim(&self) -> usize {
-        self.assignment_coord_dim() + self.total_coord_dim()
+        self.assignment_coord_dim() + self.amplitude_coord_dim() + self.total_coord_dim()
     }
 
     pub fn coord_offsets(&self) -> Vec<usize> {
         let mut out = Vec::with_capacity(self.k_atoms());
-        let mut cursor = self.assignment_coord_dim();
+        let mut cursor = self.assignment_coord_dim() + self.amplitude_coord_dim();
         for coord in &self.coords {
             out.push(cursor);
             cursor += coord.latent_dim();
@@ -790,6 +803,10 @@ impl SaeAssignment {
         Ok(())
     }
 
+    pub(crate) fn activation_from_gate(&self, row: usize, atom: usize, gate: f64) -> f64 {
+        gate * self.log_amplitudes[[row, atom]].exp()
+    }
+
     pub(crate) fn persist_resolved_ibp_alpha(&mut self, rho: &SaeManifoldRho) -> bool {
         let AssignmentMode::IBPMap {
             temperature,
@@ -837,6 +854,10 @@ impl SaeAssignment {
             let base = row * q;
             for atom in 0..assignment_dim {
                 out[base + atom] = self.logits[[row, atom]];
+            }
+            let amp_off = self.amplitude_offset();
+            for atom in 0..k {
+                out[base + amp_off + atom] = self.log_amplitudes[[row, atom]];
             }
             for atom in 0..k {
                 let d = self.coords[atom].latent_dim();
@@ -1389,9 +1410,8 @@ pub(crate) fn fill_assignment_logit_jvp_rows(
                 if is_ungated(logit_col) || logits[logit_col] <= threshold {
                     continue;
                 }
-                let activation = gam_linalg::utils::stable_logistic(
-                    (logits[logit_col] - threshold) * inv_tau,
-                );
+                let activation =
+                    gam_linalg::utils::stable_logistic((logits[logit_col] - threshold) * inv_tau);
                 let da = activation * (1.0 - activation) * inv_tau;
                 for out_col in 0..fitted.len() {
                     local_jac[[logit_col, out_col]] = da * decoded[[logit_col, out_col]];
@@ -1546,8 +1566,7 @@ pub(crate) fn assignment_prior_log_strength_hdiag(
                 if !jumprelu_in_optimization_band(logit, threshold, temperature) {
                     continue;
                 }
-                let activation =
-                    gam_linalg::utils::stable_logistic((logit - threshold) * inv_tau);
+                let activation = gam_linalg::utils::stable_logistic((logit - threshold) * inv_tau);
                 let slope = activation * (1.0 - activation);
                 d[idx] = sparsity_strength * slope * (1.0 - 2.0 * activation) * inv_tau2;
             }
@@ -1689,8 +1708,7 @@ pub(crate) fn assignment_prior_grad_hdiag(
                 if !jumprelu_in_optimization_band(logit, threshold, temperature) {
                     continue;
                 }
-                let activation =
-                    gam_linalg::utils::stable_logistic((logit - threshold) * inv_tau);
+                let activation = gam_linalg::utils::stable_logistic((logit - threshold) * inv_tau);
                 let slope = activation * (1.0 - activation);
                 g[idx] = sparsity_strength * slope * inv_tau;
                 d[idx] = sparsity_strength * slope * (1.0 - 2.0 * activation) * inv_tau2;

--- a/crates/gam-sae/src/manifold/construction.rs
+++ b/crates/gam-sae/src/manifold/construction.rs
@@ -764,10 +764,7 @@ impl SaeManifoldTerm {
     /// metric (or never calling this) keeps the bit-identical isotropic path.
     ///
     /// The metric's row count and output dimension must match the term.
-    pub fn set_row_metric(
-        &mut self,
-        metric: gam_problem::RowMetric,
-    ) -> Result<(), String> {
+    pub fn set_row_metric(&mut self, metric: gam_problem::RowMetric) -> Result<(), String> {
         if metric.n_rows() != self.n_obs() {
             return Err(format!(
                 "SaeManifoldTerm::set_row_metric: metric has {} rows but term has {}",
@@ -816,14 +813,10 @@ impl SaeManifoldTerm {
     /// Euclidean metric of the term's own `(n_obs, output_dim)` shape. Either way
     /// a metric always exists, so the diagnostics are never gated by a flag — the
     /// Euclidean fallback is the bit-identical isotropic path.
-    pub(crate) fn diagnostic_metric(
-        &self,
-    ) -> Result<gam_problem::RowMetric, String> {
+    pub(crate) fn diagnostic_metric(&self) -> Result<gam_problem::RowMetric, String> {
         match self.row_metric() {
             Some(metric) => Ok(metric.clone()),
-            None => {
-                gam_problem::RowMetric::euclidean(self.n_obs(), self.output_dim())
-            }
+            None => gam_problem::RowMetric::euclidean(self.n_obs(), self.output_dim()),
         }
     }
 
@@ -892,30 +885,24 @@ impl SaeManifoldTerm {
         // error. Magic-by-default either way: the choice is derived from the fit,
         // never a flag.
         let views = self.atom_parameter_views();
-        let ops: Vec<Option<crate::identifiability::OrbitPenaltyOperator>> =
-            if isometry_pin_active {
-                views
-                    .iter()
-                    .map(|view| {
-                        view.as_ref().and_then(|v| {
-                            crate::identifiability::isometry_orbit_penalty_operator(
-                                v, 1.0,
-                            )
-                        })
+        let ops: Vec<Option<crate::identifiability::OrbitPenaltyOperator>> = if isometry_pin_active
+        {
+            views
+                .iter()
+                .map(|view| {
+                    view.as_ref().and_then(|v| {
+                        crate::identifiability::isometry_orbit_penalty_operator(v, 1.0)
                     })
-                    .collect()
-            } else {
-                (0..self.k_atoms()).map(|_| None).collect()
-            };
+                })
+                .collect()
+        } else {
+            (0..self.k_atoms()).map(|_| None).collect()
+        };
         let residual_gauge = if isometry_pin_active {
             // The pin-active path consumes the per-row Jacobian curvature
             // directly (the certificate_model retains it under a pin), so route
             // through the non-streamed exact entry point.
-            crate::identifiability::residual_gauge_exact(
-                &certificate_model,
-                &views,
-                &ops,
-            )?
+            crate::identifiability::residual_gauge_exact(&certificate_model, &views, &ops)?
         } else {
             let (curvature_gram, root_rows) = streamed_curvature.ok_or_else(|| {
                 "fit_diagnostics_report: missing streamed residual-gauge curvature for unpinned exact path"
@@ -938,8 +925,7 @@ impl SaeManifoldTerm {
         // harvested inner fit degrade their inference fields to `None` inside
         // `atom_inference_reports`, so this is always populated (one entry per
         // atom) and never gated by a flag.
-        let atom_inference =
-            crate::identifiability::atom_inference_reports(&certificate_model);
+        let atom_inference = crate::identifiability::atom_inference_reports(&certificate_model);
 
         Ok(SaeManifoldFitDiagnostics {
             atom_two_lens,
@@ -2484,19 +2470,21 @@ impl SaeManifoldTerm {
                         // leave-this-atom-out residual projected onto `v`.
                         self.atoms[atom_idx].fill_decoded_row(row, &mut decoded_buf);
                         for col in 0..p {
-                            resid_buf[col] =
-                                target[[row, col]] - full_curved[[row, col]] + a_k * decoded_buf[col];
+                            resid_buf[col] = target[[row, col]] - full_curved[[row, col]]
+                                + a_k * decoded_buf[col];
                         }
                         // `coordinate_from_residual` returns `None` only on a
                         // length mismatch (impossible here — validated at attach)
                         // or a non-rescued image (excluded by the branch); fall
                         // back to the train code/own-coord path if it ever does.
-                        let coord = image
-                            .coordinate_from_residual(&resid_buf)
-                            .unwrap_or_else(|| {
-                                let own_t = self.assignment.coords[atom_idx].as_matrix()[[row, 0]];
-                                image.coordinate_for_row(row, own_t)
-                            });
+                        let coord =
+                            image
+                                .coordinate_from_residual(&resid_buf)
+                                .unwrap_or_else(|| {
+                                    let own_t =
+                                        self.assignment.coords[atom_idx].as_matrix()[[row, 0]];
+                                    image.coordinate_for_row(row, own_t)
+                                });
                         image.fill_row(coord, &mut g_buf);
                     } else {
                         // Ordinary straight image: decode at the atom's own coord.
@@ -2609,9 +2597,7 @@ impl SaeManifoldTerm {
     /// fitted dictionary, or `None` until [`Self::canonicalize_charts_post_fit`]
     /// has run (or when no `d = 1` atom is eligible). Surfaced in the Python model
     /// output so the user sees which atoms genuinely earn their curvature.
-    pub fn hybrid_split_report(
-        &self,
-    ) -> Option<&crate::hybrid_split::SaeHybridSplitReport> {
+    pub fn hybrid_split_report(&self) -> Option<&crate::hybrid_split::SaeHybridSplitReport> {
         self.hybrid_split_report.as_ref()
     }
 
@@ -2958,9 +2944,7 @@ impl SaeManifoldTerm {
                     certified[row] = true;
                 }
             }
-            results.push(crate::encode::EncodeResult::from_rows(
-                coords, certified,
-            ));
+            results.push(crate::encode::EncodeResult::from_rows(coords, certified));
         }
         Ok(results)
     }
@@ -3324,51 +3308,50 @@ impl SaeManifoldTerm {
         // (the topology race owns the outer pool) to avoid nested
         // oversubscription.
         let parallel = n >= SAE_LOSS_PARALLEL_ROW_MIN && rayon::current_thread_index().is_none();
-        let row_data_fit =
-            |row: usize,
-             g_buf: &mut [f64],
-             fitted_row: &mut [f64],
-             assign_buf: &mut [f64]|
-             -> Result<f64, String> {
-                // #1557 — fill the per-atom assignment row into reused per-worker
-                // scratch via the `_into` twin instead of heap-allocating a fresh
-                // `Array1` per row per loss eval. Bit-identical to the allocating
-                // `try_assignments_row_for_rho` (same arithmetic, same order); this
-                // loss reruns every Armijo halving × inner Newton iter × outer ρ
-                // eval, so the per-row K-sized allocation was a hot-path churn.
-                self.assignment
-                    .try_assignments_row_for_rho_into(row, rho, assign_buf)?;
-                let a = &*assign_buf;
-                for slot in fitted_row.iter_mut() {
-                    *slot = 0.0;
-                }
-                for atom_idx in 0..k_atoms {
-                    self.atoms[atom_idx].fill_decoded_row(row, g_buf);
-                    let a_k = a[atom_idx];
-                    for out_col in 0..p {
-                        fitted_row[out_col] += a_k * g_buf[out_col];
-                    }
-                }
+        let row_data_fit = |row: usize,
+                            g_buf: &mut [f64],
+                            fitted_row: &mut [f64],
+                            assign_buf: &mut [f64]|
+         -> Result<f64, String> {
+            // #1557 — fill the per-atom assignment row into reused per-worker
+            // scratch via the `_into` twin instead of heap-allocating a fresh
+            // `Array1` per row per loss eval. Bit-identical to the allocating
+            // `try_assignments_row_for_rho` (same arithmetic, same order); this
+            // loss reruns every Armijo halving × inner Newton iter × outer ρ
+            // eval, so the per-row K-sized allocation was a hot-path churn.
+            self.assignment
+                .try_assignments_row_for_rho_into(row, rho, assign_buf)?;
+            let a = &*assign_buf;
+            for slot in fitted_row.iter_mut() {
+                *slot = 0.0;
+            }
+            for atom_idx in 0..k_atoms {
+                self.atoms[atom_idx].fill_decoded_row(row, g_buf);
+                let a_k = a[atom_idx];
                 for out_col in 0..p {
-                    fitted_row[out_col] = target[[row, out_col]] - fitted_row[out_col];
+                    fitted_row[out_col] += a_k * g_buf[out_col];
                 }
-                let w_row = row_loss_w.map_or(1.0, |w| w[row]);
-                let mut acc = 0.0_f64;
-                match self.row_metric.as_ref() {
-                    Some(metric) if whitens => {
-                        let resid = ArrayView1::from(&fitted_row[..p]);
-                        for w in metric.whiten_residual_row(row, resid) {
-                            acc += 0.5 * w_row * w * w;
-                        }
-                    }
-                    _ => {
-                        for &r in fitted_row[..p].iter() {
-                            acc += 0.5 * w_row * r * r;
-                        }
+            }
+            for out_col in 0..p {
+                fitted_row[out_col] = target[[row, out_col]] - fitted_row[out_col];
+            }
+            let w_row = row_loss_w.map_or(1.0, |w| w[row]);
+            let mut acc = 0.0_f64;
+            match self.row_metric.as_ref() {
+                Some(metric) if whitens => {
+                    let resid = ArrayView1::from(&fitted_row[..p]);
+                    for w in metric.whiten_residual_row(row, resid) {
+                        acc += 0.5 * w_row * w * w;
                     }
                 }
-                Ok(acc)
-            };
+                _ => {
+                    for &r in fitted_row[..p].iter() {
+                        acc += 0.5 * w_row * r * r;
+                    }
+                }
+            }
+            Ok(acc)
+        };
         let data_fit = if parallel {
             use rayon::prelude::*;
             const CHUNK: usize = 32;
@@ -4150,8 +4133,7 @@ impl SaeManifoldTerm {
                     for k in 0..k_atoms {
                         let coord = &self.assignment.coords[k];
                         let d = coord.latent_dim();
-                        let has_ard =
-                            d > 0 && k < rho.log_ard.len() && rho.log_ard[k].len() == d;
+                        let has_ard = d > 0 && k < rho.log_ard.len() && rho.log_ard[k].len() == d;
                         let periods = if has_ard {
                             coord.effective_axis_periods()
                         } else {
@@ -4164,9 +4146,8 @@ impl SaeManifoldTerm {
                             if has_ard {
                                 let row_t = coord.row(row);
                                 for axis in 0..d {
-                                    let alpha = SaeManifoldRho::stable_exp_strength(
-                                        rho.log_ard[k][axis],
-                                    );
+                                    let alpha =
+                                        SaeManifoldRho::stable_exp_strength(rho.log_ard[k][axis]);
                                     c += ArdAxisPrior::eval(alpha, row_t[axis], periods[axis])
                                         .grad
                                         .abs();
@@ -4581,6 +4562,7 @@ impl SaeManifoldTerm {
                         let a_scratch = assignments.as_slice_mut().expect("contiguous scratch");
                         self.assignment
                             .try_assignments_row_for_rho_into(row, rho, a_scratch)?;
+                        let gates = assignments.clone();
                         // Reconstruction uses the row's active support: for the dense
                         // full-support layout this is all atoms (exact); for a compact
                         // layout the dropped atoms carry negligible `O(a)` reconstruction
@@ -4597,23 +4579,25 @@ impl SaeManifoldTerm {
                                 // index the compact tangent block / `coord_starts` use),
                                 // NOT the global `atom_idx`.
                                 for (j, &atom_idx) in active.iter().enumerate() {
-                                    let a_k = assignments[atom_idx];
+                                    let gate_k = gates[atom_idx];
+                                    let s_k = self.assignment.log_amplitudes[[row, atom_idx]].exp();
                                     self.atoms[atom_idx]
                                         .fill_decoded_row(row, decoded_scratch.as_mut_slice());
                                     for out_col in 0..p {
-                                        decoded[[j, out_col]] = decoded_scratch[out_col];
-                                        fitted[out_col] += a_k * decoded_scratch[out_col];
+                                        decoded[[j, out_col]] = s_k * decoded_scratch[out_col];
+                                        fitted[out_col] += gate_k * decoded[[j, out_col]];
                                     }
                                 }
                             }
                             None => {
                                 for atom_idx in 0..k_atoms {
-                                    let a_k = assignments[atom_idx];
+                                    let gate_k = gates[atom_idx];
+                                    let s_k = self.assignment.log_amplitudes[[row, atom_idx]].exp();
                                     self.atoms[atom_idx]
                                         .fill_decoded_row(row, decoded_scratch.as_mut_slice());
                                     for out_col in 0..p {
-                                        decoded[[atom_idx, out_col]] = decoded_scratch[out_col];
-                                        fitted[out_col] += a_k * decoded_scratch[out_col];
+                                        decoded[[atom_idx, out_col]] = s_k * decoded_scratch[out_col];
+                                        fitted[out_col] += gate_k * decoded[[atom_idx, out_col]];
                                     }
                                 }
                             }
@@ -4686,7 +4670,7 @@ impl SaeManifoldTerm {
                                         mode: self.assignment.mode,
                                         k,
                                         logit_k: logits_row[k],
-                                        a_k: assignments[k],
+                                        a_k: gates[k],
                                         // #1410: compact slot `j`, not global atom `k`.
                                         decoded_k: decoded.row(j),
                                         fitted: fitted.view(),
@@ -4700,10 +4684,17 @@ impl SaeManifoldTerm {
                                     &mut jac_compact,
                                 );
                             }
+                            // Amplitude JVP rows: ∂(gate·s·g)/∂log s = gate·s·g.
+                            for (j, &k) in active.iter().enumerate() {
+                                let amp_row = active.len() + j;
+                                for out_col in 0..p {
+                                    jac_compact[[amp_row, out_col]] = gates[k] * decoded[[j, out_col]];
+                                }
+                            }
                             // Coordinate JVP rows for active atoms only.
                             for (j, &k) in active.iter().enumerate() {
                                 let d = self.atoms[k].latent_dim;
-                                let a_k = assignments[k];
+                                let a_k = self.assignment.activation_from_gate(row, k, gates[k]);
                                 let coord_start = starts[j];
                                 for axis in 0..d {
                                     self.atoms[k].fill_decoded_derivative_row(
@@ -4737,11 +4728,17 @@ impl SaeManifoldTerm {
                                 &self.assignment.fixed_logit_mask(),
                                 &mut jac_row,
                             );
+                            let amp_off = self.assignment.amplitude_offset();
+                            for atom_idx in 0..k_atoms {
+                                for out_col in 0..p {
+                                    jac_row[[amp_off + atom_idx, out_col]] = gates[atom_idx] * decoded[[atom_idx, out_col]];
+                                }
+                            }
                             // Coordinate columns for all atoms.
                             for atom_idx in 0..k_atoms {
                                 let d = self.atoms[atom_idx].latent_dim;
                                 let off = coord_offsets[atom_idx];
-                                let a_k = assignments[atom_idx];
+                                let a_k = self.assignment.activation_from_gate(row, atom_idx, gates[atom_idx]);
                                 for axis in 0..d {
                                     self.atoms[atom_idx].fill_decoded_derivative_row(
                                         row,
@@ -5080,7 +5077,7 @@ impl SaeManifoldTerm {
                                 let atom = &self.atoms[atom_idx];
                                 let atom_beta_off = beta_offsets[atom_idx];
                                 let m = atom.basis_size();
-                                let a_k = assignments[atom_idx];
+                                let a_k = self.assignment.activation_from_gate(row, atom_idx, gates[atom_idx]);
                                 let mut wphi = Vec::with_capacity(m);
                                 for basis_col in 0..m {
                                     let phi = atom.basis_values[[row, basis_col]];
@@ -5122,7 +5119,7 @@ impl SaeManifoldTerm {
                                 for &atom_idx in row_active {
                                     let atom = &self.atoms[atom_idx];
                                     let m = atom.basis_size();
-                                    let a_k = assignments[atom_idx];
+                                    let a_k = self.assignment.activation_from_gate(row, atom_idx, gates[atom_idx]);
                                     for basis_col in 0..m {
                                         let phi = atom.basis_values[[row, basis_col]];
                                         // #2022 — β data-fit Jacobian of exp(s)·a·Φ·B is
@@ -5668,11 +5665,7 @@ impl SaeManifoldTerm {
                 // `psd_majorizer_hvp` + frame-projection probe pattern the registry
                 // DecoderIncoherence uses, so the collapse-prevention curvature
                 // reaches the operator here too. No-op when no repulsion is active.
-                self.add_factored_repulsion_curvature(
-                    &mut hbb_c,
-                    penalty_scale,
-                    &frame_projection,
-                );
+                self.add_factored_repulsion_curvature(&mut hbb_c, penalty_scale, &frame_projection);
                 ops.push(Arc::new(DensePenaltyOp(hbb_c)));
             }
 
@@ -5701,8 +5694,8 @@ impl SaeManifoldTerm {
             let has_dense_beta_penalty =
                 beta_penalty_assembly.dense_written || beta_penalty_assembly.deferred_factored;
             if !has_dense_beta_penalty {
-                let device = crate::frames::build_framed_device_sae_data(
-                    crate::frames::FramedDeviceArgs {
+                let device =
+                    crate::frames::build_framed_device_sae_data(crate::frames::FramedDeviceArgs {
                         p,
                         border_dim,
                         border_offsets: off_c.as_slice(),
@@ -5711,8 +5704,7 @@ impl SaeManifoldTerm {
                         smooth_scaled_s: &smooth_scaled_s,
                         frame_blocks: device_frame_blocks,
                         rows: &sys.rows,
-                    },
-                );
+                    });
                 sys.set_device_sae_pcg_data(device);
             }
         } else {
@@ -6070,8 +6062,11 @@ impl SaeManifoldTerm {
                     projection.lift_axis_into(&mut probe, k, basis_col, frame_col);
                     let col =
                         projection.border_offsets[k] + basis_col * projection.ranks[k] + frame_col;
-                    let hv =
-                        per_fit.psd_majorizer_hvp(target_beta.view(), rho_local.view(), probe.view());
+                    let hv = per_fit.psd_majorizer_hvp(
+                        target_beta.view(),
+                        rho_local.view(),
+                        probe.view(),
+                    );
                     projection
                         .project_border_vec(hv.view())
                         .iter()
@@ -6462,8 +6457,7 @@ impl SaeManifoldTerm {
             // (The old message claimed "no dense Schur factor", which is false
             // here — the Schur factor is present; the Woodbury correction is the
             // non-finite term.)
-            if cache.cross_row_woodbury.is_some()
-                && !cache.cross_row_woodbury_log_det().is_finite()
+            if cache.cross_row_woodbury.is_some() && !cache.cross_row_woodbury_log_det().is_finite()
             {
                 "SaeManifoldTerm::reml_criterion: cross-row IBP joint Hessian is non-PD at \
                  this ρ; evidence Laplace log-det undefined (infeasible ρ probe)"
@@ -7599,8 +7593,8 @@ impl SaeManifoldTerm {
             }
             let n_total = self.n_obs();
             let options = ArrowSolveOptions::direct()
-            .with_ill_conditioning_tolerated()
-            .with_schur_pd_floor(gam_solve::arrow_schur::SPECTRAL_DEFLATION_REL_FLOOR);
+                .with_ill_conditioning_tolerated()
+                .with_schur_pd_floor(gam_solve::arrow_schur::SPECTRAL_DEFLATION_REL_FLOOR);
             // Assemble the WHOLE system once (a single "chunk" over all rows) so the
             // matrix-free reduced-Schur apply `v ↦ S·v` can iterate every row; the
             // per-row block storage is exactly what the inner solve already holds.
@@ -7619,9 +7613,7 @@ impl SaeManifoldTerm {
             // objective, matching the summed per-chunk `(end-start)/n_total` scale.
             let sys = full_chunk
                 .assemble_arrow_schur_scaled(target, rho, registry, 1.0)
-                .map_err(|err| {
-                    format!("SaeManifoldTerm::streaming_exact_arrow_log_det: {err}")
-                })?;
+                .map_err(|err| format!("SaeManifoldTerm::streaming_exact_arrow_log_det: {err}"))?;
             let (log_det_tt, slq) = matrix_free_arrow_evidence_log_det(
                 &sys,
                 0.0,
@@ -7760,9 +7752,7 @@ impl SaeManifoldTerm {
         // coupling and disagree with the dense path by exactly `log|C|`.
         if let (Some(m0), Some(w), Some(d)) = (wood_m0, wood_w, wood_d) {
             let correction = streaming_cross_row_woodbury_log_det(&schur_acc, &m0, &w, &d)
-                .map_err(|err| {
-                    format!("SaeManifoldTerm::streaming_exact_arrow_log_det: {err}")
-                })?
+                .map_err(|err| format!("SaeManifoldTerm::streaming_exact_arrow_log_det: {err}"))?
                 .ok_or_else(|| {
                     "SaeManifoldTerm::reml_criterion: cross-row IBP joint Hessian is non-PD at \
                      this ρ; evidence Laplace log-det undefined (infeasible ρ probe)"
@@ -8143,7 +8133,9 @@ impl SaeManifoldTerm {
                     let (inv_vv, _inv_vbeta) = solver
                         .selected_inverse_row_blocks(row, &selected_beta_inv)
                         .map_err(|err| {
-                            format!("assignment_log_strength_hessian_trace: selected inverse: {err}")
+                            format!(
+                                "assignment_log_strength_hessian_trace: selected inverse: {err}"
+                            )
                         })?;
                     inv_vv
                 } else {
@@ -8254,9 +8246,7 @@ impl SaeManifoldTerm {
                     rhs_t_scratch[t_i] = 1.0;
                     let solved = solver
                         .solve(rhs_t_scratch.view(), rhs_beta_zero.view())
-                        .map_err(|err| {
-                            format!("assignment_log_strength_hessian_trace: {err}")
-                        })?;
+                        .map_err(|err| format!("assignment_log_strength_hessian_trace: {err}"))?;
                     rhs_t_scratch[t_i] = 0.0;
                     for &(j, t_j) in &col_sites[k] {
                         if j == i {
@@ -8538,7 +8528,9 @@ impl SaeManifoldTerm {
                     &mut jet_window,
                 )?;
             }
-            let jets = jet_window.pop_front().expect("jet window must be non-empty");
+            let jets = jet_window
+                .pop_front()
+                .expect("jet window must be non-empty");
             // Atom index (k-weight) of each local t-var.
             let var_atom: Vec<usize> = jets
                 .vars
@@ -8567,7 +8559,9 @@ impl SaeManifoldTerm {
                     let solved = solver
                         .solve(rhs_t_scratch.view(), rhs_beta_zero.view())
                         .map_err(|err| {
-                            format!("learnable_ibp_data_logdet_alpha_trace: selected inverse: {err}")
+                            format!(
+                                "learnable_ibp_data_logdet_alpha_trace: selected inverse: {err}"
+                            )
                         })?;
                     rhs_t_scratch[base + col] = 0.0;
                     for r in 0..q {
@@ -8958,16 +8952,12 @@ impl SaeManifoldTerm {
                     return 0.0;
                 }
                 let logit = self.assignment.logits[[row, diag_atom]];
-                if !crate::assignment::jumprelu_in_optimization_band(
-                    logit,
-                    threshold,
-                    temperature,
-                ) {
+                if !crate::assignment::jumprelu_in_optimization_band(logit, threshold, temperature)
+                {
                     return 0.0;
                 }
                 let inv_tau = 1.0 / temperature;
-                let activation =
-                    gam_linalg::utils::stable_logistic((logit - threshold) * inv_tau);
+                let activation = gam_linalg::utils::stable_logistic((logit - threshold) * inv_tau);
                 let slope = activation * (1.0 - activation);
                 // #1415: P(ℓ)=λσ((ℓ−θ)/τ); P''(ℓ)=(λ/τ²)s(1−2a) so the third
                 // derivative is P'''(ℓ)=(λ/τ³)·s·(1−6a+6a²), because
@@ -9249,16 +9239,16 @@ impl SaeManifoldTerm {
                     &mut jet_window,
                 )?;
             }
-            let jets = jet_window.pop_front().expect("jet window must be non-empty");
+            let jets = jet_window
+                .pop_front()
+                .expect("jet window must be non-empty");
 
             // #932 FRONT C: row-local Takahashi on the plain arrow; per-row
             // full-system `solve` loop under gauge / cross-row Woodbury.
             let (inv_vv, inv_vbeta) = if fast_selected {
                 solver
                     .selected_inverse_row_blocks(row, &beta_inv)
-                    .map_err(|err| {
-                        format!("logdet_theta_adjoint: selected inverse: {err}")
-                    })?
+                    .map_err(|err| format!("logdet_theta_adjoint: selected inverse: {err}"))?
             } else {
                 let mut inv_vv = Array2::<f64>::zeros((q, q));
                 let mut inv_vbeta = Array2::<f64>::zeros((q, cache.k));
@@ -9391,7 +9381,10 @@ impl SaeManifoldTerm {
                 }
                 if !defl_dirs.is_empty() {
                     gamma -= Self::deflation_block_correction(
-                        &inv_vv, &dh_mat, defl_dirs, defl_spectrum,
+                        &inv_vv,
+                        &dh_mat,
+                        defl_dirs,
+                        defl_spectrum,
                     );
                 }
                 for a in 0..q {
@@ -9424,7 +9417,10 @@ impl SaeManifoldTerm {
                 }
                 if !defl_dirs.is_empty() {
                     gamma -= Self::deflation_block_correction(
-                        &inv_vv, &dh_mat, defl_dirs, defl_spectrum,
+                        &inv_vv,
+                        &dh_mat,
+                        defl_dirs,
+                        defl_spectrum,
                     );
                 }
                 for a in 0..q {
@@ -9569,7 +9565,6 @@ impl SaeManifoldTerm {
             beta: gamma_beta,
         })
     }
-
 
     /// Public analytic outer-ρ gradient at a converged inner state, constructing
     /// the deflated arrow solver from the supplied cache. Use this seam from

--- a/crates/gam-sae/src/manifold/fit_drivers.rs
+++ b/crates/gam-sae/src/manifold/fit_drivers.rs
@@ -40,7 +40,6 @@ impl SaeManifoldTerm {
         self.apply_newton_step_impl(delta_ext_coord, delta_beta, step_size, true)
     }
 
-
     /// Capture the mutable state perturbed by an `apply_newton_step` +
     /// `loss` line-search trial, plus the row-layout state read by
     /// `apply_newton_step` when unpacking compact Newton steps. See
@@ -293,9 +292,7 @@ impl SaeManifoldTerm {
         rho: &SaeManifoldRho,
         analytic_penalties: Option<&AnalyticPenaltyRegistry>,
     ) -> Result<(), String> {
-        use crate::chart_canonicalization::{
-            CHART_RECOMPOSITION_REL_TOL, CanonicalChartTopology,
-        };
+        use crate::chart_canonicalization::{CHART_RECOMPOSITION_REL_TOL, CanonicalChartTopology};
         /// Which canonical-representative construction applies to an atom:
         /// arc length for `d = 1` (#1019 stage 1), the minimum-isometry-defect
         /// flow for `d = 2` torus atoms (#1019 stage 2), and the same flow
@@ -1697,8 +1694,7 @@ impl SaeManifoldTerm {
         // and the guard does not lower its own bar at the collapse it must catch.
         let dictionary_rank =
             crate::manifold::outer_objective::reachable_dictionary_rank(&self.atoms, n, p);
-        let ev_floor =
-            crate::manifold::outer_objective::collapse_ev_bar(target, dictionary_rank);
+        let ev_floor = crate::manifold::outer_objective::collapse_ev_bar(target, dictionary_rank);
         if !(ev.is_finite() && ev <= ev_floor) {
             return Ok(false);
         }
@@ -2256,10 +2252,8 @@ impl SaeManifoldTerm {
             // so both verdicts key on the same reachable-rank bar.
             let dictionary_rank =
                 crate::manifold::outer_objective::reachable_dictionary_rank(&self.atoms, n, p);
-            let ev_floor = crate::manifold::outer_objective::collapse_ev_bar(
-                target,
-                dictionary_rank,
-            );
+            let ev_floor =
+                crate::manifold::outer_objective::collapse_ev_bar(target, dictionary_rank);
             if !(ev.is_finite() && ev <= ev_floor) {
                 return Ok(());
             }
@@ -2632,6 +2626,11 @@ impl SaeManifoldTerm {
                         * full_delta[row_base + atom_idx])
                         .clamp(-logit_step_cap, logit_step_cap);
                 }
+                let amp_off = self.assignment.amplitude_offset();
+                for atom_idx in 0..k_atoms {
+                    self.assignment.log_amplitudes[[row, atom_idx]] +=
+                        step_size * full_delta[row_base + amp_off + atom_idx];
+                }
             }
             // Apply coords from expanded buffer.
             let coord_offsets = self.assignment.coord_offsets();
@@ -2669,6 +2668,11 @@ impl SaeManifoldTerm {
                     self.assignment.logits[[row, atom_idx]] += (step_size
                         * delta_ext_coord[row_base + atom_idx])
                         .clamp(-logit_step_cap, logit_step_cap);
+                }
+                let amp_off = self.assignment.amplitude_offset();
+                for atom_idx in 0..k_atoms {
+                    self.assignment.log_amplitudes[[row, atom_idx]] +=
+                        step_size * delta_ext_coord[row_base + amp_off + atom_idx];
                 }
             }
             for atom_idx in 0..k_atoms {

--- a/crates/gam-sae/src/manifold/row_layout.rs
+++ b/crates/gam-sae/src/manifold/row_layout.rs
@@ -165,7 +165,9 @@ impl SaeRowLayout {
             };
             // Hard forward gate: nonzero assignment mass ⇒ data-fit coupling in
             // the joint block. Always retained.
-            let hard: Vec<usize> = (0..k_atoms).filter(|&k| row_logits[k] > threshold).collect();
+            let hard: Vec<usize> = (0..k_atoms)
+                .filter(|&k| row_logits[k] > threshold)
+                .collect();
             // Relative-cutoff base: the largest separable contribution over all
             // in-band atoms in this row.
             let peak = (0..k_atoms)
@@ -299,7 +301,7 @@ impl SaeRowLayout {
         let mut coord_starts_all = Vec::with_capacity(active_atoms.len());
         for active in &active_atoms {
             let mut starts = Vec::with_capacity(active.len());
-            let mut cursor = active.len();
+            let mut cursor = 2 * active.len();
             for &k in active {
                 starts.push(cursor);
                 cursor += coord_dims[k];
@@ -318,7 +320,7 @@ impl SaeRowLayout {
     pub fn row_q_active(&self, row: usize) -> usize {
         let active = &self.active_atoms[row];
         let coord_sum: usize = active.iter().map(|&k| self.coord_dims[k]).sum();
-        active.len() + coord_sum
+        2 * active.len() + coord_sum
     }
 
     /// Expand a compact `delta_t` row slice back into full-q, zeros for inactive.
@@ -330,6 +332,8 @@ impl SaeRowLayout {
         let starts = &self.coord_starts[row];
         for (j, &k) in active.iter().enumerate() {
             out[k] = delta_t_row[j];
+            out[self.coord_offsets_full[0] - self.coord_dims.len() + k] =
+                delta_t_row[active.len() + j];
             let d = self.coord_dims[k];
             let full_off = self.coord_offsets_full[k];
             for axis in 0..d {
@@ -345,10 +349,10 @@ mod jumprelu_hard_gate_tests {
     // atoms with a non-negligible column-separable prior gradient; the negligible
     // deep-band tail is dropped (see [`SaeRowLayout::from_jumprelu`]).
     use super::{JumpReluLayoutParams, SaeRowLayout};
-    use crate::assignment::{assignment_prior_grad_hdiag, AssignmentMode, SaeAssignment};
+    use crate::assignment::{AssignmentMode, SaeAssignment, assignment_prior_grad_hdiag};
     use crate::manifold::{
-        SaeAtomBasisKind, SaeManifoldAtom, SaeManifoldRho, SaeManifoldTerm,
-        SAE_DENSE_BETA_PENALTY_PROBE_MAX_DIM,
+        SAE_DENSE_BETA_PENALTY_PROBE_MAX_DIM, SaeAtomBasisKind, SaeManifoldAtom, SaeManifoldRho,
+        SaeManifoldTerm,
     };
     use gam_terms::latent::LatentManifold;
     use ndarray::{Array1, Array2, Array3};
@@ -382,7 +386,11 @@ mod jumprelu_hard_gate_tests {
         // Every logit is inside the −36 optimization band, so the OLD full-band
         // layout would put all K=6 atoms in the joint block.
         for &l in logits.iter() {
-            assert!(crate::assignment::jumprelu_in_optimization_band(l, threshold, temperature));
+            assert!(crate::assignment::jumprelu_in_optimization_band(
+                l,
+                threshold,
+                temperature
+            ));
         }
         let contribution = logits.mapv(logit_slope);
         let coord_dims = vec![1usize; k];
@@ -472,8 +480,11 @@ mod jumprelu_hard_gate_tests {
                     1,
                     Array2::<f64>::from_elem((n, 2), 1.0),
                     Array3::<f64>::zeros((n, 2, 1)),
-                    Array2::<f64>::from_shape_vec((2, p), vec![0.1 * f, -0.2 * f, 0.15 * f, 0.3 * f])
-                        .unwrap(),
+                    Array2::<f64>::from_shape_vec(
+                        (2, p),
+                        vec![0.1 * f, -0.2 * f, 0.15 * f, 0.3 * f],
+                    )
+                    .unwrap(),
                     Array2::<f64>::eye(2),
                 )
                 .unwrap()
@@ -496,10 +507,8 @@ mod jumprelu_hard_gate_tests {
 
         // Reproduce the production `contribution` (construction.rs): the sparsity
         // prior separable gradient magnitude (ARD is zero at the origin).
-        let (assignment_grad, _) =
-            assignment_prior_grad_hdiag(&term.assignment, &rho).unwrap();
-        let contribution =
-            Array2::from_shape_fn((n, k), |(r, c)| assignment_grad[r * k + c].abs());
+        let (assignment_grad, _) = assignment_prior_grad_hdiag(&term.assignment, &rho).unwrap();
+        let contribution = Array2::from_shape_fn((n, k), |(r, c)| assignment_grad[r * k + c].abs());
         let coord_dims = vec![1usize; k];
         let coord_offsets = term.assignment.coord_offsets();
         let layout = SaeRowLayout::from_jumprelu(JumpReluLayoutParams {
@@ -586,7 +595,10 @@ mod jumprelu_hard_gate_tests {
                 dgt[2]
             );
         }
-        assert!(saw_drop, "the compact layout must actually drop deep-band atoms");
+        assert!(
+            saw_drop,
+            "the compact layout must actually drop deep-band atoms"
+        );
         // Tolerance is met with margin: dropped atoms' separable contribution
         // (~e^{-28..-35}) is far below the 1e-8 gate.
         assert!(max_diff < 1.0e-8, "max full-q gradient diff {max_diff:e}");


### PR DESCRIPTION
## Motivation
Cone atoms conflate **existence** and **intensity**: the gate is used both as an existence indicator and as a magnitude, which drives decoder co-collapse and mismatches the closed-form vs torch paths. Decouple them by restoring a positive per-row/per-atom amplitude (stored as `log s`) so the gate stays an honest existence indicator and intensity lives in a separate scalar.

## Description
- Add `log_amplitudes: Array2<f64>` (n×K) to `SaeAssignment`; `activation_from_gate(row, atom, gate) = gate · exp(log_amplitudes[row, atom])`.
- Reserve amplitude coordinate slots in the per-row block: `amplitude_coord_dim() = K`, `amplitude_offset() = assignment_coord_dim()`, with `row_block_dim()` and `coord_offsets()` updated so the block layout is `[logits | amplitudes | latent coords]`.
- Thread amplitude rows through `expand_row`.
- Incidental rustfmt-only reflow in `construction.rs` (no behavior change).

## Testing
Converted from a completed Codex Cloud task (https://chatgpt.com/codex/tasks/task_e_6a45dfbdbe04832492262a73c3eda977). **Unaudited** — not built or tested here.

## Overlap that must be reconciled before merge
- **#2045** ("Reintroduce per-row amplitude coordinate") is a *competing implementation of the same concept* (per-row `log_amplitudes` + gate·amplitude). Only one should land.
- The landed **#2022** scale-quotient added an **atom-level** `SaeManifoldAtom.log_amplitude`. With per-row `log_amplitudes` there would be two amplitude representations — clarify how they compose so intensity isn't double-counted (`exp(atom log_amplitude) · exp(row log_amplitudes)`?).

_Body authored from the diff during PR triage (the original conversion had only a stub body)._
