### PR TITLE
#2147: Fix inverse_alr 1-D ALR coordinate roundtrip

### DIFF
--- a/gamfit/_response_geometry.py
+++ b/gamfit/_response_geometry.py
@@ -85,11 +85,16 @@ def alr(values: Any, *, reference: int = -1) -> Any:
 
 
 def inverse_alr(coords: Any, *, reference: int = -1) -> Any:
-    """Map ALR coordinates back to the simplex."""
+    """Map ALR coordinates back to the simplex.
+
+    Accepts either a 2-D ``(rows, parts - 1)`` ALR-coordinate batch or a single
+    1-D ALR-coordinate vector; a 1-D input yields the reconstructed 1-D
+    composition matching the corresponding batch row.
+    """
     np = _np()
-    return _ffi(
-        "response_geometry_inverse_alr", np.asarray(coords, dtype=float), int(reference)
-    )
+    rows, was_1d = _composition_rows(np, coords)
+    out = _ffi("response_geometry_inverse_alr", rows, int(reference))
+    return np.asarray(out)[0] if was_1d else out
 
 
 def simplex_frechet_mean(values: Any, weights: Any | None = None) -> Any:

--- a/tests/test_response_geometry.py
+++ b/tests/test_response_geometry.py
@@ -8,6 +8,7 @@ from gamfit._response_geometry import (
     closure,
     clr,
     geometry_log_map,
+    inverse_alr,
     simplex_exp_map,
     simplex_frechet_mean,
     sphere_exp_map,
@@ -47,6 +48,24 @@ def test_simplex_clr_and_alr_roundtrip_at_frechet_base() -> None:
         rtol=1e-12,
         atol=1e-12,
     )
+
+
+def test_inverse_alr_accepts_single_coordinate_vector_roundtrip() -> None:
+    x = np.array([0.2, 0.5, 0.3], dtype=float)
+    expected = closure(x)
+
+    for reference in (-1, 0, 1):
+        coords = alr(x, reference=reference)
+        reconstructed = inverse_alr(coords, reference=reference)
+
+        assert coords.shape == (2,)
+        assert reconstructed.shape == x.shape
+        np.testing.assert_allclose(
+            reconstructed,
+            expected,
+            rtol=1e-12,
+            atol=1e-12,
+        )
 
 
 def test_sphere_frechet_mean_is_intrinsic_and_log_exp_roundtrip() -> None:


### PR DESCRIPTION
### Motivation
- `inverse_alr` crossed the PyO3 FFI with a raw array and rejected natural 1-D ALR coordinate vectors (e.g. `inverse_alr(alr(x))`) while its siblings (`closure`, `clr`, `alr`) promote 1-D→(1, parts) and squeeze the result back; the change restores a consistent shape contract so single-composition round-trips work.

### Description
- Route `inverse_alr` through the existing `_composition_rows` marshalling helper and squeeze single-row outputs to preserve the 1-D return shape (file: `gamfit/_response_geometry.py`).
- Add a regression test `test_inverse_alr_accepts_single_coordinate_vector_roundtrip` that asserts `inverse_alr(alr(x, reference=r))` round-trips to the original 1-D composition for `r in {-1,0,1}` (file: `tests/test_response_geometry.py`).

### Testing
- Built and compiled the workspace and pyffi: `./build.sh` (success), `./build.sh check -p gam-pyffi --lib` (success), and `maturin develop` (success and package installed); added/ran pytest for the touched tests: `python -m pytest tests/test_response_geometry.py -k inverse_alr_accepts_single_coordinate_vector_roundtrip` passed (`1 passed`), and `python -m pytest tests/test_response_geometry.py -q` passed (`7 passed`).

---
Fixes #2147.

<details><summary>codex self-assessment</summary>

