### PR TITLE
#1610: Regression lock — SAE separation-barrier curvature survives deferred/framed β-tier (Refs #1610)

### DIFF
--- a/crates/gam-sae/src/manifold/tests.rs
+++ b/crates/gam-sae/src/manifold/tests.rs
@@ -4012,10 +4012,70 @@ pub(crate) fn sae_arrow_schur_beta_quadratic_model_matches_penalized_loss_change
     );
 }
 
+/// #1610 — the separation barrier's PSD majorizer must survive the production
+/// matrix-free / framed β-tier. The dense path writes a per-atom scalar ridge onto
+/// `sys.hbb`; the deferred path must return the SAME scalar through `atom_curv` so
+/// assembly can fold it into the structured penalty operator instead of silently
+/// dropping collapse-prevention curvature.
+#[test]
+pub(crate) fn separation_barrier_deferred_curvature_matches_dense_hbb_1610() {
+    let (term, _target, _rho) = small_two_atom_periodic_term();
+    let beta_dim = term.beta_dim();
+    let mut dense = ArrowSchurSystem::new(0, 0, beta_dim);
+    dense.gb = Array1::<f64>::zeros(beta_dim);
+    dense.hbb = Array2::<f64>::zeros((beta_dim, beta_dim));
+    let mut dense_atom_curv = vec![0.0_f64; term.k_atoms()];
+    assert!(
+        term.add_sae_separation_barrier(&mut dense, 1.0, true, &mut dense_atom_curv),
+        "fixture must activate the co-collapse separation barrier on the dense path"
+    );
+    assert!(
+        dense_atom_curv.iter().all(|v| *v == 0.0),
+        "dense path writes curvature directly to hbb, not the deferred atom accumulator"
+    );
+
+    let mut deferred = ArrowSchurSystem::new(0, 0, beta_dim);
+    deferred.gb = Array1::<f64>::zeros(beta_dim);
+    deferred.hbb = Array2::<f64>::zeros((0, 0));
+    let mut atom_curv = vec![0.0_f64; term.k_atoms()];
+    assert!(
+        term.add_sae_separation_barrier(&mut deferred, 1.0, false, &mut atom_curv),
+        "fixture must activate the co-collapse separation barrier on the deferred path"
+    );
+
+    for idx in 0..beta_dim {
+        assert!(
+            (dense.gb[idx] - deferred.gb[idx]).abs() <= 1.0e-12,
+            "dense and deferred paths must assemble the same barrier gradient at β[{idx}]"
+        );
+    }
+
+    let offsets = term.beta_offsets();
+    for atom_idx in 0..term.k_atoms() {
+        let start = offsets[atom_idx];
+        let end = if atom_idx + 1 < offsets.len() {
+            offsets[atom_idx + 1]
+        } else {
+            beta_dim
+        };
+        assert!(
+            atom_curv[atom_idx] > 0.0,
+            "deferred path must export positive per-atom collapse-prevention curvature"
+        );
+        for idx in start..end {
+            assert!(
+                (dense.hbb[[idx, idx]] - atom_curv[atom_idx]).abs() <= 1.0e-12,
+                "deferred atom curvature must equal the dense hbb diagonal for atom {atom_idx}"
+            );
+        }
+    }
+}
+
 /// `SaeRowLayout::from_dense_weights` must keep, per row, the
 /// top-`k_active_cap` atoms above the magnitude cutoff (always at least
 /// one), with compact coord starts that reproduce the `expand_row`
 /// round-trip back to full-q positions.
+
 #[test]
 pub(crate) fn sae_row_layout_from_dense_weights_top_k_and_cutoff() {
     // 3 atoms, coord dims [2, 1, 2] ⇒ full q = 3 + 5 = 8.

--- a/crates/gam-sae/src/manifold/tests_logdet_adjoint_780.rs
+++ b/crates/gam-sae/src/manifold/tests_logdet_adjoint_780.rs
@@ -214,20 +214,6 @@ fn dual_half_logdet_trace_2156(cache: &ArrowFactorCache, h: &Array2<f64>, dh: &A
     0.5 * report.total_derivative
 }
 
-fn dual_logdet_trace_2156(
-    label: &'static str,
-    cache: &ArrowFactorCache,
-    h: &Array2<f64>,
-    dh: &Array2<f64>,
-) -> (f64, BranchCertificate) {
-    let report = dual_trace_report_2156(
-        cache,
-        h,
-        vec![(DerivativeTraceChannel::Other(label), dh.clone())],
-    );
-    (report.total_derivative, report.certificate)
-}
-
 fn relative_error_2156(exact: f64, production: f64) -> f64 {
     (exact - production).abs() / exact.abs().max(production.abs()).max(1.0)
 }


### PR DESCRIPTION
### What this PR is
A focused **regression lock only** for the already-landed collapse-prevention curvature-engagement mechanism.

- Adds `separation_barrier_deferred_curvature_matches_dense_hbb_1610` (`crates/gam-sae/src/manifold/tests.rs`): asserts the dense path writes the per-atom Levenberg ridge into `sys.hbb` (`penalties.rs:1047`) while the deferred/framed β-tier exports the SAME scalar through `atom_curv` (`penalties.rs:1076/1079`), and that both paths assemble an identical barrier gradient. Non-tautological (1e-12 bound, `atom_curv > 0`); fails-before/passes-after the curvature dual-write.
- Removes the unused `dual_logdet_trace_2156` helper (dead code under `-D warnings`). Note: this helper is already absent on current `main`, so this deletion is a no-op after rebase.

### Scope note (panel edit)
Retargeted `Fixes #1610` → **Refs #1610**. This PR does **not** derive or delete any hand-picked penalty strength / collapse threshold — the substantive #1610 ask. The `SAE_SEPARATION_BARRIER_STRENGTH`/`SAE_DECODER_REPULSION_STRENGTH` derivations and the reachable-rank collapse bar landed on `main` via separate commits (d3f63d62e / 8381579f2 / 339fe754b); the remaining evidence-derivation of `μ_C` is untouched here. So this must NOT auto-close the epic.

Refs #1610.

— panel review, seat 1/4
