### PR TITLE
#2023: Plumb `block_tile` through Tier-1→Tier-2 seam so block-chart projection honors caller routing budget

### DIFF
--- a/crates/gam-pyffi/src/manifold/geometry_ffi.rs
+++ b/crates/gam-pyffi/src/manifold/geometry_ffi.rs
@@ -5354,7 +5354,8 @@ fn block_sparse_dictionary_firings_ffi<'py>(
     residual_target = true,
     n_basis_chart = 4,
     include_bases = true,
-    name_prefix = "block"
+    name_prefix = "block",
+    block_tile = 1024
 ))]
 fn block_sparse_dictionary_seed_manifest_ffi<'py>(
     py: Python<'py>,
@@ -5371,6 +5372,7 @@ fn block_sparse_dictionary_seed_manifest_ffi<'py>(
     n_basis_chart: usize,
     include_bases: bool,
     name_prefix: &str,
+    block_tile: usize,
 ) -> PyResult<Py<PyDict>> {
     let x_values = x.as_array().to_owned();
     let decoder_values = decoder.as_array().to_owned();
@@ -5385,6 +5387,7 @@ fn block_sparse_dictionary_seed_manifest_ffi<'py>(
         n_basis_chart,
         include_bases,
         name_prefix: name_prefix.to_string(),
+        block_tile,
     };
     let manifest = detach_py_result(py, "block_sparse_dictionary_seed_manifest", move || {
         block_sparse_dictionary_seed_manifest(
@@ -5419,7 +5422,8 @@ fn block_sparse_dictionary_seed_manifest_ffi<'py>(
     pair_top_blocks = 64,
     max_pairs = 128,
     pair_min_cofirings = 64,
-    pair_min_score = 0.20
+    pair_min_score = 0.20,
+    block_tile = 1024
 ))]
 fn block_coordinate_chart_compose_ffi<'py>(
     py: Python<'py>,
@@ -5442,6 +5446,7 @@ fn block_coordinate_chart_compose_ffi<'py>(
     max_pairs: usize,
     pair_min_cofirings: usize,
     pair_min_score: f64,
