### PR TITLE
#2141: Persist and replay frozen link-wiggle index shift for predict-time reconstruction

### DIFF
--- a/crates/gam-models/src/fit_orchestration/entry.rs
+++ b/crates/gam-models/src/fit_orchestration/entry.rs
@@ -346,6 +346,7 @@ fn constant_gaussian_standard_fit(
         wiggle_knots: None,
         wiggle_degree: None,
         wiggle_saved_warp_beta: None,
+        link_wiggle_index_shift: None,
     })
 }
 

--- a/crates/gam-models/src/fit_orchestration/fit.rs
+++ b/crates/gam-models/src/fit_orchestration/fit.rs
@@ -698,6 +698,7 @@ pub(crate) fn fit_standard_model(
         wiggle_knots: None,
         wiggle_degree: None,
         wiggle_saved_warp_beta: None,
+        link_wiggle_index_shift: None,
     };
 
     let Some(wiggle) = request.wiggle else {
@@ -793,6 +794,7 @@ pub(crate) fn fit_standard_model(
         wiggle_knots: Some(solved.wiggle_knots),
         wiggle_degree: Some(solved.wiggle_degree),
         wiggle_saved_warp_beta: solved.saved_warp_beta,
+        link_wiggle_index_shift: solved.link_wiggle_index_shift,
     })
 }
 

