### PR TITLE
#932: Stabilize Gamma jet FD oracle step

### DIFF
--- a/crates/gam-math/src/jet_gamma_oracle_tests.rs
+++ b/crates/gam-math/src/jet_gamma_oracle_tests.rs
@@ -211,7 +211,18 @@ fn fd_partial(row: &GammaRow, a: usize, b: usize) -> f64 {
     if b >= 1 {
         p = p.min(STENCIL_TRUNC[b]);
     }
-    let h = 1e-2;
+    // The fourth-order tensor-product stencil subtracts nearly equal row-NLL
+    // values before dividing by `h^4` (or `h^(a+b)` for mixed entries).  A
+    // `1e-2` step is inside the roundoff-dominated side of that balance for the
+    // p₀⁴ channel of the deterministic fixtures: the Gamma row NLL contains an
+    // `O(1)` log-normalizer, while the p₀⁴ signal is only the
+    // `y·exp(-(p₀+2p₁))` term, so cancellation in the constant-in-p₀ pieces can
+    // exceed the oracle's stated band.  Use a dyadic log-primary step instead:
+    // `2^-5` is still local on the fixture domain (`p ∈ [-0.5, 0.5] ×
+    // [-0.3, 0.3]`, stencil reaches only `±1/16` at the coarse level) but keeps
+    // the fourth-order denominator large enough that the Richardson oracle is
+    // measuring the row expression rather than floating-point cancellation.
+    let h = 1.0 / 32.0;
     let coarse = fd_partial_at(row, a, b, h);
     let fine = fd_partial_at(row, a, b, h * 0.5);
     let two_p = 2f64.powi(p);


### PR DESCRIPTION
### Motivation
- The Gamma-dispersion jet oracle used a 5-point tensor-product finite-difference stencil with `h = 1e-2`, which put the p₀⁴ channel into a roundoff-dominated cancellation regime and caused the independent FD oracle to falsely disagree with the jet tower.

### Description
- Replace the FD step `h = 1e-2` with a dyadic log-primary step `h = 1.0 / 32.0` in the Gamma oracle to keep the stencil local while increasing the denominator to avoid cancellation. (file: `crates/gam-math/src/jet_gamma_oracle_tests.rs`).
- Add an explanatory comment documenting why the dyadic step is chosen and that the change is test-only (stabilizes the independent FD oracle without touching production jet algebra).

### Testing
- Ran `./build.sh check -p gam-math --lib` which completed successfully with no warnings.
- Ran `./build.sh test -p gam-math --lib gamma_dispersion_jet_tower_matches_independent_fd_oracle -- --nocapture` and the specific Gamma FD oracle test passed (`ok`).
- Ran the `jet_tower` test group with `./build.sh test -p gam-math --lib jet_tower -- --nocapture` and all tests passed (34 passed, 0 failed).

---
Fixes #932.

<details><summary>codex self-assessment</summary>

derivative_stack_known_values_at_2 ... ok\ntest jet_tower::rowjet_bridge_tests::ln_gamma_derivative_stack_order2_is_prefix ... ok\ntest jet_tower::rowjet_bridge_tests::scale_rows_scalar_is_bit_identical_to_scale ... ok\ntest jet_tower::rowjet_bridge_tests::trigamma_derivative_stack_overlaps_digamma_stack ... ok\ntest jet_tower::tests::crossing_edge_constraint_frame_matches_bare_velocity_constants ... ok\ntest jet_tower::tests::crossing_edge_tower_matches_handpath_velocity_formulas ... ok\ntest jet_tower::tests::gamma_special_function_stacks_match_reference_values ... ok\ntest jet_tower::tests::gamma_special_function_stacks_obey_recurrences ... ok\ntest jet_tower::tests::gnarly_tower_is_fd_consistent_order_by_order ... ok\ntest jet_tower::tests::implicit_solve_matches_scalar_resolve_to_fourth_order ... ok\ntest jet_tower::tests::implicit_solve_matches_textbook_ift_recursion ... ok\ntest jet_tower::tests::locscale_tower_matches_closed_forms_including_cross_blocks ... ok\ntest jet_tower::tests::logit_tower_matches_closed_forms ... ok\ntest jet_tower::tests::moving_boundary_flux_carries_b_zuv_term ... ok\ntest jet_tower::tests::moving_boundary_theta_integrand_matches_handpath_and_closed_form ... ok\ntest jet_tower::tests::oracle_catches_planted_cross_block_sign_flip ... ok\ntest jet_tower::tests::t3_t4_are_fully_index_symmetric ... ok\ntest jet_tower::tests::tower3_matches_tower4_through_third_order ... ok\n[contraction-symmetry speedup K=9] sym=5497.0ns/call full=8471.8ns/call wall_speedup=1.54x\ntest jet_tower::contraction_symmetry_tests::contraction_symmetry_speedup_is_reported ... ok\n\nfailures:\n\nfailures:\n    jet_gamma_oracle_tests::gamma_dispersion_jet_tower_matches_independent_fd_oracle\n\ntest result: FAILED. 33 passed; 1 failed; 0 ignored; 0 measured; 127 filtered out; finished in 3.48s\n```\n\nRelevant failure detail from `.buildd/last.log`:\n\n```text\nthread 'jet_gamma_oracle_tests::gamma_dispersion_jet_tower_matches_independent_fd_oracle' (8959) panicked at crates/gam-math/src/jet_gamma_oracle_tests.rs:253:9:\nrow 1 t4[0][0][0][0]: jet +1.267205903066e0 vs FD +1.267197250835e0 (|\u0394| 8.652e-6 > band 6.436e-6)\n```\n\n**After fix \u2014 build/check/test output:**\n\n* \u2705 `./build.sh`\n\n```text\n[build.sh] LIB -> exit 0 in 1203s (dedup=MISS, recompiled 285 crates)\n   Compiling indicatif v0.18.6\n   Compiling anstyle-parse v1.0.0\n   Compiling ndarray-stats v0.6.0\n   Compiling rustfft v6.4.1\n   Compiling gam-models v0.3.148 (/workspace/gam/crates/gam-models)\n   Compiling burn v0.18.0\n   Compiling anstyle-query v1.1.5\n   Compiling anstyle v1.0.14\n   Compiling colorchoice v1.0.5\n   Compiling linux-raw-sys v0.12.1\n   Compiling is_terminal_polyfill v1.70.2\n   Compiling litrs v1.0.0\n   Compiling general-mcmc v0.9.0\n   Compiling document-features v0.2.12\n   Compiling anstream v1.0.0\n   Compiling parking_lot v0.12.5\n   Compiling gam-sae v0.3.148 (/workspace/gam/crates/gam-sae)\n   Compiling heck v0.5.0\n   Compiling clap_lex v1.1.0\n   Compiling clap_builder v4.6.0\n   Compiling clap_derive v4.6.1\n   Compiling gam-inference v0.3.148 (/workspace/gam/crates/gam-inference)\n   Compiling crossterm v0.29.0\n   Compiling gam v0.3.148 (/workspace/gam)\n   Compiling gam-config v0.3.148 (/workspace/gam/crates/gam-config)\n   Compiling comfy-table v7.2.2\n   Compiling clap v4.6.1\n   Compiling gam-test-support v0.3.148 (/workspace/gam/crates/gam-test-support)\n   Compiling gam-report v0.3.148 (/workspace/gam/crates/gam-report)\n    Finished `dev` profile [unoptimized + debuginfo] target(s) in 20m 01s\n```\n\n* \u2705 `./build.sh check -p gam-math --lib`\n\n```text\n[build.sh] check -p gam-math --lib -> exit 0 in 0s (dedup=SUBSUMED, recompiled 0 crates)\n```\n\n* \u2705 `./build.sh test -p gam-math --lib --no-run`\n\n```text\n[build.sh] test -p gam-math --lib --no-run -> exit 0 in 0s (dedup=MISS, recompiled 0 crates)\n    Finished `test` profile [optimized + debuginfo] target(s) in 0.45s\n  Executable unittests
</details>

_Codex-generated; pending adversarial audit before merge._