### PR TITLE
#2153: fix(sae): require certified inner stalls for K=1 circle fits

### DIFF
--- a/crates/gam-sae/src/manifold/construction.rs
+++ b/crates/gam-sae/src/manifold/construction.rs
@@ -5609,8 +5609,9 @@ impl SaeManifoldTerm {
             };
             let stalled = new_loss_total.is_finite()
                 && relative_decrease.is_finite()
-                && (relative_decrease < SAE_MANIFOLD_INNER_OBJECTIVE_STALL_REL_TOL
-                    || captured_fraction < SAE_MANIFOLD_INNER_OBJECTIVE_STALL_FRACTION);
+                && captured_fraction.is_finite()
+                && relative_decrease < SAE_MANIFOLD_INNER_OBJECTIVE_STALL_REL_TOL
+                && captured_fraction < SAE_MANIFOLD_INNER_OBJECTIVE_STALL_FRACTION;
             previous_loss_total = new_loss_total;
             if stalled && refine_rounds >= SAE_MANIFOLD_INNER_OBJECTIVE_STALL_MIN_ROUNDS {
                 let stationary_sys = self
@@ -5636,13 +5637,16 @@ impl SaeManifoldTerm {
                     {
                         return Ok(stationary_cache);
                     }
-                    return Err(format!(
-                        "SaeManifoldTerm::reml_criterion: objective stalled but the stalled \
-                         point is not stationary (‖g‖={stationary_grad_norm:.6e}, \
-                         ‖Π⊥gauge g‖={stationary_quotient_grad_norm:.6e}, \
-                         tol {grad_tolerance:.6e}); refusing to rank an off-optimum \
-                         Laplace criterion"
-                    ));
+                    // A flat objective round is only a convergence shortcut when
+                    // the KKT certificate above is stationary. If not, keep using
+                    // the deterministic refinement budget: either later rounds
+                    // reach stationarity, or the normal `total_inner_iter >=
+                    // refine_limit` branch reports non-convergence without
+                    // ranking an off-optimum Laplace criterion. Returning `Err`
+                    // here was too strong for K=1 circle fits: one weakly
+                    // identified round could abort a still-descending solve and
+                    // poison the outer BFGS line search with a false value-probe
+                    // refusal.
                 }
                 // Stagnated AND the undamped factor still fails: this is the
                 // numerical fixed point of the inner solve under rank-deficient

--- a/crates/gam-sae/src/manifold/tests_logdet_adjoint_780.rs
+++ b/crates/gam-sae/src/manifold/tests_logdet_adjoint_780.rs
@@ -5,7 +5,7 @@
 //! `tests` module.
 
 use super::derivative_oracle::{
-    BranchCertificate, DerivativeTraceChannel, ExactTraceChannel, ExactTraceReport,
+    DerivativeTraceChannel, ExactTraceChannel, ExactTraceReport,
     MajorizerAnchorMode, PivotBranch, dual_spd_logdet, guarded_exact_trace_report,
 };
 use super::construction::{active_softmax_gershgorin_majorizer_entry, softmax_majorizer_log_mean};
@@ -212,20 +212,6 @@ fn dual_half_logdet_trace_2156(cache: &ArrowFactorCache, h: &Array2<f64>, dh: &A
         vec![(DerivativeTraceChannel::Other("rho"), dh.clone())],
     );
     0.5 * report.total_derivative
-}
-
-fn dual_logdet_trace_2156(
-    label: &'static str,
-    cache: &ArrowFactorCache,
-    h: &Array2<f64>,
-    dh: &Array2<f64>,
-) -> (f64, BranchCertificate) {
-    let report = dual_trace_report_2156(
-        cache,
-        h,
-        vec![(DerivativeTraceChannel::Other(label), dh.clone())],
-    );
-    (report.total_derivative, report.certificate)
 }
 
 fn relative_error_2156(exact: f64, production: f64) -> f64 {


### PR DESCRIPTION
### Motivation
- The inner SAE manifold refinement prematurely classified a refine round as a fixed-point "stalled" event when either the tiny relative-decrease OR the tiny captured-fraction signal fired, rather than requiring both signals the comments documented; this misclassification could abort non-stationary inner solves and poison the outer BFGS/line-search path for K=1 circle fits.

### Description
- Require both stagnation signals (`relative_decrease` and `captured_fraction`) and that `captured_fraction` is finite before treating an inner-round as stalled (change in `crates/gam-sae/src/manifold/construction.rs`).
- Only accept the short-cut (returning the stationary cache) when the KKT / quotient-gradient certificate is stationary; if not stationary, do not return `Err` immediately but continue under the deterministic refinement budget so the solve either reaches stationarity or triggers the normal non-convergence path (same file, nearby lines).
- Remove an unused test helper/import from `crates/gam-sae/src/manifold/tests_logdet_adjoint_780.rs` to keep the lib-test build clean under `-D warnings`.

### Testing
- Ran full workspace build: `./build.sh` which completed successfully.
- Ran crate check: `./build.sh check -p gam-sae --lib` which passed.
- Built test binary: `./build.sh test -p gam-sae --lib --no-run` which succeeded.
- Regression test that exercised the issue: `./build.sh test -p gam-sae --lib k1_generated_seed_circle_outer_reml_does_not_livelock_2153 -- --nocapture` passed after the fix with telemetry showing bounded probe/criterion counts and EV ~0.8180.
- Instrument test: `./build.sh test -p gam-sae --lib ceiling_vs_pathology_outer_reml_instrument_2156 -- --nocapture` passed and reported no live-lock.

---
Fixes #2153.

<details><summary>codex self-assessment</summary>

ted seed):\n  generated=1, screened=1, exact_validated=1, solver_started=0\n  rejection breakdown: rejected_by_kkt=0, rejected_by_domain=0, rejected_by_objective=0, rejected_by_budget=0, rejected_other=1 (total=1)\n  per-seed reasons:\n    seed 0 (validation): REML smoothing optimization failed to converge: outer eval failed: REML smoothing optimization failed to converge: SaeManifoldTerm::reml_criterion: objective stalled but the stalled point is not stationary (\u2016g\u2016=5.281436e-2, \u2016\u03a0\u22a5gauge g\u2016=5.281436e-2, tol 7.916782e-4); refusing to rank an off-optimum Laplace criterion\n```\n\n**After fix \u2014 build/check/test evidence**\n\n* \u2705 `./build.sh`\n\n```text\n[build.sh] LIB -> exit 0 in 1319s (dedup=MISS, recompiled 293 crates)\n    Finished `dev` profile [unoptimized + debuginfo] target(s) in 21m 58s\n```\n\n* \u2705 `./build.sh check -p gam-sae --lib`\n\n```text\n[build.sh] check -p gam-sae --lib -> exit 0 in 267s (dedup=MISS, recompiled 9 crates)\n    Finished `dev` profile [unoptimized + debuginfo] target(s) in 4m 26s\n```\n\n* \u2705 `./build.sh test -p gam-sae --lib --no-run`\n\n```text\n[build.sh] test -p gam-sae --lib --no-run -> exit 0 in 1s (dedup=MISS, recompiled 0 crates)\n    Finished `test` profile [optimized + debuginfo] target(s) in 0.57s\n  Executable unittests src/lib.rs (target/debug/deps/gam_sae-a2c4802d7e5c9eac)\n```\n\n* \u2705 `./build.sh test -p gam-sae --lib k1_generated_seed_circle_outer_reml_does_not_livelock_2153 -- --nocapture`\n\n```text\n[build.sh] test -p gam-sae --lib k1_generated_seed_circle_outer_reml_does_not_livelock_2153 -- --nocapture -> exit 0 in 161s (dedup=MISS, recompiled 1 crates)\n   Compiling gam-sae v0.3.148 (/workspace/gam/crates/gam-sae)\n    Finished `test` profile [optimized + debuginfo] target(s) in 2m 14s\n     Running unittests src/lib.rs (target/debug/deps/gam_sae-a2c4802d7e5c9eac)\n\nrunning 1 test\n[#2153] K=1 generated-seed outer fit: ev=0.8180, criterion_calls=15, fd_probe_calls=8, wall_cost_value_probes=60, infeasible_total=60, mutating_value_probes=0\ntest manifold::tests_outer_reml_probe_budget_2080::k1_generated_seed_circle_outer_reml_does_not_livelock_2153 ... ok\n\ntest result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 909 filtered out; finished in 26.35s\n```\n\n* \u2705 `./build.sh test -p gam-sae --lib ceiling_vs_pathology_outer_reml_instrument_2156 -- --nocapture`\n\n```text\n[build.sh] test -p gam-sae --lib ceiling_vs_pathology_outer_reml_instrument_2156 -- --nocapture -> exit 0 in 64s (dedup=MISS, recompiled 0 crates)\n    Finished `test` profile [optimized + debuginfo] target(s) in 0.57s\n     Running unittests src/lib.rs (target/debug/deps/gam_sae-a2c4802d7e5c9eac)\n\nrunning 1 test\ntest manifold::tests_outer_reml_probe_budget_2080::ceiling_vs_pathology_outer_reml_instrument_2156 has been running for over 60 seconds\n[#2156 ceiling-vs-pathology] initial_cost=1.000000e12, initial_grad_norm=0.000000e0, predicted_decrease=0.000000e0, actual_decrease=0.000000e0, materialization_ratio=NaN, outer_converged=true, outer_iterations=0, final_value=1.000000e12, final_grad_norm=0.000000e0, rho_displacement=0.000000e0, ev=0.8498, criterion_calls=7, fd_probe_calls=0, wall_cost_value_probes=7, infeasible_total=7, outer_error=None, predicted_not_materializing=false, step_collapsed=true, huge_final_gradient=false, live_lock_present=false\ntest manifold::tests_outer_reml_probe_budget_2080::ceiling_vs_pathology_outer_reml_instrument_2156 ... ok\n\ntest result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 909 filtered out; finished in 63.55s\n```\n\n### CODE DIFF\n\n```diff\ndiff --git a/crates/gam-sae/src/manifold/construction.rs b/crates/gam-sae/src/manifold/construction.rs\nindex dde2957..63d4d20 100644\n--- a/crates/gam-sae/src/manifold/construction.rs\n+++ b/crates/gam-sae/src/manifold/construction.rs\n@@ -5609,8 +5609,9 @@ impl SaeManifoldTerm {\n             };\n             let stalled = new_loss_total.is_finite()\n            
</details>

_Codex-generated; pending adversarial audit before merge._