### PR TITLE
#2159: Fix SAE torus persistence Betti counting

### DIFF
--- a/crates/gam-sae/src/manifold/persistence.rs
+++ b/crates/gam-sae/src/manifold/persistence.rs
@@ -706,43 +706,87 @@ fn smallest_linkage_component(distances: &Array2<f64>, scale: f64) -> usize {
 }
 
 fn dominant_persistence(bars: &[PersistenceBar]) -> f64 {
-    bars.iter()
-        .map(|b| b.persistence())
-        .fold(0.0_f64, f64::max)
+    bars.iter().map(|b| b.persistence()).fold(0.0_f64, f64::max)
 }
 
-fn dominant_gap_bar_count(bars: &[PersistenceBar], within_scale: f64) -> usize {
+fn dominant_gap_bar_count(bars: &[PersistenceBar]) -> usize {
     let essential = bars.iter().filter(|b| b.is_essential()).count();
-    let mut lengths: Vec<f64> = bars
+    let finite: Vec<PersistenceBar> = bars
         .iter()
-        .map(|b| b.persistence())
-        .filter(|p| p.is_finite() && *p > 0.0)
+        .copied()
+        .filter(|b| b.birth.is_finite() && b.death.is_finite() && b.death > b.birth)
         .collect();
-    if lengths.is_empty() {
+    if finite.is_empty() {
         return essential;
     }
-    lengths.sort_by(|a, b| b.partial_cmp(a).unwrap_or(std::cmp::Ordering::Equal));
-    if lengths.len() == 1 {
-        return essential + usize::from(lengths[0] > within_scale);
+
+    // Count the Pareto frontier of the birth/death diagram.  A genuine sampled
+    // homology generator is not made less valid merely because the H0 covering
+    // scale is larger than its lifetime; what distinguishes diagram noise is
+    // that it is born no earlier and dies no later than a more persistent class.
+    // This partial-order rule is scale-free and uses only the diagram geometry:
+    // dominated bars cannot represent additional stable topology, while each
+    // undominated bar witnesses an independent class on some filtration band.
+    let mut frontier = 0usize;
+    'candidate: for (idx, bar) in finite.iter().enumerate() {
+        for (other_idx, other) in finite.iter().enumerate() {
+            if idx == other_idx {
+                continue;
+            }
+            let born_no_later = other.birth <= bar.birth;
+            let dies_no_earlier = other.death >= bar.death;
+            let strictly_better = other.birth < bar.birth || other.death > bar.death;
+            if born_no_later && dies_no_earlier && strictly_better {
+                continue 'candidate;
+            }
+        }
+        frontier += 1;
     }
-    let logs: Vec<f64> = lengths.iter().map(|d| d.ln()).collect();
-    let gaps: Vec<f64> = (0..lengths.len() - 1)
-        .map(|i| logs[i] - logs[i + 1])
+
+    essential + frontier
+}
+
+fn shell_plateau_bar_count(bars: &[PersistenceBar]) -> usize {
+    let essential = bars.iter().filter(|b| b.is_essential()).count();
+    let finite: Vec<PersistenceBar> = bars
+        .iter()
+        .copied()
+        .filter(|b| b.birth.is_finite() && b.death.is_finite() && b.death > b.birth)
         .collect();
-    let mut gmax = f64::NEG_INFINITY;
-    let mut gmax_idx = 0usize;
-    for (i, &g) in gaps.iter().enumerate() {
-        if g > gmax {
-            gmax = g;
-            gmax_idx = i;
+    if finite.is_empty() {
+        return essential;
+    }
+    let mut critical = Vec::with_capacity(finite.len() * 2);
+    for bar in &finite {
+        critical.push(bar.birth);
+        critical.push(bar.death);
+    }
+    critical.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+    critical.dedup_by(|a, b| *a == *b);
+    let mut best = essential;
+    let mut best_width = f64::NEG_INFINITY;
+    for window in critical.windows(2) {
+        let lo = window[0];
+        let hi = window[1];
+        if !(hi > lo) {
+            continue;
+        }
+        let probe = if lo > 0.0 { (lo * hi).sqrt() } else { hi / 2.0 };
+        let count = essential
+            + finite
+                .iter()
+                .filter(|bar| bar.birth < probe && probe < bar.death)
+                .count();
+        if count == 0 {
+            continue;
+        }
+        let width = if lo > 0.0 { (hi / lo).ln() } else { hi - lo };
+        if width > best_width || (width == best_width && count < best) {
+            best_width = width;
+            best = count;
         }
     }
-    let sum_others: f64 = gaps.iter().sum::<f64>() - gmax;
-    if gmax > sum_others.max(std::f64::consts::LN_2) {
-        essential + gmax_idx + 1
-    } else {
-        essential + lengths.iter().filter(|&&p| p > within_scale).count()
-    }
+    best
 }
 
 fn support_summary(weights: Option<ArrayView1<'_, f64>>, full: usize) -> (f64, f64, f64) {
@@ -816,25 +860,20 @@ fn topology_persistence_verdict_impl(
         .copied()
         .filter(|b| !b.is_essential())
         .collect();
-    let distances = dtm_weighted_distances(
-        sub.view(),
-        sub_weights.as_ref().map(|w| w.view()),
-    );
-    let (n_components, within_scale) = components_and_scale(&finite_h0, &distances);
+    let distances = dtm_weighted_distances(sub.view(), sub_weights.as_ref().map(|w| w.view()));
+    let (n_components, _) = components_and_scale(&finite_h0, &distances);
 
     let measured_betti = BettiSignature {
         b0: n_components,
-        b1: dominant_gap_bar_count(&diagram.h1, within_scale),
-        b2: expected_betti
-            .b2
-            .map(|expected_h2| {
-                let counted = dominant_gap_bar_count(&diagram.h2, within_scale);
-                if expected_h2 == 0 && counted == 0 {
-                    0
-                } else {
-                    counted
-                }
-            }),
+        b1: dominant_gap_bar_count(&diagram.h1),
+        b2: expected_betti.b2.map(|expected_h2| {
+            let counted = shell_plateau_bar_count(&diagram.h2);
+            if expected_h2 == 0 && counted == 0 {
+                0
+            } else {
+                counted
+            }
+        }),
     };
     let dominant_h1_persistence = dominant_persistence(&diagram.h1);
     let dominant_h2_persistence = dominant_persistence(&diagram.h2);
@@ -1087,7 +1126,7 @@ pub fn atlas_nerve(points: ArrayView2<'_, f64>) -> AtlasNerveReport {
 
 #[cfg(test)]
 mod tests {
-    use super::{components_and_scale, dtm_weighted_distances, PersistenceBar};
+    use super::{PersistenceBar, components_and_scale, dtm_weighted_distances};
     use ndarray::Array2;
 
     fn bars(deaths: &[f64]) -> Vec<PersistenceBar> {
@@ -1159,8 +1198,14 @@ mod tests {
         let pts = line_points(&[0.0, 0.1, 0.2, 50.0, 50.1]);
         let distances = dtm_weighted_distances(pts.view(), None);
         let (n, within) = components_and_scale(&bars(&deaths), &distances);
-        assert_eq!(n, 2, "a real inter-cluster gap with ≥2 per side must still split");
-        assert!((within - 0.1).abs() < 1e-12, "within-scale is the coarsest sub-cut merge");
+        assert_eq!(
+            n, 2,
+            "a real inter-cluster gap with ≥2 per side must still split"
+        );
+        assert!(
+            (within - 0.1).abs() < 1e-12,
+            "within-scale is the coarsest sub-cut merge"
+        );
     }
 
     #[test]

--- a/crates/gam-sae/src/manifold/tests_logdet_adjoint_780.rs
+++ b/crates/gam-sae/src/manifold/tests_logdet_adjoint_780.rs
@@ -214,20 +214,6 @@ fn dual_half_logdet_trace_2156(cache: &ArrowFactorCache, h: &Array2<f64>, dh: &A
     0.5 * report.total_derivative
 }
 
-fn dual_logdet_trace_2156(
-    label: &'static str,
-    cache: &ArrowFactorCache,
-    h: &Array2<f64>,
-    dh: &Array2<f64>,
-) -> (f64, BranchCertificate) {
-    let report = dual_trace_report_2156(
-        cache,
-        h,
-        vec![(DerivativeTraceChannel::Other(label), dh.clone())],
-    );
-    (report.total_derivative, report.certificate)
-}
-
 fn relative_error_2156(exact: f64, production: f64) -> f64 {
     (exact - production).abs() / exact.abs().max(production.abs()).max(1.0)
 }

--- a/crates/gam-sae/src/manifold/tests_topology_persistence_f3.rs
+++ b/crates/gam-sae/src/manifold/tests_topology_persistence_f3.rs
@@ -77,14 +77,33 @@ fn torus_points(nu: usize, nv: usize) -> Array2<f64> {
     pts
 }
 
+/// Standard embedded torus in R3 with ring radius `major` and tube radius
+/// `minor`, sampled on a deterministic product grid.
+fn embedded_torus_points(nu: usize, nv: usize, major: f64, minor: f64) -> Array2<f64> {
+    let mut pts = Array2::<f64>::zeros((nu * nv, 3));
+    let mut row = 0usize;
+    for i in 0..nu {
+        let u = std::f64::consts::TAU * (i as f64) / (nu as f64);
+        for j in 0..nv {
+            let v = std::f64::consts::TAU * (j as f64) / (nv as f64);
+            let tube = major + minor * v.cos();
+            pts[[row, 0]] = tube * u.cos();
+            pts[[row, 1]] = tube * u.sin();
+            pts[[row, 2]] = minor * v.sin();
+            row += 1;
+        }
+    }
+    pts
+}
+
 /// Six vertices of the octahedron on S2. Its VR complex has one dominant H2
 /// shell before the opposite-vertex edges fill it.
 fn octahedron_sphere_points() -> Array2<f64> {
     Array2::from_shape_vec(
         (6, 3),
         vec![
-            1.0, 0.0, 0.0, -1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, -1.0, 0.0, 0.0, 0.0, 1.0, 0.0,
-            0.0, -1.0,
+            1.0, 0.0, 0.0, -1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, -1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0,
+            -1.0,
         ],
     )
     .unwrap()
@@ -117,7 +136,10 @@ fn circle_cloud_agrees_with_a_raced_circle() {
         .expect("periodic atom has a topology prediction");
     assert_eq!(verdict.measured_betti.b0, 1, "circle is connected");
     assert_eq!(verdict.measured_betti.b1, 1, "circle must show one loop");
-    assert_eq!(verdict.expected_betti.b1, 1, "periodic type predicts one loop");
+    assert_eq!(
+        verdict.expected_betti.b1, 1,
+        "periodic type predicts one loop"
+    );
     assert!(
         !verdict.contested,
         "a true circle raced as a circle is not contested: {}",
@@ -161,7 +183,10 @@ fn line_is_clean_against_a_line_and_contested_against_a_circle() {
     let as_circle = topology_persistence_verdict(pts.view(), &SaeAtomBasisKind::Periodic)
         .expect("periodic atom has a topology prediction");
     assert_eq!(as_circle.expected_betti.b1, 1, "periodic predicts a loop");
-    assert_eq!(as_circle.measured_betti.b1, 0, "the line has no loop to find");
+    assert_eq!(
+        as_circle.measured_betti.b1, 0,
+        "the line has no loop to find"
+    );
     assert!(
         as_circle.contested,
         "a circle fit on a line is contested: {}",
@@ -175,7 +200,10 @@ fn torus_signature_requires_two_independent_loops() {
     let as_torus = topology_persistence_verdict(pts.view(), &SaeAtomBasisKind::Torus)
         .expect("torus atom has a topology prediction");
     assert_eq!(as_torus.measured_betti.b0, 1, "torus is connected");
-    assert_eq!(as_torus.measured_betti.b1, 2, "torus must show two H1 loops");
+    assert_eq!(
+        as_torus.measured_betti.b1, 2,
+        "torus must show two H1 loops"
+    );
     assert_eq!(as_torus.expected_betti.b1, 2, "torus predicts two H1 loops");
 
     let as_circle = topology_persistence_verdict(pts.view(), &SaeAtomBasisKind::Periodic)
@@ -193,13 +221,40 @@ fn torus_signature_requires_two_independent_loops() {
 }
 
 #[test]
+fn embedded_torus_grid_measures_two_h1_generators() {
+    let pts = embedded_torus_points(16, 14, 2.5, 1.5);
+    let verdict = topology_persistence_verdict(pts.view(), &SaeAtomBasisKind::Torus)
+        .expect("torus atom has a topology prediction");
+    assert_eq!(verdict.measured_betti.b0, 1, "torus is connected");
+    assert_eq!(
+        verdict.measured_betti.b1, 2,
+        "an embedded torus has two independent H1 generators; note: {}; H1: {:?}",
+        verdict.note, verdict.h1
+    );
+    assert_eq!(
+        verdict.measured_betti.b2,
+        Some(1),
+        "torus encloses one H2 void"
+    );
+    assert!(
+        !verdict.contested,
+        "a canonical torus raced as a torus must not be contested: {}",
+        verdict.note
+    );
+}
+
+#[test]
 fn sphere_signature_measures_h2_shell() {
     let pts = octahedron_sphere_points();
     let verdict = topology_persistence_verdict(pts.view(), &SaeAtomBasisKind::Sphere)
         .expect("sphere atom has a topology prediction");
     assert_eq!(verdict.measured_betti.b0, 1, "sphere is connected");
     assert_eq!(verdict.measured_betti.b1, 0, "sphere has no H1 loop");
-    assert_eq!(verdict.measured_betti.b2, Some(1), "sphere has one H2 shell");
+    assert_eq!(
+        verdict.measured_betti.b2,
+        Some(1),
+        "sphere has one H2 shell"
+    );
     assert!(
         !verdict.contested,
         "octahedron sphere should match the sphere signature: {}",


### PR DESCRIPTION
### Motivation

- The SAE topology-persistence audit was discarding genuine multi-generator H1 classes by comparing H1 bar lifetimes to an H0-derived `within_scale` and a single dominant-log-gap rule, which fails for tori where the two loops have unequal persistence.

### Description

- Replace the H1 counting heuristic in `crates/gam-sae/src/manifold/persistence.rs` with a diagram-intrinsic Pareto-frontier count over finite birth/death bars (undominated bars count as independent generators). 
- Add `shell_plateau_bar_count` to count H2 shells by selecting the widest positive plateau in the H2 birth/death critical values instead of reusing the H1 rule. 
- Wire measured Betti assembly to use the new H1/H2 counters (remove the H0 `within_scale` dependence for H1). 
- Add a deterministic embedded-torus regression test (`embedded_torus_grid_measures_two_h1_generators`) that asserts `b0=1, b1=2, b2=1` and that the torus is not `contested`. 
- Remove an unused test helper that caused `-D warnings` failures during lib-test compilation.

### Testing

- Built the repo: `./build.sh` — succeeded (lib build finished). 
- Static check: `./build.sh check -p gam-sae --lib` — succeeded with no warnings. 
- Test binary build: `./build.sh test -p gam-sae --lib --no-run` — test binary built successfully. 
- Relevant unit tests: `./build.sh test -p gam-sae topology_persistence -- --nocapture` — all topology persistence tests passed (9 passed, 0 failed), including the new embedded-torus regression.

---
Fixes #2159.

<details><summary>codex self-assessment</summary>

2d7e5c9eac)\n\nrunning 1 test\n\nthread 'manifold::tests_topology_persistence_f3::embedded_torus_grid_measures_two_h1_generators' ... panicked ...\nassertion `left == right` failed: torus encloses one H2 void\n  left: Some(3)\n right: Some(1)\n...\ntest result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 910 filtered out\n```\n\nAfter the fix:\n\n* \u2705 `./build.sh`\n\n```text\n[build.sh] LIB -> exit 0 in 114s (dedup=MISS, recompiled 4 crates)\n   Compiling gam-sae v0.3.148 (/workspace/gam/crates/gam-sae)\n   Compiling gam v0.3.148 (/workspace/gam)\n   Compiling gam-inference v0.3.148 (/workspace/gam/crates/gam-inference)\n   Compiling gam-config v0.3.148 (/workspace/gam/crates/gam-config)\n    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 53s\n```\n\n* \u2705 `./build.sh check -p gam-sae --lib`\n\n```text\n[build.sh] check -p gam-sae --lib -> exit 0 in 14s (dedup=MISS, recompiled 0 crates)\n    Checking gam-sae v0.3.148 (/workspace/gam/crates/gam-sae)\n    Finished `dev` profile [unoptimized + debuginfo] target(s) in 13.82s\n```\n\n* \u2705 `./build.sh test -p gam-sae --lib --no-run`\n\n```text\n[build.sh] test -p gam-sae --lib --no-run -> exit 0 in 1s (dedup=MISS, recompiled 0 crates)\n    Finished `test` profile [optimized + debuginfo] target(s) in 0.60s\n  Executable unittests src/lib.rs (target/debug/deps/gam_sae-a2c4802d7e5c9eac)\n```\n\n* \u2705 `./build.sh test -p gam-sae topology_persistence -- --nocapture`\n\n```text\n[build.sh] test -p gam-sae topology_persistence -- --nocapture -> exit 0 in 57s (dedup=MISS, recompiled 1 crates)\ntest manifold::tests_topology_persistence_f3::atlas_nerve_recovers_circle_and_arc ... ok\ntest manifold::tests_topology_persistence_f3::circle_cloud_agrees_with_a_raced_circle ... ok\ntest manifold::tests_topology_persistence_f3::line_is_clean_against_a_line_and_contested_against_a_circle ... ok\ntest manifold::tests_topology_persistence_f3::precomputed_kind_has_no_prediction_to_contest ... ok\ntest manifold::tests_topology_persistence_f3::seven_cluster_ring_forced_through_circle_is_contested ... ok\ntest manifold::tests_topology_persistence_f3::sphere_signature_measures_h2_shell ... ok\ntest manifold::tests_topology_persistence_f3::torus_signature_requires_two_independent_loops ... ok\ntest manifold::tests_topology_persistence_f3::vietoris_rips_finds_the_circle_loop ... ok\ntest manifold::tests_topology_persistence_f3::embedded_torus_grid_measures_two_h1_generators ... ok\n\ntest result: ok. 9 passed; 0 failed; 0 ignored; 0 measured; 902 filtered out; finished in 1.19s\n```\n\n### CODE DIFF\n\nCommitted on the current branch:\n\n```text\n2a42bf83a3b0c1be59424f6e07a243aa526a0831 Fix SAE torus persistence Betti counting\n```\n\nFiles changed:\n\n```text\ncrates/gam-sae/src/manifold/persistence.rs\ncrates/gam-sae/src/manifold/tests_topology_persistence_f3.rs\ncrates/gam-sae/src/manifold/tests_logdet_adjoint_780.rs\n```\n\nThe substantive diff is:\n* H\u2081: replace lifetime-vs-H\u2080-scale counting with Pareto-frontier birth/death counting. "}, {"content_type": "repo_file_citation", "path": "crates/gam-sae/src/manifold/persistence.rs", "line_range_start": 712, "line_range_end": 747}, {"content_type": "text", "text": "\n* H\u2082: add widest-positive-shell-plateau counting. "}, {"content_type": "repo_file_citation", "path": "crates/gam-sae/src/manifold/persistence.rs", "line_range_start": 749, "line_range_end": 790}, {"content_type": "text", "text": "\n* Verdict: wire H\u2081/H\u2082 to their dimension-appropriate counters. "}, {"content_type": "repo_file_citation", "path": "crates/gam-sae/src/manifold/persistence.rs", "line_range_start": 866, "line_range_end": 877}, {"content_type": "text", "text": "\n* Regression: add canonical embedded torus generator and assertion. "}, {"content_type": "repo_file_citation", "path": "crates/gam-sae/src/manifold/tests_topology_persistence_f3.rs", "line_range_start": 80, "line_range_end": 97}, {"content_type": "repo_file_citation
</details>

_Codex-generated; pending adversarial audit before merge._