### PR TITLE
#979: Avoid redundant outer-gradient assembly during continuation pre-warm (refs #979)

### DIFF
--- a/crates/gam-solve/src/continuation_path.rs
+++ b/crates/gam-solve/src/continuation_path.rs
@@ -869,11 +869,19 @@ impl ContinuationPath {
         let spine = match self.warm.clone() {
             Some(start) => {
                 self.evals_budgeted += WARM_LEG_EVAL_BUDGET;
+                // The coupled path is still a continuation pre-warm: its only
+                // payload is the converged inner coefficient state carried by
+                // `inner_beta_hint`.  Requesting an outer gradient here repeats
+                // the expensive REML/LAML derivative assembly at every waypoint
+                // even though no line search or stationarity test consumes it;
+                // the real outer optimizer asks for the gradient once after the
+                // path arrives.  `Value` preserves the same inner solve and warm
+                // beta propagation while removing that redundant derivative work.
                 continue_path_from(
                     obj,
                     start,
                     &rho_target,
-                    OuterEvalOrder::ValueAndGradient,
+                    OuterEvalOrder::Value,
                     WARM_LEG_EVAL_BUDGET,
                 )
             }
@@ -884,7 +892,7 @@ impl ContinuationPath {
                     &rho_target,
                     &self.schedules.rho_bounds_upper,
                     initial_beta,
-                    OuterEvalOrder::ValueAndGradient,
+                    OuterEvalOrder::Value,
                 )
             }
         };
