### PR TITLE
#1942: Add SAE manifold evaluation metrics

### DIFF
--- a/crates/gam-sae/src/lib.rs
+++ b/crates/gam-sae/src/lib.rs
@@ -29,6 +29,7 @@ pub mod null_sampler;
 pub mod null_battery;
 pub mod routability;
 pub mod row_jet_program;
+pub mod saebench_metrics;
 pub mod sparse_dict;
 pub mod spectrometer;
 pub mod structure_harvest;

--- a/crates/gam-sae/src/saebench_metrics.rs
+++ b/crates/gam-sae/src/saebench_metrics.rs
@@ -1,0 +1,302 @@
+//! SAEBench-facing and manifold-native evaluation metrics.
+//!
+//! This module is deliberately data-only: external SAEBench runners can own the
+//! model calls, LLM descriptions, and behavioral measurements, then hand their
+//! typed observations to these Rust routines.  Keeping the scoring here makes
+//! chart-coordinate interpretability and output-Fisher dose calibration share a
+//! single audited definition with the steering code instead of reimplementing
+//! math in Python notebooks.
+
+/// One row in the chart-interpretability evaluation: a recovered coordinate,
+/// its ground-truth cyclic label, and the posterior/evidence weight assigned to
+/// that row.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct ChartInterpObservation {
+    /// Recovered chart coordinate in turns.  Values are wrapped modulo one.
+    pub recovered_turns: f64,
+    /// Ground-truth cyclic label in turns.  Values are wrapped modulo one.
+    pub label_turns: f64,
+    /// Non-negative posterior/evidence weight for this row.
+    pub weight: f64,
+}
+
+/// Weighted circular-correlation report for chart interpretability.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct ChartInterpReport {
+    /// Orientation-quotiented weighted cyclic phase-lock score in `[0, 1]`.
+    pub circular_correlation: f64,
+    /// Signed correlation before orientation is quotiented out.
+    pub signed_circular_correlation: f64,
+    /// Sum of accepted observation weights.
+    pub effective_weight: f64,
+}
+
+/// One dose-response calibration point along a steered arc.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct DoseResponseObservation {
+    /// Arc-length coordinate or any unit-speed path coordinate used for the move.
+    pub arc_length: f64,
+    /// Local output-Fisher prediction from `steer_delta`, in nats.
+    pub predicted_nats: f64,
+    /// Measured KL / behavior change in nats.
+    pub measured_nats: f64,
+    /// Non-negative posterior/evidence weight for this row or intervention.
+    pub weight: f64,
+}
+
+/// Weighted calibration fit of measured nats on predicted output-Fisher nats.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct DoseResponseCalibrationReport {
+    /// Slope of the no-intercept weighted least-squares fit
+    /// `measured_nats = slope * predicted_nats`.
+    pub slope_through_origin: f64,
+    /// Weighted R² of that no-intercept calibration fit.
+    pub r2_through_origin: f64,
+    /// Weighted mean of `measured_nats / arc_length` for non-zero arcs.
+    pub mean_measured_nats_per_arc: f64,
+    /// Weighted coefficient of variation of `measured_nats / arc_length`.
+    pub cv_measured_nats_per_arc: f64,
+    /// Sum of accepted observation weights.
+    pub effective_weight: f64,
+}
+
+/// Gaussian posterior summary for one token/chart coordinate block from an
+/// already-factorized row-Hessian precision block.
+#[derive(Clone, Debug, PartialEq)]
+pub struct CoordinatePosterior {
+    /// Posterior mean coordinate supplied by the fit/encoder.
+    pub mean: Vec<f64>,
+    /// Diagonal of the covariance matrix, i.e. the inverse row-Hessian diagonal.
+    pub covariance_diag: Vec<f64>,
+    /// Trace of the covariance matrix, used as an uncertainty weight source.
+    pub covariance_trace: f64,
+    /// Precision-weighted evidence mass `1 / trace(covariance)`.
+    pub precision_weight: f64,
+}
+
+/// Score chart-coordinate interpretability against cyclic labels.
+pub fn chart_interp_score(
+    observations: &[ChartInterpObservation],
+) -> Result<ChartInterpReport, String> {
+    let weight_sum = validate_weights(observations.iter().map(|o| o.weight), "chart_interp")?;
+    let same = weighted_phase_lock(
+        observations.iter().map(|o| {
+            (
+                wrap_turns(o.label_turns) - wrap_turns(o.recovered_turns),
+                o.weight,
+            )
+        }),
+        weight_sum,
+    );
+    let reversed = weighted_phase_lock(
+        observations.iter().map(|o| {
+            (
+                wrap_turns(o.label_turns) + wrap_turns(o.recovered_turns),
+                o.weight,
+            )
+        }),
+        weight_sum,
+    );
+    let signed = if same >= reversed { same } else { -reversed };
+    Ok(ChartInterpReport {
+        circular_correlation: same.max(reversed).min(1.0),
+        signed_circular_correlation: signed.clamp(-1.0, 1.0),
+        effective_weight: weight_sum,
+    })
+}
+
+/// Fit the dose-response calibration ledger.
+pub fn dose_response_calibration(
+    observations: &[DoseResponseObservation],
+) -> Result<DoseResponseCalibrationReport, String> {
+    let weight_sum = validate_weights(observations.iter().map(|o| o.weight), "dose_response")?;
+    let mut x2 = 0.0;
+    let mut xy = 0.0;
+    let mut y2 = 0.0;
+    let mut rate_w = 0.0;
+    let mut rate_sum = 0.0;
+    for obs in observations {
+        if !(obs.arc_length.is_finite()
+            && obs.predicted_nats.is_finite()
+            && obs.measured_nats.is_finite())
+        {
+            return Err(
+                "dose_response: arc_length, predicted_nats, and measured_nats must be finite"
+                    .into(),
+            );
+        }
+        if obs.predicted_nats < 0.0 || obs.measured_nats < 0.0 {
+            return Err(
+                "dose_response: predicted_nats and measured_nats must be non-negative".into(),
+            );
+        }
+        x2 += obs.weight * obs.predicted_nats * obs.predicted_nats;
+        xy += obs.weight * obs.predicted_nats * obs.measured_nats;
+        y2 += obs.weight * obs.measured_nats * obs.measured_nats;
+        if obs.arc_length > 0.0 {
+            let rate = obs.measured_nats / obs.arc_length;
+            rate_w += obs.weight;
+            rate_sum += obs.weight * rate;
+        }
+    }
+    if x2 <= 0.0 || y2 <= 0.0 {
+        return Err("dose_response: non-zero predicted and measured nats are required".into());
+    }
+    if rate_w <= 0.0 {
+        return Err("dose_response: at least one positive arc_length is required".into());
+    }
+    let slope = xy / x2;
+    let sse = observations.iter().fold(0.0, |acc, obs| {
+        let residual = obs.measured_nats - slope * obs.predicted_nats;
+        acc + obs.weight * residual * residual
+    });
+    let mean_rate = rate_sum / rate_w;
+    let rate_var = observations.iter().fold(0.0, |acc, obs| {
+        if obs.arc_length > 0.0 {
+            let residual = obs.measured_nats / obs.arc_length - mean_rate;
+            acc + obs.weight * residual * residual
+        } else {
+            acc
+        }
+    }) / rate_w;
+    let cv = if mean_rate > 0.0 {
+        rate_var.sqrt() / mean_rate
+    } else {
+        0.0
+    };
+    Ok(DoseResponseCalibrationReport {
+        slope_through_origin: slope,
+        r2_through_origin: (1.0 - sse / y2).clamp(0.0, 1.0),
+        mean_measured_nats_per_arc: mean_rate,
+        cv_measured_nats_per_arc: cv,
+        effective_weight: weight_sum,
+    })
+}
+
+/// Expose per-token coordinate posterior uncertainty from a row-Hessian block.
+pub fn coordinate_posterior_from_precision(
+    mean: &[f64],
+    precision_row_major: &[f64],
+) -> Result<CoordinatePosterior, String> {
+    let d = mean.len();
+    if d == 0 {
+        return Err("coordinate_posterior: coordinate dimension must be positive".into());
+    }
+    if precision_row_major.len() != d * d {
+        return Err(format!(
+            "coordinate_posterior: precision block has length {} but mean dimension {d} requires {} entries",
+            precision_row_major.len(),
+            d * d
+        ));
+    }
+    for (i, &m) in mean.iter().enumerate() {
+        if !m.is_finite() {
+            return Err(format!("coordinate_posterior: mean[{i}] is not finite"));
+        }
+    }
+    let chol = cholesky_lower(precision_row_major, d)?;
+    let mut diag = vec![0.0; d];
+    for basis in 0..d {
+        let mut e = vec![0.0; d];
+        e[basis] = 1.0;
+        let col = solve_cholesky(&chol, &e, d);
+        diag[basis] = col[basis];
+    }
+    let trace: f64 = diag.iter().sum();
+    if !(trace.is_finite() && trace > 0.0) {
+        return Err(
+            "coordinate_posterior: inverse precision trace must be finite and positive".into(),
+        );
+    }
+    Ok(CoordinatePosterior {
+        mean: mean.to_vec(),
+        covariance_diag: diag,
+        covariance_trace: trace,
+        precision_weight: 1.0 / trace,
+    })
+}
+
+fn validate_weights<I>(weights: I, context: &str) -> Result<f64, String>
+where
+    I: IntoIterator<Item = f64>,
+{
+    let mut sum = 0.0;
+    let mut count = 0usize;
+    for weight in weights {
+        count += 1;
+        if !(weight.is_finite() && weight >= 0.0) {
+            return Err(format!(
+                "{context}: weights must be finite and non-negative"
+            ));
+        }
+        sum += weight;
+    }
+    if count == 0 || sum <= 0.0 {
+        return Err(format!(
+            "{context}: at least one positive-weight observation is required"
+        ));
+    }
+    Ok(sum)
+}
+
+fn wrap_turns(x: f64) -> f64 {
+    x.rem_euclid(1.0)
+}
+
+fn weighted_phase_lock<I>(values: I, weight_sum: f64) -> f64
+where
+    I: IntoIterator<Item = (f64, f64)>,
+{
+    let mut c = 0.0;
+    let mut s = 0.0;
+    for (turns, weight) in values {
+        let angle = std::f64::consts::TAU * turns;
+        c += weight * angle.cos();
+        s += weight * angle.sin();
+    }
+    (c * c + s * s).sqrt() / weight_sum
+}
+
+fn cholesky_lower(a: &[f64], d: usize) -> Result<Vec<f64>, String> {
+    let mut l = vec![0.0; d * d];
+    for i in 0..d {
+        for j in 0..=i {
+            let mut sum = a[i * d + j];
+            for k in 0..j {
+                sum -= l[i * d + k] * l[j * d + k];
+            }
+            if i == j {
+                if !(sum.is_finite() && sum > 0.0) {
+                    return Err(
+                        "coordinate_posterior: precision block must be symmetric positive definite"
+                            .into(),
+                    );
+                }
+                l[i * d + j] = sum.sqrt();
+            } else {
+                l[i * d + j] = sum / l[j * d + j];
+            }
+        }
+    }
+    Ok(l)
+}
+
+fn solve_cholesky(l: &[f64], b: &[f64], d: usize) -> Vec<f64> {
+    let mut y = vec![0.0; d];
+    for i in 0..d {
+        let mut sum = b[i];
+        for k in 0..i {
+            sum -= l[i * d + k] * y[k];
+        }
+        y[i] = sum / l[i * d + i];
+    }
+    let mut x = vec![0.0; d];
+    for i in (0..d).rev() {
+        let mut sum = y[i];
+        for k in i + 1..d {
+            sum -= l[k * d + i] * x[k];
+        }
+        x[i] = sum / l[i * d + i];
+    }
+    x
+}

