### PR TITLE
#1893: Default Python SAE fits to realised-rank (MP) evidence ledger

### DIFF
--- a/crates/gam-pyffi/src/latent/latent_basis_and_sae_ffi.rs
+++ b/crates/gam-pyffi/src/latent/latent_basis_and_sae_ffi.rs
@@ -2292,6 +2292,9 @@ fn sae_structured_residual_model(
     run_outer_rho_search = true,
     quotient_scale = false,
     data_row_reseed = false,
+    // #1893: production Python fits use the realised-rank REML/Laplace
+    // complexity ledger by default; callers can set false for historical A/B.
+    rank_charge_evidence = true,
 ))]
 fn sae_manifold_fit<'py>(
     py: Python<'py>,
@@ -2346,6 +2349,7 @@ fn sae_manifold_fit<'py>(
     run_outer_rho_search: bool,
     quotient_scale: bool,
     data_row_reseed: bool,
+    rank_charge_evidence: bool,
 ) -> PyResult<Py<PyDict>> {
     // The precomputed-basis entry point carries no Duchon centers / kernel
     // metadata, so any basis kind whose refresh needs them cannot re-evaluate
@@ -2405,6 +2409,7 @@ fn sae_manifold_fit<'py>(
         run_outer_rho_search,
         quotient_scale,
         data_row_reseed,
+        rank_charge_evidence,
     )
 }
 
@@ -2594,7 +2599,7 @@ fn stagewise_progress_py<'py>(
     cone_atom_recovery = false,
     // #5/(B) — appended LAST (after cone_atom_recovery) so the signature stays
     // strictly additive: existing positional/kwarg callers are byte-unaffected.
-    rank_charge_evidence = false,
+    rank_charge_evidence = true,
     // Rung 1 (B4) — the harvest-emitted output-Fisher factor stack `(n, p, r)` and
     // its provenance tag. Appended LAST so the signature stays strictly additive.
     // Presence installs the metric on the seed term (carried across every birth /
@@ -2716,8 +2721,8 @@ fn sae_manifold_fit_stagewise<'py>(
     // from `quotient_scale` (which the stagewise entry never sets): this only arms
     // the stable breach-gated boundary retraction, never the #2022 per-Newton fold.
     base_term.set_cone_atom_recovery(cone_atom_recovery);
-    // #5/(B) — rank-charge evidence criterion (default false ⇒ bit-for-bit
-    // historical). Replaces the coord-block ½log|H_tt| with the realised-rank BIC.
+    // #5/(B) — rank-charge evidence criterion (default true: the valid realised-rank
+    // REML/Laplace complexity ledger). Replaces the coord-block ½log|H_tt| with the realised-rank BIC.
     base_term.set_rank_charge_evidence(rank_charge_evidence);
     // Rung 1 (B4) — install the harvest-emitted output-Fisher `RowMetric` on the
     // seed term BEFORE the fit consumes it. `fit_stagewise` carries the seed's
@@ -2836,7 +2841,16 @@ fn sae_manifold_fit_stagewise<'py>(
     // `detach`) and already re-enters Python (raising there) each event.
     let cancel_flag = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
     let result = match progress_hook {
-        Some(hook) => gam::terms::sae::manifold::fit_stagewise(base_term, init_rho, z_view, None, weights.as_deref(), &config, Some(hook), None),
+        Some(hook) => gam::terms::sae::manifold::fit_stagewise(
+            base_term,
+            init_rho,
+            z_view,
+            None,
+            weights.as_deref(),
+            &config,
+            Some(hook),
+            None,
+        ),
         None => {
             // The worker thread is `'static`, but `z_view` borrows the (Python)
             // numpy buffer — own the target so nothing non-`'static` crosses in
@@ -2844,7 +2858,16 @@ fn sae_manifold_fit_stagewise<'py>(
             let target_owned = z_view.to_owned();
             let worker_cancel = std::sync::Arc::clone(&cancel_flag);
             run_sae_fit_interruptible(py, "gam-sae-stagewise", &cancel_flag, move || {
-                gam::terms::sae::manifold::fit_stagewise(base_term, init_rho, target_owned.view(), None, weights.as_deref(), &config, None, Some(&*worker_cancel))
+                gam::terms::sae::manifold::fit_stagewise(
+                    base_term,
+                    init_rho,
+                    target_owned.view(),
+                    None,
+                    weights.as_deref(),
+                    &config,
+                    None,
+                    Some(&*worker_cancel),
+                )
             })?
         }
     }
