### PR TITLE
#2022: Enforce SAE quotient-scale retraction at accepted outer iterates

### DIFF
--- a/crates/gam-sae/src/manifold/fit_drivers.rs
+++ b/crates/gam-sae/src/manifold/fit_drivers.rs
@@ -4590,31 +4590,25 @@ impl SaeManifoldTerm {
             // post-fit. SEAM: this boundary overlaps seed-audit STEP2's reseed/refit
             // hooks — reconcile ordering there (retraction after guards/reseed).
             self.retract_unit_speed_charts_in_loop()?;
-            // #1939 cone-atom RECOVERY retraction (Design B) — at this accepted
-            // OUTER-iterate boundary, retract ONLY the atoms whose decoder has
-            // COLLAPSED relative to its dictionary peers (breach vs peer median),
-            // folding the vanished ‖B_k‖ into s_k so the paired amplitude solve can
-            // re-home it — recovering a co-vanished born decoder (the K≥2
-            // 0.7255→0.0023 collapse) — while leaving HEALTHY atoms' scale in B.
-            //
-            // Shared by two flags, both breach-gated at this settled boundary:
-            //   * `cone_atom_recovery` (#1939) — recover a co-vanished born decoder.
-            //   * `quotient_scale` (#2022 SCALE-gauge) — after #2100 removed the
-            //     detonating per-β-Newton fold at `apply_newton_step_impl` (which
-            //     forced ‖B_k‖≡1 on EVERY atom every TRIAL and blew a healthy K=2
-            //     fit to EV→−1e128), the #2022 unit-Frobenius retraction lives HERE
-            //     instead: at the ACCEPTED iterate where the norms have settled, and
-            //     gated to the COLLAPSED atoms only. On a healthy dictionary nothing
-            //     breaches ⇒ strict no-op ⇒ EV preserved (healthy K=2 back to ~+0.43);
-            //     K<2 is a no-op inside the helper (the K=1 low-amp fit is untouched).
-            // Either flag does ONLY the breach-gated boundary retraction and never a
-            // per-Newton fold, so neither can detonate. K<2 / all-zero-median are
-            // no-ops inside the helper. Run the paired amplitude solve solely when an
-            // atom was actually retracted, so a fit with no collapsed atom is a strict
-            // no-op (bit-for-bit the flag-off path).
-            if (self.cone_atom_recovery || self.quotient_scale)
-                && self.retract_collapsed_decoders_in_loop() > 0
-            {
+            // #2022 SCALE quotient and #1939 cone-atom recovery live at the
+            // ACCEPTED-iterate boundary, never inside a line-search trial.  The two
+            // flags intentionally differ:
+            //   * `quotient_scale` is the hard quotient: every decoder frame is
+            //     retracted to unit Frobenius and its removed magnitude is carried by
+            //     `log_amplitude`, so the terminal dictionary cannot represent the
+            //     decoder-scale ↔ amplitude gauge ray.
+            //   * `cone_atom_recovery` (without the quotient flag) is the narrower
+            //     recovery path: retract only peer-collapsed atoms, then solve their
+            //     explicit amplitudes.
+            // In both cases the paired amplitude solve profiles the positive
+            // amplitudes against the fit's own weighted/whitened reconstruction
+            // metric.  Running it after the image-frozen peel keeps healthy fits on
+            // the same reconstruction while making the converged state live on the
+            // quotient rather than relying on PD floors in the gauge direction.
+            if self.quotient_scale {
+                self.retract_decoder_gauge_in_loop();
+                self.optimize_log_amplitudes_closed_form(target, rho)?;
+            } else if self.cone_atom_recovery && self.retract_collapsed_decoders_in_loop() > 0 {
                 self.optimize_log_amplitudes_closed_form(target, rho)?;
             }
             // #972 / #977 T1 — U-block of the alternating block-coordinate ascent.

--- a/crates/gam-sae/src/manifold/tests_logdet_adjoint_780.rs
+++ b/crates/gam-sae/src/manifold/tests_logdet_adjoint_780.rs
@@ -214,20 +214,6 @@ fn dual_half_logdet_trace_2156(cache: &ArrowFactorCache, h: &Array2<f64>, dh: &A
     0.5 * report.total_derivative
 }
 
-fn dual_logdet_trace_2156(
-    label: &'static str,
-    cache: &ArrowFactorCache,
-    h: &Array2<f64>,
-    dh: &Array2<f64>,
-) -> (f64, BranchCertificate) {
-    let report = dual_trace_report_2156(
-        cache,
-        h,
-        vec![(DerivativeTraceChannel::Other(label), dh.clone())],
-    );
-    (report.total_derivative, report.certificate)
-}
-
 fn relative_error_2156(exact: f64, production: f64) -> f64 {
     (exact - production).abs() / exact.abs().max(production.abs()).max(1.0)
 }


### PR DESCRIPTION
### Motivation
- The SCALE gauge (`decoder` magnitude ↔ `log_amplitude`) was not being hard-quotiented at accepted iterate boundaries: the existing path only recovered peer-collapsed atoms, leaving healthy decoder norms free and the scale↔amplitude gauge representable, which produced downstream null Hessian directions and runtime compensation machinery usage.
- Making the quotient a representation-level invariant (unit-Frobenius frames + explicit `log_amplitude`) removes those null directions by construction and avoids ad-hoc PD floors/deflation-budget interventions.

### Description
- At the post-accept boundary the `quotient_scale` flag now calls `retract_decoder_gauge_in_loop()` for every atom and then runs `optimize_log_amplitudes_closed_form(...)` to profile amplitudes on the whitened reconstruction metric, so the converged dictionary lives on the scale quotient (unit Frobenius frames + explicit amplitudes).
- Preserved the narrower `cone_atom_recovery` behavior: when `quotient_scale` is off we keep the previous peer-collapsed-only `retract_collapsed_decoders_in_loop()` + amplitude solve.
- Removed an unused test helper (`dual_logdet_trace_2156`) that triggered `-D warnings` (deny-warnings) during the `gam-sae` test build so the relevant crate can compile cleanly under CI.

### Testing
- Built the tree and checks: ran `./build.sh` and `./build.sh check -p gam-sae --lib` and both completed successfully (no warnings/errors).
- Verified test binaries build: `./build.sh test -p gam-sae --no-run` completed successfully and produced the expected test executables.
- Exercised targeted regression tests: `./build.sh test -p gam-sae quotient_scale_on_does_not_detonate_healthy_k2_two_circle_2100 -- --nocapture` passed (test reports `ok` and shows unit-Frobenius norms), and `./build.sh test -p gam-sae unit_speed_active_retraction_moves_only_ard_2070 -- --nocapture` and `./build.sh test -p gam-sae unit_speed_hook_gradient_consistent_and_noop_safe_2022 -- --nocapture` also passed locally.
- Fixed an initial compile failure caused by dead test code (deny-warnings) by removing the unused helper; after that all above commands completed green.

---
Refs #2022 (epic; acceptance not yet delivered — see review).

<details><summary>codex self-assessment</summary>

e v0.3.148 (/workspace/gam/crates/gam-sae)\n     Compiling gam v0.3.148 (/workspace/gam)\n     Compiling gam-inference v0.3.148 (/workspace/gam/crates/gam-inference)\n     Compiling gam-config v0.3.148 (/workspace/gam/crates/gam-config)\n      Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 21s\n  ```\n* \u2705 `./build.sh check -p gam-sae --lib`\n  ```text\n  [build.sh] check -p gam-sae --lib -> exit 0 in 0s (dedup=SUBSUMED, recompiled 0 crates)\n  ```\n* \u2705 `./build.sh test -p gam-sae --no-run`\n  ```text\n  [build.sh] test -p gam-sae --no-run -> exit 0 in 208s (dedup=MISS, recompiled 1 crates)\n     Compiling gam-sae v0.3.148 (/workspace/gam/crates/gam-sae)\n      Finished `test` profile [optimized + debuginfo] target(s) in 3m 28s\n    Executable unittests src/lib.rs (target/debug/deps/gam_sae-a2c4802d7e5c9eac)\n    Executable tests/atlas_real_transport.rs (target/debug/deps/atlas_real_transport-49a8b8cfa3e6bb80)\n    Executable tests/calendar_ground_truth_benchmark.rs (target/debug/deps/calendar_ground_truth_benchmark-0b495ae8247fef1b)\n    Executable tests/sae_ev_vs_k_1026.rs (target/debug/deps/sae_ev_vs_k_1026-b69c5228de6fc160)\n  ```\n* \u2705 `./build.sh test -p gam-sae quotient_scale_on_does_not_detonate_healthy_k2_two_circle_2100 -- --nocapture`\n  ```text\n  [build.sh] test -p gam-sae quotient_scale_on_does_not_detonate_healthy_k2_two_circle_2100 -- --nocapture -> exit 0 in 3s (dedup=MISS, recompiled 0 crates)\n      Finished `test` profile [optimized + debuginfo] target(s) in 0.38s\n       Running unittests src/lib.rs (target/debug/deps/gam_sae-a2c4802d7e5c9eac)\n\n  running 1 test\n  [#2100 repro] quotient_scale ON: EV=0.6696 (OFF=0.6533), norms=[1.0000, 1.0000]\n  test manifold::tests_cocollapse_disjoint_2027::quotient_scale_on_does_not_detonate_healthy_k2_two_circle_2100 ... ok\n\n  test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 909 filtered out; finished in 2.67s\n  ```\n* \u2705 `./build.sh test -p gam-sae unit_speed_active_retraction_moves_only_ard_2070 -- --nocapture`\n  ```text\n  [build.sh] test -p gam-sae unit_speed_active_retraction_moves_only_ard_2070 -- --nocapture -> exit 0 in 1s (dedup=MISS, recompiled 0 crates)\n      Finished `test` profile [optimized + debuginfo] target(s) in 0.37s\n       Running unittests src/lib.rs (target/debug/deps/gam_sae-a2c4802d7e5c9eac)\n\n  running 1 test\n  test manifold::tests_unit_speed_inloop_2022::unit_speed_active_retraction_moves_only_ard_2070 ... ok\n\n  test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 909 filtered out; finished in 0.03s\n  ```\n* \u2705 `./build.sh test -p gam-sae unit_speed_hook_gradient_consistent_and_noop_safe_2022 -- --nocapture`\n  ```text\n  [build.sh] test -p gam-sae unit_speed_hook_gradient_consistent_and_noop_safe_2022 -- --nocapture -> exit 0 in 1s (dedup=MISS, recompiled 0 crates)\n      Finished `test` profile [optimized + debuginfo] target(s) in 0.36s\n       Running unittests src/lib.rs (target/debug/deps/gam_sae-a2c4802d7e5c9eac)\n\n  running 1 test\n  test manifold::tests_unit_speed_inloop_2022::unit_speed_hook_gradient_consistent_and_noop_safe_2022 ... ok\n\n  test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 909 filtered out; finished in 0.02s\n  ```\n\n## CODE DIFF\n\n```diff\ndiff --git a/crates/gam-sae/src/manifold/fit_drivers.rs b/crates/gam-sae/src/manifold/fit_drivers.rs\nindex 034abcc..26b2a87 100644\n--- a/crates/gam-sae/src/manifold/fit_drivers.rs\n+++ b/crates/gam-sae/src/manifold/fit_drivers.rs\n@@ -4590,31 +4590,25 @@ impl SaeManifoldTerm {\n             // post-fit. SEAM: this boundary overlaps seed-audit STEP2's reseed/refit\n             // hooks \u2014 reconcile ordering there (retraction after guards/reseed).\n             self.retract_unit_speed_charts_in_loop()?;\n-            // #1939 cone-atom RECOVERY retraction (Design B) \u2014 at this accepted\n-            // OUTER-iterate boundary, retract ONLY the atoms whose decoder has\n-            // COLLAPSE
</details>

_Codex-generated; pending adversarial audit before merge._