### PR TITLE
#1757: test: lock Duchon low-rank default

### DIFF
--- a/crates/gam-terms/src/term_builder.rs
+++ b/crates/gam-terms/src/term_builder.rs
@@ -4489,7 +4489,7 @@ fn default_duchon_center_count(
     polynomial_cols: usize,
     univariate_floor: usize,
 ) -> usize {
-    // Duchon fits pay a larger setup cost than Matérn/TPS because the
+    // #1757: Duchon fits pay a larger setup cost than Matérn/TPS because the
     // constrained radial block is rotated through its center Gram and several
     // operator-collocation penalties.  The old generic spatial default handed a
     // 2-D Gaussian Duchon at n≈500 more than one hundred centers, so cold fits
@@ -4850,6 +4850,37 @@ mod tests {
         // The floor is scoped to 1-D: a multivariate smooth passes 0 and keeps
         // the generic n-scaling plan unchanged.
         assert_eq!(default_matern_center_count(200, 2, 40, 0), 40);
+    }
+
+    /// #1757 regression: an omitted `k=`/`centers=` on a 2-D Duchon smooth must
+    /// remain a low-rank representer basis. The generic spatial planner grows
+    /// with `n` (125 centers at n=500), which makes the Duchon center-Gram
+    /// rotation and REML linear algebra scale as dense `O(k^3)` setup work
+    /// before the data-fit iterations even start. The Duchon-specific default
+    /// caps the implicit basis at the thin-plate/Duchon spline rank
+    /// `10 * 3^(d - 1)` (30 in 2-D) while explicit `k=`/`centers=` still bypass
+    /// this helper upstream.
+    #[test]
+    fn duchon_2d_default_is_low_rank_not_generic_spatial_width_1757() {
+        let n = 500usize;
+        let d = 2usize;
+        let polynomial_cols = d + 1;
+        let generic_plan = default_num_centers(n, d);
+        let duchon_default = default_duchon_center_count(n, d, generic_plan, polynomial_cols, 0);
+        let spline_rank = 10usize.saturating_mul(3usize.saturating_pow((d - 1) as u32));
+
+        assert!(
+            generic_plan > spline_rank,
+            "precondition: generic spatial plan should be wider than the Duchon low-rank spline rank"
+        );
+        assert_eq!(
+            duchon_default, spline_rank,
+            "2-D Duchon default must use the low-rank spline representer size, not the generic spatial width"
+        );
+        assert!(
+            duchon_default > polynomial_cols,
+            "the capped default must still contain the affine polynomial null space"
+        );
     }
 
     fn continuous_dataset(headers: &[&str], rows: Vec<Vec<f64>>) -> Dataset {


### PR DESCRIPTION
### Motivation
- Prevent the Duchon default from inheriting the generic spatial width (which grows with `n`) and forces expensive dense `O(k^3)` Gram work; the implicit Duchon default should remain the low-rank spline-sized representer (mgcv-style `k = 10 * 3^(d-1)`) when the user omits `k=`/`centers=` (#1757).

### Description
- Clarify the `default_duchon_center_count` comment to link the cap to #1757 and document that explicit `k=`/`centers=` still bypass the helper (file `crates/gam-terms/src/term_builder.rs`).
- Add a unit test `duchon_2d_default_is_low_rank_not_generic_spatial_width_1757` that asserts for `n=500,d=2` the Duchon implicit default equals the spline low-rank `10 * 3^(d-1)` and still exceeds the polynomial null-space columns (file `crates/gam-terms/src/term_builder.rs`).

### Testing
- Ran `./build.sh check -p gam-terms --lib` and it completed successfully (exit 0).
- Ran `./build.sh test -p gam-terms --lib --no-run` and test binary build completed successfully (exit 0).
- Ran the new test with `./build.sh test -p gam-terms --lib duchon_2d_default_is_low_rank_not_generic_spatial_width_1757 -- --nocapture` and it passed (`ok`).
- Also ran `./build.sh test -p gam-terms --lib radial_1d_default_not_starved_below_univariate_spline_resolution_1867 -- --nocapture` and it passed (`ok`).
- Note: attempting to pass two test filters in one `cargo test` invocation failed due to `cargo test` accepting only a single TESTNAME positional filter; tests were run individually to prove passing status.

---
Fixes #1757.

<details><summary>codex self-assessment</summary>

 --no-run`\n\n```text\n[build.sh] test -p gam-terms --lib --no-run -> exit 0 in 1692s (dedup=MISS, recompiled 96 crates)\n   Compiling arrow-ord v54.3.1\n   Compiling arrow-row v54.3.1\n   Compiling arrow-arith v54.3.1\n   Compiling parquet v54.3.1\n   Compiling gam-linalg v0.3.148 (/workspace/gam/crates/gam-linalg)\n   Compiling gam-geometry v0.3.148 (/workspace/gam/crates/gam-geometry)\n   Compiling gam-problem v0.3.148 (/workspace/gam/crates/gam-problem)\n   Compiling gam-gpu v0.3.148 (/workspace/gam/crates/gam-gpu)\n   Compiling arrow v54.3.1\n   Compiling gam-data v0.3.148 (/workspace/gam/crates/gam-data)\n   Compiling gam-terms v0.3.148 (/workspace/gam/crates/gam-terms)\n   Compiling gam-identifiability v0.3.148 (/workspace/gam/crates/gam-identifiability)\n   Compiling gam-model-api v0.3.148 (/workspace/gam/crates/gam-model-api)\n   Compiling opt v0.5.11\n   Compiling cpufeatures v0.3.0\n   Compiling chacha20 v0.10.1\n   Compiling getrandom v0.4.3\n   Compiling rand v0.10.2\n   Compiling rand_distr v0.6.0\n   Compiling sysinfo v0.32.1\n   Compiling nalgebra-macros v0.3.0\n   Compiling nalgebra v0.34.2\n   Compiling gam-solve v0.3.148 (/workspace/gam/crates/gam-solve)\n   Compiling num-dual v0.13.7\n   Compiling gam-model-kernels v0.3.148 (/workspace/gam/crates/gam-model-kernels)\n   Compiling gam-custom-family v0.3.148 (/workspace/gam/crates/gam-custom-family)\n   Compiling gam-models v0.3.148 (/workspace/gam/crates/gam-models)\n   Compiling gam-test-support v0.3.148 (/workspace/gam/crates/gam-test-support)\n    Finished `test` profile [optimized + debuginfo] target(s) in 28m 11s\n  Executable unittests src/lib.rs (target/debug/deps/gam_terms-e44a500d3580d2ee)\n```\n\n* \u2705 `./build.sh test -p gam-terms --lib duchon_2d_default_is_low_rank_not_generic_spatial_width_1757 -- --nocapture`\n\n```text\n[build.sh] test -p gam-terms --lib duchon_2d_default_is_low_rank_not_generic_spatial_width_1757 -- --nocapture -> exit 0 in 0s (dedup=MISS, recompiled 0 crates)\n    Finished `test` profile [optimized + debuginfo] target(s) in 0.58s\n     Running unittests src/lib.rs (target/debug/deps/gam_terms-e44a500d3580d2ee)\n\nrunning 1 test\ntest term_builder::tests::duchon_2d_default_is_low_rank_not_generic_spatial_width_1757 ... ok\n\ntest result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 688 filtered out; finished in 0.00s\n```\n\n* \u2705 `./build.sh test -p gam-terms --lib radial_1d_default_not_starved_below_univariate_spline_resolution_1867 -- --nocapture`\n\n```text\n[build.sh] test -p gam-terms --lib radial_1d_default_not_starved_below_univariate_spline_resolution_1867 -- --nocapture -> exit 0 in 0s (dedup=MISS, recompiled 0 crates)\n    Finished `test` profile [optimized + debuginfo] target(s) in 0.64s\n     Running unittests src/lib.rs (target/debug/deps/gam_terms-e44a500d3580d2ee)\n\nrunning 1 test\ntest term_builder::tests::radial_1d_default_not_starved_below_univariate_spline_resolution_1867 ... ok\n\ntest result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 688 filtered out; finished in 0.00s\n```\n\n* \u274c `./build.sh test -p gam-terms --lib radial_1d_default_not_starved_below_univariate_spline_resolution_1867 duchon_2d_default_is_low_rank_not_generic_spatial_width_1757 -- --nocapture`\n\n```text\n[build.sh] test -p gam-terms --lib radial_1d_default_not_starved_below_univariate_spline_resolution_1867 duchon_2d_default_is_low_rank_not_generic_spatial_width_1757 -- --nocapture -> exit 1 in 1s (dedup=MISS, recompiled 0 crates)\nFAILED (1):\nerror: unexpected argument 'duchon_2d_default_is_low_rank_not_generic_spatial_width_1757' found\n\nUsage: cargo test [OPTIONS] [TESTNAME] [-- [ARGS]...]\n\nFor more information, try '--help'.\n```\n\n* \u26a0\ufe0f `./build.sh` \u2014 I started the requested warm build, but it produced no terminal output for over 10 minutes and I interrupted it so the scoped compile/test gates could run. The scoped build and unit-test binary build above both completed successfully.\n\n## CODE DI
</details>

_Codex-generated; pending adversarial audit before merge._