### PR TITLE
#2154: test: assert survival CSV writer returns output path

### DIFF
--- a/tests/bug_hunt_survival_write_survival_at_csv_crashes_test.py
+++ b/tests/bug_hunt_survival_write_survival_at_csv_crashes_test.py
@@ -99,6 +99,7 @@ def test_write_survival_at_csv_emits_valid_csv() -> None:
     out_path = Path(tempfile.mkdtemp()) / "survival_at.csv"
     returned = pred.write_survival_at_csv(str(out_path), query_times)
 
+    assert returned == str(out_path)
     assert out_path.exists() and out_path.stat().st_size > 0, (
         "write_survival_at_csv must create a non-empty CSV; "
         f"returned={returned!r}"


### PR DESCRIPTION
### Motivation
- Tighten the regression test for `SurvivalPrediction.write_survival_at_csv` to assert the method returns the path it wrote in addition to producing a non-empty CSV that matches `survival_at`.

### Description
- Add an assertion `assert returned == str(out_path)` to `tests/bug_hunt_survival_write_survival_at_csv_crashes_test.py` so the public API return contract is explicitly enforced.

### Testing
- Ran `./build.sh` which completed successfully (dev build finished). 
- Ran `./build.sh check -p gam-pyffi --lib` which succeeded without recompilation.
- Ran the targeted Python tests via `uv run --extra test pytest -q tests/bug_hunt_survival_write_survival_at_csv_crashes_test.py tests/test_python_api.py::test_survival_prediction_write_csv_matches_survival_at_at_extrapolation_edges` and observed `2 passed, 1 warning`.
- Attempts to run `maturin develop` failed because `maturin` was not available in the environment, and `./build.sh test -p gam-pyffi --lib --no-run` hit an OOM/timeout in this environment and was not completed.

---
Fixes #2154.

<details><summary>codex self-assessment</summary>

utput:\n  ```text\n  [build.sh] check -p gam-pyffi --lib -> exit 0 in 0s (dedup=SUBSUMED, recompiled 0 crates)\n  ```\n\n* \u26a0\ufe0f `maturin develop`\n\n  Output:\n  ```text\n  /bin/bash: line 1: maturin: command not found\n  ```\n\n* \u26a0\ufe0f `uv run maturin develop`\n\n  Output:\n  ```text\n     Building gamfit @ file:///workspace/gam\n        Built gamfit @ file:///workspace/gam\n  Installed 2 packages in 24ms\n  error: Failed to spawn: `maturin`\n    Caused by: No such file or directory (os error 2)\n  ```\n\n  This built and installed the local package through uv\u2019s PEP517 path, then failed because the `maturin` executable itself was not present as a spawned command in that uv environment.\n\n* \u26a0\ufe0f `uv run pytest -q tests/bug_hunt_survival_write_survival_at_csv_crashes_test.py tests/test_python_api.py::test_survival_prediction_write_csv_matches_survival_at_at_extrapolation_edges`\n\n  Output before installing test extras:\n  ```text\n  ImportError while loading conftest '/workspace/gam/tests/conftest.py'.\n  tests/conftest.py:10: in <module>\n      import numpy as np\n  E   ModuleNotFoundError: No module named 'numpy'\n  ```\n\n* \u2705 `uv run --extra test pytest -q tests/bug_hunt_survival_write_survival_at_csv_crashes_test.py tests/test_python_api.py::test_survival_prediction_write_csv_matches_survival_at_at_extrapolation_edges`\n\n  Output:\n  ```text\n  Downloading scipy (33.6MiB)\n  Downloading pyarrow (46.6MiB)\n  Downloading kiwisolver (1.4MiB)\n  Downloading fonttools (4.8MiB)\n  Downloading pandas (10.4MiB)\n  Downloading scikit-learn (8.5MiB)\n  Downloading pillow (6.8MiB)\n  Downloading matplotlib (8.4MiB)\n  Downloading pygments (1.2MiB)\n   Downloading kiwisolver\n   Downloading pillow\n   Downloading pygments\n   Downloading fonttools\n   Downloading matplotlib\n   Downloading scikit-learn\n   Downloading pandas\n   Downloading pyarrow\n   Downloading scipy\n  Installed 20 packages in 75ms\n  ..                                                                       [100%]\n  =============================== warnings summary ===============================\n  tests/bug_hunt_survival_write_survival_at_csv_crashes_test.py::test_write_survival_at_csv_emits_valid_csv\n    /workspace/gam/gamfit/_api.py:660: GamInferenceWarning: Automatically set 8 internal knots for smooth 'x' from 300 unique values (rule: clamp(unique/4, 4..max(20, cbrt(unique))) = clamp(unique/4, 4..20)). Override with knots=... or k=....\n      return fn(*args, **kwargs)\n\n  -- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html\n  2 passed, 1 warning in 19.38s\n  ```\n\n* \u26a0\ufe0f `./build.sh test -p gam-pyffi --lib --no-run`\n\n  Output:\n  ```text\n  [build.sh] transient failure (OOM/timeout, exit 124) attempt 1/3 \u2014 retrying with CARGO_BUILD_JOBS=1 (lower peak RAM)\u2026\n  Terminated\n  [build.sh] transient failure (OOM/timeout, exit 143) attempt 2/3 \u2014 backing off for memory, retrying\u2026\n  Terminated\n  ```\n\n  This was manually terminated after the first 30-minute timeout and the retry had started, to avoid another long compile cycle in this environment.\n\n## CODE DIFF\n\n```diff\ndiff --git a/tests/bug_hunt_survival_write_survival_at_csv_crashes_test.py b/tests/bug_hunt_survival_write_survival_at_csv_crashes_test.py\nindex 856fe56..1abd82b 100644\n--- a/tests/bug_hunt_survival_write_survival_at_csv_crashes_test.py\n+++ b/tests/bug_hunt_survival_write_survival_at_csv_crashes_test.py\n@@ -99,6 +99,7 @@ def test_write_survival_at_csv_emits_valid_csv() -> None:\n     out_path = Path(tempfile.mkdtemp()) / \"survival_at.csv\"\n     returned = pred.write_survival_at_csv(str(out_path), query_times)\n \n+    assert returned == str(out_path)\n     assert out_path.exists() and out_path.stat().st_size > 0, (\n         \"write_survival_at_csv must create a non-empty CSV; \"\n         f\"returned={returned!r}\"\n```\n\n## COMMIT / PR\n\n* Committed on the current branch:\n  ```text\n  50dd3da tes
</details>

_Codex-generated; pending adversarial audit before merge._