### PR TITLE
#1995: fix(solve): keep sparse Schur GEMM row-local

### DIFF
--- a/crates/gam-solve/src/arrow_schur/solve_options.rs
+++ b/crates/gam-solve/src/arrow_schur/solve_options.rs
@@ -656,38 +656,25 @@ impl BatchedBlockSolver for CpuBatchedBlockSolver {
 
         let mut left_active = Vec::with_capacity(k);
         let mut right_active = Vec::with_capacity(k);
-        for col in 0..k {
-            let mut left_nz = false;
-            let mut right_nz = false;
-            for row in 0..d {
-                left_nz |= left[[row, col]] != 0.0;
-                right_nz |= right[[row, col]] != 0.0;
-                if left_nz && right_nz {
-                    break;
-                }
-            }
-            if left_nz {
-                left_active.push(col);
-            }
-            if right_nz {
-                right_active.push(col);
-            }
-        }
-        if left_active.is_empty() || right_active.is_empty() {
-            return;
-        }
-
         for c in 0..d {
-            for &a in &left_active {
-                let lca = left[[c, a]];
-                if lca == 0.0 {
-                    continue;
+            left_active.clear();
+            right_active.clear();
+            for col in 0..k {
+                let l = left[[c, col]];
+                let r = right[[c, col]];
+                if l != 0.0 {
+                    left_active.push((col, l));
                 }
-                for &b in &right_active {
-                    let rcb = right[[c, b]];
-                    if rcb != 0.0 {
-                        schur[[a, b]] -= lca * rcb;
-                    }
+                if r != 0.0 {
+                    right_active.push((col, r));
+                }
+            }
+            if left_active.is_empty() || right_active.is_empty() {
+                continue;
+            }
+            for &(a, lca) in &left_active {
+                for &(b, rcb) in &right_active {
+                    schur[[a, b]] -= lca * rcb;
                 }
             }
         }


### PR DESCRIPTION
### Motivation
- The CPU fallback for reduced-Schur assembly was discovering nonzero columns once across the entire `d` row block and replaying that union for every local row, reintroducing many zero multiplies and making sparse JumpReLU/top-k SAE rows scale with the union-of-support rather than the true per-row support (#1995). 
- The symptom was high compute time with small RSS: the code was on a sparse path (no huge dense allocation) but still doing O(K·d·...) work instead of O(top_k·d·...).

### Description
- Kept the `block_gemm_subtract` algorithm row-local by rebuilding the active `(column, value)` lists per local row `c` so each row only multiplies its own nonzero left/right beta columns (file: `crates/gam-solve/src/arrow_schur/solve_options.rs`, the `CpuBatchedBlockSolver::block_gemm_subtract` loop). 
- This preserves exact dense-GEMM equivalence for dense callers while making sparse SAE rows' arithmetic proportional to actual per-row support rather than the cross-row union. 
- No tests or behaviour were weakened; the existing regression test that compares the sparse path to a dense reference (`block_gemm_subtract_matches_dense_on_sparse_column_support`) still validates the algebraic equality.

### Testing
- Built the tree with `./build.sh` and the full library build completed successfully (exit 0).
- Type-check/deny-warnings for the solver crate succeeded with `./build.sh check -p gam-solve --lib` (exit 0).
- Test binary build succeeded with `./build.sh test -p gam-solve --lib --no-run` (exit 0).
- The focused unit test was run with `./build.sh test -p gam-solve --lib block_gemm_subtract_matches_dense_on_sparse_column_support -- --nocapture` and passed: `ok` (1 passed; 0 failed).

---
Fixes #1995.

<details><summary>codex self-assessment</summary>

/workspace/gam/crates/gam-test-support)\n     Compiling gam-report v0.3.148 (/workspace/gam/crates/gam-report)\n      Finished `dev` profile [unoptimized + debuginfo] target(s) in 21m 21s\n  ```\n\n* \u2705 `./build.sh check -p gam-solve --lib`  \n  Output:\n  ```text\n  [build.sh] check -p gam-solve --lib -> exit 0 in 356s (dedup=MISS, recompiled 59 crates)\n      Checking twox-hash v2.1.2\n      Checking static_assertions v1.1.0\n      Checking integer-encoding v3.0.4\n      Checking twox-hash v1.6.3\n      Checking thrift v0.17.0\n      Checking lz4_flex v0.11.6\n      Checking arrow-string v54.3.1\n      Checking arrow-ipc v54.3.1\n      Checking arrow-ord v54.3.1\n      Checking arrow-row v54.3.1\n      Checking arrow-arith v54.3.1\n      Checking csv-core v0.1.13\n      Checking libloading v0.8.9\n      Checking csv v1.4.0\n      Checking gam-linalg v0.3.148 (/workspace/gam/crates/gam-linalg)\n      Checking arrow v54.3.1\n      Checking memmap2 v0.9.11\n      Checking smallvec v1.15.2\n      Checking opt v0.5.11\n      Checking gam-geometry v0.3.148 (/workspace/gam/crates/gam-geometry)\n      Checking gam-problem v0.3.148 (/workspace/gam/crates/gam-problem)\n      Checking gam-gpu v0.3.148 (/workspace/gam/crates/gam-gpu)\n      Checking gam-model-api v0.3.148 (/workspace/gam/crates/gam-model-api)\n      Checking gam-identifiability v0.3.148 (/workspace/gam/crates/gam-identifiability)\n      Checking zstd v0.13.3\n      Checking parquet v54.3.1\n      Checking gam-data v0.3.148 (/workspace/gam/crates/gam-data)\n      Checking gam-terms v0.3.148 (/workspace/gam/crates/gam-terms)\n      Checking gam-solve v0.3.148 (/workspace/gam/crates/gam-solve)\n      Finished `dev` profile [unoptimized + debuginfo] target(s) in 5m 55s\n  ```\n\n* \u2705 `./build.sh test -p gam-solve --lib --no-run`  \n  Output:\n  ```text\n  [build.sh] transient failure (OOM/timeout, exit 124) attempt 1/3 \u2014 retrying with CARGO_BUILD_JOBS=1 (lower peak RAM)\u2026\n  [build.sh] test -p gam-solve --lib --no-run -> exit 0 in 552s (dedup=MISS, recompiled 1 crates)\n     Compiling gam-solve v0.3.148 (/workspace/gam/crates/gam-solve)\n      Finished `test` profile [optimized + debuginfo] target(s) in 9m 11s\n    Executable unittests src/lib.rs (target/debug/deps/gam_solve-5434b1d24a5f273e)\n  ```\n\n* \u2705 `./build.sh test -p gam-solve --lib block_gemm_subtract_matches_dense_on_sparse_column_support -- --nocapture`  \n  Output:\n  ```text\n  [build.sh] test -p gam-solve --lib block_gemm_subtract_matches_dense_on_sparse_column_support -- --nocapture -> exit 0 in 1s (dedup=MISS, recompiled 0 crates)\n      Finished `test` profile [optimized + debuginfo] target(s) in 0.65s\n       Running unittests src/lib.rs (target/debug/deps/gam_solve-5434b1d24a5f273e)\n\n  running 1 test\n  test arrow_schur::tests::block_gemm_subtract_matches_dense_on_sparse_column_support ... ok\n\n  test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 1198 filtered out; finished in 0.00s\n  ```\n\n## CODE DIFF\n\n```diff\ncommit 135676e3fc729c2cac981941de4eb0509ae8f37d\nAuthor: Codex <codex@openai.com>\n\n    fix(solve): keep sparse schur gemm row-local\n\ndiff --git a/crates/gam-solve/src/arrow_schur/solve_options.rs b/crates/gam-solve/src/arrow_schur/solve_options.rs\nindex e9611de..769af41 100644\n--- a/crates/gam-solve/src/arrow_schur/solve_options.rs\n+++ b/crates/gam-solve/src/arrow_schur/solve_options.rs\n@@ -656,38 +656,25 @@ impl BatchedBlockSolver for CpuBatchedBlockSolver {\n \n         let mut left_active = Vec::with_capacity(k);\n         let mut right_active = Vec::with_capacity(k);\n-        for col in 0..k {\n-            let mut left_nz = false;\n-            let mut right_nz = false;\n-            for row in 0..d {\n-                left_nz |= left[[row, col]] != 0.0;\n-                right_nz |= right[[row, col]] != 0.0;\n-                if left_nz && right_nz {\n-                    break;\n+        for c in 0..d {\n+            left_active.clear();\n+  
</details>

_Codex-generated; pending adversarial audit before merge._