### PR TITLE
#2020: fix(torch): report ManifoldSAE routing amplitudes as magnitudes and default to linear encoder

### DIFF
--- a/gamfit/torch/manifold_sae.py
+++ b/gamfit/torch/manifold_sae.py
@@ -246,7 +246,11 @@ class ManifoldSAEConfig:
     sparsity: SparsityConfig = field(default_factory=SparsityConfig)
     decoder: DecoderConfig = field(default_factory=DecoderConfig)
     reml: RemlConfig = field(default_factory=RemlConfig)
-    encoder_hidden: int = 16
+    # Default to the direct linear encoder used by the closed-form/Rust SAE
+    # family. A positive value is an explicit opt-in to an extra nonlinear
+    # PyTorch-only mixer, which can reconstruct well while hiding feature
+    # presence from per-atom amplitudes in routing diagnostics.
+    encoder_hidden: int = 0
     init_scale: float = 0.05
     dtype: Any = field(default=None)
     # ``K`` is constructor sugar for ``n_atoms`` (the spelling the docs and the
@@ -1711,13 +1715,16 @@ class ManifoldSAE(nn.Module):
         reml_score = torch.tensor(float("nan"), dtype=x.dtype, device=x.device)
         lambdas = torch.exp(self.log_lambda).to(dtype=x.dtype, device=x.device)
 
