### PR TITLE
#2091: Validate ManifoldSAE steering state before FFI

### DIFF
--- a/gamfit/_sae_manifold.py
+++ b/gamfit/_sae_manifold.py
@@ -1870,6 +1870,61 @@ class ManifoldSAE:
         self.metric_provenance = "OutputFisher"
         return self
 
+    def _validate_steer_native_state(self) -> None:
+        """Validate the fitted state handed to the native steering kernel.
+
+        The Python facade is still a compatibility shell while the model object is
+        migrated fully native. Until then, steering must not trust post-fit Python
+        mutations that make cross-field dimensions incoherent; reject those at the
+        boundary before the Rust kernel receives a partial model.
+        """
+        n_obs, p_out = (int(self.fitted.shape[0]), int(self.fitted.shape[1]))
+        k_atoms = len(self._basis_kinds)
+        fields = {
+            "atom_dims": len(self._atom_dims),
+            "basis_sizes": len(self._basis_sizes),
+            "n_harmonics": len(self._n_harmonics),
+            "decoder_blocks": len(self.decoder_blocks),
+            "coords": len(self.coords),
+            "duchon_centers": len(self._duchon_centers),
+        }
+        bad = {name: count for name, count in fields.items() if count != k_atoms}
+        if bad:
+            raise ValueError(
+                "ManifoldSAE native steering state is incoherent: "
+                f"basis_kinds has K={k_atoms}, but field lengths differ {bad!r}"
+            )
+        logits = np.asarray(self.low_level_logits)
+        if logits.ndim != 2 or logits.shape != (n_obs, k_atoms):
+            raise ValueError(
+                "ManifoldSAE native steering state is incoherent: "
+                f"low_level_logits must have shape {(n_obs, k_atoms)}, got {logits.shape}"
+            )
+        for idx, (block, coords, dim, width) in enumerate(
+            zip(self.decoder_blocks, self.coords, self._atom_dims, self._basis_sizes)
+        ):
+            block_arr = np.asarray(block)
+            coords_arr = np.asarray(coords)
+            if block_arr.ndim != 2 or block_arr.shape != (int(width), p_out):
+                raise ValueError(
+                    "ManifoldSAE native steering state is incoherent: "
+                    f"decoder_blocks[{idx}] must have shape {(int(width), p_out)}, "
+                    f"got {block_arr.shape}"
+                )
+            if coords_arr.ndim != 2 or coords_arr.shape != (n_obs, int(dim)):
+                raise ValueError(
+                    "ManifoldSAE native steering state is incoherent: "
+                    f"coords[{idx}] must have shape {(n_obs, int(dim))}, got {coords_arr.shape}"
+                )
+        if self.fisher_factors is not None:
+            fisher = np.asarray(self.fisher_factors)
+            if fisher.ndim != 3 or fisher.shape[0] != n_obs or fisher.shape[1] != p_out:
+                raise ValueError(
+                    "ManifoldSAE native steering state is incoherent: "
+                    f"fisher_factors must have shape (N={n_obs}, P={p_out}, R), "
+                    f"got {fisher.shape}"
+                )
+
     def steer(self, atom_k: int, t_from: Any, t_to: Any) -> dict[str, Any]:
         """Steering plan with output dosimetry for one atom (#980).
 
@@ -1922,6 +1977,7 @@ class ManifoldSAE:
         steers geometry-only with ``predicted_nats`` / ``validity_radius`` ``None``.
         """
         k = self._atom_index(atom_k)
+        self._validate_steer_native_state()
         t_from_arr = np.ascontiguousarray(np.asarray(t_from, dtype=np.float64).reshape(-1))
         t_to_arr = np.ascontiguousarray(np.asarray(t_to, dtype=np.float64).reshape(-1))
         kind = _canonical_assignment(self.assignment, "assignment")

--- a/tests/test_sae_facade_audit.py
+++ b/tests/test_sae_facade_audit.py
@@ -770,3 +770,11 @@ def test_from_payload_rejects_chosen_k_mismatch(monkeypatch):
         sae.ManifoldSAE.from_payload(
             x, payload, topology="circle", assignment="softmax", penalties=[]
         )
+
+
+def test_steer_rejects_incoherent_mutated_core_state_before_ffi():
+    fit = _make_fit("softmax", n_atoms=1)
+    fit.decoder_blocks = []
+
+    with pytest.raises(ValueError, match="native steering state is incoherent"):
+        fit.steer(0, [0.0], [1.0])


### PR DESCRIPTION
### Motivation
- The Python `ManifoldSAE` facade stores core fitted arrays in mutable fields so post‑fit Python-side mutation can make per-field dimensions incoherent and cause low-level Rust FFI failures when `steer()` is called.
- Rejecting incoherent model state at the facade boundary prevents mutated/incomplete state from reaching the native kernel and makes failures local, readable, and safe while the full Rust `#[pyclass]` migration proceeds.

### Description
- Add `_validate_steer_native_state()` to `gamfit/_sae_manifold.py` to assert cross-field coherence for `K`, `(N,P)`, `decoder_blocks`, `coords`, `_atom_dims`/`_basis_sizes`/`_n_harmonics`, `low_level_logits`, and optional `fisher_factors` before calling native steering logic.
- Call `_validate_steer_native_state()` at the start of `ManifoldSAE.steer()` so incoherent state is rejected with a `ValueError` before any FFI invocation.
- Add a regression test `test_steer_rejects_incoherent_mutated_core_state_before_ffi` to `tests/test_sae_facade_audit.py` that mutates `decoder_blocks` and asserts `steer()` raises the coherence `ValueError`.

