### PR TITLE
#2011: Port Duchon low-discrepancy center lift to Rust and expose via PyO3

### DIFF
--- a/crates/gam-geometry/src/lib.rs
+++ b/crates/gam-geometry/src/lib.rs
@@ -6,6 +6,7 @@ pub mod manifold;
 pub mod manifolds;
 pub mod optimizer;
 pub mod response_geometry;
+pub mod sae_routing;
 pub mod sinkhorn_barycenter;
 
 // Re-export each manifold submodule at the crate root so the historical paths

--- a/crates/gam-geometry/src/sae_routing.rs
+++ b/crates/gam-geometry/src/sae_routing.rs
@@ -1,0 +1,71 @@
+//! Rust-owned numerical helpers for the torch-only manifold-SAE routing lane.
+//!
+//! These kernels are intentionally small, deterministic primitives that the
+//! Python torch module calls as FFI glue.  Keeping them here preserves the repo
+//! doctrine that Python marshals tensors while Rust owns numeric rules.
+
+use ndarray::{Array2, ArrayView1};
+
+/// Lift a one-dimensional Duchon center vector into a deterministic `(K, d)`
+/// low-discrepancy cloud in `[0, 1]^d`.
+///
+/// The first coordinate is the caller-provided 1-D center.  Remaining axes use
+/// the generalized golden-ratio additive recurrence (`R_d`) keyed only to
+/// `(K, d)`, matching the historical torch implementation bit-for-bit for f64
+/// inputs before dtype conversion at the Python boundary.
+#[must_use]
+pub fn duchon_centers_nd(centers_1d: ArrayView1<'_, f64>, d: usize) -> Array2<f64> {
+    let k = centers_1d.len();
+    let width = d.max(1);
+    let mut out = Array2::<f64>::zeros((k, width));
+    for (row, center) in centers_1d.iter().enumerate() {
+        out[(row, 0)] = *center;
+    }
+    if d <= 1 || k == 0 {
+        return out;
+    }
+
+    // Historical R_d generalized golden-ratio fixed point: x^d = x + 1.
+    // Thirty-two fixed-point refinements are retained deliberately for
+    // bit-level continuity with the previous torch lane.  The count is not a
+    // tuning knob: for the smallest routed multi-axis case (d=2) each step
+    // roughly doubles correct digits near the fixed point, so 32 iterations is
+    // beyond f64 mantissa resolution; larger d is contractive more quickly.
+    let mut phi = 2.0_f64;
+    for _ in 0..32 {
+        phi = (1.0 + phi).powf(1.0 / d as f64);
+    }
+    for axis in 1..d {
+        let alpha = (1.0 / phi).powi(axis as i32).rem_euclid(1.0);
+        for row in 0..k {
+            let idx = (row + 1) as f64;
+            out[(row, axis)] = (idx * alpha + 0.5).rem_euclid(1.0);
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::duchon_centers_nd;
+    use ndarray::array;
+
+    #[test]
+    fn duchon_centers_nd_preserves_first_axis_and_shape() {
+        let centers = array![0.0, 0.5, 1.0];
+        let lifted = duchon_centers_nd(centers.view(), 3);
+        assert_eq!(lifted.shape(), &[3, 3]);
+        assert_eq!(lifted.column(0), centers);
+    }
+
+    #[test]
+    fn duchon_centers_nd_handles_empty_and_one_dimensional_inputs() {
+        let empty = array![];
+        assert_eq!(duchon_centers_nd(empty.view(), 4).shape(), &[0, 4]);
+        let centers = array![0.25, 0.75];
+        assert_eq!(
+            duchon_centers_nd(centers.view(), 1),
+            centers.into_shape_clone((2, 1)).unwrap()
+        );
+    }
+}

--- a/crates/gam-pyffi/src/ffi/ffi_prelude.rs
+++ b/crates/gam-pyffi/src/ffi/ffi_prelude.rs
@@ -102,6 +102,8 @@ pub(crate) use gam_predict::posterior_bands::{self, PosteriorPredictBandsPayload
 pub(crate) use gam_predict::FittedModelPredictExt;
 pub(crate) use gam_predict::input::build_predict_input_for_model;
 
+pub(crate) use gam::geometry::sae_routing::duchon_centers_nd as sae_duchon_centers_nd_impl;
+
 pub(crate) use gam::geometry::sinkhorn_barycenter::{
     circular_cost as sinkhorn_circular_cost_impl, euclidean_cost as sinkhorn_euclidean_cost_impl,
     geodesic_sphere_cost as sinkhorn_geodesic_sphere_cost_impl,

--- a/crates/gam-pyffi/src/manifold/geometry_ffi.rs
+++ b/crates/gam-pyffi/src/manifold/geometry_ffi.rs
@@ -594,6 +594,17 @@ fn response_geometry_fit_curvature<'py>(
 }
 
 #[pyfunction]
+fn sae_duchon_centers_nd<'py>(
+    py: Python<'py>,
+    centers_1d: PyReadonlyArray1<'py, f64>,
+    d: usize,
+) -> PyResult<Py<PyArray2<f64>>> {
+    let centers_owned = centers_1d.as_array().to_owned();
+    let out = py.detach(move || sae_duchon_centers_nd_impl(centers_owned.view(), d));
+    Ok(out.into_pyarray(py).unbind())
+}
+
+#[pyfunction]
 fn sinkhorn_circular_cost<'py>(py: Python<'py>, m: usize) -> PyResult<Py<PyArray2<f64>>> {
     let out = py.detach(move || sinkhorn_circular_cost_impl(m));
     Ok(out.into_pyarray(py).unbind())
@@ -4226,6 +4237,7 @@ fn rust_extension(module: &Bound<'_, PyModule>) -> PyResult<()> {
         response_geometry_sphere_normalize_base,
         module
     )?)?;
+    module.add_function(wrap_pyfunction!(sae_duchon_centers_nd, module)?)?;
     module.add_function(wrap_pyfunction!(sinkhorn_circular_cost, module)?)?;
     module.add_function(wrap_pyfunction!(sinkhorn_euclidean_cost, module)?)?;
     module.add_function(wrap_pyfunction!(sinkhorn_geodesic_sphere_cost, module)?)?;

--- a/gamfit/torch/manifold_sae.py
+++ b/gamfit/torch/manifold_sae.py
@@ -556,35 +556,10 @@ def _basis_rust(
 
 
 def _duchon_centers_nd(centers_1d: torch.Tensor, d: int) -> torch.Tensor:
-    """Lift the ``(K,)`` 1-D Duchon centers to a ``(K, d)`` cloud in ``[0, 1]^d``.
-
-    Axis 0 keeps the caller's 1-D centers (so the periodic/leading coordinate of
-    a cylinder or product patch is seeded exactly as in the 1-D case). The
-    remaining ``d - 1`` axes are filled by an additive-recurrence (Kronecker /
-    generalized-golden-ratio) low-discrepancy sequence keyed only to ``(K, d)``:
-    deterministic, buffer-free, and non-degenerate (the centers do not collapse
-    onto a diagonal, so the multi-axis Duchon kernel is well-conditioned). The
-    centers are a *fixed* design the decoder learns against, so any deterministic
-    well-spread placement is admissible; this one is reproducible and stable
-    across forward calls without enlarging the serialized state.
-    """
-    base = centers_1d.reshape(-1, 1)
-    k = int(base.shape[0])
-    dtype = base.dtype
-    device = base.device
-    if d <= 1 or k == 0:
-        return base
-    # Generalized golden ratio phi_d: the real root of x^{d} = x + 1; its
-    # reciprocal powers give the canonical R_d low-discrepancy generators.
-    phi = 2.0
-    for _ in range(32):
-        phi = (1.0 + phi) ** (1.0 / float(d))
-    alphas = [((1.0 / phi) ** (j + 1)) % 1.0 for j in range(d - 1)]
-    idx = torch.arange(1, k + 1, dtype=dtype, device=device).reshape(-1, 1)
-    extra = torch.empty((k, d - 1), dtype=dtype, device=device)
-    for j, a in enumerate(alphas):
-        extra[:, j] = torch.remainder(idx[:, 0] * float(a) + 0.5, 1.0)
-    return torch.cat([base, extra], dim=-1)
+    """Rust-owned lift of ``(K,)`` 1-D Duchon centers to ``(K, d)``."""
+    centers_np = to_numpy_f64(centers_1d.reshape(-1))
+    lifted = rust_module().sae_duchon_centers_nd(centers_np, int(d))
+    return from_numpy_like(lifted, centers_1d)
 
 
 def _eval_basis_on_manifold(

--- a/tests/torch/test_manifold_sae_softmax_topk_contract.py
+++ b/tests/torch/test_manifold_sae_softmax_topk_contract.py
@@ -169,3 +169,22 @@ def _selftest_softmax_topk_honors_target_k() -> None:
 
 def test_softmax_topk_honors_target_k() -> None:
     _selftest_softmax_topk_honors_target_k()
+
+
+def test_duchon_centers_nd_uses_rust_low_discrepancy_lift() -> None:
+    """The product-patch Duchon lift is Rust-owned and preserves the legacy R_d cloud."""
+    from gamfit.torch.manifold_sae import _duchon_centers_nd
+
+    centers = torch.linspace(0.0, 1.0, 4, dtype=torch.float64)
+    lifted = _duchon_centers_nd(centers, 3)
+    expected = torch.tensor(
+        [
+            [0.0, 0.2548776662466927, 0.06984029099805333],
+            [1.0 / 3.0, 0.009755332493385449, 0.6396805819961064],
+            [2.0 / 3.0, 0.764632998740078, 0.20952087299415956],
+            [1.0, 0.5195106649867709, 0.7793611639922129],
+        ],
+        dtype=torch.float64,
+    )
+    torch.testing.assert_close(lifted, expected, rtol=0.0, atol=2.0e-16)
+    assert lifted.dtype == centers.dtype


### PR DESCRIPTION
### Motivation
- The repository doctrine requires Python to be a thin wrapper and keep numeric rules in Rust; `_duchon_centers_nd` was doing nontrivial deterministic math in Python, risking divergence and violating parity. 
- Move the deterministic low-discrepancy Duchon center lift into Rust so the torch lane and the core share a single, bit-stable implementation.

### Description
- Add a Rust helper `duchon_centers_nd` in `crates/gam-geometry/src/sae_routing.rs` that lifts `(K,)` 1‑D centers into a `(K,d)` R_d low-discrepancy cloud (32 fixed-point refinements retained for bit-continuity). 
- Export and re-export the new helper via `crates/gam-geometry/src/lib.rs` and `crates/gam-pyffi/src/ffi/ffi_prelude.rs`, and add a PyO3 binding `sae_duchon_centers_nd` in `crates/gam-pyffi/src/manifold/geometry_ffi.rs`. 
- Replace the Python numeric body in `gamfit/torch/manifold_sae.py::_duchon_centers_nd` with a thin FFI wrapper that calls `rust_module().sae_duchon_centers_nd`, using `to_numpy_f64` / `from_numpy_like` for device/dtype marshalling. 
- Add a torch contract test `test_duchon_centers_nd_uses_rust_low_discrepancy_lift` in `tests/torch/test_manifold_sae_softmax_topk_contract.py` that pins the legacy R_d cloud values.

### Testing
- Built the tree and warmed the library with `./build.sh`, which completed successfully (full lib build). 
- Verified the Python FFI surface compiles with `./build.sh check -p gam-pyffi --lib` (transient duplicate-build retry observed, final run exited 0). 
- Ran the new Rust unit tests with `./build.sh test -p gam-geometry --lib duchon_centers_nd -- --nocapture`, and the `duchon_centers_nd` unit tests passed. 
- Exercised the torch contract unit in isolation with `pytest` (`tests/torch/test_manifold_sae_softmax_topk_contract.py::test_duchon_centers_nd_uses_rust_low_discrepancy_lift`), which passed; a combined run of the broader routing tests (`tests/torch/test_manifold_sae_backprop_routing_issue_583.py`, `tests/torch/test_manifold_sae_two_circle_routing_issue_1282.py`, and the softmax contract suite) showed the new test and the two-circle tests passing but two failures remained in the #583 backprop routing tests (these failures pre-existed in richer integration and are outside this specific Duchon-lift port).

---
Refs #2011 (epic sweep item 1 of 4: `_duchon_centers_nd`; does not close the epic).

<details><summary>codex self-assessment</summary>

erive v4.6.1\n   Compiling clap_builder v4.6.0\n   Compiling crossterm v0.29.0\n   Compiling gam v0.3.148 (/workspace/gam)\n   Compiling comfy-table v7.2.2\n   Compiling clap v4.6.1\n   Compiling gam-report v0.3.148 (/workspace/gam/crates/gam-report)\n   Compiling gam-inference v0.3.148 (/workspace/gam/crates/gam-inference)\n   Compiling gam-test-support v0.3.148 (/workspace/gam/crates/gam-test-support)\n   Compiling gam-config v0.3.148 (/workspace/gam/crates/gam-config)\n    Finished `dev` profile [unoptimized + debuginfo] target(s) in 19m 32s\n```\n\n* \u26a0\ufe0f `./build.sh check -p gam-pyffi --lib` first combined run\n\n```text\n[build.sh] active duplicate produced no cached/stable result \u2014 retry\n```\n\n* \u2705 `./build.sh check -p gam-pyffi --lib` retry after the transient duplicate-build exit 75\n\n```text\n[build.sh] check -p gam-pyffi --lib -> exit 0 in 126s (dedup=MISS, recompiled 2 crates)\n    Checking gam-geometry v0.3.148 (/workspace/gam/crates/gam-geometry)\n   Compiling gam v0.3.148 (/workspace/gam)\n   Compiling gam-pyffi v0.1.250 (/workspace/gam/crates/gam-pyffi)\n    Checking gam-problem v0.3.148 (/workspace/gam/crates/gam-problem)\n    Checking gam-identifiability v0.3.148 (/workspace/gam/crates/gam-identifiability)\n    Checking gam-model-api v0.3.148 (/workspace/gam/crates/gam-model-api)\n    Checking gam-terms v0.3.148 (/workspace/gam/crates/gam-terms)\n    Checking gam-solve v0.3.148 (/workspace/gam/crates/gam-solve)\n    Checking gam-custom-family v0.3.148 (/workspace/gam/crates/gam-custom-family)\n    Checking gam-model-kernels v0.3.148 (/workspace/gam/crates/gam-model-kernels)\n    Checking gam-sae v0.3.148 (/workspace/gam/crates/gam-sae)\n    Checking gam-models v0.3.148 (/workspace/gam/crates/gam-models)\n    Checking gam-inference v0.3.148 (/workspace/gam/crates/gam-inference)\n    Checking gam-test-support v0.3.148 (/workspace/gam/crates/gam-test-support)\n    Checking gam-config v0.3.148 (/workspace/gam/crates/gam-config)\n    Checking gam-predict v0.3.148 (/workspace/gam/crates/gam-predict)\n    Finished `dev` profile [unoptimized + debuginfo] target(s) in 2m 05s\n```\n\n* \u2705 `./build.sh test -p gam-geometry --lib duchon_centers_nd -- --nocapture`\n\n```text\n[build.sh] test -p gam-geometry --lib duchon_centers_nd -- --nocapture -> exit 0 in 18s (dedup=MISS, recompiled 4 crates)\n   Compiling gam-runtime v0.3.148 (/workspace/gam/crates/gam-runtime)\n   Compiling gam-math v0.3.148 (/workspace/gam/crates/gam-math)\n   Compiling gam-linalg v0.3.148 (/workspace/gam/crates/gam-linalg)\n   Compiling gam-geometry v0.3.148 (/workspace/gam/crates/gam-geometry)\n    Finished `test` profile [optimized + debuginfo] target(s) in 18.69s\n     Running unittests src/lib.rs (target/debug/deps/gam_geometry-19f708c341dddf93)\n\nrunning 2 tests\ntest sae_routing::tests::duchon_centers_nd_handles_empty_and_one_dimensional_inputs ... ok\ntest sae_routing::tests::duchon_centers_nd_preserves_first_axis_and_shape ... ok\n\ntest result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 209 filtered out; finished in 0.00s\n```\n\n* \u2705 `uv run pytest -q tests/torch/test_manifold_sae_softmax_topk_contract.py::test_duchon_centers_nd_uses_rust_low_discrepancy_lift`\n\n```text\n.                                                                        [100%]\n1 passed in 4.41s\n```\n\n### Relevant regression run that did **not** pass\n\n* \u274c `uv run pytest -q tests/torch/test_manifold_sae_backprop_routing_issue_583.py tests/torch/test_manifold_sae_two_circle_routing_issue_1282.py tests/torch/test_manifold_sae_softmax_topk_contract.py`\n\n```text\nFF....                                                                   [100%]\n=================================== FAILURES ===================================\n_______________ test_backprop_topk_learns_nondegenerate_routing ________________\n\nE       AssertionError: some planted feature is not routed to any atom: best_atom_corr_per_feature=[0.698, 0.607, 0.713, 0.1
</details>

_Codex-generated; pending adversarial audit before merge._