-        # `amplitudes` is the magnitude the decoder actually used (== z), so a
-        # dropped atom reports zero, never its raw pre-mask activation.
+        # `z` is the signed coefficient used by reconstruction. `amplitudes`
+        # is the corresponding activation magnitude: in the multi-atom
+        # softmax-top-k lane a negative least-squares coefficient is phase/sign
+        # information, not feature absence, so routing diagnostics must observe
+        # |z| while reconstruction keeps the signed value.
         return ManifoldSAEOutput(
             z=z,
             x_hat=x_hat,
             positions=positions,
-            amplitudes=z,
+            amplitudes=z.abs(),
             curves=curves,
             gate=gate_pre,
             assignments=assignments,


### PR DESCRIPTION
### Motivation

- Tests showed routing diagnostics could report near-zero Pearson correlations even when an atom was selected because `ManifoldSAEOutput.amplitudes` exposed the signed least-squares coefficient used for reconstruction instead of its magnitude, causing sign cancellation on phase-varying atoms. 
- The torch wrapper default `encoder_hidden=16` introduced a PyTorch-only nonlinear mixer that diverged the backprop-only lane from the direct linear encoder the closed-form/Rust SAE family expects, so default training dynamics differed from the closed-form contract.

### Description

- Change the `ManifoldSAEConfig` default `encoder_hidden` from `16` to `0` and add a comment explaining that positive values are an explicit opt-in to a PyTorch-only nonlinear mixer. (file: `gamfit/torch/manifold_sae.py`)
- Keep the signed reconstruction coefficients in `z` for use in `x_hat`, but expose activation magnitudes as `ManifoldSAEOutput.amplitudes = z.abs()`, so routing diagnostics observe magnitude rather than sign. (file: `gamfit/torch/manifold_sae.py`)

### Testing

- Built and installed the Python/Rust wheel with `maturin develop`, which completed successfully and produced an editable install of `gamfit`.
- Ran the torch routing regression suite via pytest: `pytest tests/torch/test_manifold_sae_backprop_routing_issue_583.py` and the focused routing test `::test_backprop_topk_learns_nondegenerate_routing`, both of which passed (all relevant routing tests green).
- Ran the joint-fit matrix regression `pytest tests/torch/test_manifold_sae_fit_config_matrix_issue_356.py` and observed a remaining Rust solver refusal (dictionary co-collapse after reseed multi-starts) which is a genuine solver/runtime failure and was not suppressed or papered over by this change.

---
Refs #2020 (partial — routing group only; the #356 solver co-collapse group remains open).

<details><summary>codex self-assessment</summary>

.98s (0:08:56)\n  ```\n\n* \u2705 `.venv/bin/python -m pytest -q tests/torch/test_manifold_sae_backprop_routing_issue_583.py::test_backprop_topk_learns_nondegenerate_routing`\n\n  Passing-after output:\n\n  ```text\n  .                                                                        [100%]\n  1 passed in 175.10s (0:02:55)\n  ```\n\n* \u274c `.venv/bin/python -m pytest -vv -x tests/torch/test_manifold_sae_fit_config_matrix_issue_356.py::test_fit_joint_solve_does_not_panic_across_configs --tb=short`\n\n  This still fails, but with a Rust solver co-collapse refusal, not the original ragged `decoder_blocks` symptom. I did not paper over this because doing so would violate the issue\u2019s explicit solver-forbidden list.\n\n  Relevant output:\n\n  ```text\n  tests/torch/test_manifold_sae_fit_config_matrix_issue_356.py::test_fit_joint_solve_does_not_panic_across_configs[circle-1-sparsity0] FAILED [ 25%]\n\n  E   gamfit._rust.GamError: SaeManifoldTerm::run_joint_fit_arrow_schur: dictionary did not escape total co-collapse after 3 reseed multi-starts (reconstruction EV=0.0646 at or below the signal-free null floor 0.2500); every atom's decoder co-vanished and no residual structure could anchor K=8 distinct charts for this input [mu_hat_max=0.9990, decoder_norms=[0.9067, 1.2347, 1.8001, 2.1292, 2.6741, 2.8838, 1.4854, 10.5448]]. Refusing to continue the degenerate fit. Try fewer atoms (a smaller K), a different atom_topology/assignment, more observations, or a different random_state.\n\n  =========================== short test summary info ============================\n  FAILED tests/torch/test_manifold_sae_fit_config_matrix_issue_356.py::test_fit_joint_solve_does_not_panic_across_configs[circle-1-sparsity0] - gamfit._rust.GamError: SaeManifoldTerm::run_joint_fit_arrow_schur: dictionary did not escape total co-collapse after 3 reseed multi-starts (reconstruction EV=0.0646 at or below the signal-free null floor 0.2500); every atom's decoder co-vanished and no residual structure could anchor K=8 distinct charts for this input [mu_hat_max=0.9990, decoder_norms=[0.9067, 1.2347, 1.8001, 2.1292, 2.6741, 2.8838, 1.4854, 10.5448]]. Refusing to continue the degenerate fit. Try fewer atoms (a smaller K), a different atom_topology/assignment, more observations, or a different random_state.\n  !!!!!!!!!!!!!!!!!!!!!!!!!! stopping after 1 failures !!!!!!!!!!!!!!!!!!!!!!!!!!!\n  ========================= 1 failed in 71.03s (0:01:11) =========================\n  ```\n\n## CODE DIFF\n\n```diff\ndiff --git a/gamfit/torch/manifold_sae.py b/gamfit/torch/manifold_sae.py\nindex d9ae259..901265a 100644\n--- a/gamfit/torch/manifold_sae.py\n+++ b/gamfit/torch/manifold_sae.py\n@@ -246,7 +246,11 @@ class ManifoldSAEConfig:\n     sparsity: SparsityConfig = field(default_factory=SparsityConfig)\n     decoder: DecoderConfig = field(default_factory=DecoderConfig)\n     reml: RemlConfig = field(default_factory=RemlConfig)\n-    encoder_hidden: int = 16\n+    # Default to the direct linear encoder used by the closed-form/Rust SAE\n+    # family. A positive value is an explicit opt-in to an extra nonlinear\n+    # PyTorch-only mixer, which can reconstruct well while hiding feature\n+    # presence from per-atom amplitudes in routing diagnostics.\n+    encoder_hidden: int = 0\n     init_scale: float = 0.05\n     dtype: Any = field(default=None)\n     # ``K`` is constructor sugar for ``n_atoms`` (the spelling the docs and the\n@@ -1711,13 +1715,16 @@ class ManifoldSAE(nn.Module):\n         reml_score = torch.tensor(float(\"nan\"), dtype=x.dtype, device=x.device)\n         lambdas = torch.exp(self.log_lambda).to(dtype=x.dtype, device=x.device)\n \n-        # `amplitudes` is the magnitude the decoder actually used (== z), so a\n-        # dropped atom reports zero, never its raw pre-mask activation.\n+        # `z` is the signed coefficient used by reconstruction. `amplitudes`\n+        # is the corresponding activation magnitude: in the multi-atom\n+        # softm
</details>

_Codex-generated; pending adversarial audit before merge._