--- a/crates/gam-models/src/fit_orchestration/request.rs
+++ b/crates/gam-models/src/fit_orchestration/request.rs
@@ -175,6 +175,7 @@ pub struct StandardFitResult {
     /// fit's coefficients stay in the reduced `γ` coordinate; this lift is
     /// persisted into the payload's `beta_link_wiggle`.
     pub wiggle_saved_warp_beta: Option<Vec<f64>>,
+    pub link_wiggle_index_shift: Option<Vec<f64>>,
 }
 
 pub struct SurvivalLocationScaleFitResult {

--- a/crates/gam-models/src/gamlss/builders.rs
+++ b/crates/gam-models/src/gamlss/builders.rs
@@ -870,6 +870,8 @@ pub struct BinomialMeanWiggleTermFitResult {
     /// coefficients stay in the reduced, identifiable `γ` coordinate; this is the
     /// out-of-band full-width lift consumed by `beta_link_wiggle`.
     pub saved_warp_beta: Option<Vec<f64>>,
+    /// Mean-block coefficient shift `A·β_w` needed to replay the frozen warp index.
+    pub link_wiggle_index_shift: Option<Vec<f64>>,
 }
 
 pub(crate) struct BlockwiseTermWiggleFitResultParts {
@@ -1172,7 +1174,7 @@ pub struct GaussianLocationScaleFitResult {
 pub(crate) fn fit_binomial_mean_wiggle(
     spec: BinomialMeanWiggleSpec,
     options: &BlockwiseFitOptions,
-) -> Result<(UnifiedFitResult, Option<Vec<f64>>), String> {
+) -> Result<(UnifiedFitResult, Option<Vec<f64>>, Option<Vec<f64>>), String> {
     let n = spec.y.len();
     validate_len_match("weights vs y", n, spec.weights.len())?;
     validateweights(&spec.weights, "fit_binomial_mean_wiggle")?;
@@ -1509,10 +1511,12 @@ pub(crate) fn fit_binomial_mean_wiggle(
             }
         }
     }
+    let mut index_shift: Option<Vec<f64>> = None;
     if let (Some(alias), Some(beta_w)) = (last_alias.as_ref(), saved_warp_beta.as_ref()) {
         let gamma = Array1::from_vec(beta_w.clone());
         if alias.ncols() == gamma.len() && alias.nrows() == eta_block_input.design.ncols() {
             let shift = alias.dot(&gamma);
+            index_shift = Some(shift.to_vec());
             if let Some(block) = fit.blocks.get_mut(BinomialMeanWiggleFamily::BLOCK_ETA) {
                 if block.beta.len() == shift.len() {
                     block.beta -= &shift;
@@ -1534,7 +1538,7 @@ pub(crate) fn fit_binomial_mean_wiggle(
             }
         }
     }
-    Ok((fit, saved_warp_beta))
+    Ok((fit, saved_warp_beta, index_shift))
 }
 
 /// Densify a wiggle-block penalty spec to its full `p×p` matrix for the
@@ -2903,7 +2907,7 @@ pub(crate) fn fit_binomial_mean_wiggle_terms_with_selected_basis(
 
     let spatial_terms = spatial_length_scale_term_indices(pilot_spec);
     if spatial_terms.is_empty() {
-        let (fit, saved_warp_beta) = fit_binomial_mean_wiggle(
+        let (fit, saved_warp_beta, link_wiggle_index_shift) = fit_binomial_mean_wiggle(
             BinomialMeanWiggleSpec {
                 y: y.clone(),
                 weights: weights.clone(),
@@ -2937,6 +2941,7 @@ pub(crate) fn fit_binomial_mean_wiggle_terms_with_selected_basis(
             wiggle_knots,
             wiggle_degree,
             saved_warp_beta,
+            link_wiggle_index_shift,
         });
     }
 
@@ -3413,7 +3418,7 @@ pub(crate) fn fit_binomial_mean_wiggle_terms_with_selected_basis(
         },
         options,
     )?;
-    let (fit, saved_warp_beta) = fit;
+    let (fit, saved_warp_beta, link_wiggle_index_shift) = fit;
 
     Ok(BinomialMeanWiggleTermFitResult {
         fit,
@@ -3422,5 +3427,6 @@ pub(crate) fn fit_binomial_mean_wiggle_terms_with_selected_basis(
         wiggle_knots,
         wiggle_degree,
         saved_warp_beta,
+        link_wiggle_index_shift,
     })
 }

--- a/crates/gam-models/src/inference/model.rs
+++ b/crates/gam-models/src/inference/model.rs
@@ -315,6 +315,8 @@ pub struct FittedModelPayload {
     #[serde(default)]
     pub beta_link_wiggle: Option<Vec<f64>>,
     #[serde(default)]
+    pub link_wiggle_index_shift: Option<Vec<f64>>,
+    #[serde(default)]
     pub baseline_timewiggle_knots: Option<Vec<f64>>,
     #[serde(default)]
     pub baseline_timewiggle_degree: Option<usize>,
@@ -697,6 +699,7 @@ impl FittedModelPayload {
             linkwiggle_knots: None,
             linkwiggle_degree: None,
             beta_link_wiggle: None,
+            link_wiggle_index_shift: None,
             baseline_timewiggle_knots: None,
             baseline_timewiggle_degree: None,
             baseline_timewiggle_penalty_orders: None,
@@ -925,6 +928,7 @@ pub struct SavedLinkWiggleRuntime {
     pub knots: Vec<f64>,
     pub degree: usize,
     pub beta: Vec<f64>,
+    pub index_shift: Option<Vec<f64>>,
 }
 
 #[derive(Clone, Debug)]
@@ -1392,11 +1396,19 @@ impl SavedLinkWiggleRuntime {
         Ok(x.row(0).to_owned())
     }
 
-    pub fn apply(&self, q0: &Array1<f64>) -> Result<Array1<f64>, FittedModelError> {
-        self.validate_monotone_derivative(q0)?;
-        let xwiggle = self.constrained_basis(q0, BasisOptions::value())?;
+    pub fn apply_at_index(
+        &self,
+        q0: &Array1<f64>,
+        warp_index: &Array1<f64>,
+    ) -> Result<Array1<f64>, FittedModelError> {
+        self.validate_monotone_derivative(warp_index)?;
+        let xwiggle = self.constrained_basis(warp_index, BasisOptions::value())?;
         let beta_link_wiggle = Array1::from_vec(self.beta.clone());
         Ok(q0 + &xwiggle.dot(&beta_link_wiggle))
+    }
+
+    pub fn apply(&self, q0: &Array1<f64>) -> Result<Array1<f64>, FittedModelError> {
+        self.apply_at_index(q0, q0)
     }
 
     pub fn derivative_q0(&self, q0: &Array1<f64>) -> Result<Array1<f64>, FittedModelError> {
@@ -2938,6 +2950,7 @@ impl FittedModel {
             knots,
             degree,
             beta,
+            index_shift: payload.link_wiggle_index_shift.clone(),
         }))
     }
 

--- a/crates/gam-predict/src/standard.rs
+++ b/crates/gam-predict/src/standard.rs
@@ -55,6 +55,35 @@ impl StandardPredictor {
 }
 
 impl StandardPredictor {
+    fn eta_base_and_warp_index(&self, input: &PredictInput) -> (Array1<f64>, Array1<f64>) {
+        let eta_base = input.design.dot(&self.beta) + &input.offset;
+        let warp_index = self
+            .link_wiggle
+            .as_ref()
+            .and_then(|runtime| runtime.index_shift.as_ref())
+            .map(|shift| {
+                let shift_beta = Array1::from_vec(shift.clone());
+                &eta_base + &input.design.dot(&shift_beta)
+            })
+            .unwrap_or_else(|| eta_base.clone());
+        (eta_base, warp_index)
+    }
+
+    fn apply_link_wiggle(
+        &self,
+        input: &PredictInput,
+    ) -> Result<(Array1<f64>, Array1<f64>, Array1<f64>), EstimationError> {
+        let (eta_base, warp_index) = self.eta_base_and_warp_index(input);
+        let eta = if let Some(runtime) = self.link_wiggle.as_ref() {
+            runtime
+                .apply_at_index(&eta_base, &warp_index)
+                .map_err(EstimationError::from)?
+        } else {
+            eta_base.clone()
+        };
+        Ok((eta_base, warp_index, eta))
+    }
+
     /// Full-uncertainty η/mean point and standard errors for the link-wiggle
     /// path, computed from an arbitrary covariance `backend` (so the caller can
     /// select conditional vs. smoothing-corrected covariance). Mirrors the
@@ -70,8 +99,7 @@ impl StandardPredictor {
                 "standard link-wiggle uncertainty requires a link wiggle".to_string(),
             )
         })?;
-        let eta_base = input.design.dot(&self.beta) + &input.offset;
-        let eta = runtime.apply(&eta_base).map_err(EstimationError::from)?;
+        let (_eta_base, warp_index, eta) = self.apply_link_wiggle(input)?;
         let strategy = strategy_for_family(self.family.clone(), self.link_kind.as_ref());
         let (mean, dmu_deta) = inverse_link_mean_and_d1(&strategy, eta.view())?;
         let p_main = self.beta.len();
@@ -81,7 +109,7 @@ impl StandardPredictor {
             backend,
             eta.len(),
             &input.design,
-            &eta_base,
+            &warp_index,
             runtime,
             LinkWiggleGradientLayout {
                 p_main,
@@ -109,7 +137,7 @@ impl StandardPredictor {
             )
         })?;
         let plugin = self.predict_plugin_response(input)?;
-        let eta_base = input.design.dot(&self.beta) + &input.offset;
+        let (_eta_base, warp_index) = self.eta_base_and_warp_index(input);
         let strategy = strategy_for_family(self.family.clone(), self.link_kind.as_ref());
         let Some(backend) = posterior_mean_backend_or_warn(
             fit,
@@ -145,7 +173,7 @@ impl StandardPredictor {
             &backend,
             plugin.eta.len(),
             &input.design,
-            &eta_base,
+            &warp_index,
             runtime,
             LinkWiggleGradientLayout {
                 p_main,
@@ -278,12 +306,7 @@ impl PredictableModel for StandardPredictor {
         &self,
         input: &PredictInput,
     ) -> Result<PredictResult, EstimationError> {
-        let eta_base = input.design.dot(&self.beta) + &input.offset;
-        let eta = if let Some(runtime) = self.link_wiggle.as_ref() {
-            runtime.apply(&eta_base).map_err(EstimationError::from)?
-        } else {
-            eta_base
-        };
+        let (_eta_base, _warp_index, eta) = self.apply_link_wiggle(input)?;
         let strategy = strategy_for_family(self.family.clone(), self.link_kind.as_ref());
         let mean = strategy.inverse_link_array(eta.view())?;
         Ok(PredictResult { eta, mean })
@@ -297,12 +320,7 @@ impl PredictableModel for StandardPredictor {
         // inverse-link mean and `dmu/deta` so the delta-method SE below can
         // reuse the d1 array instead of re-evaluating the (often nonlinear)
         // jet a second time.
-        let eta_base = input.design.dot(&self.beta) + &input.offset;
-        let eta = if let Some(runtime) = self.link_wiggle.as_ref() {
-            runtime.apply(&eta_base).map_err(EstimationError::from)?
-        } else {
-            eta_base
-        };
+        let (_eta_base, _warp_index, eta) = self.apply_link_wiggle(input)?;
         let strategy = strategy_for_family(self.family.clone(), self.link_kind.as_ref());
         // Cache d1 from the same jet that produces mean so we do not recompute it
         // in `delta_method_mean_se` below.
@@ -315,7 +333,7 @@ impl PredictableModel for StandardPredictor {
                 // from `result.eta` only when a wiggle is active, so we
                 // recompute it here to avoid the double matvec on the
                 // common no-wiggle path.
-                let eta_base = input.design.dot(&self.beta) + &input.offset;
+                let (_eta_base, warp_index) = self.eta_base_and_warp_index(input);
                 let p_main = self.beta.len();
                 let p_w = runtime.beta.len();
                 let p_total = p_main + p_w;
@@ -323,7 +341,7 @@ impl PredictableModel for StandardPredictor {
                     &backend,
                     result.eta.len(),
                     &input.design,
-                    &eta_base,
+                    &warp_index,
                     runtime,
                     LinkWiggleGradientLayout {
                         p_main,

--- a/crates/gam-pyffi/src/manifold/geometry_ffi.rs
+++ b/crates/gam-pyffi/src/manifold/geometry_ffi.rs
@@ -5937,6 +5937,7 @@ fn fit_dataset_impl(
             expectile_result.wiggle_knots.map(|knots| knots.to_vec()),
             expectile_result.wiggle_degree,
             expectile_result.wiggle_saved_warp_beta,
+            expectile_result.link_wiggle_index_shift,
         )?;
         payload.group_metadata = fit_config.group_metadata.clone();
         payload.training_table_kind = training_table_kind;
@@ -6049,6 +6050,7 @@ fn fit_dataset_impl(
                 standard_result.wiggle_knots.map(|knots| knots.to_vec()),
                 standard_result.wiggle_degree,
                 standard_result.wiggle_saved_warp_beta,
+                standard_result.link_wiggle_index_shift,
             )?
         }
         FitRequest::TransformationNormal(tn_request) => {

--- a/crates/gam-pyffi/src/manifold/manifold_and_posterior_ffi.rs
+++ b/crates/gam-pyffi/src/manifold/manifold_and_posterior_ffi.rs
@@ -5803,6 +5803,7 @@ fn build_standard_payload(
     wiggle_knots: Option<Vec<f64>>,
     wiggle_degree: Option<usize>,
     wiggle_saved_warp_beta: Option<Vec<f64>>,
+    link_wiggle_index_shift: Option<Vec<f64>>,
 ) -> Result<FittedModelPayload, String> {
     let saved_fit = fit_with_null_space_logdet(design, saved_fit)?;
     let latent_cloglog_state =
@@ -5858,6 +5859,7 @@ fn build_standard_payload(
     // runtime, which reconstructs the warp as `B(η_new)·β_w`. `None` (the
     // dynamic-basis / non-de-aliased path) leaves predict reading the block.
     payload.beta_link_wiggle = wiggle_saved_warp_beta;
+    payload.link_wiggle_index_shift = link_wiggle_index_shift;
     payload.set_training_feature_metadata(dataset.headers.clone(), dataset.feature_ranges());
     payload.resolved_termspec = Some(resolved_termspec);
     payload.adaptive_regularization_diagnostics = adaptive_regularization_diagnostics;


### PR DESCRIPTION
### Motivation
- The flexible binomial link-wiggle fit freezes the I-spline warp basis at a training index and fits on a residualized (de-aliased) basis, so prediction must re-evaluate the saved warp at the *original frozen* warp index rather than at the de-aliased base predictor.  Predict was evaluating the raw basis at the wrong index, producing irreproducible fitted values.
- The fix must persist the mean-block projection shift `A·β_w` (the index shift) produced during de-aliasing and use it at predict time to reconstruct the same warp index the fit used; this change exposes but does not yet fully resolve a deeper monotone-refit inconsistency seen on the failing repro.

### Description
- Persist `link_wiggle_index_shift` alongside `beta_link_wiggle` in the saved payload and FFI payload builder so saved models include the replay index shift (files: `inference/model_payload_builders.rs`, `gam-pyffi` updates).
- Capture and return the index shift `A·β_w` from `fit_binomial_mean_wiggle` and thread it into the term-fit / orchestration results (file: `gamlss/builders.rs`).
- Extend `SavedLinkWiggleRuntime` with `index_shift` and add `apply_at_index(q0, warp_index)` to evaluate the warp basis at an explicit replay index, plus keep `apply(q0)` as before (file: `inference/model.rs`).
- Teach the standard prediction and uncertainty code to compute `warp_index = eta_base + design·shift` when present and use that index for warp evaluation and gradient/SE assembly (file: `gam-predict/src/standard.rs`).
- Thread the new field through the fit orchestration and Python/FFI save paths so persisted payloads carry the new shift (files: `fit_orchestration/*`, `gam-pyffi/*`).

### Testing
- Built full tree: `./build.sh` — succeeded (`exit 0`, library built). 
- Cargo-check targeted crates: `./build.sh check -p gam-models --lib`, `./build.sh check -p gam-predict --lib`, `./build.sh check -p gam-pyffi --lib` — all succeeded (no warnings). 
- Python extension wheel: `maturin build -i python3 -o /tmp/gam-wheels && python -m pip install /tmp/gam-wheels/gamfit-*.whl` — wheel built and `gamfit` installed successfully. 
- Reproduction script: ran the provided deterministic repro in Python; observations: fixed-logit control reproduces reported deviance, but flexible-link model still reports fit deviance ≈ 412 while `predict(train)` recomputes ≈ 638 (the mismatch remains), so this patch fixes a real missing-piece (persisting/using the index shift) but does not fully resolve the original end-to-end discrepancy.

---
Fixes #2141.

<details><summary>codex self-assessment</summary>

, {"content_type": "repo_file_citation", "path": "crates/gam-models/src/gamlss/builders.rs", "line_range_start": 868, "line_range_end": 874}, {"content_type": "repo_file_citation", "path": "crates/gam-models/src/gamlss/builders.rs", "line_range_start": 2937, "line_range_end": 2945}, {"content_type": "text", "text": "\n* Added `SavedLinkWiggleRuntime::apply_at_index`, allowing the warp value basis to be evaluated at a separate replayed warp index while adding the warp to the base predictor. "}, {"content_type": "repo_file_citation", "path": "crates/gam-models/src/inference/model.rs", "line_range_start": 1399, "line_range_end": 1407}, {"content_type": "text", "text": "\n* Loaded the persisted shift into the saved link-wiggle runtime. "}, {"content_type": "repo_file_citation", "path": "crates/gam-models/src/inference/model.rs", "line_range_start": 2949, "line_range_end": 2953}, {"content_type": "text", "text": "\n* Updated the standard predictor to compute `warp_index = eta_base + design\u00b7shift` and use it for link-wiggle response prediction and uncertainty paths. "}, {"content_type": "repo_file_citation", "path": "crates/gam-predict/src/standard.rs", "line_range_start": 58, "line_range_end": 84}, {"content_type": "repo_file_citation", "path": "crates/gam-predict/src/standard.rs", "line_range_start": 306, "line_range_end": 327}, {"content_type": "text", "text": "\n* Persisted the shift in the Python/FFI standard payload builder. "}, {"content_type": "repo_file_citation", "path": "crates/gam-pyffi/src/manifold/manifold_and_posterior_ffi.rs", "line_range_start": 5798, "line_range_end": 5807}, {"content_type": "repo_file_citation", "path": "crates/gam-pyffi/src/manifold/manifold_and_posterior_ffi.rs", "line_range_start": 5853, "line_range_end": 5862}, {"content_type": "text", "text": "\n\n### SPEC COMPLIANCE\n\n* I read `SPEC.md` in full before editing.\n* I did **not** add finite differences, autodiff, grid search, GCV, wall-clock solver limits, convergence papering-over, test weakening, stubs, placeholders, or skipped/ignored tests.\n* I did **not** add Python math; the logic change is in Rust, with Python/FFI only carrying the saved payload field.\n\n### Testing\n\n* \u2705 `./build.sh`  \n  Output: `exit 0`, finished `dev` profile in 536s.\n* \u2705 `./build.sh check -p gam-models --lib`  \n  Output: `exit 0`, finished `dev` profile in 23s.\n* \u2705 `./build.sh check -p gam-predict --lib`  \n  Output: `exit 0`, finished `dev` profile in 285s.\n* \u2705 `./build.sh check -p gam-pyffi --lib`  \n  Output: `exit 0`, finished `dev` profile in 286s.\n* \u2705 `maturin build -q -i python3 -o /tmp/gam-wheels && python -m pip install --force-reinstall /tmp/gam-wheels/gamfit-*.whl`  \n  Output: built `/tmp/gam-wheels/gamfit-0.1.250-cp310-abi3-manylinux_2_39_x86_64.whl` and installed `gamfit-0.1.250`.\n* \u274c `cd /tmp && python <flexible-link issue reproduction>`  \n  Output: fixed logit/probit control still reproduced closely, but flexible-link still failed: reported deviance `412.3583527228267`, predict-on-training deviance `638.3424396199929`.\n\n### SELF-ASSESSMENT\n\n* **SOLVES THE ISSUE? PARTIAL.** This change fixes one real missing piece of the reconstruction contract: the frozen warp index shift is now persisted and used by prediction. But the acceptance reproduction still fails materially, so the true end-to-end bug is not solved. A remaining save/fit inconsistency, likely in the monotone-refit or persisted warp coefficient state, still causes `predict(train)` not to reproduce the reported fitted deviance.\n* **NET EFFECT: NET-GOOD, but incomplete.** Persisting the shift is mechanistically correct for the frozen residualized basis design and should reduce one source of predict-time drift. The risk is that this adds schema surface before the deeper inconsistency is fully fixed; I marked this honestly as partial rather than claiming the issue is resolved.\n\nCommitted as:\n\n* `cdbae6a Persist link-wiggle warp index shift`"}]
</details>

_Codex-generated; pending adversarial audit before merge._