### PR TITLE
#2069: Propagate SAE structured residual fit errors

### DIFF
--- a/crates/gam-sae/src/manifold/stagewise.rs
+++ b/crates/gam-sae/src/manifold/stagewise.rs
@@ -339,15 +339,13 @@ fn fit_residual_covariance(
     }
     let activity = activity_of(term);
     let max_rank = config.max_factor_rank.min(p.saturating_sub(1)).max(1);
-    match StructuredResidualModel::fit(ResidualFactorInput {
+    StructuredResidualModel::fit(ResidualFactorInput {
         residuals: residual.view(),
         activity: activity.view(),
         max_factor_rank: max_rank,
-    }) {
-        Ok(model) => Ok(Some((residual, model))),
-        // A degenerate residual fit is a stop signal, not an error.
-        Err(_) => Ok(None),
-    }
+    })
+    .map(|model| Some((residual, model)))
+    .map_err(|err| format!("fit_residual_covariance: structured residual fit failed: {err}"))
 }
 
 fn fit_single_atom_response_in_place(
@@ -2295,6 +2293,31 @@ mod tests {
             let tol = 1e-9 * (1.0 + w[0].abs());
             w[1] >= w[0] - tol
         })
+    }
+
+    /// A structured-residual fit error is a data/solver contract violation, not
+    /// "no residual structure".  The stagewise driver may stop cleanly on an
+    /// empty/single-channel residual, but it must not silently swallow a
+    /// non-finite residual and continue as if the residual producer merely found
+    /// nothing useful.
+    #[test]
+    fn residual_covariance_propagates_invalid_residual_errors() {
+        let n = 8usize;
+        let p = 2usize;
+        let evaluator = Arc::new(PeriodicHarmonicEvaluator::new(3).unwrap());
+        let coords = Array2::<f64>::from_shape_fn((n, 1), |(row, _)| row as f64 / n as f64);
+        let (atom0, cb0) = circle_atom("seed", &evaluator, &coords, 0, 1, p);
+        let (term, _rho) = build_term(vec![atom0], vec![cb0], &vec![vec![true]; n]);
+        let mut target = Array2::<f64>::zeros((n, p));
+        target[[3, 1]] = f64::NAN;
+
+        let err = fit_residual_covariance(&term, target.view(), &test_config())
+            .expect_err("non-finite residuals must be reported, not downgraded to None");
+        assert!(
+            err.contains("structured residual fit failed")
+                && err.contains("residuals must be finite"),
+            "unexpected error: {err}"
+        );
     }
 
     /// Planted two-circles: the target is a genuine two-atom dictionary image, but

--- a/crates/gam-sae/src/manifold/tests_logdet_adjoint_780.rs
+++ b/crates/gam-sae/src/manifold/tests_logdet_adjoint_780.rs
@@ -214,20 +214,6 @@ fn dual_half_logdet_trace_2156(cache: &ArrowFactorCache, h: &Array2<f64>, dh: &A
     0.5 * report.total_derivative
 }
 
-fn dual_logdet_trace_2156(
-    label: &'static str,
-    cache: &ArrowFactorCache,
-    h: &Array2<f64>,
-    dh: &Array2<f64>,
-) -> (f64, BranchCertificate) {
-    let report = dual_trace_report_2156(
-        cache,
-        h,
-        vec![(DerivativeTraceChannel::Other(label), dh.clone())],
-    );
-    (report.total_derivative, report.certificate)
-}
-
 fn relative_error_2156(exact: f64, production: f64) -> f64 {
     (exact - production).abs() / exact.abs().max(production.abs()).max(1.0)
 }


### PR DESCRIPTION
### Motivation
- The SAE stagewise driver conflated a true absence of residual structure with solver/validation failures by turning any `StructuredResidualModel::fit` error into `Ok(None)`, allowing non-finite/invalid residuals to be silently ignored and the driver to fall back to prior geometry.
- The intent of the change is to preserve the semantic distinction: only empty or single-channel residuals are a valid `None` stop, while real fit errors should propagate and fail the structured-residual path so higher-level logic can handle the contract violation.

### Description
- Stop downgrading structured-residual fit failures to `Ok(None)` by replacing the `match` with a `map(...).map_err(...)` on `StructuredResidualModel::fit` in `crates/gam-sae/src/manifold/stagewise.rs` so errors are returned as `Err("fit_residual_covariance: ...")` and the empty/single-channel check remains the only `Ok(None)` case. (around `fit_residual_covariance`)
- Add a unit regression test `residual_covariance_propagates_invalid_residual_errors` in `crates/gam-sae/src/manifold/stagewise.rs` that injects a non-finite entry and asserts the structured-residual fit error is reported rather than treated as missing structure.
- Remove an unused local test helper that triggered a deny-warnings failure during the scoped `gam-sae` lib-test build (small cleanup in `crates/gam-sae/src/manifold/tests_logdet_adjoint_780.rs`).