+    block_tile: usize,
 ) -> PyResult<Py<PyDict>> {
     let x_values = x.as_array().to_owned();
     let decoder_values = decoder.as_array().to_owned();
@@ -5463,6 +5468,7 @@ fn block_coordinate_chart_compose_ffi<'py>(
         max_pairs,
         pair_min_cofirings,
         pair_min_score,
+        block_tile,
     };
     let result = detach_py_result(py, "block_coordinate_chart_compose", move || {
         compose_block_coordinate_charts(

--- a/crates/gam-sae/src/sparse_dict/block_chart.rs
+++ b/crates/gam-sae/src/sparse_dict/block_chart.rs
@@ -22,6 +22,9 @@ pub struct BlockChartComposeConfig {
     pub max_pairs: usize,
     pub pair_min_cofirings: usize,
     pub pair_min_score: f64,
+    /// Router tile width for block-coordinate projection. This is a memory-budget
+    /// parameter owned by the caller, not a hidden constant inside composition.
+    pub block_tile: usize,
 }
 
 impl Default for BlockChartComposeConfig {
@@ -42,6 +45,7 @@ impl Default for BlockChartComposeConfig {
             max_pairs: 128,
             pair_min_cofirings: 64,
             pair_min_score: 0.20,
+            block_tile: 1024,
         }
     }
 }
@@ -91,6 +95,8 @@ pub struct BlockSeedManifestConfig {
     pub n_basis_chart: usize,
     pub include_bases: bool,
     pub name_prefix: String,
+    /// Router tile width used when residual-target seed coordinates are emitted.
+    pub block_tile: usize,
 }
 
 #[derive(Clone, Debug)]
@@ -477,6 +483,9 @@ fn validate_inputs(
     if !(config.alpha > 0.0 && config.alpha <= 1.0) {
         return Err("block chart compose: alpha must be in (0, 1]".to_string());
     }
+    if config.block_tile == 0 {
+        return Err("block chart compose: block_tile must be >= 1".to_string());
+    }
     Ok(())
 }
 
@@ -493,7 +502,7 @@ fn block_coords_for_config(
             config.gamma,
             config.block_size,
             config.block_topk,
-            1024,
+            config.block_tile,
             block,
         )
     } else {
@@ -514,7 +523,7 @@ fn block_coords_for_seed_config(
             config.gamma,
             config.block_size,
             config.block_topk,
-            1024,
+            config.block_tile,
             block,
         )
     } else {

--- a/crates/gam-sae/src/sparse_dict/block_tests.rs
+++ b/crates/gam-sae/src/sparse_dict/block_tests.rs
@@ -622,6 +622,7 @@ fn block_seed_manifest_is_rust_owned_and_gauge_shaped() {
         n_basis_chart: 4,
         include_bases: true,
         name_prefix: "block".to_string(),
+        block_tile: 2,
     };
     let manifest = block_sparse_dictionary_seed_manifest(
         x.view(),
@@ -681,6 +682,7 @@ fn block_coordinate_chart_pair_screen_accepts_split_circle() {
         max_pairs: 1,
         pair_min_cofirings: 8,
         pair_min_score: 0.0,
+        block_tile: 2,
     };
     let result = compose_block_coordinate_charts(
         x.view(),

--- a/gamfit/_sparse_dictionary.py
+++ b/gamfit/_sparse_dictionary.py
@@ -618,6 +618,7 @@ class BlockSparseDictionaryFit:
         residual_target: bool = True,
         include_bases: bool = True,
         name_prefix: str = "block",
+        block_tile: int = 1024,
     ) -> dict:
         """A JSON-serialisable Tier-1 -> Tier-2 hand-off manifest: per-block basis,
         coordinate statistics, firing counts, and MDL featurizer rows, plus a flat
@@ -644,6 +645,7 @@ class BlockSparseDictionaryFit:
                 n_basis_chart=int(n_basis_chart),
                 include_bases=bool(include_bases),
                 name_prefix=str(name_prefix),
+                block_tile=int(block_tile),
             )
         )
 
@@ -663,6 +665,7 @@ class BlockSparseDictionaryFit:
         max_pairs: int = 128,
         pair_min_cofirings: int = 64,
         pair_min_score: float = 0.20,
+        block_tile: int = 1024,
     ) -> dict[str, Any]:
         """Compose Rust-owned block-coordinate charts over this T1 dictionary.
 
@@ -692,6 +695,7 @@ class BlockSparseDictionaryFit:
                 max_pairs=int(max_pairs),
                 pair_min_cofirings=int(pair_min_cofirings),
                 pair_min_score=float(pair_min_score),
+                block_tile=int(block_tile),
             )
         )
 


### PR DESCRIPTION
### Motivation
- The block-coordinate Tier-2 composition used a hidden fixed routing tile (`1024`) when projecting residual coordinates, which broke the caller-owned routing/memory invariant and could silently change the scaling geometry between Tier-1 and Tier-2.
- Make the projection honor the same caller-controlled router tile budget so the T1 discovery → per-block T2 fits are governed by a single memory-derived routing invariant.

### Description
- Added `block_tile: usize` to `BlockChartComposeConfig` and `BlockSeedManifestConfig` and validated it as nonzero in `block_chart.rs` so composition respects a caller-owned tile budget instead of a buried constant. (`crates/gam-sae/src/sparse_dict/block_chart.rs`)
- Routed `config.block_tile` into the residual projection calls used for both seed-manifest emission and block-chart coordinates, replacing hardcoded `1024`. (`crates/gam-sae/src/sparse_dict/block_chart.rs`)
- Plumbed `block_tile` through the PyO3 FFI functions `block_sparse_dictionary_seed_manifest_ffi` and `block_coordinate_chart_compose_ffi` and into the Rust configs. (`crates/gam-pyffi/src/manifold/geometry_ffi.rs`)
- Exposed `block_tile` on the Python wrappers `seed_manifest()` and `compose_block_charts()` so callers can control the routing tile from Python. (`gamfit/_sparse_dictionary.py`)
- Updated the two unit tests that construct seed/chart configs to include the tile parameter. (`crates/gam-sae/src/sparse_dict/block_tests.rs`)

### Notes
Result-invariant at the default tile (`1024`); this is a pure memory-budget carve-out that exposes the routing tile to the caller. Rebased onto current `main`; no test was skipped, weakened, or masked (an earlier revision carried an unrelated `dead_code` rename that has been dropped — the target function no longer exists on `main`).

---
Refs #2023. (This PR is one small seam-plumbing slice of the #2023 tiered-decomposition epic; it must not auto-close that epic.)
