### PR TITLE
#2101: Put K=1 birth sub-fit on the scale quotient to prevent decoder collapse (#2101)

### DIFF
--- a/crates/gam-sae/src/manifold/stagewise.rs
+++ b/crates/gam-sae/src/manifold/stagewise.rs
@@ -375,6 +375,17 @@ fn fit_single_atom_response_in_place(
         SaeAssignment::with_mode(sub_logits, vec![coord_block], term.assignment.mode)?;
     let mut sub_term = SaeManifoldTerm::new(vec![sub_atom], sub_assignment)?;
     sub_term.set_guards_enabled(false);
+    // #2101: a birth sub-fit is a one-atom response fit, so there is no
+    // dictionary peer against which the normal cone-atom collapse recovery can
+    // identify a scale-gauge failure.  Put this local K=1 problem directly on
+    // the scale quotient before Newton: keep the seeded function unchanged by
+    // moving the decoder Frobenius norm into the explicit log-amplitude, then
+    // let the fit adjust the unit-shape decoder and its amplitude.  This makes
+    // the smoothness/ARD terms see the atom's shape instead of charging the raw
+    // LSQ coefficient magnitude that carries residual scale, which is the
+    // mechanism that collapsed genuine born circles to zero/DC rows.
+    sub_term.set_quotient_scale(true);
+    sub_term.atoms[0].absorb_decoder_norm_into_log_amplitude(f64::MIN_POSITIVE);
     if let Some(w) = term.row_loss_weights().map(|w| w.to_vec()) {
         sub_term.set_row_loss_weights(w)?;
     }

--- a/crates/gam-sae/src/manifold/tests_logdet_adjoint_780.rs
+++ b/crates/gam-sae/src/manifold/tests_logdet_adjoint_780.rs
@@ -214,20 +214,6 @@ fn dual_half_logdet_trace_2156(cache: &ArrowFactorCache, h: &Array2<f64>, dh: &A
     0.5 * report.total_derivative
 }
 
-fn dual_logdet_trace_2156(
-    label: &'static str,
-    cache: &ArrowFactorCache,
-    h: &Array2<f64>,
-    dh: &Array2<f64>,
-) -> (f64, BranchCertificate) {
-    let report = dual_trace_report_2156(
-        cache,
-        h,
-        vec![(DerivativeTraceChannel::Other(label), dh.clone())],
-    );
-    (report.total_derivative, report.certificate)
-}
-
 fn relative_error_2156(exact: f64, production: f64) -> f64 {
     (exact - production).abs() / exact.abs().max(production.abs()).max(1.0)
 }


### PR DESCRIPTION
### Motivation
- The one-atom stagewise birth sub-fit (`fit_single_atom_response_in_place`) was carrying the LSQ seed’s full decoder magnitude in raw `B`, so fixed-λ smoothness/ARD penalised coefficient magnitude (not shape) and drove good born-circle decoders to collapse or to a DC row, causing otherwise-valid births to be rejected.
- K=1 sub-fits have no dictionary peer for the existing cone-atom recovery to detect/re-home collapsed scale, so the local K=1 path must itself place the fit on the scale quotient to avoid charging raw coefficients.

### Description
- In `fit_single_atom_response_in_place` (`crates/gam-sae/src/manifold/stagewise.rs`) enable the scale quotient for the freshly-built one-atom `sub_term` and immediately fold the seeded decoder Frobenius norm into the atom's explicit `log_amplitude` by calling `sub_term.set_quotient_scale(true)` and `sub_term.atoms[0].absorb_decoder_norm_into_log_amplitude(f64::MIN_POSITIVE)`, so the Newton solve optimizes a unit-shape decoder + amplitude rather than penalizing raw `B` scale.
- Removed an unused test helper (`dual_logdet_trace_2156`) from `crates/gam-sae/src/manifold/tests_logdet_adjoint_780.rs` that caused a `-D warnings` lib-test build failure so the behavioral birth-fit tests can run under the repo deny-warnings policy.

### Testing
- Built the tree: ran `./build.sh` and it completed successfully (exit 0).
- Ran the crate check: `./build.sh check -p gam-sae --lib` completed successfully (exit 0).
- Verified test binary build: `./build.sh test -p gam-sae --test sae_ev_vs_k_1026 --no-run` completed successfully (exit 0).
- Ran the focused behavioral tests exercising the birth sub-fit and seed logic and they passed:
  - `./build.sh test -p gam-sae --lib born_circle_survives_on_incumbent_sparse_rows_2109 -- --nocapture` → ok (1 passed).
  - `./build.sh test -p gam-sae --lib residual_principal_seeds_circle_as_rank2_not_dc_2101 -- --nocapture` → ok (1 passed).
  - `./build.sh test -p gam-sae --lib top_factor_birth_mirrors_circle_seed_2109 -- --nocapture` → ok (1 passed).
- Note: an unrelated lib-test failure on the original base (dead-code denied by `-D warnings`) prevented the behavioral assertion from being exercised; that unused helper was removed so the lib-test surface now builds and the above tests run cleanly.

---
Fixes #2101.

<details><summary>codex self-assessment</summary>

gam-sae --lib -> exit 0 in 235s (dedup=MISS, recompiled 9 crates)\n...\n    Checking gam-sae v0.3.148 (/workspace/gam/crates/gam-sae)\n    Finished `dev` profile [unoptimized + debuginfo] target(s) in 3m 54s\n```\n\n* \u2705 `./build.sh test -p gam-sae --test sae_ev_vs_k_1026 --no-run`\n\n```text\n[build.sh] test -p gam-sae --test sae_ev_vs_k_1026 --no-run -> exit 0 in 145s (dedup=MISS, recompiled 1 crates)\n   Compiling gam-sae v0.3.148 (/workspace/gam/crates/gam-sae)\n    Finished `test` profile [optimized + debuginfo] target(s) in 2m 24s\n  Executable tests/sae_ev_vs_k_1026.rs (target/debug/deps/sae_ev_vs_k_1026-b69c5228de6fc160)\n```\n\n* \u2705 `./build.sh test -p gam-sae --lib born_circle_survives_on_incumbent_sparse_rows_2109 -- --nocapture`\n\n```text\n[build.sh] test -p gam-sae --lib born_circle_survives_on_incumbent_sparse_rows_2109 -- --nocapture -> exit 0 in 127s (dedup=MISS, recompiled 1 crates)\n   Compiling gam-sae v0.3.148 (/workspace/gam/crates/gam-sae)\n    Finished `test` profile [optimized + debuginfo] target(s) in 2m 06s\n     Running unittests src/lib.rs (target/debug/deps/gam_sae-a2c4802d7e5c9eac)\n\nrunning 1 test\ntest manifold::stagewise::tests::born_circle_survives_on_incumbent_sparse_rows_2109 ... ok\n\ntest result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 909 filtered out; finished in 0.56s\n```\n\n* \u2705 `./build.sh test -p gam-sae --lib residual_principal_seeds_circle_as_rank2_not_dc_2101 -- --nocapture`\n\n```text\n[build.sh] test -p gam-sae --lib residual_principal_seeds_circle_as_rank2_not_dc_2101 -- --nocapture -> exit 0 in 1s (dedup=MISS, recompiled 0 crates)\n    Finished `test` profile [optimized + debuginfo] target(s) in 0.55s\n     Running unittests src/lib.rs (target/debug/deps/gam_sae-a2c4802d7e5c9eac)\n\nrunning 1 test\ntest manifold::stagewise::tests::residual_principal_seeds_circle_as_rank2_not_dc_2101 ... ok\n\ntest result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 909 filtered out; finished in 0.01s\n```\n\n* \u2705 `./build.sh test -p gam-sae --lib top_factor_birth_mirrors_circle_seed_2109 -- --nocapture`\n\n```text\n[build.sh] test -p gam-sae --lib top_factor_birth_mirrors_circle_seed_2109 -- --nocapture -> exit 0 in 1s (dedup=MISS, recompiled 0 crates)\n    Finished `test` profile [optimized + debuginfo] target(s) in 0.56s\n     Running unittests src/lib.rs (target/debug/deps/gam_sae-a2c4802d7e5c9eac)\n\nrunning 1 test\ntest manifold::stagewise::tests::top_factor_birth_mirrors_circle_seed_2109 ... ok\n\ntest result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 909 filtered out; finished in 0.04s\n```\n\n## CODE DIFF\n\n```diff\ndiff --git a/crates/gam-sae/src/manifold/stagewise.rs b/crates/gam-sae/src/manifold/stagewise.rs\nindex 0ed9e35..82d94af 100644\n--- a/crates/gam-sae/src/manifold/stagewise.rs\n+++ b/crates/gam-sae/src/manifold/stagewise.rs\n@@ -375,6 +375,17 @@ fn fit_single_atom_response_in_place(\n         SaeAssignment::with_mode(sub_logits, vec![coord_block], term.assignment.mode)?;\n     let mut sub_term = SaeManifoldTerm::new(vec![sub_atom], sub_assignment)?;\n     sub_term.set_guards_enabled(false);\n+    // #2101: a birth sub-fit is a one-atom response fit, so there is no\n+    // dictionary peer against which the normal cone-atom collapse recovery can\n+    // identify a scale-gauge failure.  Put this local K=1 problem directly on\n+    // the scale quotient before Newton: keep the seeded function unchanged by\n+    // moving the decoder Frobenius norm into the explicit log-amplitude, then\n+    // let the fit adjust the unit-shape decoder and its amplitude.  This makes\n+    // the smoothness/ARD terms see the atom's shape instead of charging the raw\n+    // LSQ coefficient magnitude that carries residual scale, which is the\n+    // mechanism that collapsed genuine born circles to zero/DC rows.\n+    sub_term.set_quotient_scale(true);\n+    sub_term.atoms[0].absorb_decoder_norm_into_log_amplitude(f64::MIN_POSITIVE);\n     if let Some(w) = term
</details>

_Codex-generated; pending adversarial audit before merge._