### PR TITLE
#1818: Fix Duchon lazy radial reparam path

### DIFF
--- a/crates/gam-terms/src/basis/duchon_thinplate.rs
+++ b/crates/gam-terms/src/basis/duchon_thinplate.rs
@@ -326,30 +326,78 @@ fn build_duchon_basis_uncached(
             )))
         } else {
             let coeffs = coeffs.clone();
-            let kernel = move |data_row: &[f64], center_row: &[f64]| -> f64 {
-                let r = stable_euclidean_norm((0..d).map(|axis| data_row[axis] - center_row[axis]));
-                let raw = if let Some(ppc) = pure_poly_coeff {
-                    ppc.eval(r)
-                } else {
-                    duchon_matern_kernel_general_from_distance(
-                        r,
-                        length_scale,
-                        p_order,
-                        s_order_int.expect("hybrid Duchon requires integer power"),
-                        d,
-                        coeffs.as_ref(),
-                    )
-                    .expect("validated Duchon inputs should not fail")
-                };
-                raw * kernel_amp
+            let make_kernel = || {
+                let coeffs = coeffs.clone();
+                let pure_poly_coeff = pure_poly_coeff;
+                Arc::new(move |data_row: &[f64], center_row: &[f64]| -> f64 {
+                    let r =
+                        stable_euclidean_norm((0..d).map(|axis| data_row[axis] - center_row[axis]));
+                    let raw = if let Some(ppc) = pure_poly_coeff {
+                        ppc.eval(r)
+                    } else {
+                        duchon_matern_kernel_general_from_distance(
+                            r,
+                            length_scale,
+                            p_order,
+                            s_order_int.expect("hybrid Duchon requires integer power"),
+                            d,
+                            coeffs.as_ref(),
+                        )
+                        .expect("validated Duchon inputs should not fail")
+                    };
+                    raw * kernel_amp
+                }) as Arc<dyn crate::chunked_kernel_design::SpatialKernelEvaluator>
             };
+            let operators_active = matches!(
+                spec.operator_penalties.mass,
+                OperatorPenaltySpec::Active { .. }
+            ) || matches!(
+                spec.operator_penalties.tension,
+                OperatorPenaltySpec::Active { .. }
+            ) || matches!(
+                spec.operator_penalties.stiffness,
+                OperatorPenaltySpec::Active { .. }
+            );
+            if frozen_radial_reparam.is_none() && !operators_active {
+                let raw_gauge = Arc::new(gam_problem::Gauge::from_block_transforms(&[
+                    kernel_transform.clone(),
+                ]));
+                let raw_op = ChunkedKernelDesignOperator::new(
+                    shared_data.clone(),
+                    Arc::new(centers.clone()),
+                    make_kernel(),
+                    Some(raw_gauge),
+                    Some(Arc::new(poly_block.clone())),
+                )
+                .map_err(BasisError::InvalidInput)?;
+                let ones = Array1::<f64>::ones(raw_op.nrows());
+                let raw_gram = raw_op.diag_xtw_x(&ones).map_err(BasisError::InvalidInput)?;
+                let kernel_cols = kernel_transform.ncols();
+                let design_gram = symmetrize_penalty(
+                    &raw_gram.slice(s![..kernel_cols, ..kernel_cols]).to_owned(),
+                );
+                let omega_constrained = duchon_constrained_bending_penalty(
+                    centers.view(),
+                    spec.length_scale,
+                    spec.power,
+                    effective_nullspace_order,
+                    aniso.as_deref(),
+                    &kernel_transform,
+                )?;
+                let (v, _mu) =
+                    thin_plate_radial_reparam_data_metric(&omega_constrained, &design_gram)?;
+                if v.ncols() > 0 {
+                    kernel_transform = fast_ab(&kernel_transform, &v);
+                    frozen_radial_reparam = Some(v);
+                }
+            }
             let kernel_gauge = Arc::new(gam_problem::Gauge::from_block_transforms(&[
                 kernel_transform.clone(),
             ]));
             let base_op = ChunkedKernelDesignOperator::new(
                 shared_data,
                 Arc::new(centers.clone()),
-                kernel,
+                make_kernel(),
                 Some(kernel_gauge),
                 Some(Arc::new(poly_block)),
             )

--- a/crates/gam-terms/src/chunked_kernel_design.rs
+++ b/crates/gam-terms/src/chunked_kernel_design.rs
@@ -40,6 +40,12 @@ where
     }
 }
 
