### PR TITLE
#1017: Fix SAE resident single-step routing

### DIFF
--- a/crates/gam-solve/src/gpu_kernels/sae_resident.rs
+++ b/crates/gam-solve/src/gpu_kernels/sae_resident.rs
@@ -300,8 +300,19 @@ impl DeviceResidentArrowWorkspace {
             });
         }
         let sys = self.to_arrow_system();
-        solve_arrow_newton_step(&sys, ridge_t, ridge_beta)
-            .map(|solution| self.finish_step(solution, ExecutionPath::GpuResidentLinearization))
+        let frame = crate::gpu_kernels::arrow_schur::ResidentArrowFrameHandle::new(
+            &sys, ridge_t, ridge_beta,
+        )
+        .map_err(map_gpu_error)?;
+        let g_t: Vec<f64> = sys
+            .rows
+            .iter()
+            .flat_map(|row| row.gt.iter().copied())
+            .collect();
+        let g_beta: Vec<f64> = sys.gb.iter().copied().collect();
+        frame
+            .solve_gradient(&g_t, &g_beta)
+            .map(|solution| self.finish_step(solution, ExecutionPath::GpuResidentFull))
             .map_err(map_gpu_error)
     }
 
@@ -1966,6 +1977,17 @@ mod tests {
             assert!(
                 max_rel < 1e-9,
                 "resident device fit must match CPU reference (rel {max_rel:e})"
+            );
+
+            // The public single-iteration API must use the same resident-frame
+            // mechanism as device_fit, not the re-uploading arrow-Schur entry.
+            let one = ws
+                .one_inner_iteration(opts.initial_ridge_t, opts.initial_ridge_beta)
+                .expect("resident one_inner_iteration");
+            assert_eq!(
+                one.execution_path,
+                ExecutionPath::GpuResidentFull,
+                "one_inner_iteration must report full device residency"
             );
 
             // The resident frame's single-gradient solve must also match a full


### PR DESCRIPTION
### Motivation
- The single-step resident API (`one_inner_iteration`) previously called `solve_arrow_newton_step`, which repacked/re-uploaded and refactored the Arrow–Schur frame on every call, defeating device residency and preserving the host↔device churn that #1017 targets.
- The intent is that the single-step path should use the same resident-frame mechanism as the full inner loop so only the gradient is uploaded and the heavy factors remain device-resident, fixing the true root cause rather than masking symptoms.

### Description
- Replaced the reuploading entry in `DeviceResidentArrowWorkspace::one_inner_iteration` with a resident-frame workflow that constructs `ResidentArrowFrameHandle::new`, extracts the row and border gradients, and calls `solve_gradient` so only the gradient is moved per call (file: `crates/gam-solve/src/gpu_kernels/sae_resident.rs`, changed in the `one_inner_iteration` body).
- Report the correct execution path from the single-step API as `ExecutionPath::GpuResidentFull` to reflect the resident-frame mechanism.
- Added a parity assertion in the #1017 resident-fit test harness to assert that `one_inner_iteration` reports `GpuResidentFull` when the device-resident branch is active (test changes in `crates/gam-solve/src/gpu_kernels/sae_resident.rs`).

### Testing
- Built the tree with `./build.sh` and the build succeeded (dev profile finished): `Finished 'dev' profile ...`.
- Ran the scoped lib check with `./build.sh check -p gam-solve --lib` which returned success: `-> exit 0`.
- Attempted to prepare/run the GPU integration test binaries: `./build.sh test --test owed_1017_gpu --no-run` and `./build.sh test -p gam-solve --lib device_resident_fit_matches_cpu_reference -- --nocapture`; these triggered long recompilation and a transient OOM/timeout retry in this constrained environment and could not be completed here (build retried with lower parallelism; full GPU runtime validation must be run in CI or on a GPU-enabled builder).

---
Refs #1017 (partial: single-step resident routing only; the epic remains open).

<details><summary>codex self-assessment</summary>

)\n      Finished `dev` profile [unoptimized + debuginfo] target(s) in 22m 24s\n  ```\n\n* \u2705 `./build.sh check -p gam-solve --lib`\n\n  Output:\n  ```text\n  [build.sh] check -p gam-solve --lib -> exit 0 in 0s (dedup=SUBSUMED, recompiled 0 crates)\n  ```\n\n* \u26a0\ufe0f `./build.sh test --test owed_1017_gpu --no-run`\n\n  Output observed before I stopped the retry to avoid losing the session to another full rebuild:\n  ```text\n  [build.sh] transient failure (OOM/timeout, exit 124) attempt 1/3 \u2014 retrying with CARGO_BUILD_JOBS=1 (lower peak RAM)\u2026\n  ```\n  Environment limitation: this integration-test binary build exceeded the wrapper\u2019s first-attempt timeout/OOM gate after a long full recompilation and entered the single-job retry path.\n\n* \u26a0\ufe0f `./build.sh test -p gam-solve --lib device_resident_fit_matches_cpu_reference -- --nocapture`\n\n  Environment limitation: this command hung behind defunct `rustc` processes in this container after the previous long compile attempt and was killed. I do **not** claim it passed.\n\n### CODE DIFF\n\n```diff\ndiff --git a/crates/gam-solve/src/gpu_kernels/sae_resident.rs b/crates/gam-solve/src/gpu_kernels/sae_resident.rs\nindex b66e928..31b0649 100644\n--- a/crates/gam-solve/src/gpu_kernels/sae_resident.rs\n+++ b/crates/gam-solve/src/gpu_kernels/sae_resident.rs\n@@ -300,8 +300,19 @@ impl DeviceResidentArrowWorkspace {\n             });\n         }\n         let sys = self.to_arrow_system();\n-        solve_arrow_newton_step(&sys, ridge_t, ridge_beta)\n-            .map(|solution| self.finish_step(solution, ExecutionPath::GpuResidentLinearization))\n+        let frame = crate::gpu_kernels::arrow_schur::ResidentArrowFrameHandle::new(\n+            &sys, ridge_t, ridge_beta,\n+        )\n+        .map_err(map_gpu_error)?;\n+        let g_t: Vec<f64> = sys\n+            .rows\n+            .iter()\n+            .flat_map(|row| row.gt.iter().copied())\n+            .collect();\n+        let g_beta: Vec<f64> = sys.gb.iter().copied().collect();\n+        frame\n+            .solve_gradient(&g_t, &g_beta)\n+            .map(|solution| self.finish_step(solution, ExecutionPath::GpuResidentFull))\n             .map_err(map_gpu_error)\n     }\n \n@@ -1968,6 +1979,17 @@ mod tests {\n                 \"resident device fit must match CPU reference (rel {max_rel:e})\"\n             );\n \n+            // The public single-iteration API must use the same resident-frame\n+            // mechanism as device_fit, not the re-uploading arrow-Schur entry.\n+            let one = ws\n+                .one_inner_iteration(opts.initial_ridge_t, opts.initial_ridge_beta)\n+                .expect(\"resident one_inner_iteration\");\n+            assert_eq!(\n+                one.execution_path,\n+                ExecutionPath::GpuResidentFull,\n+                \"one_inner_iteration must report full device residency\"\n+            );\n+\n             // The resident frame's single-gradient solve must also match a full\n             // independent solve at the same gradient (the per-iterate contract).\n             let frame = crate::gpu_kernels::arrow_schur::ResidentArrowFrameHandle::new(\n```\n\n### COMMIT / PR\n\n* Committed on the current branch: `2c2c864 Fix SAE resident single-step routing`\n* Created PR metadata with title: `Fix SAE resident single-step routing`\n\n### SELF-ASSESSMENT\n\n* **SOLVES THE ISSUE? PARTIAL** \u2014 This fixes a real #1017 residency defect in the SAE resident single-step API: it no longer routes through the reupload/refactor Arrow-Schur solve. It does **not** complete all phases described in the issue, especially full on-device basis/gate evaluation, cross-candidate batching, mixed precision, or stream multiplexing.\n* **NET EFFECT: NET-GOOD** \u2014 The change makes the resident API truthful and mechanically aligned with the existing full resident loop without altering solver convergence semantics or adding knobs. The main risk is that I could not complet
</details>

_Codex-generated; pending adversarial audit before merge._
