### PR TITLE
#2134: Default sparse-dictionary score routing to auto; thread score_mode through SAE front-door; add CPU-route regression test

### DIFF
--- a/crates/gam-pyffi/src/manifold/geometry_ffi.rs
+++ b/crates/gam-pyffi/src/manifold/geometry_ffi.rs
@@ -4916,7 +4916,7 @@ const SPARSE_DICT_DUAL_CERT_MAX_BIRTHS: usize = 16;
     code_ridge = 1.0e-6,
     decoder_ridge = 1.0e-6,
     tolerance = 1.0e-6,
-    score_mode = "required"
+    score_mode = "auto"
 ))]
 fn sparse_dictionary_fit<'py>(
     py: Python<'py>,
@@ -4988,7 +4988,7 @@ fn sparse_dictionary_fit<'py>(
     active,
     score_tile = 4096,
     code_ridge = 1.0e-6,
-    score_mode = "required"
+    score_mode = "auto"
 ))]
 fn sparse_dictionary_transform_ffi<'py>(
     py: Python<'py>,
@@ -5530,7 +5530,7 @@ impl SparseDictStream {
         code_ridge = 1.0e-6,
         decoder_ridge = 1.0e-6,
         tolerance = 1.0e-6,
-        score_mode = "required"
+        score_mode = "auto"
     ))]
     fn new(
         py: Python<'_>,

--- a/crates/gam-sae/src/manifold/tests_logdet_adjoint_780.rs
+++ b/crates/gam-sae/src/manifold/tests_logdet_adjoint_780.rs
@@ -214,20 +214,6 @@ fn dual_half_logdet_trace_2156(cache: &ArrowFactorCache, h: &Array2<f64>, dh: &A
     0.5 * report.total_derivative
 }
 
-fn dual_logdet_trace_2156(
-    label: &'static str,
-    cache: &ArrowFactorCache,
-    h: &Array2<f64>,
-    dh: &Array2<f64>,
-) -> (f64, BranchCertificate) {
-    let report = dual_trace_report_2156(
-        cache,
-        h,
-        vec![(DerivativeTraceChannel::Other(label), dh.clone())],
-    );
-    (report.total_derivative, report.certificate)
-}
-
 fn relative_error_2156(exact: f64, production: f64) -> f64 {
     (exact - production).abs() / exact.abs().max(production.abs()).max(1.0)
 }

--- a/crates/gam-sae/src/sparse_dict/tests.rs
+++ b/crates/gam-sae/src/sparse_dict/tests.rs
@@ -343,6 +343,30 @@ fn sparse_transform_with_explicit_mode_reports_cpu_route_stats() {
     );
 }
 
