### PR TITLE
#2015: Add Hellinger behavior sphere preprocessing

### DIFF
--- a/crates/gam-geometry/src/manifolds/sphere.rs
+++ b/crates/gam-geometry/src/manifolds/sphere.rs
@@ -944,6 +944,85 @@ pub fn sphere_frechet_mean(
     Err("spherical Fréchet mean is not identifiable for these points".to_string())
 }
 
+/// Convert concept-restricted next-token probabilities to the behavior block's
+/// Hellinger-sphere chart response.
+///
+/// The steering/behavior-anchored SAE block is fitted in `q = sqrt(p)` rather
+/// than directly in probability coordinates.  For closed probability rows,
+/// `q` lies on the positive orthant of the unit sphere and the Fisher-Rao line
+/// element satisfies `ds_FR^2 = 4 ||dq||^2`; consequently a unit-speed chart in
+/// `q`-space has the local calibration `KL(t -> t + δ) = 2 δ^2 + O(δ^3)`.
+/// This helper is the single Rust-owned preprocessing seam for that block:
+/// validate and close the probabilities, take the square-root embedding,
+/// choose (or accept) the spherical Fréchet base point, and return the tangent
+/// log-map rows at that base.  The returned tangent coordinates are ambient
+/// sphere tangent vectors; callers can stack them as the second response block
+/// while sharing gates and latent `t` with the activation block.
+pub fn hellinger_behavior_tangent_block(
+    probabilities: ArrayView2<'_, f64>,
+    weights: Option<ArrayView1<'_, f64>>,
+    base: Option<ArrayView1<'_, f64>>,
+    tol: f64,
+    max_iter: usize,
+) -> Result<(Array2<f64>, Array1<f64>), String> {
+    let (n, d) = probabilities.dim();
+    if n == 0 || d == 0 {
+        return Err("behavior probabilities must be a non-empty matrix".to_string());
+    }
+    let mut q = Array2::<f64>::zeros((n, d));
+    for row in 0..n {
+        let mut row_sum = 0.0_f64;
+        for col in 0..d {
+            let value = probabilities[[row, col]];
+            if !value.is_finite() || value < 0.0 {
+                return Err(format!(
+                    "behavior probabilities must be finite and non-negative; got {value} \
+                     at ({row}, {col})"
+                ));
+            }
+            row_sum += value;
+        }
+        if !(row_sum.is_finite() && row_sum > 0.0) {
+            return Err(format!(
+                "behavior probability row {row} must have positive finite mass"
+            ));
+        }
+        let inv_sum = row_sum.recip();
+        for col in 0..d {
+            q[[row, col]] = (probabilities[[row, col]] * inv_sum).sqrt();
+        }
+    }
+    let base_point = match base {
+        Some(b) => {
+            if b.len() != d {
+                return Err(format!(
+                    "behavior base dimension {} does not match probability width {d}",
+                    b.len()
+                ));
+            }
+            normalize_sphere_matrix(Array2::from_shape_fn((1, d), |(_, j)| b[j]).view())?
+                .row(0)
+                .to_owned()
+        }
+        None => Array1::from(sphere_frechet_mean(q.view(), weights, tol, max_iter)?),
+    };
+    let tangent = response_sphere_log_map(q.view(), base_point.view())?;
+    Ok((tangent, base_point))
+}
+
+/// Local KL/nats calibration for a unit-speed Hellinger-sphere chart step.
+///
+/// Since `KL(p(t) || p(t + δ)) = 2 δ² + O(δ³)` when the chart has unit speed in
+/// `q = sqrt(p)` space, this is the scalar used by behavior-pinned steering
+/// reports for an already unit-gauged coordinate.  Non-finite deltas are
+/// rejected so diagnostics cannot silently publish fabricated nats.
+pub fn hellinger_unit_speed_predicted_nats(delta: f64) -> Result<f64, String> {
+    if !delta.is_finite() {
+        return Err("behavior chart delta must be finite".to_string());
+    }
+    Ok(2.0 * delta * delta)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1028,6 +1107,36 @@ mod tests {
         let mean = sphere_frechet_mean(values.view(), None, 1.0e-12, 256).unwrap();
         // Mean should be close to e1 (dominant direction), not on the equator.
         assert!(mean[0] > 0.9, "expected near-e1 mean, got {mean:?}");
+    }
+
+    #[test]
+    fn hellinger_behavior_block_closes_sqrt_embeds_and_logs_at_base() {
+        let probs = array![
+            [4.0, 0.0, 0.0],
+            [0.0, 9.0, 0.0],
+            [1.0, 1.0, 2.0],
+        ];
+        let base = array![1.0, 0.0, 0.0];
+        let (tangent, returned_base) =
+            hellinger_behavior_tangent_block(probs.view(), None, Some(base.view()), 1.0e-12, 256)
+                .expect("valid probability rows must produce a tangent block");
+        assert_eq!(returned_base.to_vec(), vec![1.0, 0.0, 0.0]);
+        // Row 0 closes to p=(1,0,0), hence q equals the base and the tangent is
+        // exactly zero.
+        assert!(tangent.row(0).iter().all(|v| v.abs() < 1.0e-12));
+        // Row 1 closes to p=(0,1,0), q=e2, whose spherical log at e1 is
+        // (π/2)e2 in ambient tangent coordinates.
+        assert!(tangent[[1, 0]].abs() < 1.0e-12);
+        assert!((tangent[[1, 1]] - std::f64::consts::FRAC_PI_2).abs() < 1.0e-12);
+        assert!(tangent[[1, 2]].abs() < 1.0e-12);
+    }
+
+    #[test]
+    fn hellinger_unit_speed_nats_uses_fisher_rao_calibration() {
+        let delta = 0.125_f64;
+        let nats = hellinger_unit_speed_predicted_nats(delta).unwrap();
+        assert_eq!(nats, 2.0 * delta * delta);
+        assert!(hellinger_unit_speed_predicted_nats(f64::NAN).is_err());
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- The joint activation+behavior two-block fit needs a validated, nats-calibrated tangent representation of next-token probabilities (`q = sqrt(p)`) so behavior residuals are measured in Fisher–Rao units rather than treated as Euclidean activations.
- The codebase already had sphere log/exp primitives but lacked a single Rust seam that closes/normalizes probabilities, embeds them on the unit sphere, chooses a Fréchet base point, and returns tangent coordinates for a behavior response block.
- Adding this preprocessing prevents ad‑hoc Python duplication and enables later wiring of a REML-selected behavior block without contaminating the calibration or gauge semantics.

### Description
- Added `hellinger_behavior_tangent_block` in `crates/gam-geometry/src/manifolds/sphere.rs` which: validates probability rows, closes each row (normalizes to sum 1), computes `q = sqrt(p)`, chooses (or accepts) a spherical Fréchet base point, and returns ambient tangent log-map rows plus the base point for use as a behavior response block.
- Added `hellinger_unit_speed_predicted_nats` to expose the unit-speed Hellinger / Fisher–Rao local KL calibration (`KL ≈ 2·δ²`) with finite-input validation for diagnostics.
- Added unit tests exercising the new seam: `hellinger_behavior_block_closes_sqrt_embeds_and_logs_at_base` verifies closing/sqrt/embed/log-map behavior and `hellinger_unit_speed_nats_uses_fisher_rao_calibration` verifies the `2 * delta^2` calibration and NaN rejection.

### Testing
- Built the tree: ran `./build.sh` and the full build completed successfully (dev profile). (Succeeded.)
- Scoped compile check: ran `./build.sh check -p gam-geometry --lib` and it completed with exit 0 and no warnings. (Succeeded.)
- Unit tests: ran `./build.sh test -p gam-geometry --lib hellinger -- --nocapture` and the two new tests passed: both tests reported `ok` (2 passed; 0 failed). (Succeeded.)

---
Fixes #2015.

<details><summary>codex self-assessment</summary>

0.3.148 (/workspace/gam/crates/gam-test-support)\n   Compiling gam-config v0.3.148 (/workspace/gam/crates/gam-config)\n    Finished `dev` profile [unoptimized + debuginfo] target(s) in 13m 14s\n```\n\n* \u2705 `./build.sh check -p gam-geometry --lib`\n\n```text\n[build.sh] check -p gam-geometry --lib -> exit 0 in 155s (dedup=MISS, recompiled 46 crates)\n    Checking gemm-f64 v0.19.0\n    Checking gemm-c32 v0.19.0\n    Checking gemm-f32 v0.19.0\n    Checking gemm-c64 v0.19.0\n    Checking qd v0.8.0\n    Checking num-rational v0.4.2\n    Checking rand_distr v0.4.3\n    Checking num_cpus v1.17.0\n    Checking cpufeatures v0.2.17\n    Checking itoa v1.0.18\n    Checking generativity v1.2.1\n    Checking byteorder v1.5.0\n   Compiling equator-macro v0.6.0\n    Checking npyz v0.8.4\n    Checking faer-traits v0.24.0\n    Checking equator v0.6.0\n    Checking sha2 v0.10.9\n    Checking nalgebra v0.33.3\n    Checking gemm v0.19.0\n    Checking nano-gemm v0.2.2\n    Checking ndarray v0.17.2\n    Checking rand_distr v0.5.1\n    Checking log v0.4.33\n    Checking faer v0.24.4\n    Checking statrs v0.18.0\n    Checking gam-runtime v0.3.148 (/workspace/gam/crates/gam-runtime)\n    Checking gam-math v0.3.148 (/workspace/gam/crates/gam-math)\n    Checking gam-linalg v0.3.148 (/workspace/gam/crates/gam-linalg)\n    Checking gam-geometry v0.3.148 (/workspace/gam/crates/gam-geometry)\n    Finished `dev` profile [unoptimized + debuginfo] target(s) in 2m 35s\n```\n\n* \u2705 `./build.sh test -p gam-geometry --lib hellinger -- --nocapture`\n\n```text\n[build.sh] test -p gam-geometry --lib hellinger -- --nocapture -> exit 0 in 258s (dedup=MISS, recompiled 96 crates)\n   Compiling itoa v1.0.18\n   Compiling generativity v1.2.1\n   Compiling npyz v0.8.4\n   Compiling faer-traits v0.24.0\n   Compiling serde_json v1.0.150\n   Compiling sha2 v0.10.9\n   Compiling equator v0.6.0\n   Compiling private-gemm-x86 v0.1.20\n   Compiling nalgebra v0.33.3\n   Compiling thiserror v2.0.18\n   Compiling gemm v0.19.0\n   Compiling nano-gemm v0.2.2\n   Compiling rand_distr v0.5.1\n   Compiling ndarray v0.17.2\n   Compiling log v0.4.33\n   Compiling faer v0.24.4\n   Compiling gam-runtime v0.3.148 (/workspace/gam/crates/gam-runtime)\n   Compiling statrs v0.18.0\n   Compiling gam-math v0.3.148 (/workspace/gam/crates/gam-math)\n   Compiling gam-linalg v0.3.148 (/workspace/gam/crates/gam-linalg)\n   Compiling gam-geometry v0.3.148 (/workspace/gam/crates/gam-geometry)\n    Finished `test` profile [optimized + debuginfo] target(s) in 4m 17s\n     Running unittests src/lib.rs (target/debug/deps/gam_geometry-19f708c341dddf93)\n\nrunning 2 tests\ntest manifolds::sphere::tests::hellinger_unit_speed_nats_uses_fisher_rao_calibration ... ok\ntest manifolds::sphere::tests::hellinger_behavior_block_closes_sqrt_embeds_and_logs_at_base ... ok\n\ntest result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 209 filtered out; finished in 0.00s\n```\n\n## CODE DIFF\n\n```diff\ndiff --git a/crates/gam-geometry/src/manifolds/sphere.rs b/crates/gam-geometry/src/manifolds/sphere.rs\nindex 639f8db..72b52f2 100644\n--- a/crates/gam-geometry/src/manifolds/sphere.rs\n+++ b/crates/gam-geometry/src/manifolds/sphere.rs\n@@ -944,6 +944,85 @@ pub fn sphere_frechet_mean(\n     Err(\"spherical Fr\u00e9chet mean is not identifiable for these points\".to_string())\n }\n \n+/// Convert concept-restricted next-token probabilities to the behavior block's\n+/// Hellinger-sphere chart response.\n+///\n+/// The steering/behavior-anchored SAE block is fitted in `q = sqrt(p)` rather\n+/// than directly in probability coordinates.  For closed probability rows,\n+/// `q` lies on the positive orthant of the unit sphere and the Fisher-Rao line\n+/// element satisfies `ds_FR^2 = 4 ||dq||^2`; consequently a unit-speed chart in\n+/// `q`-space has the local calibration `KL(t -> t + \u03b4) = 2 \u03b4^2 + O(\u03b4^3)`.\n+/// This helper is the single Rust-owned preprocessing seam for that block:\n+/// validate and close th
</details>

_Codex-generated; pending adversarial audit before merge._