### PR TITLE
#2136: Fix predict uncertainty gating for curved links

### DIFF
--- a/crates/gam-cli/src/main/run_predict.rs
+++ b/crates/gam-cli/src/main/run_predict.rs
@@ -231,32 +231,22 @@ pub(crate) fn run_predict_unified(
             Some(pred.mean_upper),
         )
     } else if nonlinear && args.mode == PredictModeArg::PosteriorMean {
-        // Mirror the `--uncertainty` arm's covariance-mode handling so the
-        // posterior-mean credible interval includes smoothing-parameter
-        // uncertainty by default (issue #812), instead of the bare conditional.
+        // Point-only curved-link prediction still needs the posterior mean
+        // `E[link⁻¹(X·β)]`, but it must not ask the posterior-mean backend for
+        // interval quantities. Passing a confidence level is the switch that
+        // populates `mean_standard_error`/bounds, and the CSV writer emits any
+        // populated optionals. Keep the default point estimate identical to the
+        // `--uncertainty` arm while leaving SE/band columns absent unless the
+        // user requested them (#2136).
         let pm_options = PosteriorMeanOptions {
-            confidence_level: Some(args.level),
+            confidence_level: None,
             covariance_mode: infer_covariance_mode(args.covariance_mode),
             include_observation_interval: false,
         };
         let pm = predictor
             .predict_posterior_mean(pred_input, &fit_for_predict, &pm_options)
             .map_err(|e| format!("predict_posterior_mean failed: {e}"))?;
-        (
-            pm.eta,
-            pm.mean,
-            // Response-scale `std_error` (#1536): the posterior-mean path
-            // populates `mean_standard_error` whenever a confidence level is
-            // requested (it is here); fall back to the link-scale SE only for
-            // the unreachable point-only case.
-            Some(
-                pm.mean_standard_error
-                    .clone()
-                    .unwrap_or(pm.eta_standard_error),
-            ),
-            pm.mean_lower,
-            pm.mean_upper,
-        )
+        (pm.eta, pm.mean, None, None, None)
     } else {
         let pred = predictor
             .predict_plugin_response(pred_input)

--- a/tests/bug_hunt_cli_predict_uncertainty_flag_is_noop_for_curved_link_families_test.py
+++ b/tests/bug_hunt_cli_predict_uncertainty_flag_is_noop_for_curved_link_families_test.py
@@ -1,0 +1,96 @@
+import csv
+import os
+import shutil
+import subprocess
+
+import numpy as np
+import pandas as pd
+import pytest
+
+
+def gam_bin():
+    candidates = [
+        os.environ.get("GAM_BIN"),
+        "target/release/gam",
+        "target/debug/gam",
+        shutil.which("gam"),
+    ]
+    for candidate in candidates:
+        if candidate and os.path.exists(candidate):
+            return candidate
+    pytest.skip("gam binary not built")
+
+
+def write_data(tmp_path):
+    rng = np.random.default_rng(1)
+    n = 1500
+    x = rng.uniform(0.0, 1.0, n)
+    poisson = tmp_path / "poisson.csv"
+    gaussian = tmp_path / "gaussian.csv"
+    pd.DataFrame(
+        {"y": rng.poisson(np.exp(0.3 + np.sin(2 * np.pi * x))), "x": x}
+    ).to_csv(poisson, index=False)
+    pd.DataFrame(
+        {"y": np.sin(2 * np.pi * x) + rng.normal(0.0, 0.3, n), "x": x}
+    ).to_csv(gaussian, index=False)
+    return poisson, gaussian
+
+
+def run_gam(*args):
+    subprocess.run([gam_bin(), *map(str, args)], check=True)
+
+
+def header(path):
+    with open(path, newline="") as f:
+        return next(csv.reader(f))
+
+
+def test_gaussian_reference_honours_uncertainty_flag(tmp_path):
+    _, gaussian = write_data(tmp_path)
+    model = tmp_path / "gaussian.gam"
+    no_uncertainty = tmp_path / "gaussian-no.csv"
+    yes_uncertainty = tmp_path / "gaussian-yes.csv"
+
+    run_gam("fit", gaussian, "y ~ s(x)", "--family", "gaussian", "--out", model, "-q")
+    run_gam("predict", model, gaussian, "--out", no_uncertainty, "-q")
+    run_gam("predict", model, gaussian, "--out", yes_uncertainty, "--uncertainty", "-q")
+
+    assert header(no_uncertainty) == ["eta", "mean"]
+    assert header(yes_uncertainty) == [
+        "eta",
+        "mean",
+        "std_error",
+        "mean_lower",
+        "mean_upper",
+    ]
+
+
+def test_poisson_predict_without_uncertainty_must_not_emit_band_columns(tmp_path):
+    poisson, _ = write_data(tmp_path)
+    model = tmp_path / "poisson.gam"
+    no_uncertainty = tmp_path / "poisson-no.csv"
+
+    run_gam("fit", poisson, "y ~ s(x)", "--family", "poisson-log", "--out", model, "-q")
+    run_gam("predict", model, poisson, "--out", no_uncertainty, "-q")
+
+    assert header(no_uncertainty) == ["eta", "mean"]
+
+
+def test_uncertainty_flag_is_not_a_noop_for_poisson(tmp_path):
+    poisson, _ = write_data(tmp_path)
+    model = tmp_path / "poisson.gam"
+    no_uncertainty = tmp_path / "poisson-no.csv"
+    yes_uncertainty = tmp_path / "poisson-yes.csv"
+
+    run_gam("fit", poisson, "y ~ s(x)", "--family", "poisson-log", "--out", model, "-q")
+    run_gam("predict", model, poisson, "--out", no_uncertainty, "-q")
+    run_gam("predict", model, poisson, "--out", yes_uncertainty, "--uncertainty", "-q")
+
+    assert header(no_uncertainty) == ["eta", "mean"]
+    assert header(yes_uncertainty) == [
+        "eta",
+        "mean",
+        "std_error",
+        "mean_lower",
+        "mean_upper",
+    ]


### PR DESCRIPTION
### Motivation
- `gam predict` was documented to only append SE and credible-band columns when `--uncertainty` is set, but curved-inverse-link families (Poisson/Gamma/Binomial) unconditionally emitted `std_error`, `mean_lower`, and `mean_upper`. 
- The root cause was that the posterior-mean prediction path requested a confidence level even in the point-only default, which populated optional interval arrays and caused the CSV writer to emit band columns. 
- The change restores the documented contract: point-only prediction must output only `eta,mean` for all families unless intervals are requested. 

### Description
- In `crates/gam-cli/src/main/run_predict.rs` the curved-link posterior-mean point-only branch now calls `predict_posterior_mean` with `confidence_level: None` and returns `None` for the optional SE/band arrays so those columns are not emitted. 
- The `--uncertainty` and identity-link (`gaussian`) paths remain unchanged and still request/emit SE and band columns when requested. 
- Added a CLI regression test `tests/bug_hunt_cli_predict_uncertainty_flag_is_noop_for_curved_link_families_test.py` that verifies the gaussian control, poisson no-uncertainty (point-only) emits `eta,mean`, and poisson with `--uncertainty` emits `std_error`, `mean_lower`, `mean_upper`. 

### Testing
- Built the project and CLI with `./build.sh` and `./build.sh build -p gam-cli --bin gam`, both completed successfully. 
- Ran `./build.sh check -p gam-cli --bin gam` which completed with no warnings/errors. 
- Executed the new regression `pytest tests/bug_hunt_cli_predict_uncertainty_flag_is_noop_for_curved_link_families_test.py` and it passed (3 tests passed).

---
Fixes #2136.

<details><summary>codex self-assessment</summary>

lies_test.py::test_poisson_predict_without_uncertainty_must_not_emit_band_columns\nFAILED tests/bug_hunt_cli_predict_uncertainty_flag_is_noop_for_curved_link_families_test.py::test_uncertainty_flag_is_not_a_noop_for_poisson\n========================= 2 failed, 1 passed in 40.97s =========================\n```\n\n**Build/check/test output after the fix:**\n\n* \u2705 `./build.sh`\n\n```text\n[build.sh] LIB -> exit 0 in 1242s (dedup=MISS, recompiled 293 crates)\n    Finished `dev` profile [unoptimized + debuginfo] target(s) in 20m 41s\n```\n\n* \u2705 `./build.sh check -p gam-cli --bin gam`\n\n```text\n[build.sh] check -p gam-cli --bin gam -> exit 0 in 3s (dedup=MISS, recompiled 0 crates)\n    Checking gam v0.3.148 (/workspace/gam)\n    Checking gam-predict v0.3.148 (/workspace/gam/crates/gam-predict)\n    Checking gam-cli v0.3.148 (/workspace/gam/crates/gam-cli)\n    Finished `dev` profile [unoptimized + debuginfo] target(s) in 2.96s\n```\n\n* \u2705 `./build.sh build -p gam-cli --bin gam`\n\n```text\n[build.sh] build -p gam-cli --bin gam -> exit 0 in 121s (dedup=MISS, recompiled 3 crates)\n   Compiling gam v0.3.148 (/workspace/gam)\n   Compiling gam-predict v0.3.148 (/workspace/gam/crates/gam-predict)\n   Compiling gam-cli v0.3.148 (/workspace/gam/crates/gam-cli)\n    Finished `dev` profile [unoptimized + debuginfo] target(s) in 2m 01s\n```\n\n* \u2705 `pytest tests/bug_hunt_cli_predict_uncertainty_flag_is_noop_for_curved_link_families_test.py`\n\n```text\n============================= test session starts ==============================\nplatform linux -- Python 3.12.13, pytest-9.0.3, pluggy-1.6.0\nrootdir: /workspace/gam\nconfigfile: pyproject.toml\ncollected 3 items\n\ntests/bug_hunt_cli_predict_uncertainty_flag_is_noop_for_curved_link_families_test.py . [ 33%]\n..                                                                       [100%]\n\n============================== 3 passed in 39.86s ==============================\n```\n\n### CODE DIFF\n\n```diff\ndiff --git a/crates/gam-cli/src/main/run_predict.rs b/crates/gam-cli/src/main/run_predict.rs\nindex 0ff4034..121f771 100644\n--- a/crates/gam-cli/src/main/run_predict.rs\n+++ b/crates/gam-cli/src/main/run_predict.rs\n@@ -231,32 +231,22 @@ pub(crate) fn run_predict_unified(\n             Some(pred.mean_upper),\n         )\n     } else if nonlinear && args.mode == PredictModeArg::PosteriorMean {\n-        // Mirror the `--uncertainty` arm's covariance-mode handling so the\n-        // posterior-mean credible interval includes smoothing-parameter\n-        // uncertainty by default (issue #812), instead of the bare conditional.\n+        // Point-only curved-link prediction still needs the posterior mean\n+        // `E[link\u207b\u00b9(X\u00b7\u03b2)]`, but it must not ask the posterior-mean backend for\n+        // interval quantities. Passing a confidence level is the switch that\n+        // populates `mean_standard_error`/bounds, and the CSV writer emits any\n+        // populated optionals. Keep the default point estimate identical to the\n+        // `--uncertainty` arm while leaving SE/band columns absent unless the\n+        // user requested them (#2136).\n         let pm_options = PosteriorMeanOptions {\n-            confidence_level: Some(args.level),\n+            confidence_level: None,\n             covariance_mode: infer_covariance_mode(args.covariance_mode),\n             include_observation_interval: false,\n         };\n         let pm = predictor\n             .predict_posterior_mean(pred_input, &fit_for_predict, &pm_options)\n             .map_err(|e| format!(\"predict_posterior_mean failed: {e}\"))?;\n-        (\n-            pm.eta,\n-            pm.mean,\n-            // Response-scale `std_error` (#1536): the posterior-mean path\n-            // populates `mean_standard_error` whenever a confidence level is\n-            // requested (it is here); fall back to the link-scale SE only for\n-            // the unreachable point-only case.\n-            So
</details>

_Codex-generated; pending adversarial audit before merge._