@@ -2982,6 +3005,7 @@ fn sae_manifold_fit_inner<'py>(
     run_outer_rho_search: bool,
     quotient_scale: bool,
     data_row_reseed: bool,
+    rank_charge_evidence: bool,
 ) -> PyResult<Py<PyDict>> {
     let analytic_penalties: Option<serde_json::Value> = match analytic_penalties {
         Some(s) => Some(serde_json::from_str(&s).map_err(serde_json_error_to_pyerr)?),
@@ -3236,10 +3260,13 @@ fn sae_manifold_fit_inner<'py>(
         &evaluators,
     )
     .map_err(py_value_error)?;
-    // #2022/#2023 — install the typed per-fit opt-ins before the fit consumes the
-    // term. Default false ⇒ bit-for-bit historical path.
+    // #2022/#2023/#1893 — install typed per-fit switches before the fit consumes
+    // the term. The quotient/data-row recovery levers remain opt-in; the Python
+    // surface defaults the rank-charge evidence ledger on because the historical
+    // coordinate-block Laplace charge mis-prices vanishing/co-collapsed atoms.
     base_term.set_quotient_scale(quotient_scale);
     base_term.set_data_row_reseed(data_row_reseed);
+    base_term.set_rank_charge_evidence(rank_charge_evidence);
     // #2022 SEED peel — moved here from the (env-free) padded-blocks builder.
     // Quotient on ⇒ gauge-fix each seed decoder onto the unit Frobenius sphere
     // with its magnitude in the explicit log-amplitude (reconstruction preserved:
@@ -3472,23 +3499,24 @@ fn sae_manifold_fit_inner<'py>(
     // (the objective bails out of its next outer eval).
     let cancel_flag = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
     objective.set_cancel_flag(std::sync::Arc::clone(&cancel_flag));
-    let (mut objective, run_result) = run_sae_fit_interruptible(py, "gam-sae-fit", &cancel_flag, move || {
-        let run_result = if run_outer_rho_search {
-            let problem = gam::solver::rho_optimizer::OuterProblem::new(n_params)
-                .with_initial_rho(init_rho_flat.clone())
-                .with_seed_config(gam::solver::seeding::SeedConfig {
-                    max_seeds: 1,
-                    seed_budget: 1,
-                    ..Default::default()
-                });
-            problem.run(&mut objective, "SAE manifold").map(|_| ())
-        } else {
-            objective
-                .fit_at_fixed_rho(init_rho_flat.view())
-                .map_err(gam::model_types::EstimationError::RemlOptimizationFailed)
-        };
-        (objective, run_result)
-    })?;
+    let (mut objective, run_result) =
+        run_sae_fit_interruptible(py, "gam-sae-fit", &cancel_flag, move || {
+            let run_result = if run_outer_rho_search {
+                let problem = gam::solver::rho_optimizer::OuterProblem::new(n_params)
+                    .with_initial_rho(init_rho_flat.clone())
+                    .with_seed_config(gam::solver::seeding::SeedConfig {
+                        max_seeds: 1,
+                        seed_budget: 1,
+                        ..Default::default()
+                    });
+                problem.run(&mut objective, "SAE manifold").map(|_| ())
+            } else {
+                objective
+                    .fit_at_fixed_rho(init_rho_flat.view())
+                    .map_err(gam::model_types::EstimationError::RemlOptimizationFailed)
+            };
+            (objective, run_result)
+        })?;
     run_result.map_err(estimation_error_to_pyerr)?;
     // Posterior shape uncertainty: per-atom φ-scaled decoder covariance and
     // ambient bands, read off the converged joint-Hessian Schur factor at the
@@ -3619,7 +3647,9 @@ fn sae_manifold_fit_inner<'py>(
             objective.set_cancel_flag(std::sync::Arc::clone(&cancel_flag));
             let (mut objective, run_result) =
                 run_sae_fit_interruptible(py, "gam-sae-fit-structured", &cancel_flag, move || {
-                    let run_result = problem.run(&mut objective, "SAE manifold (structured)").map(|_| ());
+                    let run_result = problem
+                        .run(&mut objective, "SAE manifold (structured)")
+                        .map(|_| ());
                     (objective, run_result)
                 })?;
             run_result.map_err(estimation_error_to_pyerr)?;
@@ -4366,7 +4396,9 @@ fn sae_manifold_fit_inner<'py>(
             );
         ledger.record(&coordinate_fidelity_certificate);
         let topology_persistence_certificate =
