### PR TITLE
Change s(x) double_penalty default to false

### DIFF
--- a/crates/gam-terms/src/term_builder.rs
+++ b/crates/gam-terms/src/term_builder.rs
@@ -1838,7 +1838,7 @@ pub fn build_smooth_basis(
         });
     }
 
-    let smooth_double_penalty = option_bool(options, "double_penalty").unwrap_or(true);
+    let smooth_double_penalty = option_bool(options, "double_penalty").unwrap_or(false);
     let type_opt = resolve_smooth_type_name(kind, cols.len(), options);
 
     if matches!(type_opt.as_str(), "fs" | "sz" | "re") {
@@ -3509,14 +3509,12 @@ pub fn build_smooth_basis(
             // mgcv only adds a null-space shrinkage penalty there under the
             // opt-in `select = TRUE` (which gam exposes as `double_penalty`).
             //
-            // The general smooth default (`smooth_double_penalty`, true) is
-            // calibrated for 1-D `s()` terms; carrying it into tensors silently
-            // shrinks the genuinely-present bilinear interaction signal, so
-            // REML places positive weight on the extra ridge and systematically
-            // OVER-SMOOTHS the recovered surface relative to mgcv's plain
-            // `te`/`ti` (gam#700/#701/#702/#703). Default tensors to no extra
-            // null-space penalty; an explicit user `double_penalty=`/`select=`
-            // still wins.
+            // The general smooth default (`smooth_double_penalty`, false) now
+            // matches mgcv's DEFAULT `select = FALSE`: plain smooths expose one
+            // roughness coordinate per smooth, while Marra-Wood null-space
+            // shrinkage is opt-in via `double_penalty=true`/`select=true`.
+            // Tensors keep the same no-extra-ridge default; an explicit user
+            // `double_penalty=`/`select=` still wins.
             let tensor_double_penalty = option_bool(options, "double_penalty").unwrap_or(false);
             Ok(SmoothBasisSpec::TensorBSpline {
                 feature_cols: canon_cols,
@@ -5166,6 +5164,45 @@ mod tests {
             err.contains("Valid options: ["),
             "error should list valid option names, got: {err}"
         );
+    }
+
+    #[test]
+    fn plain_univariate_smooth_defaults_to_single_penalty_block() {
+        let ds = continuous_dataset(
+            &["y", "x"],
+            (0..40)
+                .map(|i| {
+                    let x = i as f64 / 39.0;
+                    vec![x.sin(), x]
+                })
+                .collect(),
+        );
+        let col_map = ds.column_map();
+
+        for (formula, expected) in [
+            ("y ~ s(x)", false),
+            ("y ~ s(x, double_penalty=false)", false),
+            ("y ~ s(x, double_penalty=true)", true),
+        ] {
+            let parsed = parse_formula(formula).expect("parse smooth formula");
+            let mut notes = Vec::new();
+            let terms = build_termspec(
+                &parsed.terms,
+                &ds,
+                &col_map,
+                &mut notes,
+                &gam_runtime::resource::ResourcePolicy::default_library(),
+            )
+            .unwrap_or_else(|err| panic!("{formula} must build, got: {err:?}"));
+            let SmoothBasisSpec::BSpline1D { spec, .. } = &terms.smooth_terms[0].basis else {
+                panic!("{formula} must lower to a BSpline1D smooth");
+            };
+            assert_eq!(
+                spec.double_penalty, expected,
+                "{formula} resolved double_penalty={}; expected {expected}",
+                spec.double_penalty
+            );
+        }
     }
 
     #[test]

--- a/docs/formulas.md
+++ b/docs/formulas.md
@@ -135,7 +135,7 @@ second-order difference penalty.
 | `degree` | 3 | Polynomial degree of the B-spline. |
 | `penalty_order` | 2 | Derivative order penalised (1 = slope, 2 = curvature). |
 | `type` | `ps` (1-D), `tps` (2+D) | `ps`, `tps`, `matern`, `duchon`, `sphere`. |
-| `double_penalty` | `true` | Add a ridge penalty alongside the difference penalty. |
+| `double_penalty` | `false` | Opt in to a Marra-Wood null-space ridge alongside the difference penalty. |
 | `bc` | `none` | Boundary condition for both endpoints: `none`, `clamped` (zero first derivative), or `anchored` (fixed value). Combine with `side=left`/`right` for half-open smooths. |
 | `bc_left`, `bc_right` | inherit from `bc` | Per-endpoint overrides, with aliases `start_bc`/`end_bc`. |
 | `anchor`, `anchor_left`, `anchor_right` | `0` for anchored endpoints | Fixed endpoint value(s) when an endpoint uses `anchored`. |


### PR DESCRIPTION
## Motivation
The `double_penalty` option for `s(x)` smooths defaulted to `true`, adding a nullspace (extra) penalty by default.

## Description
Changes the default of `smooth_double_penalty` in `build_smooth_basis` from `option_bool(options,"double_penalty").unwrap_or(true)` to `unwrap_or(false)` (`crates/gam-terms/src/term_builder.rs`).

## ⚠️ Review note — user-facing default change
This flips a default: smooths no longer receive the double (nullspace) penalty unless explicitly requested. Weigh against SPEC ("the default should allow a configuration which recovers the null … users must opt-in to overfitting potential, not the other way around"): without the double penalty a smooth's nullspace (e.g. the linear trend) is unpenalized by default, which can prevent the empirical-Bayes null from being recoverable by default. Justify the flip or gate it.

## Testing
Converted from a completed Codex Cloud task — **unaudited**, not built/tested here.