+impl SpatialKernelEvaluator for Arc<dyn SpatialKernelEvaluator> {
+    fn eval(&self, x: &[f64], c: &[f64]) -> f64 {
+        self.as_ref().eval(x, c)
+    }
+}
+
 /// Chunked kernel design operator for spatial smooths (TPS, Matérn, Duchon).
 ///
 /// Instead of storing a dense n × k matrix, evaluates K(data[i], center[j])

--- a/tests/basis_smooth/smooths/duchon_scale_and_memory.rs
+++ b/tests/basis_smooth/smooths/duchon_scale_and_memory.rs
@@ -28,7 +28,7 @@ use gam::test_support::reference::rmse;
 use gam::{
     FitConfig, FitResult, encode_recordswith_inferred_schema, fit_from_formula, init_parallelism,
 };
-use gam::{ProblemHints, ResourcePolicy};
+use gam::ResourcePolicy;
 use ndarray::Array2;
 use rand::SeedableRng;
 use rand::rngs::StdRng;
@@ -66,6 +66,26 @@ fn encode_xzy(x: &[f64], z: &[f64], y: &[f64]) -> gam::data::EncodedDataset {
 fn fit_gaussian(formula: &str, ds: &gam::data::EncodedDataset) -> gam::StandardFitResult {
     let cfg = FitConfig {
         family: Some("gaussian".to_string()),
+        ..FitConfig::default()
+    };
+    let result = fit_from_formula(formula, ds, &cfg)
+        .unwrap_or_else(|e| panic!("gam duchon fit failed for `{formula}`: {e}"));
+    match result {
+        FitResult::Standard(fit) => fit,
+        _ => panic!("expected a standard GAM fit for a gaussian Duchon smooth: `{formula}`"),
+    }
+}
+
+/// Fit with the strict analytic-operator policy so the basis builder must use
+/// its operator-backed spatial path whenever the design crosses the derived
+/// single-materialization budget.
+fn fit_gaussian_operator_required(
+    formula: &str,
+    ds: &gam::data::EncodedDataset,
+) -> gam::StandardFitResult {
+    let cfg = FitConfig {
+        family: Some("gaussian".to_string()),
+        resource_policy: Some(ResourcePolicy::analytic_operator_required()),
         ..FitConfig::default()
     };
     let result = fit_from_formula(formula, ds, &cfg)
@@ -250,10 +270,10 @@ fn duchon_lazy_chunked_path_is_exercised_and_recovers_truth() {
     // This test forces the MEMORY-SAVING lazy chunked design operator
     // (`ChunkedKernelDesignOperator`, gated by `should_use_lazy_spatial_design`)
     // and asserts the streamed path is still correct. The lazy path activates
-    // when the would-be dense `n × p` design exceeds the auto-derived policy's
-    // `max_single_materialization_bytes`. The fit path derives that policy via
-    // `ResourcePolicy::for_problem(n_rows, 0, ProblemHints::default())`; below
-    // the large-scale row threshold this is the 256 MiB default budget.
+    // when the would-be dense `n × p` design exceeds the active policy's
+    // `max_single_materialization_bytes`. The test fit uses
+    // `ResourcePolicy::analytic_operator_required()`, whose derived
+    // single-materialization budget is the strict operator-path budget.
     //
     // n = 40_000, k = 900. WHY THESE NUMBERS: the design has p ≈ k centers (plus
     // a 2-column affine null space). dense_bytes = n·p·8 ≈ 40_000·902·8
@@ -273,7 +293,7 @@ fn duchon_lazy_chunked_path_is_exercised_and_recovers_truth() {
     // would-be dense width used by the lazy gate is on the order of k; use a
     // conservative lower bound (k itself) so the assertion can only UNDER-count,
     // never falsely claim the lazy path triggers.
-    let policy = ResourcePolicy::for_problem(n, 0, ProblemHints::default());
+    let policy = ResourcePolicy::analytic_operator_required();
     let dense_bytes_lower_bound = n
         .saturating_mul(k)
         .saturating_mul(std::mem::size_of::<f64>());
@@ -300,7 +320,7 @@ fn duchon_lazy_chunked_path_is_exercised_and_recovers_truth() {
 
     let ds = encode_xy(&x, &y);
     let x_idx = ds.column_map()["x"];
-    let fit = fit_gaussian(&format!("y ~ duchon(x, k={k})"), &ds);
+    let fit = fit_gaussian_operator_required(&format!("y ~ duchon(x, k={k})"), &ds);
 
     let train_fitted: Vec<f64> = fit.design.design.apply(&fit.fit.beta).to_vec();
     assert!(


### PR DESCRIPTION
### Motivation
- The lazy/chunked Duchon build skipped the dense-path data-metric radial reparameterization `V` because it lacked a dense `n×k` design, leaving lazy fits in the un-rotated constrained frame and exposing REML over-smoothing behavior the dense path had already corrected.
- The lazy-path test became stale after the library `ResourcePolicy::default_library()` single-materialization budget moved to 1 GiB, so the `n=40_000,k=900` configuration no longer triggered the lazy path and the test failed to exercise the intended operator-backed path.

### Description
- Stream the realized constrained kernel Gram from the chunked operator and compute the same data-metric reparameterization `V` on the lazy non-anisotropic native-Gram path, folding `V` into the chunked operator before final construction; gated to native-Gram-only fits so explicit operator-penalty frames remain unrotated (`crates/gam-terms/src/basis/duchon_thinplate.rs`).
- Expose an `Arc<dyn SpatialKernelEvaluator>` adapter so the kernel evaluator can be instantiated/used for the streamed Gram and again for the final operator (`crates/gam-terms/src/chunked_kernel_design.rs`).
- Keep the reparamization conditional on operators being inactive to avoid desync with operator-collocated penalties (same file and gating logic added).
- Update the lazy-path test to drive the fit with the strict operator policy via `ResourcePolicy::analytic_operator_required()` and add a helper `fit_gaussian_operator_required` so the test reliably forces the chunked/operator path under the intended 256 MiB gate (`tests/basis_smooth/smooths/duchon_scale_and_memory.rs`).

### Testing
- Before the fix, `./build.sh test --test basis_smooth duchon_lazy_chunked_path_is_exercised_and_recovers_truth -- --nocapture` failed because the test no longer crossed the default 1 GiB materialization budget (stale assertion). (failed)
- After the change, `./build.sh` completed successfully and the library built. (passed)
- `./build.sh check -p gam-terms --lib` completed successfully with no warnings. (passed)
- `./build.sh test --test basis_smooth --no-run` finished successfully (test binary builds). (passed)
- The focused test `./build.sh test --test basis_smooth duchon_lazy_chunked_path_is_exercised_and_recovers_truth -- --nocapture` now runs and passes, demonstrating the lazy/chunked reparam path is exercised and recovers truth. (passed)

---
Fixes #1818.

<details><summary>codex self-assessment</summary>

-models v0.3.148 (/workspace/gam/crates/gam-models)\n   Compiling gam-sae v0.3.148 (/workspace/gam/crates/gam-sae)\n   Compiling gam-inference v0.3.148 (/workspace/gam/crates/gam-inference)\n   Compiling gam-config v0.3.148 (/workspace/gam/crates/gam-config)\n   Compiling gam-test-support v0.3.148 (/workspace/gam/crates/gam-test-support)\n   Compiling gam-predict v0.3.148 (/workspace/gam/crates/gam-predict)\n    Finished `test` profile [optimized + debuginfo] target(s) in 16m 30s\n     Running tests/basis_smooth/main.rs (target/debug/deps/basis_smooth-24226fcdc1a6375e)\n\nrunning 1 test\n\nthread 'smooths::duchon_scale_and_memory::duchon_lazy_chunked_path_is_exercised_and_recovers_truth' (32336) panicked at tests/basis_smooth/smooths/duchon_scale_and_memory.rs:280:5:\nlazy-path test misconfigured: dense lower bound 288000000 bytes does not exceed the auto-derived materialization budget 1073741824 bytes for n=40000, k=900; pick a larger k or n so the chunked operator is actually exercised\nnote: run with `RUST_BACKTRACE=1` environment variable to display a backtrace\ntest smooths::duchon_scale_and_memory::duchon_lazy_chunked_path_is_exercised_and_recovers_truth ... FAILED\n\nfailures:\n\nfailures:\n    smooths::duchon_scale_and_memory::duchon_lazy_chunked_path_is_exercised_and_recovers_truth\n\ntest result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 299 filtered out; finished in 0.00s\n\nerror: test failed, to rerun pass `--test basis_smooth`\n```\n\n### Passing checks after the fix\n\n* \u2705 `./build.sh`\n\n```text\n[build.sh] LIB -> exit 0 in 752s (dedup=MISS, recompiled 76 crates)\n   Compiling burn-tensor v0.18.0\n   Compiling gam-model-api v0.3.148 (/workspace/gam/crates/gam-model-api)\n   Compiling gam-identifiability v0.3.148 (/workspace/gam/crates/gam-identifiability)\n   Compiling opt v0.5.11\n   Compiling gam-data v0.3.148 (/workspace/gam/crates/gam-data)\n   Compiling ndarray v0.16.1\n   Compiling gam-terms v0.3.148 (/workspace/gam/crates/gam-terms)\n   Compiling burn-autodiff v0.18.0\n   Compiling burn-ir v0.18.0\n   Compiling burn-core v0.18.0\n   Compiling burn-ndarray v0.18.0\n   Compiling itertools v0.13.0\n   Compiling rustix v1.1.4\n   Compiling gam-solve v0.3.148 (/workspace/gam/crates/gam-solve)\n   Compiling ndarray-stats v0.6.0\n   Compiling rustfft v6.4.1\n   Compiling burn v0.18.0\n   Compiling general-mcmc v0.9.0\n   Compiling crossterm v0.29.0\n   Compiling gam v0.3.148 (/workspace/gam)\n   Compiling comfy-table v7.2.2\n   Compiling gam-model-kernels v0.3.148 (/workspace/gam/crates/gam-model-kernels)\n   Compiling gam-custom-family v0.3.148 (/workspace/gam/crates/gam-custom-family)\n   Compiling gam-models v0.3.148 (/workspace/gam/crates/gam-models)\n   Compiling gam-sae v0.3.148 (/workspace/gam/crates/gam-sae)\n   Compiling gam-report v0.3.148 (/workspace/gam/crates/gam-report)\n   Compiling gam-inference v0.3.148 (/workspace/gam/crates/gam-inference)\n   Compiling gam-test-support v0.3.148 (/workspace/gam/crates/gam-test-support)\n   Compiling gam-config v0.3.148 (/workspace/gam/crates/gam-config)\n    Finished `dev` profile [unoptimized + debuginfo] target(s) in 12m 32s\n```\n\n* \u2705 `./build.sh check -p gam-terms --lib`\n\n```text\n[build.sh] check -p gam-terms --lib -> exit 0 in 6s (dedup=MISS, recompiled 0 crates)\n    Checking gam-terms v0.3.148 (/workspace/gam/crates/gam-terms)\n    Finished `dev` profile [unoptimized + debuginfo] target(s) in 5.79s\n```\n\n* \u2705 `./build.sh test --test basis_smooth --no-run`\n\n```text\n[build.sh] test --test basis_smooth --no-run -> exit 0 in 1s (dedup=MISS, recompiled 0 crates)\n    Finished `test` profile [optimized + debuginfo] target(s) in 1.03s\n  Executable tests/basis_smooth/main.rs (target/debug/deps/basis_smooth-24226fcdc1a6375e)\n```\n\n* \u2705 `./build.sh test --test basis_smooth duchon_lazy_chunked_path_is_exercised_and_recovers_truth -- --nocapture`\n\n```text\n[build.sh] test --test basis_smooth duchon_lazy_chunked_path_is_exerc
</details>

_Codex-generated; pending adversarial audit before merge._