-            gam::terms::sae::manifold::TopologyPersistenceCertificate::new(&fit_diagnostics.topology_persistence);
+            gam::terms::sae::manifold::TopologyPersistenceCertificate::new(
+                &fit_diagnostics.topology_persistence,
+            );
         ledger.record(&topology_persistence_certificate);
         if let Some(report) = &fit_diagnostics.incoherence_report {
             ledger.record(report);
@@ -5134,6 +5166,7 @@ fn sae_manifold_fit_ibp<'py>(
         true,
         false,
         false,
+        true,
     )
 }
 

--- a/crates/gam-pyffi/src/latent/latent_basis_and_sae_ffi_tail.rs
+++ b/crates/gam-pyffi/src/latent/latent_basis_and_sae_ffi_tail.rs
@@ -249,6 +249,9 @@ fn sae_build_atom_plans(
     run_outer_rho_search = true,
     quotient_scale = false,
     data_row_reseed = false,
+    // #1893: default Python auto fits to the realised-rank REML/Laplace
+    // complexity ledger; callers can set false for historical A/B.
+    rank_charge_evidence = true,
 ))]
 fn sae_manifold_fit_minimal<'py>(
     py: Python<'py>,
@@ -300,6 +303,7 @@ fn sae_manifold_fit_minimal<'py>(
     run_outer_rho_search: bool,
     quotient_scale: bool,
     data_row_reseed: bool,
+    rank_charge_evidence: bool,
 ) -> PyResult<Py<PyDict>> {
     // #1777 — accept both "threshold_gate" (primary) and legacy "jumprelu".
     let assignment_kind = canonicalize_assignment_kind(&assignment_kind).map_err(py_value_error)?;
@@ -595,6 +599,7 @@ fn sae_manifold_fit_minimal<'py>(
         run_outer_rho_search,
         quotient_scale,
         data_row_reseed,
+        rank_charge_evidence,
     )?;
     // #977 — the per-atom `atom_plans` are now emitted by `sae_manifold_fit_inner`
     // FROM THE POST-SEARCH dictionary (variable K), so OOS predict can rebuild the

--- a/crates/gam-sae/src/manifold/tests_logdet_adjoint_780.rs
+++ b/crates/gam-sae/src/manifold/tests_logdet_adjoint_780.rs
@@ -214,20 +214,6 @@ fn dual_half_logdet_trace_2156(cache: &ArrowFactorCache, h: &Array2<f64>, dh: &A
     0.5 * report.total_derivative
 }
 
-fn dual_logdet_trace_2156(
-    label: &'static str,
-    cache: &ArrowFactorCache,
-    h: &Array2<f64>,
-    dh: &Array2<f64>,
-) -> (f64, BranchCertificate) {
-    let report = dual_trace_report_2156(
-        cache,
-        h,
-        vec![(DerivativeTraceChannel::Other(label), dh.clone())],
-    );
-    (report.total_derivative, report.certificate)
-}
-
 fn relative_error_2156(exact: f64, production: f64) -> f64 {
     (exact - production).abs() / exact.abs().max(production.abs()).max(1.0)
 }

