### PR TITLE
#2150: Route transformation-normal family to CTN materializer

### DIFF
--- a/crates/gam-models/src/fit_orchestration/entry.rs
+++ b/crates/gam-models/src/fit_orchestration/entry.rs
@@ -1102,6 +1102,13 @@ pub fn fit_residual_cascade_from_formula(
 }
 
 /// Parse a formula, resolve it against a dataset, and produce a ready-to-fit `FitRequest`.
+fn family_requests_transformation_normal(family: Option<&str>) -> bool {
+    family
+        .map(|name| name.trim().to_ascii_lowercase().replace('_', "-"))
+        .as_deref()
+        == Some("transformation-normal")
+}
+
 pub fn materialize<'a>(
     formula: &str,
     data: &'a Dataset,
@@ -1110,10 +1117,26 @@ pub fn materialize<'a>(
     gam_gpu::configure_global_policy(config.gpu_policy);
     let parsed = parse_formula(formula)?;
     let col_map = data.column_map();
+    let family_transformation_normal =
+        family_requests_transformation_normal(config.family.as_deref());
+    let transformation_normal_config;
+    let effective_config = if family_transformation_normal && !config.transformation_normal {
+        // `family="transformation-normal"` is a documented spelling of the CTN
+        // model class, not a Gaussian identity likelihood. Normalize it into the
+        // same orchestration flag used by `transformation_normal=true` before any
+        // dispatch/validation branch can silently treat the request as standard.
+        transformation_normal_config = FitConfig {
+            transformation_normal: true,
+            ..config.clone()
+        };
+        &transformation_normal_config
+    } else {
+        config
+    };
 
     if let Some((left_col, right_col, event_col)) = parse_surv_interval_response(&parsed.response)?
     {
-        if config.transformation_normal {
+        if effective_config.transformation_normal {
             return Err(WorkflowError::InvalidConfig {
                 reason:
                     "transformation_normal cannot be combined with a SurvInterval(...) response"
@@ -1131,14 +1154,14 @@ pub fn materialize<'a>(
             &parsed,
             data,
             &col_map,
-            config,
+            effective_config,
             None,
             &left_col,
             &event_col,
             Some(&right_col),
         )
     } else if let Some((entry_col, exit_col, event_col)) = parse_surv_response(&parsed.response)? {
-        if config.transformation_normal {
+        if effective_config.transformation_normal {
             return Err(WorkflowError::InvalidConfig {
                 reason: "transformation_normal cannot be combined with a Surv(...) response"
                     .to_string(),
@@ -1152,7 +1175,7 @@ pub fn materialize<'a>(
             &parsed,
             data,
             &col_map,
-            config,
+            effective_config,
             entry_col.as_deref(),
             &exit_col,
             &event_col,
@@ -1174,28 +1197,30 @@ pub fn materialize<'a>(
         // non-survival branch a non-default value (e.g. "weibull") would be
         // discarded and the fit would silently degrade to an ordinary GAM
         // (#1767). Reject it at the same chokepoint.
-        reject_survival_likelihood_for_nonsurvival(config)?;
-        if config.transformation_normal {
+        reject_survival_likelihood_for_nonsurvival(effective_config)?;
+        if effective_config.transformation_normal {
             // Issue #789A: a Bernoulli marginal-slope request with
             // `transformation_normal=true` used to dispatch as a CTN fit while
             // retaining marginal-slope controls, leaving the transformation path
             // in a non-advancing loop. CTN score calibration now uses the
             // explicit `ctn_stage1` recipe instead, so the legacy boolean is a
             // hard configuration error for marginal-slope requests.
-            reject_marginal_slope_controls_for_transformation_normal(config)?;
-            if config.noise_formula.is_some() {
+            reject_marginal_slope_controls_for_transformation_normal(effective_config)?;
+            if effective_config.noise_formula.is_some() {
                 return Err(WorkflowError::InvalidConfig {
                     reason: "transformation_normal cannot be combined with noise_formula"
                         .to_string(),
                 });
             }
-            materialize_transformation_normal(&parsed, data, &col_map, config)
-        } else if config.logslope_formula.is_some() || config.z_column.is_some() {
-            materialize_bernoulli_marginal_slope(&parsed, data, &col_map, config)
-        } else if config.noise_formula.is_some() {
-            materialize_location_scale(&parsed, data, &col_map, config)
+            materialize_transformation_normal(&parsed, data, &col_map, effective_config)
+        } else if effective_config.logslope_formula.is_some()
+            || effective_config.z_column.is_some()
+        {
+            materialize_bernoulli_marginal_slope(&parsed, data, &col_map, effective_config)
+        } else if effective_config.noise_formula.is_some() {
+            materialize_location_scale(&parsed, data, &col_map, effective_config)
         } else {
-            materialize_standard(&parsed, data, &col_map, config)
+            materialize_standard(&parsed, data, &col_map, effective_config)
         }
     }
 }

--- a/crates/gam-models/src/fit_orchestration/materialize/tests.rs
+++ b/crates/gam-models/src/fit_orchestration/materialize/tests.rs
@@ -692,6 +692,42 @@ fn issue_789_transformation_normal_rejects_marginal_slope_controls_before_dispat
 }
 
 #[test]
+fn family_transformation_normal_routes_to_ctn_materializer() {
+    let data = workflow_test_dataset();
+    let config = FitConfig {
+        family: Some("transformation-normal".to_string()),
+        ..FitConfig::default()
+    };
+
+    let mat = materialize("bmi ~ s(age_entry, k=4)", &data, &config)
+        .expect("family='transformation-normal' must materialize as CTN");
+
+    assert!(
+        matches!(mat.request, FitRequest::TransformationNormal(_)),
+        "family='transformation-normal' must not silently fall through to a standard Gaussian GAM"
+    );
+}
+
+#[test]
+fn family_transformation_normal_uses_ctn_conflict_validation() {
+    let data = workflow_test_dataset();
+    let config = FitConfig {
+        family: Some("transformation_normal".to_string()),
+        noise_formula: Some("~ 1".to_string()),
+        ..FitConfig::default()
+    };
+
+    let err = materialize("bmi ~ s(age_entry, k=4)", &data, &config)
+        .expect_err("family='transformation-normal' must reject CTN-incompatible controls");
+
+    assert!(
+        err.to_string()
+            .contains("transformation_normal cannot be combined with noise_formula"),
+        "unexpected error: {err}"
+    );
+}
+
+#[test]
 fn survival_marginal_slope_rejects_zero_event_data_before_fit() {
     let mut data = workflow_test_dataset();
     data.values.column_mut(2).fill(0.0);


### PR DESCRIPTION
### Motivation
- `family="transformation-normal"` was being parsed to a Gaussian/identity `LikelihoodSpec` but never routed into the CTN (conditional-transformation-normal) orchestration, so it silently fell through to an ordinary Gaussian GAM instead of producing a CTN or an error.\
- The orchestration branch that selects the CTN path was gated only on `FitConfig::transformation_normal`, so the documented family spelling did not toggle the required dispatch flag.\
- The change aligns the documented `family` alias with the existing `transformation_normal` boolean so users who specify the family string get the intended CTN materialization and validation.

### Description
- Add a helper `family_requests_transformation_normal(family: Option<&str>)` that canonicalizes and recognizes `"transformation-normal"` (also accepts underscore vs hyphen variants). (file: `crates/gam-models/src/fit_orchestration/entry.rs`)\
- In `materialize`, create an `effective_config` that clones `config` but sets `transformation_normal = true` when the family string requests CTN, and use `effective_config` for all subsequent dispatch and validation so the CTN path is taken when appropriate. (file: `crates/gam-models/src/fit_orchestration/entry.rs`)\
- Replace downstream uses of the raw `config` in survival / non-survival branches with `effective_config` so CTN incompatibility checks (`noise_formula`, `Surv(...)`, marginal-slope controls, etc.) are enforced rather than silently dropped. (file: `crates/gam-models/src/fit_orchestration/entry.rs`)\
- Add two regression unit tests that assert (1) `family="transformation-normal"` materializes to `FitRequest::TransformationNormal` and (2) the underscore/hybrid alias triggers CTN conflict validation (rejects `noise_formula`). (file: `crates/gam-models/src/fit_orchestration/materialize/tests.rs`)

### Testing
- Ran `./build.sh check -p gam-models --lib`, which completed successfully (crate compiled with deny-warnings).\
- Added `family_transformation_normal_routes_to_ctn_materializer` and `family_transformation_normal_uses_ctn_conflict_validation` unit tests under `crates/gam-models/src/fit_orchestration/materialize/tests.rs`.\
- Attempted `./build.sh test -p gam-models --lib family_transformation_normal -- --nocapture` for the scoped tests, but the test-binary compilation did not complete within this environment (compile runtimes are long here) and the process was terminated to avoid leaving long-running jobs; the scoped `check` above demonstrates the touched crate builds cleanly.

---
Fixes #2150.

<details><summary>codex self-assessment</summary>

aving a long-running process. This is an environment/time limitation, not a source failure observed from compiler diagnostics.\n\n* \u26a0\ufe0f `./build.sh test -p gam-models --lib family_transformation_normal -- --nocapture`\n\n  I started the relevant regression test command, but the test binary compilation did not complete after an extended period; I killed the cargo process to avoid leaving it running. No test failure output was produced before termination. The scoped library check above did compile the touched crate successfully with deny-warnings.\n\n### CODE DIFF\n\n```diff\ndiff --git a/crates/gam-models/src/fit_orchestration/entry.rs b/crates/gam-models/src/fit_orchestration/entry.rs\nindex bd10b2d..0701b4e 100644\n--- a/crates/gam-models/src/fit_orchestration/entry.rs\n+++ b/crates/gam-models/src/fit_orchestration/entry.rs\n@@ -1102,6 +1102,13 @@ pub fn fit_residual_cascade_from_formula(\n }\n \n /// Parse a formula, resolve it against a dataset, and produce a ready-to-fit `FitRequest`.\n+fn family_requests_transformation_normal(family: Option<&str>) -> bool {\n+    family\n+        .map(|name| name.trim().to_ascii_lowercase().replace('_', \"-\"))\n+        .as_deref()\n+        == Some(\"transformation-normal\")\n+}\n+\n pub fn materialize<'a>(\n     formula: &str,\n     data: &'a Dataset,\n@@ -1110,10 +1117,26 @@ pub fn materialize<'a>(\n     gam_gpu::configure_global_policy(config.gpu_policy);\n     let parsed = parse_formula(formula)?;\n     let col_map = data.column_map();\n+    let family_transformation_normal =\n+        family_requests_transformation_normal(config.family.as_deref());\n+    let transformation_normal_config;\n+    let effective_config = if family_transformation_normal && !config.transformation_normal {\n+        // `family=\"transformation-normal\"` is a documented spelling of the CTN\n+        // model class, not a Gaussian identity likelihood. Normalize it into the\n+        // same orchestration flag used by `transformation_normal=true` before any\n+        // dispatch/validation branch can silently treat the request as standard.\n+        transformation_normal_config = FitConfig {\n+            transformation_normal: true,\n+            ..config.clone()\n+        };\n+        &transformation_normal_config\n+    } else {\n+        config\n+    };\n \n     if let Some((left_col, right_col, event_col)) = parse_surv_interval_response(&parsed.response)?\n     {\n-        if config.transformation_normal {\n+        if effective_config.transformation_normal {\n             return Err(WorkflowError::InvalidConfig {\n                 reason:\n                     \"transformation_normal cannot be combined with a SurvInterval(...) response\"\n@@ -1131,14 +1154,14 @@ pub fn materialize<'a>(\n             &parsed,\n             data,\n             &col_map,\n-            config,\n+            effective_config,\n             None,\n             &left_col,\n             &event_col,\n             Some(&right_col),\n         )\n     } else if let Some((entry_col, exit_col, event_col)) = parse_surv_response(&parsed.response)? {\n-        if config.transformation_normal {\n+        if effective_config.transformation_normal {\n             return Err(WorkflowError::InvalidConfig {\n                 reason: \"transformation_normal cannot be combined with a Surv(...) response\"\n                     .to_string(),\n@@ -1152,7 +1175,7 @@ pub fn materialize<'a>(\n             &parsed,\n             data,\n             &col_map,\n-            config,\n+            effective_config,\n             entry_col.as_deref(),\n             &exit_col,\n             &event_col,\n@@ -1174,28 +1197,30 @@ pub fn materialize<'a>(\n         // non-survival branch a non-default value (e.g. \"weibull\") would be\n         // discarded and the fit would silently degrade to an ordinary GAM\n         // (#1767). Reject it at the same chokepoint.\n-        reject_survival_likelihood_for_nonsurvival(config)?;\n-        if config.transfo
</details>

_Codex-generated; pending adversarial audit before merge._