### PR TITLE
#2087: test(terms): guard IBP cross-row mass derivative

### DIFF
--- a/crates/gam-terms/src/analytic_penalties/tests.rs
+++ b/crates/gam-terms/src/analytic_penalties/tests.rs
@@ -573,6 +573,52 @@ fn ibp_cross_row_d_logalpha_matches_finite_difference() {
 }
 
 #[test]
+fn ibp_cross_row_dd_matches_mass_derivative_of_cross_row_d_2087() {
+    // #2087/#1416 root cause guard: the IBP log-det θ-adjoint differentiates the
+    // same cross-row rank-one coefficient `d_k = w·score'_k` that the Hessian
+    // assembly puts into the Woodbury block. Its mass channel must therefore be
+    // `∂d_k/∂M_k = w·score''_k`, not a hand-expanded surrogate with a missing
+    // posterior-π Jacobian factor. Perturbing every row in one column by the same
+    // concrete-probability amount gives a direct central difference of `d_k` with
+    // respect to the empirical mass `M_k`.
+    let pen = IBPAssignmentPenalty::new(3, 6.0, 0.8, false);
+    let t = array![
+        0.2_f64, -0.3, 0.7, -0.1, 0.4, 0.5, 0.6, -0.2, 0.3, 0.1, 0.8, -0.4
+    ];
+    let rho = Array1::<f64>::zeros(0);
+    let raw = pen.hessian_diag_logit_third_channels(t.view(), rho.view(), false);
+    let eps = 1.0e-6_f64;
+    let tau = 0.8_f64;
+    let z = t.mapv(|logit| 1.0 / (1.0 + (-logit / tau).exp()));
+    let n = t.len() / pen.k_max;
+    for col in 0..pen.k_max {
+        let mut plus = t.clone();
+        let mut minus = t.clone();
+        for row in 0..n {
+            let idx = row * pen.k_max + col;
+            // Convert a probability-space perturbation `±eps` to the logit-space
+            // perturbation that realizes it to first order: dz = J dℓ. The
+            // fixture is comfortably interior, so every Jacobian is nonzero.
+            let jac = z[idx] * (1.0 - z[idx]) / tau;
+            plus[idx] += eps / jac;
+            minus[idx] -= eps / jac;
+        }
+        let d_plus = pen
+            .hessian_diag_logit_third_channels(plus.view(), rho.view(), false)
+            .cross_row_d[col];
+        let d_minus = pen
+            .hessian_diag_logit_third_channels(minus.view(), rho.view(), false)
+            .cross_row_d[col];
+        let fd = (d_plus - d_minus) / (2.0 * eps * n as f64);
+        assert!(
+            (raw.cross_row_dd[col] - fd).abs() <= 2.0e-6,
+            "column {col}: cross_row_dd={} must match ∂cross_row_d/∂M={fd}",
+            raw.cross_row_dd[col]
+        );
+    }
+}
+
+#[test]
 fn ibp_assignment_learnable_alpha_grad_rho_matches_value_finite_difference() {
     let pen = IBPAssignmentPenalty::new(3, 6.0, 0.8, true);
     let t = array![


### PR DESCRIPTION
### Motivation
- Add a mechanistic regression guard for #2087 to ensure the IBP θ-adjoint differentiates the same cross-row Woodbury coefficient the Hessian assembly uses, preventing reintroduction of a stale hand-expanded surrogate for the mass derivative.

### Description
- Add `ibp_cross_row_dd_matches_mass_derivative_of_cross_row_d_2087` in `crates/gam-terms/src/analytic_penalties/tests.rs` which perturbs a column's concrete probabilities, recomputes `cross_row_d`, and asserts `cross_row_dd == ∂cross_row_d/∂M` (central difference of the assembled coefficient).
- The test converts probability-space perturbations to logit-space (`dz = J dℓ`) so it probes the concrete-logit channel while measuring the mass derivative precisely.

### Testing
- Ran `./build.sh test -p gam-terms ibp_cross_row_dd_matches_mass_derivative_of_cross_row_d_2087 -- --nocapture` and the test passed (1 passed, 0 failed).
- Ran full crate-level build/check: `./build.sh && ./build.sh check -p gam-terms --lib && ./build.sh test -p gam-terms --no-run` which completed successfully.
- Also exercised related finite-difference guard `ibp_cross_row_d_logalpha_matches_finite_difference` via `./build.sh test -p gam-terms ibp_cross_row_d_logalpha_matches_finite_difference -- --nocapture`, which passed.

---
Refs #2087.

<details><summary>codex self-assessment</summary>

0s (dedup=SUBSUMED, recompiled 0 crates)\n[build.sh] test -p gam-terms --no-run -> exit 0 in 0s (dedup=MISS, recompiled 0 crates)\n    Finished `test` profile [optimized + debuginfo] target(s) in 0.61s\n  Executable unittests src/lib.rs (target/debug/deps/gam_terms-e44a500d3580d2ee)\n  Executable tests/average_derivative_design.rs (target/debug/deps/average_derivative_design-a7da1f0fc40e34a3)\n  Executable tests/duchon_single_design_build_1718.rs (target/debug/deps/duchon_single_design_build_1718-9e6369fc8d473244)\n```\n\n* \u2705 `./build.sh test -p gam-terms ibp_cross_row_d_logalpha_matches_finite_difference -- --nocapture`\n\n```text\n[build.sh] test -p gam-terms ibp_cross_row_d_logalpha_matches_finite_difference -- --nocapture -> exit 0 in 1s (dedup=MISS, recompiled 0 crates)\n    Finished `test` profile [optimized + debuginfo] target(s) in 0.64s\n     Running unittests src/lib.rs (target/debug/deps/gam_terms-e44a500d3580d2ee)\n\nrunning 1 test\ntest analytic_penalties::tests::ibp_cross_row_d_logalpha_matches_finite_difference ... ok\n\ntest result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 688 filtered out; finished in 0.00s\n```\n\n* \u274c `./build.sh test -p gam-terms ibp_cross_row_dd_matches_mass_derivative_of_cross_row_d_2087 -- --nocapture` initially failed because my first version used unsupported `assert_abs_diff_eq!` message syntax and then private helper methods from the test. I fixed both test-authoring errors before committing.\n\n### CODE DIFF\n\n```diff\ndiff --git a/crates/gam-terms/src/analytic_penalties/tests.rs b/crates/gam-terms/src/analytic_penalties/tests.rs\nindex 49799ab..6f2e618 100644\n--- a/crates/gam-terms/src/analytic_penalties/tests.rs\n+++ b/crates/gam-terms/src/analytic_penalties/tests.rs\n@@ -572,6 +572,52 @@ fn ibp_cross_row_d_logalpha_matches_finite_difference() {\n     );\n }\n \n+#[test]\n+fn ibp_cross_row_dd_matches_mass_derivative_of_cross_row_d_2087() {\n+    // #2087/#1416 root cause guard: the IBP log-det \u03b8-adjoint differentiates the\n+    // same cross-row rank-one coefficient `d_k = w\u00b7score'_k` that the Hessian\n+    // assembly puts into the Woodbury block. Its mass channel must therefore be\n+    // `\u2202d_k/\u2202M_k = w\u00b7score''_k`, not a hand-expanded surrogate with a missing\n+    // posterior-\u03c0 Jacobian factor. Perturbing every row in one column by the same\n+    // concrete-probability amount gives a direct central difference of `d_k` with\n+    // respect to the empirical mass `M_k`.\n+    let pen = IBPAssignmentPenalty::new(3, 6.0, 0.8, false);\n+    let t = array![\n+        0.2_f64, -0.3, 0.7, -0.1, 0.4, 0.5, 0.6, -0.2, 0.3, 0.1, 0.8, -0.4\n+    ];\n+    let rho = Array1::<f64>::zeros(0);\n+    let raw = pen.hessian_diag_logit_third_channels(t.view(), rho.view(), false);\n+    let eps = 1.0e-6_f64;\n+    let tau = 0.8_f64;\n+    let z = t.mapv(|logit| 1.0 / (1.0 + (-logit / tau).exp()));\n+    let n = t.len() / pen.k_max;\n+    for col in 0..pen.k_max {\n+        let mut plus = t.clone();\n+        let mut minus = t.clone();\n+        for row in 0..n {\n+            let idx = row * pen.k_max + col;\n+            // Convert a probability-space perturbation `\u00b1eps` to the logit-space\n+            // perturbation that realizes it to first order: dz = J d\u2113. The\n+            // fixture is comfortably interior, so every Jacobian is nonzero.\n+            let jac = z[idx] * (1.0 - z[idx]) / tau;\n+            plus[idx] += eps / jac;\n+            minus[idx] -= eps / jac;\n+        }\n+        let d_plus = pen\n+            .hessian_diag_logit_third_channels(plus.view(), rho.view(), false)\n+            .cross_row_d[col];\n+        let d_minus = pen\n+            .hessian_diag_logit_third_channels(minus.view(), rho.view(), false)\n+            .cross_row_d[col];\n+        let fd = (d_plus - d_minus) / (2.0 * eps * n as f64);\n+        assert!(\n+            (raw.cross_row_dd[col] - fd).abs() <= 2.0e-6,\n+            \"column {col}: cross_r
</details>

_Codex-generated; pending adversarial audit before merge._
