### PR TITLE
#2023 tiered spine P0/P1: Tier-0 shared mean + Tier-1 interference emitter

### DIFF
--- a/crates/gam-sae/src/lib.rs
+++ b/crates/gam-sae/src/lib.rs
@@ -21,6 +21,7 @@ pub mod manifold;
 pub mod row_jet_program;
 pub mod sparse_dict;
 pub mod structure_harvest;
+pub mod tiered;
 
 // The pre-split engine referenced GPU infrastructure as `crate::gpu::*`; after
 // the #1521 split that code lives in the `gam-gpu` crate. Alias it back so the

--- a/crates/gam-sae/src/tiered/mod.rs
+++ b/crates/gam-sae/src/tiered/mod.rs
@@ -1,0 +1,335 @@
+//! #2023 tiered SAE spine: the orchestration container that composes a shared
+//! mean (Tier-0), a large linear sparse-dictionary bulk (Tier-1), and an
+//! evidence-K curved tier (Tier-2) fit on the whitened Tier-1 residual.
+//!
+//! This module owns the **spine-level** types every tier hangs off:
+//!   * [`Tier0Mean`] — the single shared mean μ. Moving the DC out of every atom
+//!     into ONE Tier-0 mean is the structural kill of the co-collapse-to-mean
+//!     class (issue #10 / #1893): on the de-meaned data the all-atoms-equal-to-
+//!     mean state reconstructs zero, so it is EV-invisible and gets pruned rather
+//!     than rewarded and PC-reseeded.
+//!   * [`TieredConfig`] — the composed-fit knobs.
+//!   * [`interference_subspace`] — Tier-1's active subspace `Q` (what the linear
+//!     dictionary already explains) and its orthogonal complement `Q⊥`. Per the
+//!     #2021 coupling the linear dictionary *is* the interference model for the
+//!     curved fit: the Tier-2 GLS weight down-weights `Q` (penalizes `Q⊥`), so
+//!     curved atoms chase only residual directions. Emitted so Tier-2 can install
+//!     a HELD `behavioral_fisher` metric (`structured_whitening=False`) — the
+//!     path that both realizes #2021 and avoids the structured-whitening fitter
+//!     bug.
+//!   * [`WhitenedResidualHandoff`] — the Mode-B (shared whitened residual)
+//!     hand-off to Tier-2.
+//!   * [`TieredSaeFit`] — the composed artifact. Generic over the Tier-2 artifact
+//!     type `T2` so the `tier2-curved` owner defines that struct without a
+//!     circular dependency on this module.
+//!
+//! Term-level composition (concatenating a Tier-1 linear term with a Tier-2
+//! curved term into one solve) already lives in [`crate::manifold`]:
+//! `SaeManifoldTerm::merge_tiers` + `manifold::stagewise::terminal_joint_assembly`
+//! (exact additivity under independent JumpReLU/IBP gates). The Mode-A per-block
+//! scale-out (one K=1 curved chart per orthonormal Tier-1 block) consumes the
+//! block frames on the block-sparse fit directly; see `sparse_dict::block`.
+
+use gam_linalg::faer_ndarray::FaerEigh;
+use ndarray::{Array1, Array2, ArrayView2, Axis};
+
+use crate::sparse_dict::{SparseDictConfig, SparseDictFit};
+
+/// Tier-0: the single shared mean μ (length `p`). The global DC lives here, not
+/// duplicated across `K` per-atom intercepts.
+#[derive(Clone, Debug)]
+pub struct Tier0Mean {
+    /// The shared mean, length `p`.
+    pub mean: Array1<f64>,
+}
+
+impl Tier0Mean {
+    /// Fit Tier-0 as the column mean of `z` (`N×P`). This is the train-split mean;
+    /// hold it fixed and reuse it for out-of-sample de-meaning and for the EV
+    /// baseline so held-out EV is measured against the same Tier-0 constant.
+    pub fn fit(z: ArrayView2<'_, f64>) -> Result<Self, String> {
+        if z.nrows() == 0 || z.ncols() == 0 {
+            return Err("Tier0Mean::fit requires a non-empty (N, P) matrix".to_string());
+        }
+        let mean = z
+            .mean_axis(Axis(0))
+            .ok_or_else(|| "Tier0Mean::fit: mean_axis returned None".to_string())?;
+        Ok(Self { mean })
+    }
+
+    /// De-mean: `R0 = z − μ` (row-broadcast). The Tier-1 bulk is fit on this.
+    pub fn apply(&self, z: ArrayView2<'_, f64>) -> Result<Array2<f64>, String> {
+        if z.ncols() != self.mean.len() {
+            return Err(format!(
+                "Tier0Mean::apply: z has P={} but μ has length {}",
+                z.ncols(),
+                self.mean.len()
+            ));
+        }
+        Ok(&z - &self.mean.view().insert_axis(Axis(0)))
+    }
+
+    /// Add μ back to a de-meaned reconstruction (`recon + μ`), row-broadcast.
+    pub fn reconstruct(&self, recon: ArrayView2<'_, f64>) -> Result<Array2<f64>, String> {
+        if recon.ncols() != self.mean.len() {
+            return Err(format!(
+                "Tier0Mean::reconstruct: recon has P={} but μ has length {}",
+                recon.ncols(),
+                self.mean.len()
+            ));
+        }
+        Ok(&recon + &self.mean.view().insert_axis(Axis(0)))
+    }
+}
+
+/// Knobs for a composed tiered fit.
+#[derive(Clone, Debug)]
+pub struct TieredConfig {
+    /// Tier-1 collapsed-linear sparse dictionary configuration (carries `K`, the
+    /// active budget `s`, epochs, and the GPU score-routing mode).
+    pub tier1: SparseDictConfig,
+    /// Rank `r` of the interference subspace `Q` handed to Tier-2 (`None` ⇒ pick
+    /// by the 99% energy threshold in [`interference_subspace`]).
+    pub lambda_seed_rank: Option<usize>,
+    /// Whether to run the Tier-2 curved tier at all (`false` ⇒ Tier-0 + Tier-1
+    /// only, the linear-bulk baseline).
+    pub tier2_enabled: bool,
+}
+
+impl TieredConfig {
+    /// A Tier-0 + Tier-1 config at dictionary width `k_linear` (Tier-2 disabled).
+    pub fn linear_bulk(k_linear: usize) -> Self {
+        Self {
+            tier1: SparseDictConfig::new(k_linear),
+            lambda_seed_rank: None,
+            tier2_enabled: false,
+        }
+    }
+}
+
+/// Tier-1's interference subspace: the directions the linear dictionary already
+/// explains (`q`), its orthogonal complement (`q_perp`), and the per-direction
+/// energy scale (`scale`, the singular values of the usage-weighted decoder).
+///
+/// `q` is `P×r` with orthonormal columns; `q_perp` is `P×(P−r)` with orthonormal
+/// columns; together they are a full orthonormal basis of `ℝ^P` (`q ⟂ q_perp`).
+/// Tier-2's GLS weight `G = q_perp q_perpᵀ = I − q qᵀ` down-weights `q` — so the
+/// curved fit pursues only what Tier-1 misses. `scale` (length `r`) lets Tier-2
+/// set the `Σ = Λ c Λᵀ + D` factor magnitude without refitting.
+#[derive(Clone, Debug)]
+pub struct InterferenceSubspace {
+    /// Active subspace, `P×r`, orthonormal columns (what Tier-1 explains).
+    pub q: Array2<f64>,
+    /// Orthogonal complement, `P×(P−r)`, orthonormal columns (`Q⊥`).
+    pub q_perp: Array2<f64>,
+    /// Singular values of the usage-weighted decoder along `q`, length `r`.
+    pub scale: Array1<f64>,
+}
+
+/// Compute Tier-1's [`InterferenceSubspace`] from a fitted sparse dictionary.
+///
+/// Forms the usage-weighted decoder Gram `G = Σ_k w_k d_k d_kᵀ` (`P×P`), where
+/// `d_k` is atom `k`'s decoder row and `w_k = Σ_i codes[i,k]²` is its total fired
+/// energy (so dead atoms contribute nothing and `Q` is genuinely the *active*
+/// subspace). The eigenvectors of `G` split into the top-`r` (the active subspace
+/// `Q`) and the trailing `P−r` (`Q⊥`); `scale = √eval` along `Q`.
+///
+/// `rank`: `Some(r)` pins `r = min(r, P)`; `None` keeps the smallest `r` whose
+/// eigen-energy reaches 99% of the total (at least 1).
+pub fn interference_subspace(
+    fit: &SparseDictFit,
+    rank: Option<usize>,
+) -> Result<InterferenceSubspace, String> {
+    let decoder = fit.decoder.view();
+    let k = decoder.nrows();
+    let p = decoder.ncols();
+    if k == 0 || p == 0 {
+        return Err("interference_subspace: empty decoder".to_string());
+    }
+
+    // Per-atom fired energy w_k = Σ_i codes[i,k]².
+    let mut weight = vec![0.0f64; k];
+    for (idx_row, code_row) in fit.indices.rows().into_iter().zip(fit.codes.rows()) {
+        for (&atom_u32, &code) in idx_row.iter().zip(code_row.iter()) {
+            let atom = atom_u32 as usize;
+            if atom < k {
+                weight[atom] += (code as f64) * (code as f64);
+            }
+        }
+    }
+
+    // Usage-weighted decoder `Dw` (K×P), Dw_k = √w_k · d_k, then G = Dwᵀ Dw (P×P)
+    // via a single GEMM rather than K rank-1 updates.
+    let mut dw = Array2::<f64>::zeros((k, p));
+    for atom in 0..k {
+        let sw = weight[atom].max(0.0).sqrt();
+        if sw == 0.0 {
+            continue;
+        }
+        let src = decoder.row(atom);
+        let mut dst = dw.row_mut(atom);
+        for c in 0..p {
+            dst[c] = sw * (src[c] as f64);
+        }
+    }
+    let gram = dw.t().dot(&dw);
+
+    // Symmetric eigendecomposition: ascending eigenvalues, columns are the
+    // orthonormal eigenvectors (leading direction is the LAST column).
+    let (evals, evecs) = gram
+        .eigh(faer::Side::Lower)
+        .map_err(|err| format!("interference_subspace eigensolve failed: {err}"))?;
+    let total: f64 = evals.iter().map(|&e| e.max(0.0)).sum();
+    if total <= 0.0 {
+        return Err(
+            "interference_subspace: Tier-1 decoder carries no fired energy (all atoms dead)"
+                .to_string(),
+        );
+    }
+
+    // Choose r (columns are ascending, so the active subspace is the TAIL).
+    let r = match rank {
+        Some(r) => r.min(p).max(1),
+        None => {
+            // Smallest r whose top-r eigen-energy reaches 99% of the total.
+            let mut acc = 0.0f64;
+            let mut chosen = 1usize;
+            for (taken, &e) in evals.iter().rev().enumerate() {
+                acc += e.max(0.0);
+                chosen = taken + 1;
+                if acc >= 0.99 * total {
+                    break;
+                }
+            }
+            chosen.min(p).max(1)
+        }
+    };
+
+    // q = last r columns (largest eigenvalues), scale = √eval along q.
+    let mut q = Array2::<f64>::zeros((p, r));
+    let mut scale = Array1::<f64>::zeros(r);
+    for j in 0..r {
+        let col = p - 1 - j; // descending: p-1 is the largest
+        q.column_mut(j).assign(&evecs.column(col));
+        scale[j] = evals[col].max(0.0).sqrt();
+    }
+    // q_perp = the leading (p − r) columns (smallest eigenvalues), the complement.
+    let pr = p - r;
+    let mut q_perp = Array2::<f64>::zeros((p, pr));
+    for j in 0..pr {
+        q_perp.column_mut(j).assign(&evecs.column(j));
+    }
+
+    Ok(InterferenceSubspace { q, q_perp, scale })
+}
+
+/// Mode-B hand-off: the whitened *shared* residual and Tier-1's interference
+/// model, handed to the Tier-2 curved fit (`tier2-curved` / #17). Tier-2 fits its
+/// curved atoms on `residual`, installing a held GLS metric built from
+/// `interference` (down-weighting `q`, i.e. what Tier-1 explains).
+#[derive(Clone, Debug)]
+pub struct WhitenedResidualHandoff {
+    /// Post-Tier-1 residual `R = (z − μ) − T1.reconstruct()`, `N×P`, f64.
+    pub residual: Array2<f64>,
+    /// Tier-1's interference subspace (`q`, `q_perp`, `scale`).
+    pub interference: InterferenceSubspace,
+    /// The frozen Tier-1 decoder, `K×P` (for out-of-sample residual recompute).
+    pub tier1_decoder: Array2<f32>,
+    /// The Tier-0 shared mean μ, length `P`.
+    pub mean: Array1<f64>,
+}
+
+/// The composed tiered artifact. Generic over the Tier-2 artifact `T2` (defined
+/// by the `tier2-curved` owner as `Tier2CurvedArtifact`) so this container has no
+/// circular dependency on the curved-tier module. `tier2` is `None` when Tier-2
+/// is disabled or every curved birth is rejected.
+#[derive(Clone, Debug)]
+pub struct TieredSaeFit<T2> {
+    /// Tier-0 shared mean.
+    pub tier0: Tier0Mean,
+    /// Tier-1 linear sparse-dictionary bulk.
+    pub tier1: SparseDictFit,
+    /// Tier-2 curved artifact (owner-defined), if present.
+    pub tier2: Option<T2>,
+    /// Combined held-in explained variance against the Tier-0 mean baseline.
+    pub explained_variance: f64,
+}
+
+/// Explained variance `1 − RSS/TSS` of `recon` against `z`, with the total sum of
+/// squares taken about the supplied Tier-0 `mean` (the honest tiered baseline: a
+/// model must beat "predict the shared mean", not "predict zero").
+pub fn explained_variance_vs_mean(
+    z: ArrayView2<'_, f64>,
+    recon: ArrayView2<'_, f64>,
+    mean: &Array1<f64>,
+) -> f64 {
+    let mut rss = 0.0f64;
+    for (zr, rr) in z.rows().into_iter().zip(recon.rows()) {
+        for c in 0..z.ncols() {
+            let d = zr[c] - rr[c];
+            rss += d * d;
+        }
+    }
+    let baseline = &z - &mean.view().insert_axis(Axis(0));
+    let tss: f64 = baseline.iter().map(|&v| v * v).sum();
+    if tss <= 0.0 {
+        return f64::NAN;
+    }
+    1.0 - rss / tss
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ndarray::array;
+
+    #[test]
+    fn tier0_mean_roundtrips() {
+        let z = array![[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]];
+        let t0 = Tier0Mean::fit(z.view()).expect("fit");
+        assert!((t0.mean[0] - 3.0).abs() < 1e-12);
+        assert!((t0.mean[1] - 4.0).abs() < 1e-12);
+        let demeaned = t0.apply(z.view()).expect("apply");
+        // Column means of the de-meaned data are ~0.
+        let cm = demeaned.mean_axis(Axis(0)).unwrap();
+        assert!(cm[0].abs() < 1e-12 && cm[1].abs() < 1e-12);
+        // reconstruct(apply(z)) == z.
+        let back = t0.reconstruct(demeaned.view()).expect("reconstruct");
+        for (a, b) in back.iter().zip(z.iter()) {
+            assert!((a - b).abs() < 1e-12);
+        }
+    }
+
+    #[test]
+    fn interference_subspace_q_and_qperp_are_orthonormal_complements() {
+        // A 2-atom dictionary in p=3 spanning e0 and e1; e2 is unexplained.
+        let decoder = array![[1.0f32, 0.0, 0.0], [0.0, 1.0, 0.0]];
+        let indices = array![[0u32, 1u32], [0u32, 1u32]];
+        let codes = array![[2.0f32, 1.0f32], [2.0f32, 1.0f32]];
+        let fit = SparseDictFit {
+            decoder,
+            indices,
+            codes,
+            explained_variance: 0.0,
+            epochs: 0,
+            converged: true,
+            active: 2,
+            score_route_stats: Default::default(),
+        };
+        let sub = interference_subspace(&fit, Some(2)).expect("subspace");
+        assert_eq!(sub.q.dim(), (3, 2));
+        assert_eq!(sub.q_perp.dim(), (3, 1));
+        // q columns orthonormal.
+        let gq = sub.q.t().dot(&sub.q);
+        assert!((gq[[0, 0]] - 1.0).abs() < 1e-9 && (gq[[1, 1]] - 1.0).abs() < 1e-9);
+        assert!(gq[[0, 1]].abs() < 1e-9);
+        // q ⟂ q_perp.
+        let cross = sub.q.t().dot(&sub.q_perp);
+        assert!(cross.iter().all(|&v| v.abs() < 1e-9));
+        // q_perp must be (±)e2, the unexplained direction.
+        assert!(sub.q_perp[[2, 0]].abs() > 0.999);
+        assert!(sub.q_perp[[0, 0]].abs() < 1e-6 && sub.q_perp[[1, 0]].abs() < 1e-6);
+        // Atom 0 (code 2) carries more energy than atom 1 (code 1) ⇒ larger scale first.
+        assert!(sub.scale[0] >= sub.scale[1]);
+    }
+}

