### PR TITLE
#1575: Route penalty-only REML rho optimization through EFS

### DIFF
--- a/crates/gam-solve/src/rho_optimizer/capability.rs
+++ b/crates/gam-solve/src/rho_optimizer/capability.rs
@@ -219,10 +219,7 @@ impl OuterCapability {
     }
 
     fn efs_plan_eligible(&self) -> bool {
-        self.fixed_point_available
-            && !self.disable_fixed_point
-            && self.all_penalty_like()
-            && self.n_params > SMALL_OUTER_BFGS_MAX_PARAMS
+        self.fixed_point_available && !self.disable_fixed_point && self.all_penalty_like()
     }
 
     fn hybrid_efs_plan_eligible(&self) -> bool {
@@ -352,19 +349,24 @@ pub fn plan(cap: &OuterCapability) -> OuterPlan {
     use Solver as S;
 
     match (cap.gradient, cap.declared_hessian_for_planning()) {
-        (Analytic, Analytic) => OuterPlan {
-            solver: S::Arc,
-            hessian_source: H::Analytic,
-        },
-        // EFS: all penalty-like coords, no analytic Hessian, many params.
+        // EFS: all penalty-like coords with an available fixed-point lane.
         // Multiplicative fixed-point needs only traces — no gradient evals.
-        // Much cheaper than BFGS for k=10-50 smoothing parameters.
+        // Much cheaper than generic BFGS/ARC probing for smoothing parameters.
+        // It is also the mathematically native REML smoothing-parameter
+        // stationarity solve when an analytic Hessian is available: the Hessian
+        // is useful for uncertainty diagnostics, but it should not force the
+        // production optimizer onto generic ARC probes that re-solve the full
+        // inner problem many times for a penalty-only rho block.
         //
         // When a log-barrier is present (monotonicity constraints), EFS is
         // still selected here. The EFS iteration loop in `run_outer` performs
         // a quantitative check each step via `barrier_curvature_is_significant`
         // and bails out early if the barrier curvature becomes non-negligible
         // relative to the penalized Hessian diagonal.
+        (Analytic, Analytic) if cap.efs_plan_eligible() => OuterPlan {
+            solver: S::Efs,
+            hessian_source: H::EfsFixedPoint,
+        },
         (Analytic, Unavailable) if cap.efs_plan_eligible() => OuterPlan {
             solver: S::Efs,
             hessian_source: H::EfsFixedPoint,
@@ -372,6 +374,11 @@ pub fn plan(cap: &OuterCapability) -> OuterPlan {
         (Unavailable, Unavailable) if cap.efs_plan_eligible() => OuterPlan {
             solver: S::Efs,
             hessian_source: H::EfsFixedPoint,
+        },
+
+        (Analytic, Analytic) => OuterPlan {
+            solver: S::Arc,
+            hessian_source: H::Analytic,
         },
 
         // Hybrid EFS: ψ (design-moving) coords present alongside ρ coords.

--- a/crates/gam-solve/src/rho_optimizer/run_plan_tests.rs
+++ b/crates/gam-solve/src/rho_optimizer/run_plan_tests.rs
@@ -548,6 +548,23 @@ fn plan_prefer_gradient_only_does_not_hide_analytic_hessian() {
 }
 
 #[test]
+fn plan_penalty_like_fixed_point_takes_efs_even_with_exact_hessian() {
+    let cap = OuterCapability {
+        gradient: Derivative::Analytic,
+        hessian: DeclaredHessianForm::Either,
+        n_params: 3,
+        psi_dim: 0,
+        fixed_point_available: true,
+        barrier_config: None,
+        prefer_gradient_only: false,
+        disable_fixed_point: false,
+    };
+    let p = plan(&cap);
+    assert_eq!(p.solver, Solver::Efs);
+    assert_eq!(p.hessian_source, HessianSource::EfsFixedPoint);
+}
+
+#[test]
 fn plan_survival_baseline_exact_hessian_selects_arc() {
     let cap = OuterCapability {
         gradient: Derivative::Analytic,
@@ -629,6 +646,23 @@ fn plan_cost_only_many_params_with_fixed_point_still_efs() {
         gradient: Derivative::Unavailable,
         hessian: DeclaredHessianForm::Unavailable,
         n_params: 20,
+        psi_dim: 0,
+        fixed_point_available: true,
+        barrier_config: None,
+        prefer_gradient_only: false,
+        disable_fixed_point: false,
+    };
+    let p = plan(&cap);
+    assert_eq!(p.solver, Solver::Efs);
+    assert_eq!(p.hessian_source, HessianSource::EfsFixedPoint);
+}
+
+#[test]
+fn plan_cost_only_few_penalty_params_with_fixed_point_uses_efs() {
+    let cap = OuterCapability {
+        gradient: Derivative::Unavailable,
+        hessian: DeclaredHessianForm::Unavailable,
+        n_params: 3,
         psi_dim: 0,
         fixed_point_available: true,
         barrier_config: None,
@@ -728,7 +762,7 @@ fn plan_penalty_like_without_fixed_point_stays_bfgs() {
 }
 
 #[test]
-fn plan_efs_not_selected_few_params_even_if_penalty_like() {
+fn plan_efs_selected_few_params_when_penalty_like() {
     let cap = OuterCapability {
         gradient: Derivative::Analytic,
         hessian: DeclaredHessianForm::Unavailable,
@@ -740,12 +774,12 @@ fn plan_efs_not_selected_few_params_even_if_penalty_like() {
         disable_fixed_point: false,
     };
     let p = plan(&cap);
-    assert_eq!(p.solver, Solver::Bfgs);
-    assert_eq!(p.hessian_source, HessianSource::BfgsApprox);
+    assert_eq!(p.solver, Solver::Efs);
+    assert_eq!(p.hessian_source, HessianSource::EfsFixedPoint);
 }
 
 #[test]
-fn plan_efs_not_selected_with_analytic_hessian() {
+fn plan_efs_selected_with_analytic_hessian_for_penalty_like_rho() {
     let cap = OuterCapability {
         gradient: Derivative::Analytic,
         hessian: DeclaredHessianForm::Either,
@@ -757,8 +791,8 @@ fn plan_efs_not_selected_with_analytic_hessian() {
         disable_fixed_point: false,
     };
     let p = plan(&cap);
-    // Arc is always preferred when analytic Hessian is available.
-    assert_eq!(p.solver, Solver::Arc);
+    assert_eq!(p.solver, Solver::Efs);
+    assert_eq!(p.hessian_source, HessianSource::EfsFixedPoint);
 }
 
 #[test]
@@ -2609,15 +2643,12 @@ fn automatic_fallbacks_without_gradient_stop_at_fixed_point_status() {
 }
 
 #[test]
-fn automatic_fallbacks_do_not_repeat_arc_when_fixed_point_is_irrelevant() {
-    // The contract here is that the cascade does not lateral-hop ARC
-    // through the EFS planner arm when `fixed_point_available=true` is
-    // incidentally set on an (Analytic, Analytic) capability that the
-    // planner already chose ARC for. Combined with the
-    // analytic-Hessian-preservation contract enforced by
-    // `automatic_fallbacks_preserve_analytic_hessian_for_arc_primary`,
-    // the ARC primary now has zero degraded fallbacks — the runner's
-    // ARC budget-bump retry ladder owns recovery.
+fn automatic_fallbacks_degrade_efs_to_first_order_once() {
+    // A penalty-only REML block with an EFS implementation must use that
+    // stationarity solver even if exact Hessians are available for other
+    // consumers. If the EFS attempt itself requests fallback, the automatic
+    // cascade disables fixed-point once and exposes the analytic gradient to
+    // the standalone first-order route.
     let cap = OuterCapability {
         gradient: Derivative::Analytic,
         hessian: DeclaredHessianForm::Either,
@@ -2628,14 +2659,12 @@ fn automatic_fallbacks_do_not_repeat_arc_when_fixed_point_is_irrelevant() {
         prefer_gradient_only: false,
         disable_fixed_point: false,
     };
-    assert_eq!(plan(&cap).solver, Solver::Arc);
+    assert_eq!(plan(&cap).solver, Solver::Efs);
 
     let attempts = automatic_fallback_attempts(&cap);
-    assert!(
-        attempts.is_empty(),
-        "ARC primary with incidental fixed_point_available must not \
-             cascade through the EFS arm or lateral-demote to BFGS",
-    );
+    assert_eq!(attempts.len(), 1);
+    assert!(attempts[0].disable_fixed_point);
+    assert_eq!(plan(&attempts[0]).solver, Solver::Arc);
 }
 
 #[test]


### PR DESCRIPTION
### Motivation
- The outer REML planner was forcing penalty-only smoothing-parameter (`ρ`) problems with an available fixed-point (EFS) implementation onto generic second-order solvers just because an analytic Hessian existed, which caused many expensive outer probes and repeated full inner P-IRLS solves. 
- An arbitrary small-parameter cutoff prevented small/ordinary penalty-only problems from using the cheaper fixed-point stationarity solver, amplifying the cost on typical binomial/logit GAMs.

### Description
- Make EFS eligible for any `all_penalty_like()` capability with a provided fixed-point lane by removing the `n_params > SMALL_OUTER_BFGS_MAX_PARAMS` cutoff in `efs_plan_eligible()` so small penalty-only `ρ` blocks are not excluded (file: `crates/gam-solve/src/rho_optimizer/capability.rs`).
- Prefer the fixed-point `Efs` routing ahead of the `(Analytic, Analytic) -> Arc` rule when the capability is penalty-like and has a fixed-point implementation, while preserving `Arc` for analytic-Hessian paths that do not expose fixed-point (file: `crates/gam-solve/src/rho_optimizer/capability.rs`).
- Update planner unit tests to reflect the new policy and add assertions that penalty-only fixed-point-capable objectives choose `Efs` even at small parameter counts and when an analytic Hessian is present (file: `crates/gam-solve/src/rho_optimizer/run_plan_tests.rs`).
- Minor comment clarifications describing reasoning for the routing change (file: `crates/gam-solve/src/rho_optimizer/capability.rs`).

### Testing
- Ran targeted unit tests for the planner: `./build.sh test -p gam-solve run_plan_tests -- --nocapture`, which passed after the changes (`127 passed; 0 failed`).
- Verified build and test gates: `./build.sh`, `./build.sh check -p gam-solve --lib`, and `./build.sh test -p gam-solve --lib --no-run` all completed successfully.
- Note: an initial test run (before updating tests to match the new policy) surfaced 3 failing planner tests which motivated adapting expectations; after updating tests the suite passes as reported above.

---
Refs #1575.

<details><summary>codex self-assessment</summary>

\n\n## SPEC COMPLIANCE\n\n* Added no finite differences, autodiff, grid search, GCV, wall-clock budgets, deadlines, timeouts, fabricated convergence, skipped tests, ignored tests, stubs, or placeholder values.\n* The change routes an existing analytic stationarity solver for penalty-only REML smoothing parameters; it does not loosen convergence or paper over non-convergence.\n* The only changed production logic is Rust planner logic; no Python math was added.\n\n## TEST EVIDENCE\n\n### Before \u2192 after regression evidence\n\n* \u274c `./build.sh test -p gam-solve run_plan_tests -- --nocapture` before updating the planner tests after the production change failed with:\n  ```text\n  [build.sh] test -p gam-solve run_plan_tests -- --nocapture -> exit 101 in 517s (dedup=MISS, recompiled 1 crates)\n  ...\n  failures:\n      rho_optimizer::run_plan::run_plan_tests::automatic_fallbacks_do_not_repeat_arc_when_fixed_point_is_irrelevant\n      rho_optimizer::run_plan::run_plan_tests::plan_efs_not_selected_few_params_even_if_penalty_like\n      rho_optimizer::run_plan::run_plan_tests::plan_efs_not_selected_with_analytic_hessian\n\n  test result: FAILED. 124 passed; 3 failed; 0 ignored; 0 measured; 1074 filtered out; finished in 0.10s\n  ```\n* \u2705 `./build.sh test -p gam-solve run_plan_tests -- --nocapture` after updating the tests and implementation passed with:\n  ```text\n  [build.sh] test -p gam-solve run_plan_tests -- --nocapture -> exit 0 in 7s (dedup=MISS, recompiled 1 crates)\n  ...\n  test result: ok. 127 passed; 0 failed; 0 ignored; 0 measured; 1074 filtered out; finished in 0.09s\n  ```\n\n### Compile/build gates and relevant checks\n\n* \u2705 `./build.sh`\n  ```text\n  [build.sh] LIB -> exit 0 in 1044s (dedup=MISS, recompiled 186 crates)\n  ...\n  Finished `dev` profile [unoptimized + debuginfo] target(s) in 17m 23s\n  ```\n* \u2705 `./build.sh check -p gam-solve --lib`\n  ```text\n  [build.sh] check -p gam-solve --lib -> exit 0 in 227s (dedup=MISS, recompiled 9 crates)\n  ...\n  Finished `dev` profile [unoptimized + debuginfo] target(s) in 3m 47s\n  ```\n* \u2705 `./build.sh test -p gam-solve --lib --no-run`\n  ```text\n  [build.sh] test -p gam-solve --lib --no-run -> exit 0 in 66s (dedup=MISS, recompiled 5 crates)\n  ...\n  Executable unittests src/lib.rs (target/debug/deps/gam_solve-5434b1d24a5f273e)\n  ```\n* \u2705 `./build.sh test -p gam-solve run_plan_tests -- --nocapture`\n  ```text\n  [build.sh] test -p gam-solve run_plan_tests -- --nocapture -> exit 0 in 7s (dedup=MISS, recompiled 1 crates)\n  ...\n  test result: ok. 127 passed; 0 failed; 0 ignored; 0 measured; 1074 filtered out; finished in 0.09s\n  ```\n\n## CODE DIFF\n\nCommitted as:\n\n```text\n426ce51 Route penalty-only REML rho through EFS\n```\n\nDiff summary:\n\n```text\ncrates/gam-solve/src/rho_optimizer/capability.rs   | 27 +++++---\ncrates/gam-solve/src/rho_optimizer/run_plan_tests.rs | 71 +++++++++++++++-------\n2 files changed, 67 insertions(+), 31 deletions(-)\n```\n\n## SELF-ASSESSMENT\n\n* **SOLVES THE ISSUE? PARTIAL.** This fixes the planner mechanism identified in the issue logs: pure binomial/logit smoothing-parameter REML no longer routes to generic ARC just because analytic Hessians are available, and small 3-smooth/6-parameter cases are no longer excluded from EFS by a dimension cutoff. I did not run the full Python/R mgcv benchmark from the issue, so I cannot honestly claim the 16k-row wall time is now within the requested constant factor.\n* **NET EFFECT: NET-GOOD.** The change aligns the production optimizer with the mathematical structure of penalty-only REML smoothing selection and removes an arbitrary small-dimension exclusion that directly caused ordinary GAMs to miss the stationarity solver. The main risk is that more all-penalty-like fixed-point-capable paths will now exercise EFS first; the automatic fallback remains in place for explicit EFS fallback requests, and non-fixed-point exact-Hessian objectives continue to use ARC."}]
</details>

_Codex-generated; pending adversarial audit before merge._
