### PR TITLE
#2021: add per-pass structured-residual diagnostics (opt-in; default-on deferred to #2080)

### DIFF
--- a/crates/gam-pyffi/src/latent/latent_basis_and_sae_ffi.rs
+++ b/crates/gam-pyffi/src/latent/latent_basis_and_sae_ffi.rs
@@ -2179,6 +2179,45 @@ fn metric_provenance_label(
     }
 }
 
+#[derive(Clone, Debug)]
+struct StructuredResidualPassDiagnostic {
+    pass: usize,
+    gamma: f64,
+    factor_rank: usize,
+    log_evidence: f64,
+    factor_energy: f64,
+    diagonal_mean: f64,
+    dispersion_before: f64,
+    dispersion_after: f64,
+    log_lambda_smooth_before: Vec<f64>,
+    log_lambda_smooth_after: Vec<f64>,
+}
+
+fn structured_residual_pass_diagnostics_dict<'py>(
+    py: Python<'py>,
+    diagnostics: &[StructuredResidualPassDiagnostic],
+) -> PyResult<Bound<'py, PyList>> {
+    let out = PyList::empty(py);
+    for d in diagnostics {
+        let item = PyDict::new(py);
+        item.set_item("pass", d.pass)?;
+        item.set_item("gamma", d.gamma)?;
+        item.set_item("factor_rank", d.factor_rank)?;
+        item.set_item("log_evidence", d.log_evidence)?;
+        item.set_item("factor_energy", d.factor_energy)?;
+        item.set_item("diagonal_mean", d.diagonal_mean)?;
+        item.set_item("dispersion_before", d.dispersion_before)?;
+        item.set_item("dispersion_after", d.dispersion_after)?;
+        item.set_item(
+            "log_lambda_smooth_before",
+            d.log_lambda_smooth_before.clone(),
+        )?;
+        item.set_item("log_lambda_smooth_after", d.log_lambda_smooth_after.clone())?;
+        out.append(item)?;
+    }
+    Ok(out)
+}
+
 /// #2021 — ceiling on the number of EXTRA whitened-residual refit passes the
 /// structured-residual outer alternation will run after the iid pass-0 fit. The
 /// caller-supplied `structured_residual_passes` kwarg is clamped to this so a