@@ -1354,6 +1362,98 @@ mod tests {
         assert_eq!(PathRegime::from_s(0.5), PathRegime::Annealing);
         assert_eq!(PathRegime::from_s(0.9), PathRegime::Heavy);
         assert_eq!(PathRegime::from_s(1.0), PathRegime::Heavy);
+    }
+
+
+    #[derive(Default)]
+    struct RecordingObjective {
+        orders: Vec<OuterEvalOrder>,
+        seed_count: usize,
+    }
+
+    impl OuterObjective for RecordingObjective {
+        fn capability(&self) -> crate::rho_optimizer::OuterCapability {
+            crate::rho_optimizer::OuterCapability {
+                gradient: gam_problem::Derivative::Analytic,
+                hessian: crate::rho_optimizer::DeclaredHessianForm::Unavailable,
+                n_params: 2,
+                psi_dim: 0,
+                fixed_point_available: false,
+                barrier_config: None,
+                prefer_gradient_only: false,
+                disable_fixed_point: false,
+            }
+        }
+
+        fn eval_cost(
+            &mut self,
+            rho: &Array1<f64>,
+        ) -> Result<f64, crate::model_types::EstimationError> {
+            Ok(rho.iter().map(|v| v * v).sum())
+        }
+
+        fn eval(
+            &mut self,
+            rho: &Array1<f64>,
+        ) -> Result<gam_problem::OuterEval, crate::model_types::EstimationError> {
+            Ok(gam_problem::OuterEval {
+                cost: self.eval_cost(rho)?,
+                gradient: Array1::zeros(rho.len()),
+                hessian: gam_problem::HessianResult::Unavailable,
+                inner_beta_hint: Some(Array1::from_vec(vec![1.0, self.seed_count as f64])),
+            })
+        }
+
+        fn eval_with_order(
+            &mut self,
+            rho: &Array1<f64>,
+            order: OuterEvalOrder,
+        ) -> Result<gam_problem::OuterEval, crate::model_types::EstimationError> {
+            self.orders.push(order);
+            let mut eval = self.eval(rho)?;
+            if matches!(order, OuterEvalOrder::Value) {
+                eval.gradient = Array1::zeros(0);
+                eval.hessian = gam_problem::HessianResult::Unavailable;
+            }
+            Ok(eval)
+        }
+
+        fn reset(&mut self) {}
+
+        fn seed_inner_state(
+            &mut self,
+            beta: &Array1<f64>,
+        ) -> Result<crate::rho_optimizer::SeedOutcome, crate::model_types::EstimationError> {
+            self.seed_count += beta.len().max(1);
+            Ok(crate::rho_optimizer::SeedOutcome::Installed)
+        }
+    }
+
+    #[test]
+    fn coupled_path_prewarm_requests_value_only_evals() {
+        let mut path = ContinuationPath::enter(schedules());
+        let mut obj = RecordingObjective::default();
+        let initial_beta = Array1::zeros(0);
+
+        let step = path.step(&mut obj, &initial_beta);
+        assert!(
+            matches!(
+                step,
+                ContinuationStep::Descended { .. } | ContinuationStep::Arrived { .. }
+            ),
+            "recording objective should accept the first coupled-path waypoint"
+        );
+        assert!(
+            !obj.orders.is_empty(),
+            "the coupled path should evaluate at least one rho waypoint"
+        );
+        assert!(
+            obj.orders
+                .iter()
+                .all(|order| matches!(order, OuterEvalOrder::Value)),
+            "coupled continuation pre-warm must not request outer gradients: {:?}",
+            obj.orders
+        );
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- Continuation pre-warm for coupled marginal-slope fits was requesting full outer derivatives at every waypoint even though the pre-warm only needs the warmed inner coefficient state (`inner_beta_hint`), which dominated startup cost and caused the binary slowdown / survival hang symptom. 
- The change aims to remove that redundant derivative work so continuation forwards the same inner β while deferring gradient/Hessian assembly until the real outer optimizer requests it.

### Description
- Route coupled continuation pre-warm evaluations through `OuterEvalOrder::Value` instead of `ValueAndGradient` for both warm legs and the initial cold spine, removing repeated REML/LAML gradient assembly during the path (`crates/gam-solve/src/continuation_path.rs`).
- Add a regression test (in `continuation_path.rs` tests) that injects a `RecordingObjective` and asserts the coupled continuation pre-warm only requests `OuterEvalOrder::Value` to prevent regression.
- Add clarifying comments documenting why the pre-warm is value-only and how it preserves inner-solve/warm-beta propagation.

### Testing
- Built the workspace with `./build.sh` and `./build.sh check -p gam-solve --lib`, both succeeded.
- Ran outer-test scaffolding with `./build.sh test --test regressions --no-run`, which completed successfully.
- Ran the new unit test suite with `./build.sh test -p gam-solve continuation_path::tests:: -- --nocapture`, all tests passed.
- Reproducer/regression `margslope_matern_logslope_timing` was executed with `./build.sh test --test regressions margslope_matern_logslope_timing -- --nocapture` and the test passed, showing the pre-warm is now cheap and the fit completes (printed timing and converged=true).

---
Refs #979 (perf sub-item only — removes redundant pre-warm derivative assembly; the disarmed-deadline genuine-convergence root cause `survival_marginal_slope_converges_with_deadline_disarmed_979` remains open, so this must NOT auto-close the epic).

<details><summary>codex self-assessment</summary>

es)\n  running 14 tests\n  test continuation_path::tests::active_mass_floor_breach_is_recorded_never_fatal ... ok\n  test continuation_path::tests::bare_active_mass_breach_records_and_reenters ... ok\n  test continuation_path::tests::continuation_step_has_no_reject_arm ... ok\n  test continuation_path::tests::demote_with_reason_reenters_heavier_never_rejects ... ok\n  test continuation_path::tests::entry_is_the_heavy_smoothing_regime ... ok\n  test continuation_path::tests::heavy_entry_starts_in_the_heavy_regime ... ok\n  test continuation_path::tests::coupled_path_prewarm_requests_value_only_evals ... ok\n  test continuation_path::tests::legs_move_in_lockstep_along_s ... ok\n  test continuation_path::tests::logit_trust_region_tightens_as_tau_cools ... ok\n  test continuation_path::tests::mean_active_mass_distinguishes_routed_from_saddle ... ok\n  test continuation_path::tests::note_mass_breach_reenters_heavier_and_logs ... ok\n  test continuation_path::tests::path_regime_bands_are_monotone_in_s ... ok\n  test continuation_path::tests::reentry_floors_step_but_never_exits ... ok\n  test continuation_path::tests::target_endpoint_is_the_real_objective ... ok\n\n  test result: ok. 14 passed; 0 failed; 0 ignored; 0 measured; 1186 filtered out; finished in 0.00s\n  ```\n\n* \u2705 `./build.sh test --test regressions margslope_matern_logslope_timing -- --nocapture`  \n  ```text\n  [build.sh] test --test regressions margslope_matern_logslope_timing -- --nocapture -> exit 0 in 138s (dedup=MISS, recompiled 10 crates)\n      Finished `test` profile [optimized + debuginfo] target(s) in 2m 15s\n       Running tests/regressions/main.rs (target/debug/deps/regressions-2617dbd6d0900c02)\n\n  running 1 test\n  [979-REPRO] n=1500 centers=4 total_s=2.23 outer_iters=11 inner_cycles=1 converged=true\n  test smooths::margslope_matern_logslope_slowdown::margslope_matern_logslope_timing ... ok\n\n  test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 480 filtered out; finished in 2.24s\n  ```\n\n## CODE DIFF\n\n```diff\ndiff --git a/crates/gam-solve/src/continuation_path.rs b/crates/gam-solve/src/continuation_path.rs\nindex fc75497..5e9a9cd 100644\n--- a/crates/gam-solve/src/continuation_path.rs\n+++ b/crates/gam-solve/src/continuation_path.rs\n@@ -869,11 +869,19 @@ impl ContinuationPath {\n         let spine = match self.warm.clone() {\n             Some(start) => {\n                 self.evals_budgeted += WARM_LEG_EVAL_BUDGET;\n+                // The coupled path is still a continuation pre-warm: its only\n+                // payload is the converged inner coefficient state carried by\n+                // `inner_beta_hint`.  Requesting an outer gradient here repeats\n+                // the expensive REML/LAML derivative assembly at every waypoint\n+                // even though no line search or stationarity test consumes it;\n+                // the real outer optimizer asks for the gradient once after the\n+                // path arrives.  `Value` preserves the same inner solve and warm\n+                // beta propagation while removing that redundant derivative work.\n                 continue_path_from(\n                     obj,\n                     start,\n                     &rho_target,\n-                    OuterEvalOrder::ValueAndGradient,\n+                    OuterEvalOrder::Value,\n                     WARM_LEG_EVAL_BUDGET,\n                 )\n             }\n@@ -884,7 +892,7 @@ impl ContinuationPath {\n                     &rho_target,\n                     &self.schedules.rho_bounds_upper,\n                     initial_beta,\n-                    OuterEvalOrder::ValueAndGradient,\n+                    OuterEvalOrder::Value,\n                 )\n             }\n         };\n@@ -1356,6 +1364,90 @@ mod tests {\n         assert_eq!(PathRegime::from_s(1.0), PathRegime::Heavy);\n     }\n \n+    #[derive(Default)]\n+    struct RecordingObjective {\n+        orders: Vec<OuterEvalOrder>,\n+        seed_count: usize,\n+    }\n+\
</details>

_Codex-generated; pending adversarial audit before merge._