### Testing
- Built the workspace: ran `./build.sh` and it completed successfully (dev lib build passed).
- Ran the scoped static check `./build.sh check -p gam-sae --lib` and it completed with no warnings/errors.
- Built the test binary and ran the new regression with `./build.sh test -p gam-sae --lib residual_covariance_propagates_invalid_residual_errors -- --nocapture`; before the fix the test failed (it exposed the prior silent downgrade), and after the fix the test passes (1 passed).
- Also executed `./build.sh test -p gam-sae --lib --no-run` to ensure test artifacts build; the suite built successfully with no tests ignored or weakened.

---
Refs #2069 (single item of the epic; does not close it).

<details><summary>codex self-assessment</summary>

ace/gam/crates/gam-problem)\n      Checking gam-gpu v0.3.148 (/workspace/gam/crates/gam-gpu)\n     Compiling zstd-safe v7.2.4\n      Checking gam-model-api v0.3.148 (/workspace/gam/crates/gam-model-api)\n      Checking gam-identifiability v0.3.148 (/workspace/gam/crates/gam-identifiability)\n      Checking zstd v0.13.3\n      Checking parquet v54.3.1\n      Checking gam-data v0.3.148 (/workspace/gam/crates/gam-data)\n      Checking gam-terms v0.3.148 (/workspace/gam/crates/gam-terms)\n      Checking gam-solve v0.3.148 (/workspace/gam/crates/gam-solve)\n      Checking gam-sae v0.3.148 (/workspace/gam/crates/gam-sae)\n      Finished `dev` profile [unoptimized + debuginfo] target(s) in 3m 50s\n  ```\n\n* \u2705 `./build.sh test -p gam-sae --lib --no-run`  \n  ```text\n  [build.sh] test -p gam-sae --lib --no-run -> exit 0 in 127s (dedup=MISS, recompiled 1 crates)\n     Compiling gam-sae v0.3.148 (/workspace/gam/crates/gam-sae)\n      Finished `test` profile [optimized + debuginfo] target(s) in 2m 06s\n    Executable unittests src/lib.rs (target/debug/deps/gam_sae-a2c4802d7e5c9eac)\n  ```\n\n* \u274c `./build.sh test -p gam-sae --lib residual_covariance_propagates_invalid_residual_errors -- --nocapture` before the functional fix, with the regression test present  \n  ```text\n  [build.sh] test -p gam-sae --lib residual_covariance_propagates_invalid_residual_errors -- --nocapture -> exit 101 in 130s (dedup=MISS, recompiled 1 crates)\n  FAILED (101):\n     Compiling gam-sae v0.3.148 (/workspace/gam/crates/gam-sae)\n      Finished `test` profile [optimized + debuginfo] target(s) in 2m 10s\n       Running unittests src/lib.rs (target/debug/deps/gam_sae-a2c4802d7e5c9eac)\n\n  running 1 test\n\n  thread 'manifold::stagewise::tests::residual_covariance_propagates_invalid_residual_errors' (16403) panicked at crates/gam-sae/src/manifold/stagewise.rs:2317:14:\n  non-finite residuals must be reported, not downgraded to None: None\n  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace\n  test manifold::stagewise::tests::residual_covariance_propagates_invalid_residual_errors ... FAILED\n\n  failures:\n\n  failures:\n      manifold::stagewise::tests::residual_covariance_propagates_invalid_residual_errors\n\n  test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 910 filtered out; finished in 0.01s\n\n  error: test failed, to rerun pass `-p gam-sae --lib`\n  ```\n\n* \u2705 `./build.sh test -p gam-sae --lib residual_covariance_propagates_invalid_residual_errors -- --nocapture` after the fix  \n  ```text\n  [build.sh] test -p gam-sae --lib residual_covariance_propagates_invalid_residual_errors -- --nocapture -> exit 0 in 0s (dedup=MISS, recompiled 0 crates)\n      Finished `test` profile [optimized + debuginfo] target(s) in 0.59s\n       Running unittests src/lib.rs (target/debug/deps/gam_sae-a2c4802d7e5c9eac)\n\n  running 1 test\n  test manifold::stagewise::tests::residual_covariance_propagates_invalid_residual_errors ... ok\n\n  test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 910 filtered out; finished in 0.01s\n  ```\n\n## CODE DIFF\n\n```diff\ndiff --git a/crates/gam-sae/src/manifold/stagewise.rs b/crates/gam-sae/src/manifold/stagewise.rs\nindex 0ed9e35..c3b7356 100644\n--- a/crates/gam-sae/src/manifold/stagewise.rs\n+++ b/crates/gam-sae/src/manifold/stagewise.rs\n@@ -339,15 +339,13 @@ fn fit_residual_covariance(\n     }\n     let activity = activity_of(term);\n     let max_rank = config.max_factor_rank.min(p.saturating_sub(1)).max(1);\n-    match StructuredResidualModel::fit(ResidualFactorInput {\n+    StructuredResidualModel::fit(ResidualFactorInput {\n         residuals: residual.view(),\n         activity: activity.view(),\n         max_factor_rank: max_rank,\n-    }) {\n-        Ok(model) => Ok(Some((residual, model))),\n-        // A degenerate residual fit is a stop signal, not an error.\n-        Err(_) => Ok(None),\n-    }\n+    })\n+    .map(|model| Some((residual, model)))\n+    .map_e
</details>

_Codex-generated; pending adversarial audit before merge._