### PR TITLE
#1795: test(arrow-schur): add regression for cross-row preconditioner honoring schur PD floor

### DIFF
--- a/crates/gam-solve/src/arrow_schur/tests.rs
+++ b/crates/gam-solve/src/arrow_schur/tests.rs
@@ -2479,6 +2479,46 @@ pub(crate) fn streaming_cross_row_woodbury_log_det_honors_pd_floor_1795() {
     );
 }
 
+
+/// #1795 — the cross-row IBP preconditioner builder is another reduced-Schur
+/// factorization entry point. It must use the same spectral PD-floor as the
+/// direct dense solve, rather than a raw Cholesky, because the preconditioner
+/// inverts the same collapsed decoder subspace before CG handles the explicit
+/// cross-row Woodbury coupling.
+#[test]
+pub(crate) fn cross_row_preconditioner_build_honors_pd_floor_1795() {
+    let backend = CpuBatchedBlockSolver;
+    let mut sys = diagonal_arrow_fixture(2.0, 1.0);
+    // With zero H_tβ blocks, the reduced Schur is exactly H_ββ. This matrix has
+    // eigenvalues {+3, −1}: a bare Cholesky must reject it, while the #1038
+    // spectral floor unit-deflates the collapsed direction relative to λ_max=3.
+    sys.hbb = array![[1.0_f64, 2.0], [2.0, 1.0]];
+
+    let unfloored = ArrowBlockDiagInverse::build(&sys, 0.0, 0.0, None, false, &backend);
+    assert!(
+        matches!(unfloored, Err(ArrowSchurError::SchurFactorFailed { .. })),
+        "un-floored cross-row preconditioner must surface the non-PD Schur"
+    );
+
+    let floored = ArrowBlockDiagInverse::build(
+        &sys,
+        0.0,
+        0.0,
+        Some(SPECTRAL_DEFLATION_REL_FLOOR),
+        false,
+        &backend,
+    )
+    .expect("cross-row preconditioner must honor the spectral PD-floor");
+
+    let rhs_t = Array1::<f64>::zeros(sys.row_offsets[sys.rows.len()]);
+    let rhs_beta = array![0.25_f64, -0.5];
+    let (_sol_t, sol_beta) = floored.apply(rhs_t.view(), rhs_beta.view());
+    assert!(
+        sol_beta.iter().all(|v| v.is_finite()),
+        "floored cross-row preconditioner solve must produce finite beta components, got {sol_beta:?}"
+    );
+}
+
 #[test]
 pub(crate) fn ibp_cross_row_woodbury_full_inverse_and_newton_match_dense() {
     let (mut sys, source, zprime) = build_ibp_woodbury_fixture();


### PR DESCRIPTION
### Motivation
- Prevent a regression where a cross-row IBP Schur factorization path might use a raw Cholesky and abort on near-nil collapsed decoder directions instead of honoring the spectral PD-floor already used elsewhere. 

### Description
- Add `cross_row_preconditioner_build_honors_pd_floor_1795` to `crates/gam-solve/src/arrow_schur/tests.rs` which constructs an indefinite reduced Schur and asserts the un-floored `ArrowBlockDiagInverse::build` fails while the floored build succeeds and produces finite outputs. 
- The test targets the `ArrowBlockDiagInverse::build` entry point so the cross-row preconditioner path is covered by the same `schur_pd_floor` semantics already used by the dense reduced-solve code.

### Testing
- Ran `./build.sh check -p gam-solve --lib` which completed successfully.
- Ran `./build.sh test -p gam-solve --lib --no-run` which built the test binary successfully.
- Executed the new test and the existing streaming Woodbury test individually with `./build.sh test -p gam-solve cross_row_preconditioner_build_honors_pd_floor_1795 -- --nocapture` and `./build.sh test -p gam-solve streaming_cross_row_woodbury_log_det_honors_pd_floor_1795 -- --nocapture`, both of which passed.

---
Refs #1795. (Adds coverage only; the plumbing was already floored on `main` and the listed failing tests have a distinct indefinite-capacitance root cause, so this does not close the epic — see issue comments.)

<details><summary>codex self-assessment</summary>

olve v0.3.148 (/workspace/gam/crates/gam-solve)\n      Finished `test` profile [optimized + debuginfo] target(s) in 3m 21s\n    Executable unittests src/lib.rs (target/debug/deps/gam_solve-5434b1d24a5f273e)\n  ```\n\n* \u2705 `./build.sh test -p gam-solve cross_row_preconditioner_build_honors_pd_floor_1795 -- --nocapture`  \n  Output:\n  ```text\n  [build.sh] test -p gam-solve cross_row_preconditioner_build_honors_pd_floor_1795 -- --nocapture -> exit 0 in 1s (dedup=MISS, recompiled 0 crates)\n      Finished `test` profile [optimized + debuginfo] target(s) in 0.57s\n       Running unittests src/lib.rs (target/debug/deps/gam_solve-5434b1d24a5f273e)\n\n  running 1 test\n  test arrow_schur::tests::cross_row_preconditioner_build_honors_pd_floor_1795 ... ok\n\n  test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 1199 filtered out; finished in 0.01s\n  ```\n\n* \u2705 `./build.sh test -p gam-solve streaming_cross_row_woodbury_log_det_honors_pd_floor_1795 -- --nocapture`  \n  Output:\n  ```text\n  [build.sh] test -p gam-solve streaming_cross_row_woodbury_log_det_honors_pd_floor_1795 -- --nocapture -> exit 0 in 0s (dedup=MISS, recompiled 0 crates)\n      Finished `test` profile [optimized + debuginfo] target(s) in 0.62s\n       Running unittests src/lib.rs (target/debug/deps/gam_solve-5434b1d24a5f273e)\n\n  running 1 test\n  test arrow_schur::tests::streaming_cross_row_woodbury_log_det_honors_pd_floor_1795 ... ok\n\n  test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 1199 filtered out; finished in 0.02s\n  ```\n\n* \u274c `./build.sh test -p gam-solve cross_row_preconditioner_build_honors_pd_floor_1795 streaming_cross_row_woodbury_log_det_honors_pd_floor_1795 -- --nocapture`  \n  Output:\n  ```text\n  [build.sh] test -p gam-solve cross_row_preconditioner_build_honors_pd_floor_1795 streaming_cross_row_woodbury_log_det_honors_pd_floor_1795 -- --nocapture -> exit 1 in 0s (dedup=MISS, recompiled 0 crates)\n  FAILED (1):\n  error: unexpected argument 'streaming_cross_row_woodbury_log_det_honors_pd_floor_1795' found\n\n  Usage: cargo test [OPTIONS] [TESTNAME] [-- [ARGS]...]\n  ```\n  I reran the two filters as separate commands, both passing above.\n\n* \u274c `./build.sh test -p gam-solve --lib --no-run` during first local draft of the new test  \n  Output excerpt:\n  ```text\n  [build.sh] test -p gam-solve --lib --no-run -> exit 101 in 36s (dedup=MISS, recompiled 1 crates)\n  FAILED (101):\n     Compiling gam-solve v0.3.148 (/workspace/gam/crates/gam-solve)\n  error[E0277]: `newton_step::ArrowBlockDiagInverse<'_, solve_options::CpuBatchedBlockSolver>` doesn't implement `std::fmt::Debug`\n  ```\n  This was an agent-introduced test-formatting error; I removed the `{:?}` formatting of the successful `Ok` type and reran the final passing `--no-run` command above.\n\n### BEFORE/AFTER NOTE\n\nI could not honestly produce a failing \u201cbefore\u201d run for the implementation mechanism because this branch already contains the production fix: `ArrowBlockDiagInverse::build` already accepts `schur_pd_floor` and uses `factor_dense_reduced_schur`, and `solve_arrow_newton_step_cross_row` already passes `options.schur_pd_floor`. "}, {"content_type": "repo_file_citation", "path": "crates/gam-solve/src/arrow_schur/newton_step.rs", "line_range_start": 2071, "line_range_end": 2085}, {"content_type": "repo_file_citation", "path": "crates/gam-solve/src/arrow_schur/newton_step.rs", "line_range_start": 2381, "line_range_end": 2388}, {"content_type": "text", "text": "  \nThe new regression would fail on the historical raw-Cholesky implementation described in #1795, but it passes on the current implementation because the root mechanism is already corrected in this checkout.\n\n### CODE DIFF\n\n```diff\ndiff --git a/crates/gam-solve/src/arrow_schur/tests.rs b/crates/gam-solve/src/arrow_schur/tests.rs\nindex 3e530bb..a715823 100644\n--- a/crates/gam-solve/src/arrow_schur/tests.rs\n+++ b/crates/gam-solve/src/arrow_schur/tests.rs\n@@ -2479,6 +2479
</details>

_Codex-generated; pending adversarial audit before merge._