--- a/crates/gam-sae/src/manifold/tests_rank_charge_2101.rs
+++ b/crates/gam-sae/src/manifold/tests_rank_charge_2101.rs
@@ -131,11 +131,12 @@ fn rank_charge_deff_accepts_circle_and_neutralises_vanishing() {
 fn rank_charge_flag_off_is_inert() {
     let (mut term, rho) = fitted_circle_term(80, 16);
     let tgt = unit_target(&term);
-    // default (flag off)
+    // Explicitly disable the rank-charge switch to audit the historical ledger.
+    term.set_rank_charge_evidence(false);
     let (v_off, _, _) = term
         .reml_criterion_with_cache(tgt.view(), &rho, None, 0, 1.0, 1e-6, 1e-6)
         .unwrap();
-    // explicitly set off — still identical
+    // Re-applying off is still identical.
     term.set_rank_charge_evidence(false);
     let (v_off2, _, _) = term
         .reml_criterion_with_cache(tgt.view(), &rho, None, 0, 1.0, 1e-6, 1e-6)


### PR DESCRIPTION
### Motivation
- The historical Python SAE entry points used the per-row coordinate Laplace log-det complexity by default, which mis-prices vanishing/co-collapsed atoms and lets degenerate births survive the evidence gate in the K≫p regime.

### Description
- Thread an explicit `rank_charge_evidence: bool` argument through the Python FFI entry points and inner driver and default the Python-facing `sae_manifold_fit`, `sae_manifold_fit_minimal`, stagewise, and IBP convenience surfaces to `true` so production Python fits use the realised-rank (Marchenko–Pastur-derived) REML/Laplace charge by default (still allowing `false` for historical A/B audits). (files: `crates/gam-pyffi/src/latent/latent_basis_and_sae_ffi.rs`, `crates/gam-pyffi/src/latent/latent_basis_and_sae_ffi_tail.rs`, `crates/gam-pyffi` -> inner call sites)
- Ensure the threaded switch is installed on the constructed `SaeManifoldTerm` before the joint fit so the Rust fit machinery actually uses the chosen evidence ledger. (file: `crates/gam-pyffi/src/latent/latent_basis_and_sae_ffi.rs`)
- Update a rank-charge off-path regression test to explicitly disable the switch when asserting the historical behavior, and remove an unused helper causing a deny-warning in lib-test builds. (files: `crates/gam-sae/src/manifold/tests_rank_charge_2101.rs`, `crates/gam-sae/src/manifold/tests_logdet_adjoint_780.rs`)

### Testing
- Ran `./build.sh check -p gam-pyffi --lib`, which completed successfully (exit 0).
- Ran `./build.sh check -p gam-sae --lib`, which completed successfully (exit 0).
- Ran `./build.sh test -p gam-sae --lib rank_charge -- --nocapture`, which passed: 11 passed, 0 failed (exit 0).
- Built the heavy SAE test binary with `./build.sh test -p gam-sae --test sae_ev_vs_k_1026 --no-run`, which succeeded (test binary built).
- I also ran `./build.sh test -p gam-sae --lib cocollapse_startup_frontier_1026 -- --nocapture` during iteration and observed an unrelated existing startup-frontier failure; that test failed in the environment (non-stationary REML smoothing optimization refusal) but the present changes do not alter that constructor path.

---
Refs #1893 (partial: Python dense-path default flip; producer/ISA + streaming-charge + throughput still open).

<details><summary>codex self-assessment</summary>

d. "}, {"content_type": "repo_file_citation", "path": "crates/gam-sae/src/manifold/tests_logdet_adjoint_780.rs", "line_range_start": 208, "line_range_end": 218}, {"content_type": "text", "text": "\n\n### SPEC COMPLIANCE\n\n* Added no wall-clock solver deadlines/time budgets.\n* Added no grid search.\n* Added no finite differences/autodiff production logic.\n* Added no hardcoded tuning threshold for acceptance; the change routes existing production Python calls to the already-derived realised-rank/MP evidence criterion.\n* Did not weaken, skip, ignore, or delete an existing test. The rank-charge regression still asserts the historical off-path behavior, but now explicitly sets the off-path switch before measuring it. "}, {"content_type": "repo_file_citation", "path": "crates/gam-sae/src/manifold/tests_rank_charge_2101.rs", "line_range_start": 134, "line_range_end": 149}, {"content_type": "text", "text": "\n\n### TEST EVIDENCE\n\n* \u2705 `./build.sh check -p gam-pyffi --lib`\n\n  ```text\n  [build.sh] check -p gam-pyffi --lib -> exit 0 in 162s (dedup=MISS, recompiled 2 crates)\n  ...\n  Finished `dev` profile [unoptimized + debuginfo] target(s) in 2m 40s\n  ```\n\n* \u2705 `./build.sh check -p gam-sae --lib`\n\n  ```text\n  [build.sh] check -p gam-sae --lib -> exit 0 in 26s (dedup=MISS, recompiled 0 crates)\n  ...\n  Finished `dev` profile [unoptimized + debuginfo] target(s) in 26.20s\n  ```\n\n* \u2705 `./build.sh test -p gam-sae --lib rank_charge -- --nocapture`\n\n  ```text\n  [build.sh] test -p gam-sae --lib rank_charge -- --nocapture -> exit 0 in 242s (dedup=MISS, recompiled 12 crates)\n  running 11 tests\n  ...\n  test result: ok. 11 passed; 0 failed; 0 ignored; 0 measured; 899 filtered out; finished in 17.33s\n  ```\n\n* \u2705 `./build.sh test -p gam-sae --test sae_ev_vs_k_1026 --no-run`\n\n  ```text\n  [build.sh] test -p gam-sae --test sae_ev_vs_k_1026 --no-run -> exit 0 in 215s (dedup=MISS, recompiled 1 crates)\n  Finished `test` profile [optimized + debuginfo] target(s) in 3m 34s\n  Executable tests/sae_ev_vs_k_1026.rs (target/debug/deps/sae_ev_vs_k_1026-b69c5228de6fc160)\n  ```\n\n* \u26a0\ufe0f `./build.sh test -p gam-sae --lib cocollapse_startup_frontier_1026 -- --nocapture`\n\n  ```text\n  [build.sh] test -p gam-sae --lib cocollapse_startup_frontier_1026 -- --nocapture -> exit 101 in 182s (dedup=MISS, recompiled 0 crates)\n  ...\n  startup validation must hold at least to K=4 (got frontier 0)\n  ```\n\n  I am reporting this because I ran it. It failed in the existing startup-frontier path with non-stationary REML smoothing optimization refusals; this change does not modify that Rust constructor default path after I reverted the attempted Rust-default flip.\n\n### CODE DIFF\n\nCommitted as:\n\n```text\nc9b0982 Default Python SAE fits to rank-charge evidence\n```\n\nStat:\n\n```text\n4 files changed, 67 insertions(+), 42 deletions(-)\n```\n\nKey changed files:\n\n* `crates/gam-pyffi/src/latent/latent_basis_and_sae_ffi.rs`\n* `crates/gam-pyffi/src/latent/latent_basis_and_sae_ffi_tail.rs`\n* `crates/gam-sae/src/manifold/tests_rank_charge_2101.rs`\n* `crates/gam-sae/src/manifold/tests_logdet_adjoint_780.rs`\n\n### SELF-ASSESSMENT\n\n* **SOLVES THE ISSUE? PARTIAL.** This makes the ordinary Python-facing SAE fit paths use the mechanism-correct realised-rank evidence ledger by default, which addresses a real structural cause of accepting vanishing/co-collapsed atoms from the user-facing surface. It does **not** prove the full #1893 acceptance benchmark (`K=2000`, real activations, p=48, `top_k=32`, wall-clock + EV target) is solved; I did not run that benchmark here.\n* **NET EFFECT: NET-GOOD.** The change aligns the production Python defaults with the derived REML/Laplace criterion already present in Rust and keeps an explicit historical A/B escape hatch. The main risk is behavioral: Python users now get the stricter rank-charge criterion by default, but that is the intended evidence accounting for this failure mode."}]
</details>

_Codex-generated; pending adversarial audit before merge._