### Testing
- Ran `./build.sh` which completed successfully and produced the normal library build output.
- Ran `./build.sh check -p gam-pyffi --lib` which succeeded (exit 0).
- Ran `maturin develop` to install the Python package wheel for the mixed Rust/Python bindings which completed successfully and installed `gamfit` editable wheel.
- Executed the new regression test with `pytest` via the created virtualenv: ` .venv/bin/python -m pytest -q tests/test_sae_facade_audit.py::test_steer_rejects_incoherent_mutated_core_state_before_ffi` which passed (`1 passed`).
- Verified Python source compiles with `python -m py_compile gamfit/_sae_manifold.py tests/test_sae_facade_audit.py` (no errors).
- Attempted `./build.sh test -p gam-pyffi --lib --no-run` but observed environment-specific PyO3 test-linkage errors (missing Python C API symbols) when building lib test artifacts; the normal library build and `maturin develop` succeeded so the linkage issue appears to be an environment/test-artifact limitation, not a regression from this change.

---
Fixes #2091.

<details><summary>codex self-assessment</summary>

)\n     Compiling comfy-table v7.2.2\n     Compiling clap v4.6.1\n     Compiling gam-test-support v0.3.148 (/workspace/gam/crates/gam-test-support)\n     Compiling gam-report v0.3.148 (/workspace/gam/crates/gam-report)\n      Finished `dev` profile [unoptimized + debuginfo] target(s) in 20m 58s\n  ```\n\n* \u2705 `./build.sh check -p gam-pyffi --lib`\n\n  ```text\n  [build.sh] check -p gam-pyffi --lib -> exit 0 in 0s (dedup=SUBSUMED, recompiled 0 crates)\n  ```\n\n* \u2705 `maturin develop`\n\n  ```text\n  \ud83c\udf79 Building a mixed python/rust project\n  \ud83d\udc0d Found CPython 3.12 at /workspace/gam/.venv/bin/python\n  \ud83d\udd17 Found pyo3 bindings with abi3-py3.10 support\n  ...\n     Compiling gam-pyffi v0.1.250 (/workspace/gam/crates/gam-pyffi)\n     Compiling rustc-hash v2.1.3\n     Compiling gam-predict v0.3.148 (/workspace/gam/crates/gam-predict)\n      Finished `dev` profile [unoptimized + debuginfo] target(s) in 15m 18s\n  \ud83d\udce6 Built wheel for abi3 Python \u2265 3.10 to /tmp/.tmpas2AJR/gamfit-0.1.250-cp310-abi3-linux_x86_64.whl\n  \u270f\ufe0f Setting installed package as editable\n  \ud83d\udee0 Installed gamfit-0.1.250\n  ```\n\n* \u2705 `.venv/bin/python -m pytest -q tests/test_sae_facade_audit.py::test_steer_rejects_incoherent_mutated_core_state_before_ffi`\n\n  ```text\n  .                                                                        [100%]\n  1 passed in 0.58s\n  ```\n\n* \u2705 `python -m py_compile gamfit/_sae_manifold.py tests/test_sae_facade_audit.py`\n\n  ```text\n  # no output; exit 0\n  ```\n\n* \u2705 Before/after regression evidence for the same mutated-state mechanism:\n\n  Before this patch, the incoherent mutated model reached Rust and failed as a native `GamError`:\n\n  ```text\n  GamError\n  sae_steer_delta: per-atom metadata lengths must equal K=1\n  ```\n\n  After this patch, the facade rejects the incoherent model before FFI:\n\n  ```text\n  ValueError\n  ManifoldSAE native steering state is incoherent: basis_kinds has K=1, but field lengths differ {'decoder_blocks': 0}\n  ```\n\n* \u26a0\ufe0f `./build.sh test -p gam-pyffi --lib --no-run`\n\n  ```text\n  [build.sh] test -p gam-pyffi --lib --no-run -> exit 101 in 1504s (dedup=MISS, recompiled 26 crates)\n  FAILED (101):\n            \n            rust-lld: error: undefined symbol: PyErr_WriteUnraisable\n            >>> referenced by mod.rs:480 (/root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/pyo3-0.29.0/src/err/mod.rs:480)\n            ...\n            rust-lld: error: too many errors emitted, stopping now (use --error-limit=0 to see all errors)\n            collect2: error: ld returned 1 exit status\n            \n  \n  error: could not compile `gam-pyffi` (lib test) due to 1 previous error\n  ```\n\n  This appears to be an environment/PyO3 test-linkage limitation: the normal library build and `maturin develop` both succeeded.\n\n## CODE DIFF\n\nCommitted on the current branch:\n\n```text\n5de263f Validate ManifoldSAE steering state before FFI\n gamfit/_sae_manifold.py        | 56 ++++++++++++++++++++++++++++++++++++++++++\n tests/test_sae_facade_audit.py |  8 ++++++\n 2 files changed, 64 insertions(+)\n```\n\n## SELF-ASSESSMENT\n\n* **SOLVES THE ISSUE? PARTIAL** \u2014 This does **not** implement the full Rust-owned `#[pyclass] ManifoldSAE` model object, nor does it eliminate Python-owned model state or per-call marshalling. It does fix a real root mechanism called out in the issue \u2014 post-fit Python state drift reaching Rust unchecked \u2014 for the steering path by adding a boundary coherence check before native invocation.\n* **NET EFFECT: NET-GOOD** \u2014 The change improves correctness and failure locality without changing solver math, payload schema, or existing public behavior for coherent models. The main risk is that it is still Python-side validation rather than the final Rust-owned state model, so it should be treated as a migration hardening step rather than the end-state architecture."}]
</details>

_Codex-generated; pending adversarial audit before merge._