yffi)\n   Compiling rustc-hash v2.1.3\n   Compiling gam-predict v0.3.148 (/workspace/gam/crates/gam-predict)\n    Finished `dev` profile [unoptimized + debuginfo] target(s) in 16m 45s\n\ud83d\udce6 Built wheel for abi3 Python \u2265 3.10 to /tmp/.tmpiAQs0p/gamfit-0.1.250-cp310-abi3-linux_x86_64.whl\n\u270f\ufe0f Setting installed package as editable\n\ud83d\udee0 Installed gamfit-0.1.250\n```\n\n* \u2705 `./build.sh test --test bug_hunt_sphere_frechet_mean_not_minimizer_on_great_circle --no-run`\n\n```text\n[build.sh] transient failure (OOM/timeout, exit 124) attempt 1/3 \u2014 retrying with CARGO_BUILD_JOBS=1 (lower peak RAM)\u2026\n[build.sh] test --test bug_hunt_sphere_frechet_mean_not_minimizer_on_great_circle --no-run -> exit 0 in 1112s (dedup=MISS, recompiled 6 crates)\n   Compiling gam-models v0.3.148 (/workspace/gam/crates/gam-models)\n   Compiling gam-inference v0.3.148 (/workspace/gam/crates/gam-inference)\n   Compiling gam-config v0.3.148 (/workspace/gam/crates/gam-config)\n   Compiling gam-test-support v0.3.148 (/workspace/gam/crates/gam-test-support)\n   Compiling gam v0.3.148 (/workspace/gam)\n   Compiling gam-predict v0.3.148 (/workspace/gam/crates/gam-predict)\n    Finished `test` profile [optimized + debuginfo] target(s) in 18m 31s\n  Executable tests/bug_hunt_sphere_frechet_mean_not_minimizer_on_great_circle.rs (target/debug/deps/bug_hunt_sphere_frechet_mean_not_minimizer_on_great_circle-5c150594ec4dff86)\n```\n\n**Before \u2192 after regression evidence**\n\n* \u2705 `python -m pytest tests/test_response_geometry.py -k inverse_alr_accepts_single_coordinate_vector_roundtrip -q` \u2014 before the fix, with the new regression test present and the shim reverted, this reproduced the defect:\n\n```text\nF                                                                        [100%]\n=================================== FAILURES ===================================\n_________ test_inverse_alr_accepts_single_coordinate_vector_roundtrip __________\n\n    def test_inverse_alr_accepts_single_coordinate_vector_roundtrip() -> None:\n        x = np.array([0.2, 0.5, 0.3], dtype=float)\n        expected = closure(x)\n    \n        for reference in (-1, 0, 1):\n            coords = alr(x, reference=reference)\n>           reconstructed = inverse_alr(coords, reference=reference)\n                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n\ntests/test_response_geometry.py:59: \n_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ \ngamfit/_response_geometry.py:90: in inverse_alr\n    return _ffi(\ngamfit/_response_geometry.py:22: in _ffi\n    raise map_exception(exc) from exc\n_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ \n\nname = 'response_geometry_inverse_alr'\nargs = (array([-0.40546511,  0.51082562]), -1)\n\n    def _ffi(name: str, *args: Any) -> Any:\n        try:\n>           return getattr(rust_module(), name)(*args)\n                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\nE           TypeError: 'ndarray' object is not an instance of 'ndarray'\nE           while processing 'coords'\n\ngamfit/_response_geometry.py:20: TypeError\n=========================== short test summary info ============================\nFAILED tests/test_response_geometry.py::test_inverse_alr_accepts_single_coordinate_vector_roundtrip\n1 failed, 6 deselected in 0.56s\n```\n\n* \u2705 `python -m pytest tests/test_response_geometry.py -k inverse_alr_accepts_single_coordinate_vector_roundtrip -q` \u2014 after the fix:\n\n```text\n.                                                                        [100%]\n1 passed, 6 deselected in 0.45s\n```\n\n**Touched-area regression**\n\n* \u2705 `python -m pytest tests/test_response_geometry.py -q`\n\n```text\n.......                                                                  [100%]\n7 passed in 0.47s\n```\n\n### CODE DIFF\n\n```diff\ndiff --git a/gamfit/_response_geometry.py b/gamfit/_response_geometry.py\nindex c234c80..07d7284 100644\n--- a/gamfit/_response_geometry.py\n+++ b/gamfit/_response_geometry.py
</details>

_Codex-generated; pending adversarial audit before merge._