+
+#[test]
+fn sparse_fit_default_auto_uses_cpu_below_device_floor() {
+    let (k, p, n) = (8usize, 10usize, 64usize);
+    let (x, _atoms) = planted(k, p, n, 0.1);
+    let config = SparseDictConfig {
+        n_atoms: k,
+        active: 1,
+        minibatch: 16,
+        max_epochs: 1,
+        score_tile: 8,
+        ..SparseDictConfig::new(k)
+    };
+
+    let fit = fit_sparse_dictionary(x.view(), &config)
+        .expect("default Auto mode must not require a subfloor CUDA route");
+
+    assert_eq!(config.score_mode, gam_gpu::GpuMode::Auto);
+    assert_eq!(fit.score_route_stats.minibatches, 8);
+    assert_eq!(fit.score_route_stats.cpu_minibatches, 8);
+    assert_eq!(fit.score_route_stats.device_minibatches, 0);
+    assert_eq!(fit.score_route_stats.admitted_minibatches, 0);
+}
+
 #[test]
 fn sparse_fit_records_score_route_stats() {
     let (k, p, n) = (8usize, 10usize, 64usize);

--- a/gamfit/_sae_manifold.py
+++ b/gamfit/_sae_manifold.py
@@ -2429,6 +2429,7 @@ def sae_manifold_fit(X: Any = None, K: int | None = None, d_atom: int = 2, atom_
                      ibp_alpha: float | None = None,
                      structured_residual_passes: int = 0,
                      promote_from_residual: bool = False,
+                     score_mode: str = "auto",
                      _run_structure_search: bool = True,
                      _run_outer_rho_search: bool = True) -> ManifoldSAE:
     """Fit an SAE-manifold model.
@@ -2563,6 +2564,11 @@ def sae_manifold_fit(X: Any = None, K: int | None = None, d_atom: int = 2, atom_
         residual passes are promoted into the primary atom tier rather than kept
         as a secondary residual dictionary. Only meaningful when
         ``structured_residual_passes > 0``. Coerced to ``bool``.
+    score_mode
+        Sparse front-door routing residency for the collapsed sparse-code lane.
+        ``"auto"`` (default) uses CUDA only when admitted and otherwise runs the
+        exact CPU router; ``"required"`` preserves fail-closed GPU residency;
+        ``"off"`` is CPU-only.
     learning_rate
         Damped Newton/Gauss-Newton step size. If omitted, the Python facade uses
         ``1.0`` for IBP/softmax and ``0.05`` for JumpReLU.
@@ -3003,7 +3009,7 @@ def sae_manifold_fit(X: Any = None, K: int | None = None, d_atom: int = 2, atom_
             k_atoms,
             active=sparse_active,
             max_epochs=max_iter_total,
-            score_mode="required",
+            score_mode=str(score_mode),
         )
     # Warm starts (issue #357): `a_init` (N, K) seeds the assignment logits and
     # `t_init` (K, N, D_max) seeds the per-atom on-manifold coordinates, so an

--- a/gamfit/_sparse_dictionary.py
+++ b/gamfit/_sparse_dictionary.py
@@ -292,9 +292,9 @@ class SparseDictStream:
         Identical hyper-parameters to :func:`sparse_dictionary_fit`. ``max_epochs``
         is advisory here (the driving Python loop decides how many epochs to run);
         it is carried only so :meth:`end_epoch`'s convergence flag matches the
-        one-shot stopping rule. ``score_mode="required"`` fails closed if an
-        admitted route cannot run on the CUDA scorer; use ``"off"`` for deliberate
-        CPU-only runs.
+        one-shot stopping rule. ``score_mode="auto"`` uses CUDA when admitted
+        and otherwise runs the exact CPU router; use ``"required"`` to fail
+        closed or ``"off"`` for deliberate CPU-only runs.
     """
 
     def __init__(
@@ -309,7 +309,7 @@ class SparseDictStream:
         code_ridge: float = 1.0e-6,
         decoder_ridge: float = 1.0e-6,
         tolerance: float = 1.0e-6,
-        score_mode: str = "required",
+        score_mode: str = "auto",
     ) -> None:
         seed_arr = _as_2d_f32(seed, "seed")
         self._handle = rust_module().SparseDictStream(
@@ -1049,7 +1049,7 @@ def sparse_dictionary_fit_begin(
     code_ridge: float = 1.0e-6,
     decoder_ridge: float = 1.0e-6,
     tolerance: float = 1.0e-6,
-    score_mode: str = "required",
+    score_mode: str = "auto",
 ) -> SparseDictStream:
     """Begin a streaming sparse-dictionary fit and return a :class:`SparseDictStream`.
 
@@ -1081,7 +1081,7 @@ def sparse_dictionary_fit(
     code_ridge: float = 1.0e-6,
     decoder_ridge: float = 1.0e-6,
     tolerance: float = 1.0e-6,
-    score_mode: str = "required",
+    score_mode: str = "auto",
 ) -> SparseDictionaryFit:
     """Fit a fixed-``K`` sparse, minibatched linear dictionary to ``X`` (``N x P``).
 
@@ -1097,8 +1097,9 @@ def sparse_dictionary_fit(
     code_ridge, decoder_ridge, tolerance:
         Shared regularisation and stopping controls.
     score_mode:
-        ``"required"`` (default) fails closed when an admitted high-``K`` route
-        cannot run on CUDA. Use ``"off"`` for deliberate CPU-only runs.
+        ``"auto"`` (default) uses CUDA when the route is admitted and falls back
+        to the exact CPU router otherwise. Use ``"required"`` to fail closed
+        instead of falling back, or ``"off"`` for deliberate CPU-only runs.
     """
     x = _as_2d_f32(X, "X")
     payload = rust_module().sparse_dictionary_fit(


### PR DESCRIPTION
### Motivation
- Small-K, CPU runs of the collapsed sparse-dictionary trainer were being blocked by a GPU "fail-closed" residency default: callers and the SAE sparse front-door hard-coded `score_mode="required"`, forcing an error when a minibatch×K block was below the device launch break-even even though an exact CPU router exists.
- The intent is to preserve strict GPU semantics when explicitly requested while making the common small-K baseline work on CPU by default (so the two SAE lanes can be compared at small K).

### Description
- Changed the public Python defaults for the sparse-dict API from `score_mode="required"` to `score_mode="auto"` so sub-break-even blocks route to the exact CPU router by default (files: `gamfit/_sparse_dictionary.py`).
- Aligned the PyO3/FFI defaults with the Python surface by switching FFI signatures/defaults for `sparse_dictionary_fit`, `sparse_dictionary_transform`, and `SparseDictStream` to `score_mode = "auto"` (file: `crates/gam-pyffi/src/manifold/geometry_ffi.rs`).
- Threaded a new `score_mode` argument through `sae_manifold_fit` and forwarded it to the sparse front-door instead of hard-coding `required`, preserving explicit fail-closed behavior when requested (file: `gamfit/_sae_manifold.py`).
- Added a unit test that verifies the default (`auto`) sparse-dict fit below the device floor uses the CPU route and records CPU route stats (file: `crates/gam-sae/src/sparse_dict/tests.rs`).
- Removed an unused test helper that caused a `-D warnings` build failure during the iterative test runs (file: `crates/gam-sae/src/manifold/tests_logdet_adjoint_780.rs`).

### Testing
- Built and checked the tree and the touched crate: `./build.sh` completed and `./build.sh check -p gam-sae --lib` completed successfully (no warnings/errors).
- Ran relevant unit tests in the sparse-dict area and the new regression test: `./build.sh test -p gam-sae --lib sparse_fit_default_auto_uses_cpu_below_device_floor -- --nocapture` and `./build.sh test -p gam-sae --lib tile_scorer_required_mode_refuses_subfloor_route -- --nocapture` both passed.
- Verified the one-shot and streaming Python surfaces compile: `python -m py_compile gamfit/_sparse_dictionary.py gamfit/_sae_manifold.py` succeeded.
- All automated checks exercised for the change (crate lib checks and targeted tests) passed; no existing tests were weakened or skipped.

---
Fixes #2134.

<details><summary>codex self-assessment</summary>

red_mode_refuses_subfloor_route -- --nocapture -> exit 0 in 1s (dedup=MISS, recompiled 0 crates)\n    Finished `test` profile [optimized + debuginfo] target(s) in 0.42s\n     Running unittests src/lib.rs (target/debug/deps/gam_sae-a2c4802d7e5c9eac)\n\nrunning 1 test\ntest sparse_dict::tests::tile_scorer_required_mode_refuses_subfloor_route ... ok\n\ntest result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 910 filtered out; finished in 0.00s\n```\n\n* After/regression evidence: default `auto` no longer requires CUDA for subfloor sparse fits.\n\n```text\n[build.sh] test -p gam-sae --lib sparse_fit_default_auto_uses_cpu_below_device_floor -- --nocapture -> exit 0 in 1s (dedup=MISS, recompiled 0 crates)\n    Finished `test` profile [optimized + debuginfo] target(s) in 0.45s\n     Running unittests src/lib.rs (target/debug/deps/gam_sae-a2c4802d7e5c9eac)\n\nrunning 1 test\ntest sparse_dict::tests::sparse_fit_default_auto_uses_cpu_below_device_floor ... ok\n\ntest result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 910 filtered out; finished in 0.01s\n```\n\n* Build/check evidence:\n\n```text\n[build.sh] LIB -> exit 0 in 81s (dedup=MISS, recompiled 1 crates)\n   Compiling gam v0.3.148 (/workspace/gam)\n    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 20s\n```\n\n```text\n[build.sh] check -p gam-sae --lib -> exit 0 in 192s (dedup=MISS, recompiled 9 crates)\n    Checking arrow-ord v54.3.1\n    Checking arrow-row v54.3.1\n    Checking arrow-arith v54.3.1\n    Checking csv-core v0.1.13\n    Checking libloading v0.8.9\n    Checking csv v1.4.0\n    Checking arrow v54.3.1\n    Checking rand_core v0.10.1\n    Checking memmap2 v0.9.11\n    Checking smallvec v1.15.2\n    Checking cpufeatures v0.3.0\n    Checking getrandom v0.4.3\n    Checking chacha20 v0.10.1\n    Checking opt v0.5.11\n    Checking rand v0.10.2\n    Checking sysinfo v0.32.1\n    Checking gam-linalg v0.3.148 (/workspace/gam/crates/gam-linalg)\n    Checking gam-geometry v0.3.148 (/workspace/gam/crates/gam-geometry)\n    Checking gam-gpu v0.3.148 (/workspace/gam/crates/gam-gpu)\n    Checking gam-problem v0.3.148 (/workspace/gam/crates/gam-problem)\n    Checking gam-model-api v0.3.148 (/workspace/gam/crates/gam-model-api)\n    Checking gam-identifiability v0.3.148 (/workspace/gam/crates/gam-identifiability)\n   Compiling zstd-safe v7.2.4\n    Checking zstd v0.13.3\n    Checking parquet v54.3.1\n    Checking gam-data v0.3.148 (/workspace/gam/crates/gam-data)\n    Checking gam-terms v0.3.148 (/workspace/gam/crates/gam-terms)\n    Checking gam-solve v0.3.148 (/workspace/gam/crates/gam-solve)\n    Checking gam-sae v0.3.148 (/workspace/gam/crates/gam-sae)\n    Finished `dev` profile [unoptimized + debuginfo] target(s) in 3m 12s\n```\n\n```text\n[build.sh] test -p gam-sae --lib --no-run -> exit 0 in 98s (dedup=MISS, recompiled 1 crates)\n   Compiling gam-sae v0.3.148 (/workspace/gam/crates/gam-sae)\n    Finished `test` profile [optimized + debuginfo] target(s) in 1m 38s\n  Executable unittests src/lib.rs (target/debug/deps/gam_sae-a2c4802d7e5c9eac)\n```\n\n* Touched-area regression evidence:\n\n```text\n[build.sh] test -p gam-sae --lib sparse_fit_records_score_route_stats -- --nocapture -> exit 0 in 1s (dedup=MISS, recompiled 0 crates)\n    Finished `test` profile [optimized + debuginfo] target(s) in 0.42s\n     Running unittests src/lib.rs (target/debug/deps/gam_sae-a2c4802d7e5c9eac)\n\nrunning 1 test\ntest sparse_dict::tests::sparse_fit_records_score_route_stats ... ok\n\ntest result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 910 filtered out; finished in 0.01s\n```\n\n* Python syntax check:\n\n```text\npython -m py_compile gamfit/_sparse_dictionary.py gamfit/_sae_manifold.py\n```\n\n## CODE DIFF\n\n```diff\ndiff --git a/crates/gam-pyffi/src/manifold/geometry_ffi.rs b/crates/gam-pyffi/src/manifold/geometry_ffi.rs\nindex 0569cf9..f67fd22 100644\n--- a/crates/gam-pyffi/src/manifold/geometry_ffi.rs\n+++ b/crates/gam-pyffi/src/manifold/geometry_ffi.rs\n@@ -4
</details>

_Codex-generated; pending adversarial audit before merge._