--- a/examples/tier1_interference.py
+++ b/examples/tier1_interference.py
@@ -1,0 +1,199 @@
+"""Tier-0 shared mean + Tier-1 interference-subspace emitter (#2023 / #2021).
+
+This is the Python-side prototype of the spine's Tier-1 -> Tier-2 hand-off pieces,
+mirroring the Rust `gam_sae::tiered` module so both agree numerically:
+
+  * ``tier0_mean``            -- the shared mean mu (Tier-0). Subtract before T1,
+                                add back at reconstruct; use as the EV baseline.
+  * ``interference_subspace`` -- Tier-1's active subspace ``Q`` (what the linear
+                                dictionary explains), its orthogonal complement
+                                ``Q_perp``, and the per-direction ``scale``.
+  * ``behavioral_fisher_factors`` -- the ready-to-pass GLS weight square-root the
+                                curved tier hands to ``sae_manifold_fit`` as
+                                ``fisher_factors`` with
+                                ``fisher_provenance="behavioral_fisher"`` and
+                                ``structured_whitening=False``.
+
+The #2021 coupling: the curved tier's GLS weight ``G = U U^T = I - Q Q^T`` (U spans
+``Q_perp``) DOWN-WEIGHTS the directions Tier-1 already explains, so curved atoms
+pursue only residual structure. Penalizing ``Q`` itself (the sign error) would make
+the curved tier re-chase linear structure -- the whole point is the complement.
+
+Two Tier-1 sources are supported:
+  * an atom-lane fit (``gamfit.sparse_dictionary_fit`` -> decoder K x P + sparse
+    codes): ``interference_subspace_from_atoms``;
+  * a block-lane fit (``gamfit.block_sparse_dictionary_fit`` -> orthonormal block
+    frames): ``interference_subspace_from_blocks``.
+Both return the same ``InterferenceSubspace``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+
+
+def tier0_mean(z_train: np.ndarray) -> np.ndarray:
+    """The Tier-0 shared mean mu (length P): the train-split column mean.
+
+    Hold this fixed and reuse for out-of-sample de-meaning and the EV baseline so
+    held-out EV is measured against the same Tier-0 constant.
+    """
+    z = np.asarray(z_train, dtype=np.float64)
+    if z.ndim != 2 or z.shape[0] == 0 or z.shape[1] == 0:
+        raise ValueError(f"tier0_mean needs a non-empty (N, P) matrix; got {z.shape}")
+    return z.mean(axis=0)
+
+
+@dataclass
+class InterferenceSubspace:
+    """Tier-1's interference model handed to the curved tier.
+
+    ``q``      -- (P, r) orthonormal columns: what Tier-1 explains.
+    ``q_perp`` -- (P, P-r) orthonormal columns: the complement (``Q_perp``).
+    ``scale``  -- (r,) singular values of the usage-weighted decoder along ``q``.
+    """
+
+    q: np.ndarray
+    q_perp: np.ndarray
+    scale: np.ndarray
+
+    @property
+    def rank(self) -> int:
+        return int(self.q.shape[1])
+
+    @property
+    def ambient_p(self) -> int:
+        return int(self.q.shape[0])
+
+
+def _split_gram(gram: np.ndarray, rank: int | None) -> InterferenceSubspace:
+    """Eigendecompose the P x P usage-weighted decoder Gram and split into the
+    top-``r`` active subspace ``q`` and the trailing ``q_perp``."""
+    gram = 0.5 * (gram + gram.T)  # symmetrize
+    evals, evecs = np.linalg.eigh(gram)  # ascending eigenvalues, orthonormal cols
+    evals = np.clip(evals, 0.0, None)
+    p = gram.shape[0]
+    total = float(evals.sum())
+    if total <= 0.0:
+        raise ValueError("interference_subspace: Tier-1 carries no fired energy")
+    if rank is None:
+        # smallest r whose top-r energy reaches 99% of the total
+        tail = evals[::-1]  # descending
+        acc = np.cumsum(tail)
+        r = int(np.searchsorted(acc, 0.99 * total) + 1)
+        r = max(1, min(p, r))
+    else:
+        r = max(1, min(p, int(rank)))
+    # descending order columns: last is largest
+    order = np.argsort(evals)[::-1]
+    q_idx = order[:r]
+    perp_idx = order[r:]
+    q = np.ascontiguousarray(evecs[:, q_idx])
+    q_perp = np.ascontiguousarray(evecs[:, perp_idx])
+    scale = np.sqrt(evals[q_idx])
+    return InterferenceSubspace(q=q, q_perp=q_perp, scale=scale)
+
+
+def interference_subspace_from_atoms(
+    decoder: np.ndarray, indices: np.ndarray, codes: np.ndarray, rank: int | None = None
+) -> InterferenceSubspace:
+    """From an atom-lane fit: decoder (K, P) + sparse routing (indices/codes,
+    N x s). Weight atom k by its fired energy w_k = sum_i codes[i,k]^2, form the
+    usage-weighted Gram G = sum_k w_k d_k d_k^T, and split it."""
+    decoder = np.asarray(decoder, dtype=np.float64)
+    indices = np.asarray(indices)
+    codes = np.asarray(codes, dtype=np.float64)
+    k, p = decoder.shape
+    weight = np.zeros(k, dtype=np.float64)
+    np.add.at(weight, indices.reshape(-1), (codes.reshape(-1) ** 2))
+    dw = decoder * np.sqrt(weight)[:, None]
+    gram = dw.T @ dw
+    return _split_gram(gram, rank)
+
+
+def interference_subspace_from_blocks(t1, rank: int | None = None) -> InterferenceSubspace:
+    """From a block-lane fit (``gamfit.BlockSparseDictionaryFit``): the union of
+    the orthonormal block frames ``D_g`` (b x P), each weighted by its utilization
+    (the fraction of rows that fire block g), forms the usage-weighted Gram."""
+    p = int(t1.decoder.shape[1])
+    gram = np.zeros((p, p), dtype=np.float64)
+    for g in range(int(t1.n_blocks)):
+        dg = np.asarray(t1.block_frame(g), dtype=np.float64)  # (b, P), rows orthonormal
+        w = float(t1.block_utilization[g])
+        if w <= 0.0:
+            continue
+        gram += w * (dg.T @ dg)
+    return _split_gram(gram, rank)
+
+
+def behavioral_fisher_factors(
+    sub: InterferenceSubspace, *, soft_epsilon: float = 0.0, n_rows: int | None = None
+) -> np.ndarray:
+    """The GLS weight square-root U to pass as ``fisher_factors``.
+
+    ``G = U U^T`` is the per-row GLS weight the curved tier fits under. To make the
+    linear dictionary the interference model we DOWN-WEIGHT ``Q`` (penalize the
+    complement): the hard form is ``U = Q_perp`` (weight 0 on ``Q``, 1 on
+    ``Q_perp`` -> ``G = I - Q Q^T``). ``soft_epsilon > 0`` keeps a small weight on
+    ``Q`` for conditioning: ``U = [Q_perp | sqrt(eps) Q]`` -> ``G = I - (1-eps) Q Q^T``.
+
+    Returns U as (P, r_U). If ``n_rows`` is given, broadcast to the (N, P, r_U)
+    stack the FFI expects (shared across rows; per-row activity scaling is a
+    later refinement owned by the curved tier).
+    """
+    if soft_epsilon <= 0.0:
+        u = sub.q_perp
+    else:
+        u = np.concatenate([sub.q_perp, np.sqrt(soft_epsilon) * sub.q], axis=1)
+    u = np.ascontiguousarray(u, dtype=np.float64)
+    if n_rows is None:
+        return u
+    return np.broadcast_to(u[None, :, :], (int(n_rows), u.shape[0], u.shape[1])).copy()
+
+
+def _selftest() -> None:
+    """Planted-structure check: a 2-D explained subspace + a genuinely
+    unexplained direction. Verifies Q/Q_perp orthonormality, that Q_perp captures
+    the unexplained direction, and the behavioral-fisher weight sign."""
+    rng = np.random.default_rng(0)
+    n, p = 2000, 5
+    # Tier-1 explains directions e0, e1 strongly, e2 weakly; e3,e4 unexplained.
+    basis = np.eye(p)
+    codes_true = rng.standard_normal((n, 3)) * np.array([4.0, 2.0, 0.3])
+    x = codes_true @ basis[:3]
+    # A rank-3 "decoder" reproducing those directions with matching energy.
+    decoder = basis[:3].astype(np.float64)
+    indices = np.tile(np.arange(3, dtype=np.uint32), (n, 1))
+    codes = codes_true.astype(np.float64)
+
+    sub = interference_subspace_from_atoms(decoder, indices, codes, rank=None)
+    # Orthonormality.
+    assert np.allclose(sub.q.T @ sub.q, np.eye(sub.rank), atol=1e-9), "q not orthonormal"
+    assert np.allclose(
+        sub.q_perp.T @ sub.q_perp, np.eye(p - sub.rank), atol=1e-9
+    ), "q_perp not orthonormal"
+    assert np.allclose(sub.q.T @ sub.q_perp, 0.0, atol=1e-9), "q not perp q_perp"
+    # The complement must include e3, e4 (unexplained).
+    q_perp_span = sub.q_perp @ sub.q_perp.T
+    for j in (3, 4):
+        proj = q_perp_span[j, j]
+        assert proj > 0.99, f"e{j} should live in Q_perp; got projection {proj:.3f}"
+    # Behavioral-fisher weight down-weights Q, not Q_perp.
+    u = behavioral_fisher_factors(sub, soft_epsilon=0.0)
+    g = u @ u.T  # (P,P) = I - Q Q^T
+    # Weight on an explained direction (e0) ~ 0; on unexplained (e4) ~ 1.
+    assert g[0, 0] < 0.05, f"explained dir e0 should be down-weighted; got {g[0,0]:.3f}"
+    assert g[4, 4] > 0.95, f"unexplained dir e4 should keep weight; got {g[4,4]:.3f}"
+    # Tier-0 roundtrip.
+    mu = tier0_mean(x + 7.0)
+    assert np.allclose(mu, x.mean(0) + 7.0, atol=1e-9)
+    print(
+        f"[tier1_interference] selftest OK: rank(Q)={sub.rank}, scale={np.round(sub.scale,3)}, "
+        f"G[e0,e0]={g[0,0]:.3f} (down-weighted), G[e4,e4]={g[4,4]:.3f} (kept)"
+    )
+
+
+if __name__ == "__main__":
+    _selftest()


### PR DESCRIPTION
## #2023 tiered architecture spine — Phase 0/1

New `gam_sae::tiered` module (spine container) + Python twin. This is the principled route to K=32k: Tier-0 shared mean + Tier-1 linear bulk + the Tier-1→Tier-2 interference hand-off.

### What lands
- **`Tier0Mean`** (fit/apply/reconstruct) — the single shared mean μ. Structurally kills the co-collapse-to-mean class (#10 / #1893): with the global DC at Tier-0, the all-atoms-equal-to-mean state reconstructs zero on de-meaned data → EV-invisible → pruned by the mass guard, not rewarded and PC-reseeded. Per-atom local offsets preserved.
- **`interference_subspace()`** — Tier-1's active subspace `Q` (usage-weighted decoder-Gram eigenbasis), its complement `Q⊥`, and the per-direction `scale`. Realizes the #2021 coupling: the curved tier's GLS weight `G = Q⊥Q⊥ᵀ = I − QQᵀ` down-weights what Tier-1 already explains. **Sign is load-bearing** (penalizing `Q` would make curved atoms re-chase linear structure) and is asserted in tests. Consumed by Tier-2 as `behavioral_fisher` `fisher_factors` with `structured_whitening=False` — the path that avoids the confirmed structured-whitening fitter bug.
- **`WhitenedResidualHandoff`** (Mode-B) + **`TieredSaeFit<T2>`** — generic over the tier2-curved artifact so no circular dep. `explained_variance_vs_mean` takes the **train-split μ** as a parameter (no full-data EV leak by construction).
- **`examples/tier1_interference.py`** — mirrors the Rust; supports atom-lane and block-lane Tier-1; self-test verifies Q/Q⊥ orthonormality and the sign.

Term-level composition (`merge_tiers` / `terminal_joint_assembly`) already exists in `manifold`; the spine adds Tier-0, the emitter, and the containers. Mode-A per-block scale-out consumes the existing orthonormal block frames directly.

### Verification
- `cargo check -p gam-sae --lib` — clean under `--deny=warnings` (isolated target, exit 0).
- Python twin self-test passes (orthonormality + sign: explained dirs → G≈0, unexplained → G≈1).
- Rust unit tests written (`Tier0Mean` roundtrip; interference orthonormality/complement/sign). On-box `cargo test` blocked by laptop disk (99%) + concurrent-fleet target churn — **CI / MSI confirms**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012CPwPoq56Tt6XeDXAq1cky