@@ -2286,7 +2325,7 @@ fn sae_structured_residual_model(
     row_loss_weights = None,
     separation_barrier_strength_override = None,
     ibp_alpha_override = None,
-    structured_residual_passes = 0,
+    structured_residual_passes = 1,
     promote_from_residual = false,
     run_structure_search = true,
     run_outer_rho_search = true,
@@ -2836,7 +2875,16 @@ fn sae_manifold_fit_stagewise<'py>(
     // `detach`) and already re-enters Python (raising there) each event.
     let cancel_flag = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
     let result = match progress_hook {
-        Some(hook) => gam::terms::sae::manifold::fit_stagewise(base_term, init_rho, z_view, None, weights.as_deref(), &config, Some(hook), None),
+        Some(hook) => gam::terms::sae::manifold::fit_stagewise(
+            base_term,
+            init_rho,
+            z_view,
+            None,
+            weights.as_deref(),
+            &config,
+            Some(hook),
+            None,
+        ),
         None => {
             // The worker thread is `'static`, but `z_view` borrows the (Python)
             // numpy buffer — own the target so nothing non-`'static` crosses in
@@ -2844,7 +2892,16 @@ fn sae_manifold_fit_stagewise<'py>(
             let target_owned = z_view.to_owned();
             let worker_cancel = std::sync::Arc::clone(&cancel_flag);
             run_sae_fit_interruptible(py, "gam-sae-stagewise", &cancel_flag, move || {
-                gam::terms::sae::manifold::fit_stagewise(base_term, init_rho, target_owned.view(), None, weights.as_deref(), &config, None, Some(&*worker_cancel))
+                gam::terms::sae::manifold::fit_stagewise(
+                    base_term,
+                    init_rho,
+                    target_owned.view(),
+                    None,
+                    weights.as_deref(),
+                    &config,
+                    None,
+                    Some(&*worker_cancel),
+                )
             })?
         }
     }
@@ -3472,23 +3529,24 @@ fn sae_manifold_fit_inner<'py>(
     // (the objective bails out of its next outer eval).
     let cancel_flag = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
     objective.set_cancel_flag(std::sync::Arc::clone(&cancel_flag));
-    let (mut objective, run_result) = run_sae_fit_interruptible(py, "gam-sae-fit", &cancel_flag, move || {
-        let run_result = if run_outer_rho_search {
-            let problem = gam::solver::rho_optimizer::OuterProblem::new(n_params)
-                .with_initial_rho(init_rho_flat.clone())
-                .with_seed_config(gam::solver::seeding::SeedConfig {
-                    max_seeds: 1,
-                    seed_budget: 1,
-                    ..Default::default()
-                });
-            problem.run(&mut objective, "SAE manifold").map(|_| ())
-        } else {
-            objective
-                .fit_at_fixed_rho(init_rho_flat.view())
-                .map_err(gam::model_types::EstimationError::RemlOptimizationFailed)
-        };
-        (objective, run_result)
-    })?;
+    let (mut objective, run_result) =
+        run_sae_fit_interruptible(py, "gam-sae-fit", &cancel_flag, move || {
+            let run_result = if run_outer_rho_search {
+                let problem = gam::solver::rho_optimizer::OuterProblem::new(n_params)
+                    .with_initial_rho(init_rho_flat.clone())
+                    .with_seed_config(gam::solver::seeding::SeedConfig {
+                        max_seeds: 1,
+                        seed_budget: 1,
+                        ..Default::default()
+                    });
+                problem.run(&mut objective, "SAE manifold").map(|_| ())
+            } else {
+                objective
+                    .fit_at_fixed_rho(init_rho_flat.view())
+                    .map_err(gam::model_types::EstimationError::RemlOptimizationFailed)
+            };
+            (objective, run_result)
+        })?;
     run_result.map_err(estimation_error_to_pyerr)?;
     // Posterior shape uncertainty: per-atom φ-scaled decoder covariance and
     // ambient bands, read off the converged joint-Hessian Schur factor at the
@@ -3526,6 +3584,7 @@ fn sae_manifold_fit_inner<'py>(
     // damping the early jump off the iid fit (γ is never 0 or 1, so every pass
     // builds a genuine WhitenedStructured blend).
     let structured_passes = structured_residual_passes.min(STRUCTURED_RESIDUAL_PASSES_MAX);
+    let mut structured_residual_diagnostics: Vec<StructuredResidualPassDiagnostic> = Vec::new();
     if structured_passes > 0 && metric_provenance == "Euclidean" {
         let mut prev_model: Option<gam::inference::residual_factor::StructuredResidualModel> = None;
         // #2021 Λ nursery→promotion (evidence-gated). Accumulate residual-factor
@@ -3585,6 +3644,10 @@ fn sae_manifold_fit_inner<'py>(
                 .row_metric_damped(n_obs, gamma, prev_model.as_ref())
                 .map_err(py_value_error)?;
             let installed_label = metric_provenance_label(metric.provenance());
+            let factor_energy = model.factor().iter().map(|v| v * v).sum::<f64>();
+            let diagonal_mean = model.diagonal().iter().copied().sum::<f64>() / p_out as f64;
+            let dispersion_before = shape_uncertainty.dispersion;
+            let log_lambda_smooth_before = rho.log_lambda_smooth.clone();
             term.set_row_metric(metric).map_err(py_value_error)?;
             // Rebuild the analytic-penalty registry (cheap; `latent_payload` is
             // still owned) and warm-start ρ from the settled fit.
@@ -3619,7 +3682,9 @@ fn sae_manifold_fit_inner<'py>(
             objective.set_cancel_flag(std::sync::Arc::clone(&cancel_flag));
             let (mut objective, run_result) =
                 run_sae_fit_interruptible(py, "gam-sae-fit-structured", &cancel_flag, move || {
-                    let run_result = problem.run(&mut objective, "SAE manifold (structured)").map(|_| ());
+                    let run_result = problem
+                        .run(&mut objective, "SAE manifold (structured)")
+                        .map(|_| ());
                     (objective, run_result)
                 })?;
             run_result.map_err(estimation_error_to_pyerr)?;
@@ -3634,6 +3699,18 @@ fn sae_manifold_fit_inner<'py>(
             term = fitted_result.term;
             rho = fitted_result.rho;
             loss = fitted_result.loss;
+            structured_residual_diagnostics.push(StructuredResidualPassDiagnostic {
+                pass: pass + 1,
+                gamma,
+                factor_rank: model.factor_rank(),
+                log_evidence: model.log_evidence(),
+                factor_energy,
+                diagonal_mean,
+                dispersion_before,
+                dispersion_after: shape_uncertainty.dispersion,
+                log_lambda_smooth_before,
+                log_lambda_smooth_after: rho.log_lambda_smooth.clone(),
+            });
             // Report the geometry actually used by the returned fit.
             metric_provenance = installed_label;
             // #2021 promotion: fold this pass's persisted factor directions into
@@ -4266,6 +4343,10 @@ fn sae_manifold_fit_inner<'py>(
     // "Euclidean" (no shard, bit-identical isotropic path) or "OutputFisher"
     // (a WP-D shard was supplied and `RowMetric::OutputFisher` was installed).
     out.set_item("metric_provenance", metric_provenance)?;
+    out.set_item(
+        "structured_residual_diagnostics",
+        structured_residual_pass_diagnostics_dict(py, &structured_residual_diagnostics)?,
+    )?;
     // Truncation diagnostic: per-row output-Fisher mass `trace(G_n) − Σ_{k≤r} λ_k`
     // that fell off the captured rank-r subspace. Surfaced so a too-small rank is
     // visible, not silent. Present only when a Fisher shard with a mass_residual
@@ -4366,7 +4447,9 @@ fn sae_manifold_fit_inner<'py>(
             );
         ledger.record(&coordinate_fidelity_certificate);
         let topology_persistence_certificate =
-            gam::terms::sae::manifold::TopologyPersistenceCertificate::new(&fit_diagnostics.topology_persistence);
+            gam::terms::sae::manifold::TopologyPersistenceCertificate::new(
+                &fit_diagnostics.topology_persistence,
+            );
         ledger.record(&topology_persistence_certificate);
         if let Some(report) = &fit_diagnostics.incoherence_report {
             ledger.record(report);

--- a/crates/gam-pyffi/src/latent/latent_basis_and_sae_ffi.rs
+++ b/crates/gam-pyffi/src/latent/latent_basis_and_sae_ffi.rs
@@ -2325,7 +2325,7 @@ fn sae_structured_residual_model(
     row_loss_weights = None,
     separation_barrier_strength_override = None,
     ibp_alpha_override = None,
-    structured_residual_passes = 1,
+    structured_residual_passes = 0,
     promote_from_residual = false,
     run_structure_search = true,
     run_outer_rho_search = true,

--- a/crates/gam-pyffi/src/latent/latent_basis_and_sae_ffi_tail.rs
+++ b/crates/gam-pyffi/src/latent/latent_basis_and_sae_ffi_tail.rs
@@ -243,7 +243,7 @@ fn sae_build_atom_plans(
     row_loss_weights = None,
     separation_barrier_strength_override = None,
     ibp_alpha_override = None,
-    structured_residual_passes = 1,
+    structured_residual_passes = 0,
     promote_from_residual = false,
     run_structure_search = true,
     run_outer_rho_search = true,

--- a/crates/gam-pyffi/src/latent/latent_basis_and_sae_ffi_tail.rs
+++ b/crates/gam-pyffi/src/latent/latent_basis_and_sae_ffi_tail.rs
@@ -243,7 +243,7 @@ fn sae_build_atom_plans(
     row_loss_weights = None,
     separation_barrier_strength_override = None,
     ibp_alpha_override = None,
-    structured_residual_passes = 0,
+    structured_residual_passes = 1,
     promote_from_residual = false,
     run_structure_search = true,
     run_outer_rho_search = true,

--- a/gamfit/_sae_manifold.py
+++ b/gamfit/_sae_manifold.py
@@ -2437,7 +2437,7 @@ def sae_manifold_fit(X: Any = None, K: int | None = None, d_atom: int = 2, atom_
                      weights: Any = None,
                      separation_barrier_strength: float | None = None,
                      ibp_alpha: float | None = None,
-                     structured_residual_passes: int = 1,
+                     structured_residual_passes: int = 0,
                      promote_from_residual: bool = False,
                      _run_structure_search: bool = True,
                      _run_outer_rho_search: bool = True) -> ManifoldSAE:
@@ -2562,12 +2562,13 @@ def sae_manifold_fit(X: Any = None, K: int | None = None, d_atom: int = 2, atom_
         or the global ``sae_set_ibp_alpha`` setter still overrides it.
     structured_residual_passes
         Number of structured-residual sculpting passes run after the primary
-        joint fit. Defaults to ``1`` (on for the production iid→structured refit). Each
-        pass fits the current reconstruction residual and folds the recovered structure back into the
+        joint fit. Defaults to ``0`` (off). Each pass fits the current
+        reconstruction residual and folds the recovered structure back into the
         atom dictionary. Must be a non-negative int; the native core clamps the
         effective count to ``STRUCTURED_RESIDUAL_PASSES_MAX`` (currently ``4``),
-        so larger values behave like ``4``. Pass ``0`` explicitly to recover the
-        pre-#2021 iid-only behavior.
+        so larger values behave like ``4``. An explicit, typed opt-in — with the
+        default ``0`` the fit is bit-identical to the pre-existing behavior. The
+        default-on iid→structured refit is deferred to #2080.
     promote_from_residual
         When ``True`` (default ``False``), atoms discovered in the structured
         residual passes are promoted into the primary atom tier rather than kept

--- a/gamfit/_sae_manifold.py
+++ b/gamfit/_sae_manifold.py
@@ -706,6 +706,10 @@ class ManifoldSAE:
     # rank-r subspace. ``None`` when no shard (or no mass_residual) was supplied.
     # Surfaced so a too-small rank ``r`` is visible, not silent.
     fisher_mass_residual: np.ndarray | None = None
+    # Per-pass iid→structured residual alternation diagnostics (#2021): each
+    # entry records λ̂ and φ̂ before/after installing the WhitenedStructured
+    # likelihood, plus the selected residual-factor rank/evidence.
+    structured_residual_diagnostics: list[dict[str, Any]] | None = None
     # Additive two-score per-atom lens (#980): for each atom, ``presence``
     # (representational, activation-side, Fisher-free), ``coupling`` (behavioral
     # output-Fisher mass; ``NaN`` under a Euclidean / no-harvest provenance), and
@@ -1088,6 +1092,9 @@ class ManifoldSAE:
                 if payload.get("fisher_mass_residual") is None
                 else np.asarray(payload["fisher_mass_residual"], dtype=float)
             ),
+            structured_residual_diagnostics=[
+                dict(item) for item in payload.get("structured_residual_diagnostics", [])
+            ],
             # Additive post-fit diagnostics: the two-score per-atom lens,
             # residual-gauge certificate, and empirical incoherence inputs.
             # Absent ⇒ ``None`` (payloads predating each diagnostic); present
@@ -2377,6 +2384,9 @@ class ManifoldSAE:
                 if payload.get("fisher_mass_residual") is None
                 else np.asarray(payload["fisher_mass_residual"], dtype=float)
             ),
+            structured_residual_diagnostics=[
+                dict(item) for item in payload.get("structured_residual_diagnostics", [])
+            ],
         )
 
     @classmethod
@@ -2427,7 +2437,7 @@ def sae_manifold_fit(X: Any = None, K: int | None = None, d_atom: int = 2, atom_
                      weights: Any = None,
                      separation_barrier_strength: float | None = None,
                      ibp_alpha: float | None = None,
-                     structured_residual_passes: int = 0,
+                     structured_residual_passes: int = 1,
                      promote_from_residual: bool = False,
                      _run_structure_search: bool = True,
                      _run_outer_rho_search: bool = True) -> ManifoldSAE:
@@ -2552,12 +2562,12 @@ def sae_manifold_fit(X: Any = None, K: int | None = None, d_atom: int = 2, atom_
         or the global ``sae_set_ibp_alpha`` setter still overrides it.
     structured_residual_passes
         Number of structured-residual sculpting passes run after the primary
-        joint fit. Defaults to ``0`` (off). Each pass fits the current
-        reconstruction residual and folds the recovered structure back into the
+        joint fit. Defaults to ``1`` (on for the production iid→structured refit). Each
+        pass fits the current reconstruction residual and folds the recovered structure back into the
         atom dictionary. Must be a non-negative int; the native core clamps the
         effective count to ``STRUCTURED_RESIDUAL_PASSES_MAX`` (currently ``4``),
-        so larger values behave like ``4``. An explicit, typed opt-in — with the
-        default ``0`` the fit is bit-identical to the pre-existing behavior.
+        so larger values behave like ``4``. Pass ``0`` explicitly to recover the
+        pre-#2021 iid-only behavior.
     promote_from_residual
         When ``True`` (default ``False``), atoms discovered in the structured
         residual passes are promoted into the primary atom tier rather than kept


### PR DESCRIPTION
### Motivation
The structured-residual covariance fitter and WhitenedStructured RowMetric existed but were not observable in production. This PR wires per-pass diagnostics through the SAE outer fit so the iid→structured whitening effect is auditable when opted into.

### Description
- Add a Rust `StructuredResidualPassDiagnostic` and collect per-pass diagnostics (pass index, damping γ, selected factor rank and evidence, factor energy, diagonal mean, dispersion before/after, and `log_lambda_smooth` before/after) during the structured refit alternation.
- Round-trip the diagnostics into the Python `ManifoldSAE` payload as `structured_residual_diagnostics`.
- `structured_residual_passes` remains **default `0` (off / opt-in)**. The WhitenedStructured refit is engaged only when a caller explicitly requests one or more passes.

### Salvage note (panel review)
The original codex PR flipped the `structured_residual_passes` default `0→1`, turning WhitenedStructured on by default. That default-on change was reverted: the issue owner explicitly gated default-on behind #2080 (outer rho-search hang at p≈96, still OPEN), codex's own run hung, and SPEC requires defaults to recover the null (opt-IN to added structure). The diagnostics are kept; only the default flip was reverted.

---
Refs #2021 (wiring/diagnostics landed; default-on iid→structured refit deferred to #2080).