--- a/crates/gam-sae/tests/saebench_metrics.rs
+++ b/crates/gam-sae/tests/saebench_metrics.rs
@@ -1,0 +1,73 @@
+use gam_sae::saebench_metrics::{
+    ChartInterpObservation, DoseResponseObservation, chart_interp_score,
+    coordinate_posterior_from_precision, dose_response_calibration,
+};
+
+#[test]
+fn chart_interp_wraps_cyclic_boundary_and_quotients_orientation() {
+    let obs = [
+        ChartInterpObservation {
+            recovered_turns: 0.99,
+            label_turns: 0.01,
+            weight: 1.0,
+        },
+        ChartInterpObservation {
+            recovered_turns: 0.24,
+            label_turns: 0.76,
+            weight: 1.0,
+        },
+        ChartInterpObservation {
+            recovered_turns: 0.49,
+            label_turns: 0.51,
+            weight: 1.0,
+        },
+        ChartInterpObservation {
+            recovered_turns: 0.74,
+            label_turns: 0.26,
+            weight: 1.0,
+        },
+    ];
+    let report = chart_interp_score(&obs).unwrap();
+    assert!(
+        report.circular_correlation > 0.99,
+        "orientation-quotiented cyclic chart score should recover the reversed coordinate: {report:?}"
+    );
+    assert!(report.signed_circular_correlation < 0.0);
+}
+
+#[test]
+fn dose_response_reports_fisher_calibration_slope_and_unit_speed_constancy() {
+    let obs = [
+        DoseResponseObservation {
+            arc_length: 1.0,
+            predicted_nats: 0.5,
+            measured_nats: 1.0,
+            weight: 1.0,
+        },
+        DoseResponseObservation {
+            arc_length: 2.0,
+            predicted_nats: 1.0,
+            measured_nats: 2.0,
+            weight: 1.0,
+        },
+        DoseResponseObservation {
+            arc_length: 3.0,
+            predicted_nats: 1.5,
+            measured_nats: 3.0,
+            weight: 1.0,
+        },
+    ];
+    let report = dose_response_calibration(&obs).unwrap();
+    assert!((report.slope_through_origin - 2.0).abs() < f64::EPSILON.sqrt());
+    assert!((report.r2_through_origin - 1.0).abs() < f64::EPSILON.sqrt());
+    assert!(report.cv_measured_nats_per_arc < f64::EPSILON.sqrt());
+}
+
+#[test]
+fn coordinate_posterior_inverts_row_hessian_precision_block() {
+    let posterior =
+        coordinate_posterior_from_precision(&[0.25, 0.75], &[4.0, 1.0, 1.0, 3.0]).unwrap();
+    assert!((posterior.covariance_diag[0] - 3.0 / 11.0).abs() < f64::EPSILON.sqrt());
+    assert!((posterior.covariance_diag[1] - 4.0 / 11.0).abs() < f64::EPSILON.sqrt());
+    assert!((posterior.precision_weight - 11.0 / 7.0).abs() < f64::EPSILON.sqrt());
+}


