### PR TITLE
#2111: Fix ISA birth residual staleness

### DIFF
--- a/crates/gam-sae/src/manifold/stagewise.rs
+++ b/crates/gam-sae/src/manifold/stagewise.rs
@@ -492,12 +492,6 @@ struct BirthSeed {
     circle_gate: Option<Vec<f64>>,
 }
 
-struct PendingIsaSeed {
-    seed: BirthSeed,
-    residual: Array2<f64>,
-    model: StructuredResidualModel,
-}
-
 fn template_accepts_circle_births(term: &SaeManifoldTerm) -> bool {
     term.atoms
         .first()
@@ -966,7 +960,6 @@ pub fn fit_stagewise(
 
     // ── Phase 1b — forward births ──────────────────────────────────────────────
     let mut birth_round = 0usize;
-    let mut pending_isa_seeds = std::collections::VecDeque::<PendingIsaSeed>::new();
     let stopped_reason = loop {
         // #2138 — bail before starting another birth round if the host cancelled.
         if cancel.is_some_and(|c| c.load(std::sync::atomic::Ordering::Relaxed)) {
@@ -1002,9 +995,17 @@ pub fn fit_stagewise(
                 rho: &rho,
             },
         )?;
-        // Prepare the residual metric for this birth. When a joint ISA split is
-        // queued, reuse that split's residual/model snapshot; otherwise fit Σ on
-        // the current residual before harvesting or falling through to factor seeds.
+        // Prepare the residual metric for this birth from the CURRENT term.
+        // Earlier revisions queued every plane from one ISA split and then fitted
+        // later queued seeds against that old residual snapshot.  That violates
+        // the serial greedy contract unless the later K=1 fit is constrained to
+        // the seed's output block: a dense torus shares all rows, and an
+        // unconstrained single-atom fit can be attracted by strong circles that
+        // have already been accepted by previous queued births.  Recomputing the
+        // residual after every accepted birth is the stagewise deflation
+        // mechanism; the ISA split may still be joint inside one producer call,
+        // but only its best currently-certified plane is consumed by this serial
+        // path.
         emit_stagewise_progress(
             &mut progress,
             StagewiseProgress {
@@ -1026,34 +1027,24 @@ pub fn fit_stagewise(
                 rho: &rho,
             },
         )?;
-        // Certified circle residuals are harvested first: capture the residual span
-        // once, queue every jointly-rotated plane, and consume one seed per serial
-        // birth round. If no circle certifies, use the anchor-scored shared-factor
+        // Certified circle residuals are tried first on this freshly-deflated
+        // residual. If no circle certifies, use the anchor-scored shared-factor
         // seed, then the #2080 residual-principal rank-1 fallback.
-        let (seed, residual, model) = if let Some(pending) = pending_isa_seeds.pop_front() {
-            (pending.seed, pending.residual, pending.model)
+        let Some((residual, model)) = fit_residual_covariance(&term, target, config)? else {
+            break StagewiseStop::NoResidualStructure;
+        };
+        let seed = if let Some(seed) = isa_birth_seed_batch(&term, residual.view(), 1)?
+            .into_iter()
+            .next()
+        {
+            seed
         } else {
-            let Some((residual, model)) = fit_residual_covariance(&term, target, config)? else {
+            let Some(seed) = top_factor_birth_decoder(&term, &model, residual.view())
+                .or_else(|| residual_principal_birth_candidate(&term, residual.view()))
+            else {
                 break StagewiseStop::NoResidualStructure;
             };
-            let remaining = config.max_births.saturating_sub(births_accepted);
-            for seed in isa_birth_seed_batch(&term, residual.view(), remaining)? {
-                pending_isa_seeds.push_back(PendingIsaSeed {
-                    seed,
-                    residual: residual.clone(),
-                    model: model.clone(),
-                });
-            }
-            if let Some(pending) = pending_isa_seeds.pop_front() {
-                (pending.seed, pending.residual, pending.model)
-            } else {
-                let Some(seed) = top_factor_birth_decoder(&term, &model, residual.view())
-                    .or_else(|| residual_principal_birth_candidate(&term, residual.view()))
-                else {
-                    break StagewiseStop::NoResidualStructure;
-                };
-                (seed, residual, model)
-            }
+            seed
         };
         let factor_energy = seed.energy;
         if config.structured_whitening {


### PR DESCRIPTION
### Motivation
- The serial stagewise birth loop was consuming ISA seeds queued from a single joint split while still fitting them against the original (stale) residual snapshot, which in dense shared-row fixtures allowed later K=1 fits to be pulled toward already-accepted strong circles. 
- This violated the intended stagewise deflation contract and caused only the strongest circles to surface while weaker circles never did.

### Description
- Remove the queued `PendingIsaSeed` snapshot/state and its usage so ISA planes are not harvested once-and-for-all from an old residual. (file: `crates/gam-sae/src/manifold/stagewise.rs`)
- Recompute `fit_residual_covariance(&term, ...)` at the start of every birth round and request at most one ISA candidate from `isa_birth_seed_batch(..., 1)` for that fresh residual, falling back to factor/residual-principal seeds if none certifies. (file: `crates/gam-sae/src/manifold/stagewise.rs`)
- Tighten inline documentation explaining why queued ISA seeds break the serial greedy contract for shared-row dense torus cases and why consuming only the best currently-certified plane restores correct deflation semantics. (file: `crates/gam-sae/src/manifold/stagewise.rs`)

### Testing
- Ran `./build.sh check -p gam-sae --lib`, which completed successfully with no warnings (passed).
- Attempted `./build.sh test -p gam-sae --lib dense_torus_fixture_has_2k_signal_dirs_2111 -- --nocapture`, but compilation failed before running that specific target due to an unrelated existing test file dead-code warning in `tests_logdet_adjoint_780.rs` (pre-existing failure in the repo), so the integration acceptance test could not be exercised here.
- Attempted to build the `manifolds` test binary (`./build.sh test --test manifolds --no-run`) and the full `dense_torus_integrated_birth_recovery_2111` target, but those large integration builds did not complete in this environment before the wrapper/compile retries were stopped; no further test output was produced.

---
Refs #2111.

<details><summary>codex self-assessment</summary>

#[allow(dead_code)]`\n\n  error: could not compile `gam-sae` (lib test) due to 1 previous error\n  ```\n\n* \u26a0\ufe0f `./build.sh test --test manifolds --no-run`\n\n  This did not produce a build result in this environment; the wrapper was still compiling the very large integration-test surface for over 15 minutes, and I stopped it to avoid leaving a runaway build process. No pass/fail result for the test binary was obtained.\n\n* \u26a0\ufe0f `./build.sh test --test manifolds dense_torus_integrated_birth_recovery_2111 -- --nocapture`\n\n  This also did not produce a test result in this environment. The wrapper hit its transient timeout while compiling and retried with `CARGO_BUILD_JOBS=1`; no acceptance-test output was produced before I stopped the long-running compile.\n\n## CODE DIFF\n\n```diff\ndiff --git a/crates/gam-sae/src/manifold/stagewise.rs b/crates/gam-sae/src/manifold/stagewise.rs\nindex 0ed9e35..eefdb62 100644\n--- a/crates/gam-sae/src/manifold/stagewise.rs\n+++ b/crates/gam-sae/src/manifold/stagewise.rs\n@@ -492,12 +492,6 @@ struct BirthSeed {\n     circle_gate: Option<Vec<f64>>,\n }\n \n-struct PendingIsaSeed {\n-    seed: BirthSeed,\n-    residual: Array2<f64>,\n-    model: StructuredResidualModel,\n-}\n-\n fn template_accepts_circle_births(term: &SaeManifoldTerm) -> bool {\n     term.atoms\n         .first()\n@@ -966,7 +960,6 @@ pub fn fit_stagewise(\n \n     // \u2500\u2500 Phase 1b \u2014 forward births \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\n     let mut birth_round = 0usize;\n-    let mut pending_isa_seeds = std::collections::VecDeque::<PendingIsaSeed>::new();\n     let stopped_reason = loop {\n         // #2138 \u2014 bail before starting another birth round if the host cancelled.\n         if cancel.is_some_and(|c| c.load(std::sync::atomic::Ordering::Relaxed)) {\n@@ -1002,9 +995,17 @@ pub fn fit_stagewise(\n                 rho: &rho,\n             },\n         )?;\n-        // Prepare the residual metric for this birth. When a joint ISA split is\n-        // queued, reuse that split's residual/model snapshot; otherwise fit \u03a3 on\n-        // the current residual before harvesting or falling through to factor seeds.\n+        // Prepare the residual metric for this birth from the CURRENT term.\n+        // Earlier revisions queued every plane from one ISA split and then fitted\n+        // later queued seeds against that old residual snapshot.  That violates\n+        // the serial greedy contract unless the later K=1 fit is constrained to\n+        // the seed's output block: a dense torus shares all rows, and an\n+        // unconstrained single-atom fit can be attracted by strong circles that\n+        // have already been accepted by previous queued births.  Recomputing the\n+        // residual after every accepted birth is the stagewise deflation\n+        // mechanism; the ISA split may still be joint inside one producer call,\n+        // but only its best currently-certified plane is consumed by this serial\n+        // path.\n         emit_stagewise_progress(\n             &mut progress,\n             StagewiseProgress {\n@@ -1030,30 +1031,21 @@ pub fn fit_stagewise(\n-        // Certified circle residuals are harvested first: capture the residual span\n-        // once, queue every jointly-rotated plane, and consume one seed per serial\n-        // birth round. If no circle certifies, use the anchor-scored shared-factor\n-        // seed, then the #2080 residual-principal rank-1 fallback.\n-        let (seed, residual, model) = if let Some(pending) = pending_isa_seeds.pop_front() {\n-            (pending.seed, pending.residual, pending.model)\n+        // Certified circle residuals are tried first on this freshly-deflated\n+        // residual. If no c
</details>

_Codex-generated; pending adversarial audit before merge._