### PR TITLE
#2080: fix(sae): classify stalled REML probes as recoverable and return incumbent on probe-refusal

### DIFF
--- a/crates/gam-sae/src/manifold/construction.rs
+++ b/crates/gam-sae/src/manifold/construction.rs
@@ -5609,8 +5609,9 @@ impl SaeManifoldTerm {
             };
             let stalled = new_loss_total.is_finite()
                 && relative_decrease.is_finite()
-                && (relative_decrease < SAE_MANIFOLD_INNER_OBJECTIVE_STALL_REL_TOL
-                    || captured_fraction < SAE_MANIFOLD_INNER_OBJECTIVE_STALL_FRACTION);
+                && captured_fraction.is_finite()
+                && relative_decrease < SAE_MANIFOLD_INNER_OBJECTIVE_STALL_REL_TOL
+                && captured_fraction < SAE_MANIFOLD_INNER_OBJECTIVE_STALL_FRACTION;
             previous_loss_total = new_loss_total;
             if stalled && refine_rounds >= SAE_MANIFOLD_INNER_OBJECTIVE_STALL_MIN_ROUNDS {
                 let stationary_sys = self

--- a/crates/gam-sae/src/manifold/outer_objective.rs
+++ b/crates/gam-sae/src/manifold/outer_objective.rs
@@ -1640,6 +1640,9 @@ impl SaeManifoldOuterObjective {
     pub(crate) fn is_recoverable_value_probe_refusal(err: &str) -> bool {
         err.contains("inner solve did not converge at fixed ρ")
             || err.contains(
+                "objective stalled but the stalled point is not stationary",
+            )
+            || err.contains(
                 "undamped evidence factorization hit a non-PD per-row H_tt block before KKT",
             )
             // A probed ρ whose cross-row IBP joint Hessian is non-PD has an

--- a/crates/gam-sae/src/manifold/tests.rs
+++ b/crates/gam-sae/src/manifold/tests.rs
@@ -2432,6 +2432,11 @@ pub(crate) fn sae_value_probe_refusal_classification_is_inner_only() {
     );
     assert!(
         SaeManifoldOuterObjective::is_recoverable_value_probe_refusal(
+            "SaeManifoldTerm::reml_criterion: objective stalled but the stalled point is not stationary (‖g‖=1.0e0, ‖Π⊥gauge g‖=1.0e0, tol 1.0e-6); refusing to rank an off-optimum Laplace criterion"
+        )
+    );
+    assert!(
+        SaeManifoldOuterObjective::is_recoverable_value_probe_refusal(
             "SaeManifoldTerm::reml_criterion: undamped evidence factorization hit a non-PD per-row H_tt block before KKT stationarity"
         )
     );

--- a/crates/gam-sae/src/manifold/tests_logdet_adjoint_780.rs
+++ b/crates/gam-sae/src/manifold/tests_logdet_adjoint_780.rs
@@ -214,6 +214,7 @@ fn dual_half_logdet_trace_2156(cache: &ArrowFactorCache, h: &Array2<f64>, dh: &A
     0.5 * report.total_derivative
 }
 
+#[allow(dead_code)]
 fn dual_logdet_trace_2156(
     label: &'static str,
     cache: &ArrowFactorCache,

--- a/crates/gam-solve/src/rho_optimizer/run_plan.rs
+++ b/crates/gam-solve/src/rho_optimizer/run_plan.rs
@@ -1761,13 +1761,34 @@ pub(crate) fn run_outer_with_plan(
                             // (#NaN-outer-loop): every line-search cost probe at
                             // this seed was infeasible, so BFGS would have spent
                             // its entire max_iterations budget on inner solves
-                            // that all fail. Route as a seed rejection so the
-                            // cascade tries the next seed instead of propagating
-                            // a fatal error.
-                            Err(EstimationError::RemlOptimizationFailed(format!(
-                                "BFGS aborted: globally infeasible neighbourhood \
-                                 at seed (probe-refusal guard): {message}"
-                            )))
+                            // that all fail. The seed itself, however, was a
+                            // finite value-and-gradient evaluation registered in
+                            // `CostStallGuard::observe_seed` before BFGS started.
+                            // Rejecting that finite incumbent confuses
+                            // "undefined neighbouring probes" with "invalid
+                            // dictionary" and can make a single-seed REML path
+                            // abort even though it has a usable best-so-far
+                            // point. Return the published incumbent as
+                            // NON-converged instead: this bounds the probe loop
+                            // without fabricating stationarity, while preserving
+                            // genuine startup-validation rejection for seeds that
+                            // never produced a finite incumbent.
+                            let exit = cost_stall_exit.lock().ok().and_then(|mut slot| slot.take());
+                            match exit {
+                                Some(exit) => Ok(outer_result_with_gradient_norm(
+                                    exit.rho,
+                                    exit.value,
+                                    exit.iterations,
+                                    Some(exit.grad_norm),
+                                    false,
+                                    *the_plan,
+                                )),
+                                None => Err(EstimationError::RemlOptimizationFailed(format!(
+                                    "BFGS aborted: globally infeasible neighbourhood \
+                                     at seed without a finite incumbent \
+                                     (probe-refusal guard): {message}"
+                                ))),
+                            }
                         }
                         Err(BfgsError::ObjectiveFailed { message }) => {
                             Err(EstimationError::RemlOptimizationFailed(format!(


### PR DESCRIPTION
### Motivation
- The outer REML ρ-search aborted when inner `reml_criterion` hit a stalled-but-nonstationary fixed-ρ inner state because that refusal was treated as a fatal seed-validation error instead of an infeasible probe.
- The stall predicate fired too eagerly (logical OR) causing premature refusal of otherwise usable incumbents at wide `p` and emptying the seed cascade. 
- When BFGS observed many infeasible neighboring probes it rejected the seed even though a finite incumbent had been published; this turned a local infeasible neighborhood into a global abort.

### Description
- Tighten SAE inner-refinement stall detection to require both the small `relative_decrease` and the small `captured_fraction` (and that both are finite) before declaring a stall. (`crates/gam-sae/src/manifold/construction.rs`)
- Classify the specific `"objective stalled but the stalled point is not stationary"` `reml_criterion` message as a recoverable infeasible-ρ probe so value/gradient lanes map it to the finite collapse wall (steer back to PD region) rather than hard-erroring. (`crates/gam-sae/src/manifold/outer_objective.rs`)
- When the BFGS probe-refusal non-termination guard fires for a seed that previously published a finite incumbent, return that published incumbent as `converged = false` instead of rejecting the seed outright; keep the fatal path when no finite incumbent exists. (`crates/gam-solve/src/rho_optimizer/run_plan.rs`)
- Add a regression assertion for the new classifier and silence a dead helper to satisfy deny-warnings. (`crates/gam-sae/src/manifold/tests.rs`, `crates/gam-sae/src/manifold/tests_logdet_adjoint_780.rs`)

### Testing
- Built the tree with `./build.sh` and the builds completed successfully (`exit 0`).
- Ran `./build.sh check -p gam-sae --lib` and `./build.sh check -p gam-solve --lib`, both returned `exit 0` with no warnings.
- Ran unit tests and targeted regressions:
  - `./build.sh test -p gam-sae --lib sae_value_probe_refusal_classification_is_inner_only -- --nocapture` — passed.
  - `./build.sh test -p gam-sae --lib wide_p_outer_reml_terminates_within_probe_budget_2080 -- --nocapture` — passed with telemetry showing bounded probe counts and `mutating_value_probes=0`.
  - `./build.sh test -p gam-sae --lib wide_p_outer_reml_terminates_k3_heavy_2080 -- --nocapture` — passed (bounded probes) after the change.

All changed tests passed and no existing tests were weakened or skipped.

---
Fixes #2080.

<details><summary>codex self-assessment</summary>

3c1 inner non-convergence/refusal class is broadened to include its equivalent \u201cstalled but non-stationary\u201d message. "}, {"content_type": "repo_file_citation", "path": "crates/gam-sae/src/manifold/outer_objective.rs", "line_range_start": 1640, "line_range_end": 1647}, {"content_type": "text", "text": "\n\n## TEST EVIDENCE\n\n### Before \u2192 After Evidence\n\nBefore the recoverable-refusal classifier fix, the acceptance regression failed with seed-validation aborts:\n\n* \u274c `./build.sh test -p gam-sae --lib wide_p_outer_reml_terminates_within_probe_budget_2080 -- --nocapture`\n\n```text\n[build.sh] test -p gam-sae --lib wide_p_outer_reml_terminates_within_probe_budget_2080 -- --nocapture -> exit 101 in 221s\nthread 'manifold::tests_outer_reml_probe_budget_2080::wide_p_outer_reml_terminates_within_probe_budget_2080' panicked at crates/gam-sae/src/manifold/tests_outer_reml_probe_budget_2080.rs:230:10:\n#2080 wide-p outer REML fit must terminate, not hang / abort: REML smoothing optimization failed to converge: no candidate seeds passed outer startup validation (SAE manifold):\n  generated=2, screened=2, exact_validated=2, solver_started=0\n  rejection breakdown: rejected_by_kkt=0, rejected_by_domain=0, rejected_by_objective=0, rejected_by_budget=0, rejected_other=2 (total=2)\n  per-seed reasons:\n    seed 0 (validation): REML smoothing optimization failed to converge: outer eval failed: REML smoothing optimization failed to converge: SaeManifoldTerm::reml_criterion: objective stalled but the stalled point is not stationary (\u2016g\u2016=8.559661e1, \u2016\u03a0\u22a5gauge g\u2016=8.559661e1, tol 1.181569e-3); refusing to rank an off-optimum Laplace criterion\n    seed 1 (validation): REML smoothing optimization failed to converge: outer eval failed: REML smoothing optimization failed to converge: SaeManifoldTerm::reml_criterion: objective stalled but the stalled point is not stationary (\u2016g\u2016=1.660769e2, \u2016\u03a0\u22a5gauge g\u2016=1.660769e2, tol 9.227237e-4); refusing to rank an off-optimum Laplace criterion\ntest result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 909 filtered out; finished in 5.77s\n```\n\nAfter the fix:\n\n* \u2705 `./build.sh`\n\n```text\n[build.sh] LIB -> exit 0 in 1357s (dedup=MISS, recompiled 191 crates)\nFinished `dev` profile [unoptimized + debuginfo] target(s) in 22m 35s\n```\n\n* \u2705 `./build.sh check -p gam-sae --lib`\n\n```text\n[build.sh] check -p gam-sae --lib -> exit 0 in 5s (dedup=MISS, recompiled 0 crates)\nChecking gam-sae v0.3.148 (/workspace/gam/crates/gam-sae)\nFinished `dev` profile [unoptimized + debuginfo] target(s) in 4.81s\n```\n\n* \u2705 `./build.sh check -p gam-solve --lib`\n\n```text\n[build.sh] check -p gam-solve --lib -> exit 0 in 1s (dedup=MISS, recompiled 0 crates)\nFinished `dev` profile [unoptimized + debuginfo] target(s) in 0.59s\n```\n\n* \u2705 `./build.sh test -p gam-sae --lib --no-run`\n\n```text\n[build.sh] test -p gam-sae --lib --no-run -> exit 0 in 1s (dedup=MISS, recompiled 0 crates)\nFinished `test` profile [optimized + debuginfo] target(s) in 0.58s\nExecutable unittests src/lib.rs (target/debug/deps/gam_sae-a2c4802d7e5c9eac)\n```\n\n* \u2705 `./build.sh test -p gam-sae --lib sae_value_probe_refusal_classification_is_inner_only -- --nocapture`\n\n```text\n[build.sh] test -p gam-sae --lib sae_value_probe_refusal_classification_is_inner_only -- --nocapture -> exit 0 in 0s (dedup=MISS, recompiled 0 crates)\nrunning 1 test\ntest manifold::tests::sae_value_probe_refusal_classification_is_inner_only ... ok\n\ntest result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 909 filtered out; finished in 0.00s\n```\n\n* \u2705 `./build.sh test -p gam-sae --lib wide_p_outer_reml_terminates_within_probe_budget_2080 -- --nocapture`\n\n```text\n[build.sh] test -p gam-sae --lib wide_p_outer_reml_terminates_within_probe_budget_2080 -- --nocapture -> exit 0 in 192s (dedup=MISS, recompiled 1 crates)\nrunning 1 test\n[#2080] wide-p outer fit: ev=0.
</details>

_Codex-generated; pending adversarial audit before merge._