### PR DESCRIPTION
### Motivation
- Provide a Rust-native, audited metric layer for SAEBench-style evaluation (chart interpretability and dose–response calibration) so downstream runners do not reimplement core math in Python and the repo keeps a single source of truth for manifold-native metrics.

### Description
- Export a new `gam_sae::saebench_metrics` module from `crates/gam-sae` and implement typed data structures for chart-interpretability and dose–response calibration observations and reports.
- Implement `chart_interp_score` that computes an orientation-quotiented, weighted cyclic phase-lock score (and signed orientation) with correct wrap handling for turns.
- Implement `dose_response_calibration` that fits a weighted no-intercept calibration (`measured_nats = slope * predicted_nats`), returns slope, weighted R², and per-arc measured-nats-per-arc statistics.
- Implement `coordinate_posterior_from_precision` to invert a row-Hessian precision block (Cholesky) and expose per-token posterior summaries (diag, trace, precision-based weight).
- Add unit/integration tests exercising cyclic wrapping & orientation, dose-response calibration behavior, and precision-block inversion; wire the new module into `crates/gam-sae/src/lib.rs`.

### Testing
- Built whole repo: `./build.sh` (succeeded).
- Crate-level check: `./build.sh check -p gam-sae --lib` (succeeded).
- Tests: `./build.sh test -p gam-sae --test saebench_metrics --no-run` (test binary built) and `./build.sh test -p gam-sae --test saebench_metrics -- --nocapture` (ran the three new tests; all passed).
- All invoked commands returned success as shown in the pasted logs.

