### PR TITLE
#1026: Mark first Fourier harmonic as curved in PeriodicHarmonicEvaluator; add homotopy parity test

### DIFF
--- a/crates/gam-sae/src/basis.rs
+++ b/crates/gam-sae/src/basis.rs
@@ -261,7 +261,7 @@ impl SaeBasisEvaluator for PeriodicHarmonicEvaluator {
             ));
         }
         let mut curved = vec![false; n_basis];
-        for h in 2..=(n_basis - 1) / 2 {
+        for h in 1..=(n_basis - 1) / 2 {
             curved[2 * h - 1] = true;
             curved[2 * h] = true;
         }

--- a/crates/gam-sae/src/manifold/tests.rs
+++ b/crates/gam-sae/src/manifold/tests.rs
@@ -68,7 +68,7 @@ pub(crate) fn assert_eta_one_parity(
 pub(crate) fn phi_eta_one_reproduces_current_atom_bases_bit_for_bit() {
     let periodic_coords = array![[0.0_f64], [0.125], [0.4]];
     let periodic = PeriodicHarmonicEvaluator::new(7).unwrap();
-    assert_eta_one_parity(&periodic, periodic_coords.view(), 4);
+    assert_eta_one_parity(&periodic, periodic_coords.view(), 6);
 
     let raw_circle_coords = array![[0.0_f64], [0.3], [1.1]];
     let raw_circle = RawPeriodicCircleEvaluator::new(1).unwrap();
@@ -107,6 +107,24 @@ pub(crate) fn phi_eta_one_reproduces_current_atom_bases_bit_for_bit() {
         .filter(|alpha| alpha.iter().sum::<usize>() <= 1)
         .count();
     assert_eta_one_parity(&euclidean, duchon_coords.view(), total_cols - linear_cols);
+}
+
+#[test]
+pub(crate) fn periodic_first_harmonic_is_curved_for_homotopy_1026() {
+    let periodic = PeriodicHarmonicEvaluator::new(3).unwrap();
+    let split = periodic.phi_eta_split(3).unwrap();
+    assert_eq!(
+        split.linear_cols,
+        vec![0],
+        "only the constant column is η-inert for a first-harmonic circle"
+    );
+    assert_eq!(
+        split.curved_cols,
+        vec![1, 2],
+        "the constant column is η-inert, but both first-harmonic sin/cos columns \
+         have nonzero second derivatives and must be on the curved side of the \
+         homotopy; otherwise a K=1 circle is treated as a linear atom"
+    );
 }
 
 /// Minimal K=1 term for direct unit tests of term-state machinery that does

--- a/crates/gam-sae/src/manifold/tests_logdet_adjoint_780.rs
+++ b/crates/gam-sae/src/manifold/tests_logdet_adjoint_780.rs
@@ -214,20 +214,6 @@ fn dual_half_logdet_trace_2156(cache: &ArrowFactorCache, h: &Array2<f64>, dh: &A
     0.5 * report.total_derivative
 }
 
-fn dual_logdet_trace_2156(
-    label: &'static str,
-    cache: &ArrowFactorCache,
-    h: &Array2<f64>,
-    dh: &Array2<f64>,
-) -> (f64, BranchCertificate) {
-    let report = dual_trace_report_2156(
-        cache,
-        h,
-        vec![(DerivativeTraceChannel::Other(label), dh.clone())],
-    );
-    (report.total_derivative, report.certificate)
-}
-
 fn relative_error_2156(exact: f64, production: f64) -> f64 {
     (exact - production).abs() / exact.abs().max(production.abs()).max(1.0)
 }


### PR DESCRIPTION
### Motivation
- The homotopy split treated the first Fourier harmonic (sin/cos) as η‑inert/linear, so a K=1 circle basis could be routed through the linear shadow and break the #1026 reconstruction-parity mechanism; the split must reflect actual analytic curvature. 

### Description
- Change `PeriodicHarmonicEvaluator::phi_eta_split` to mark harmonic pairs starting at `h = 1` as curved instead of starting at `h = 2`, so only the constant column is η‑inert (file: `crates/gam-sae/src/basis.rs`).
- Update the `phi_eta_one` parity expectation to account for the additional curved columns (file: `crates/gam-sae/src/manifold/tests.rs`).
- Add a focused regression test `periodic_first_harmonic_is_curved_for_homotopy_1026` that asserts the first-harmonic split (file: `crates/gam-sae/src/manifold/tests.rs`).
- Remove an unused helper in `tests_logdet_adjoint_780.rs` that caused deny-warnings to fail the test build, keeping the test-suite denial policy intact (file: `crates/gam-sae/src/manifold/tests_logdet_adjoint_780.rs`).

### Testing
- Ran `./build.sh check -p gam-sae --lib` which completed successfully.
- Ran `./build.sh test -p gam-sae --lib --no-run` which completed successfully.
- Ran `./build.sh test -p gam-sae --lib phi_eta_one_reproduces_current_atom_bases_bit_for_bit -- --nocapture` and the test passed.
- Ran `./build.sh test -p gam-sae --lib periodic_first_harmonic_is_curved_for_homotopy_1026 -- --nocapture` and the new regression test passed.

---
Fixes #1026.

<details><summary>codex self-assessment</summary>

=MISS, recompiled 1 crates)\n     Compiling gam-sae v0.3.148 (/workspace/gam/crates/gam-sae)\n      Finished `test` profile [optimized + debuginfo] target(s) in 28.00s\n       Running unittests src/lib.rs (target/debug/deps/gam_sae-a2c4802d7e5c9eac)\n\n  running 1 test\n  test manifold::tests::phi_eta_one_reproduces_current_atom_bases_bit_for_bit ... ok\n\n  test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 910 filtered out; finished in 0.00s\n  ```\n\n* \u2705 `./build.sh test -p gam-sae --lib periodic_first_harmonic_is_curved_for_homotopy_1026 -- --nocapture`  \n  ```text\n  [build.sh] test -p gam-sae --lib periodic_first_harmonic_is_curved_for_homotopy_1026 -- --nocapture -> exit 0 in 0s (dedup=MISS, recompiled 0 crates)\n      Finished `test` profile [optimized + debuginfo] target(s) in 0.54s\n       Running unittests src/lib.rs (target/debug/deps/gam_sae-a2c4802d7e5c9eac)\n\n  running 1 test\n  test manifold::tests::periodic_first_harmonic_is_curved_for_homotopy_1026 ... ok\n\n  test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 910 filtered out; finished in 0.00s\n  ```\n\n* \u274c Before-fix evidence from the existing \u03b7=1 parity test after exposing the corrected expected geometry:  \n  ```text\n  [build.sh] test -p gam-sae --lib phi_eta_one_reproduces_current_atom_bases_bit_for_bit -- --nocapture -> exit 101 in 1s (dedup=MISS, recompiled 0 crates)\n  FAILED (101):\n      Finished `test` profile [optimized + debuginfo] target(s) in 0.54s\n       Running unittests src/lib.rs (target/debug/deps/gam_sae-a2c4802d7e5c9eac)\n\n  running 1 test\n\n  thread 'manifold::tests::phi_eta_one_reproduces_current_atom_bases_bit_for_bit' (29496) panicked at crates/gam-sae/src/manifold/tests.rs:42:5:\n  assertion `left == right` failed\n    left: 6\n   right: 4\n  ```\n\n### CODE DIFF\n\n```diff\ndiff --git a/crates/gam-sae/src/basis.rs b/crates/gam-sae/src/basis.rs\nindex ea61b8d..f88fe16 100644\n--- a/crates/gam-sae/src/basis.rs\n+++ b/crates/gam-sae/src/basis.rs\n@@ -261,7 +261,7 @@ impl SaeBasisEvaluator for PeriodicHarmonicEvaluator {\n             ));\n         }\n         let mut curved = vec![false; n_basis];\n-        for h in 2..=(n_basis - 1) / 2 {\n+        for h in 1..=(n_basis - 1) / 2 {\n             curved[2 * h - 1] = true;\n             curved[2 * h] = true;\n         }\ndiff --git a/crates/gam-sae/src/manifold/tests.rs b/crates/gam-sae/src/manifold/tests.rs\nindex d2a4097..f92bb26 100644\n--- a/crates/gam-sae/src/manifold/tests.rs\n+++ b/crates/gam-sae/src/manifold/tests.rs\n@@ -68,7 +68,7 @@ pub(crate) fn phi_eta_one_reproduces_current_atom_bases_bit_for_bit() {\n     let periodic_coords = array![[0.0_f64], [0.125], [0.4]];\n     let periodic = PeriodicHarmonicEvaluator::new(7).unwrap();\n-    assert_eta_one_parity(&periodic, periodic_coords.view(), 4);\n+    assert_eta_one_parity(&periodic, periodic_coords.view(), 6);\n@@ -109,6 +109,24 @@ pub(crate) fn phi_eta_one_reproduces_current_atom_bases_bit_for_bit() {\n     assert_eta_one_parity(&euclidean, duchon_coords.view(), total_cols - linear_cols);\n }\n \n+#[test]\n+pub(crate) fn periodic_first_harmonic_is_curved_for_homotopy_1026() {\n+    let periodic = PeriodicHarmonicEvaluator::new(3).unwrap();\n+    let split = periodic.phi_eta_split(3).unwrap();\n+    assert_eq!(\n+        split.linear_cols,\n+        vec![0],\n+        \"only the constant column is \u03b7-inert for a first-harmonic circle\"\n+    );\n+    assert_eq!(\n+        split.curved_cols,\n+        vec![1, 2],\n+        \"the constant column is \u03b7-inert, but both first-harmonic sin/cos columns \\\n+         have nonzero second derivatives and must be on the curved side of the \\\n+         homotopy; otherwise a K=1 circle is treated as a linear atom\"\n+    );\n+}\n+\ndiff --git a/crates/gam-sae/src/manifold/tests_logdet_adjoint_780.rs b/crates/gam-sae/src/manifold/tests_logdet_adjoint_780.rs\nindex bcf01d7..989fdb3 100644\n--- a/crates/gam-sae/src/manifold/tests_logdet_adjoin
</details>

_Codex-generated; pending adversarial audit before merge._