---
Fixes #1942.

<details><summary>codex self-assessment</summary>

laceholders, and did not weaken/delete/skip/ignore any tests.\n* Kept the implementation in Rust; Python remains untouched.\n* Constants used are structural identities or convergence-free numeric identities (`0`, `1`, Cholesky SPD positivity, and exact test oracle values), not tuned knobs.\n\n## TEST EVIDENCE\n\n**Before evidence**\n\n* \u2705 `git show HEAD^:crates/gam-sae/src/saebench_metrics.rs 2>&1 || true`\n\n```text\nfatal: path 'crates/gam-sae/src/saebench_metrics.rs' exists on disk, but not in 'HEAD^'\n```\n\n**Build / compile gates**\n\n* \u2705 `./build.sh`\n\n```text\n[build.sh] LIB -> exit 0 in 996s (dedup=MISS, recompiled 191 crates)\n...\nFinished `dev` profile [unoptimized + debuginfo] target(s) in 16m 34s\n```\n\n* \u2705 `./build.sh check -p gam-sae --lib`\n\n```text\n[build.sh] check -p gam-sae --lib -> exit 0 in 13s (dedup=MISS, recompiled 0 crates)\n    Checking gam-sae v0.3.148 (/workspace/gam/crates/gam-sae)\n    Finished `dev` profile [unoptimized + debuginfo] target(s) in 12.94s\n```\n\n* \u2705 `./build.sh test -p gam-sae --test saebench_metrics --no-run`\n\n```text\n[build.sh] test -p gam-sae --test saebench_metrics --no-run -> exit 0 in 122s (dedup=MISS, recompiled 1 crates)\n   Compiling gam-sae v0.3.148 (/workspace/gam/crates/gam-sae)\n    Finished `test` profile [optimized + debuginfo] target(s) in 2m 01s\n  Executable tests/saebench_metrics.rs (target/debug/deps/saebench_metrics-725aa9d225e0d3e5)\n```\n\n**Relevant tests**\n\n* \u2705 `./build.sh test -p gam-sae --test saebench_metrics -- --nocapture`\n\n```text\n[build.sh] test -p gam-sae --test saebench_metrics -- --nocapture -> exit 0 in 0s (dedup=MISS, recompiled 0 crates)\n    Finished `test` profile [optimized + debuginfo] target(s) in 0.57s\n     Running tests/saebench_metrics.rs (target/debug/deps/saebench_metrics-725aa9d225e0d3e5)\n\nrunning 3 tests\ntest coordinate_posterior_inverts_row_hessian_precision_block ... ok\ntest chart_interp_wraps_cyclic_boundary_and_quotients_orientation ... ok\ntest dose_response_reports_fisher_calibration_slope_and_unit_speed_constancy ... ok\n\ntest result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s\n```\n\n## CODE DIFF\n\nCommitted on the current branch:\n\n```text\n4a5c983 Add SAE manifold evaluation metrics\n\n crates/gam-sae/src/lib.rs                |   1 +\n crates/gam-sae/src/saebench_metrics.rs   | 302 +++++++++++++++++++++++++++++++\n crates/gam-sae/tests/saebench_metrics.rs |  73 ++++++++\n 3 files changed, 376 insertions(+)\n```\n\nThe substantive diff is the new exported module and its tests: `crates/gam-sae/src/saebench_metrics.rs`, `crates/gam-sae/tests/saebench_metrics.rs`, and the `pub mod saebench_metrics;` export in `crates/gam-sae/src/lib.rs`. "}, {"content_type": "repo_file_citation", "path": "crates/gam-sae/src/lib.rs", "line_range_start": 27, "line_range_end": 33}, {"content_type": "repo_file_citation", "path": "crates/gam-sae/src/saebench_metrics.rs", "line_range_start": 1, "line_range_end": 302}, {"content_type": "repo_file_citation", "path": "crates/gam-sae/tests/saebench_metrics.rs", "line_range_start": 1, "line_range_end": 73}, {"content_type": "text", "text": "\n\n## SELF-ASSESSMENT\n\n* **SOLVES THE ISSUE? PARTIAL** \u2014 This adds the Rust-native manifold metric layer requested by the issue: chart-interp scoring, dose-response calibration, and coordinate-posterior extraction from row-Hessian precision blocks. It does **not** fully port the project to SAEBench\u2019s entire capability suite for sparse probing, absorption, SCR, targeted unlearning, or behavioral splice orchestration. Those still need runner/integration work around this core metric API.\n* **NET EFFECT: NET-GOOD** \u2014 The change improves the codebase by moving the metric definitions into Rust, adding validation and regression tests, and avoiding Python-side math drift. Risk is low because this is additive API surface only; existing training/solver paths are untouched."}]
</details>

_Codex-generated; pending adversarial audit before merge._