### PR TITLE
#2148: Include std_error for Gaussian location-scale `predict --uncertainty` CSV output

### DIFF
--- a/crates/gam-cli/src/main/prediction_csv.rs
+++ b/crates/gam-cli/src/main/prediction_csv.rs
@@ -307,6 +307,7 @@ pub(crate) fn write_gaussian_location_scale_prediction_csv(
     eta: ArrayView1<'_, f64>,
     mean: ArrayView1<'_, f64>,
     sigma: ArrayView1<'_, f64>,
+    mean_standard_error: Option<ArrayView1<'_, f64>>,
     mean_lower: Option<ArrayView1<'_, f64>>,
     mean_upper: Option<ArrayView1<'_, f64>>,
 ) -> CliResult<()> {
@@ -320,22 +321,36 @@ pub(crate) fn write_gaussian_location_scale_prediction_csv(
         (GAUSSIAN_LOCATION_SCALE_BASE_COLUMNS[2], &sigma_v),
     ];
 
+    let se_v: Vec<f64>;
     let lo_v: Vec<f64>;
     let hi_v: Vec<f64>;
-    if let Some(lo) = mean_lower {
-        lo_v = lo.to_vec();
-        hi_v = mean_upper
+    if let Some(se) = mean_standard_error {
+        se_v = se.to_vec();
+        lo_v = mean_lower
             .ok_or_else(|| CliError::Internal {
-                reason: "internal error: mean_upper missing while mean_lower is present"
-                    .to_string(),
+                reason: "internal error: mean_lower missing while std_error is present".to_string(),
             })?
             .to_vec();
+        hi_v = mean_upper
+            .ok_or_else(|| CliError::Internal {
+                reason: "internal error: mean_upper missing while std_error is present".to_string(),
+            })?
+            .to_vec();
+        cols.push((PREDICTION_STD_ERROR_COLUMN, &se_v));
         cols.push((PREDICTION_INTERVAL_COLUMNS[0], &lo_v));
         cols.push((PREDICTION_INTERVAL_COLUMNS[1], &hi_v));
+    } else if let (Some(lo), Some(hi)) = (mean_lower, mean_upper) {
+        lo_v = lo.to_vec();
+        hi_v = hi.to_vec();
+        cols.push((PREDICTION_INTERVAL_COLUMNS[0], &lo_v));
+        cols.push((PREDICTION_INTERVAL_COLUMNS[1], &hi_v));
+    } else if mean_lower.is_some() {
+        return Err(CliError::Internal {
+            reason: "internal error: mean_upper missing while mean_lower is present".to_string(),
+        });
     } else if mean_upper.is_some() {
         return Err(CliError::Internal {
-            reason: "internal error: gaussian location-scale output requires both mean_lower and mean_upper"
-                .to_string(),
+            reason: "internal error: mean_lower missing while mean_upper is present".to_string(),
         });
     }
 

--- a/crates/gam-cli/src/main/run_predict.rs
+++ b/crates/gam-cli/src/main/run_predict.rs
@@ -278,6 +278,7 @@ pub(crate) fn run_predict_unified(
                 eta.view(),
                 mean.view(),
                 sigma.view(),
+                se_opt.as_ref().map(|a| a.view()),
                 mean_lo.as_ref().map(|a| a.view()),
                 mean_hi.as_ref().map(|a| a.view()),
             )?;

--- a/tests/src_modules/misc/cli_tests.rs
+++ b/tests/src_modules/misc/cli_tests.rs
@@ -4693,6 +4693,7 @@ fn gaussian_location_scale_prediction_csv_includes_sigma_column() {
         sigma.view(),
         None,
         None,
+        None,
     )
     .unwrap_or_else(|e| {
         panic!(
@@ -4731,6 +4732,7 @@ fn gaussian_location_scale_prediction_csv_includes_boundswhen_present() {
         eta.view(),
         mean.view(),
         sigma.view(),
+        None,
         Some(mean_lower.view()),
         Some(mean_upper.view()),
     )
@@ -4753,6 +4755,55 @@ fn gaussian_location_scale_prediction_csv_includes_boundswhen_present() {
 }
 
 #[test]
+fn gaussian_location_scale_prediction_csv_includes_std_error_before_bounds_when_present() {
+    let mut path = std::env::temp_dir();
+    let ts = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_else(|e| panic!("{} failed: {:?}", "clock", e))
+        .as_nanos();
+    path.push(format!("gam_gaussian_loc_scale_pred_se_{ts}.csv"));
+
+    let eta = array![1.0];
+    let mean = array![1.0];
+    let sigma = array![0.4];
+    let std_error = array![0.3];
+    let mean_lower = array![0.2];
+    let mean_upper = array![1.8];
+    write_gaussian_location_scale_prediction_csv(
+        &path,
+        eta.view(),
+        mean.view(),
+        sigma.view(),
+        Some(std_error.view()),
+        Some(mean_lower.view()),
+        Some(mean_upper.view()),
+    )
+    .unwrap_or_else(|e| {
+        panic!(
+            "{} failed: {:?}",
+            "write gaussian location-scale prediction csv with std_error", e
+        )
+    });
+
+    let text =
+        fs::read_to_string(&path).unwrap_or_else(|e| panic!("{} failed: {:?}", "read csv", e));
+    let mut lines = text.lines();
+    assert_eq!(
+        lines.next(),
+        Some("eta,mean,sigma,std_error,mean_lower,mean_upper"),
+        "gaussian location-scale uncertainty output must preserve the computed mean SE"
+    );
+    assert_eq!(
+        lines.next(),
+        Some(
+            "1.000000000000,1.000000000000,0.400000000000,0.300000000000,0.200000000000,1.800000000000"
+        )
+    );
+
+    fs::remove_file(&path).ok();
+}
+
+#[test]
 fn gaussian_location_scale_predict_restores_sigma_to_response_units() {
     // Directly test the CSV output for Gaussian location-scale predictions.
     // This model class now always goes through the unified PredictableModel path.
@@ -4768,6 +4819,7 @@ fn gaussian_location_scale_predict_restores_sigma_to_response_units() {
         eta.view(),
         mean.view(),
         sigma.view(),
+        None,
         None,
         None,
     )

--- a/tests/test_bug_hunt_cli_location_scale_uncertainty_drops_std_error.py
+++ b/tests/test_bug_hunt_cli_location_scale_uncertainty_drops_std_error.py
@@ -1,0 +1,88 @@
+"""Regression for #2148: CLI Gaussian location-scale uncertainty must emit std_error.
+
+The Rust prediction path computes the response-scale mean standard error and uses
+it to form the symmetric mean band. This test exercises the CLI serialization
+boundary so the location-scale CSV writer cannot silently drop that column.
+"""
+
+import csv
+import math
+import os
+import random
+import subprocess
+from pathlib import Path
+
+_Z_975 = 1.959963984540054
+
+
+def _gam_binary() -> str:
+    return os.environ.get("GAM_BIN", str(Path("target/debug/gam")))
+
+
+def test_cli_location_scale_uncertainty_preserves_std_error(tmp_path: Path) -> None:
+    data_path = tmp_path / "ls.csv"
+    model_path = tmp_path / "ls.gam"
+    pred_path = tmp_path / "ls_pred.csv"
+
+    rng = random.Random(51)
+    with data_path.open("w", newline="") as f:
+        writer = csv.writer(f)
+        writer.writerow(["y", "x"])
+        for _ in range(150):
+            x = rng.gauss(0.0, 1.0)
+            y = 1.0 + 2.0 * x + rng.gauss(0.0, math.exp(0.2 + 0.3 * x))
+            writer.writerow([f"{y:.8f}", f"{x:.8f}"])
+
+    gam = _gam_binary()
+    subprocess.run(
+        [
+            gam,
+            "fit",
+            "--family",
+            "gaussian",
+            "--predict-noise",
+            "x",
+            "--out",
+            str(model_path),
+            str(data_path),
+            "y ~ x",
+        ],
+        check=True,
+    )
+    subprocess.run(
+        [
+            gam,
+            "predict",
+            "--uncertainty",
+            "--out",
+            str(pred_path),
+            str(model_path),
+            str(data_path),
+        ],
+        check=True,
+    )
+
+    with pred_path.open(newline="") as f:
+        reader = csv.DictReader(f)
+        assert reader.fieldnames == [
+            "eta",
+            "mean",
+            "sigma",
+            "std_error",
+            "mean_lower",
+            "mean_upper",
+        ]
+        rows = list(reader)
+
+    assert rows
+    for row in rows[:10]:
+        mean = float(row["mean"])
+        std_error = float(row["std_error"])
+        mean_upper = float(row["mean_upper"])
+        assert std_error > 0.0
+        assert math.isclose(
+            mean_upper - mean,
+            std_error * _Z_975,
+            rel_tol=1e-8,
+            abs_tol=1e-8,
+        )


### PR DESCRIPTION
### Motivation
- `gam predict --uncertainty` for Gaussian location-scale models computed a response-scale `std_error` and used it to form the symmetric mean band but the specialized CSV writer dropped that column, producing CSVs missing `std_error` and diverging from the generic Gaussian and Python `gamfit` outputs.

### Description
- Thread the already-computed response-scale mean standard error into the location-scale CSV writer by adding a `mean_standard_error: Option<ArrayView1<'_, f64>>` parameter and emitting a `std_error` column when present (`crates/gam-cli/src/main/prediction_csv.rs`).
- Pass the `se_opt` computed in the prediction path into the Gaussian location-scale writer (`crates/gam-cli/src/main/run_predict.rs`).
- Add a pytest regression exercising the CLI end-to-end to assert the `std_error` column is present and numerically consistent with the symmetric mean band (`tests/test_bug_hunt_cli_location_scale_uncertainty_drops_std_error.py`).
- Add a Rust writer unit test verifying the CSV header and values when `std_error` is supplied (`tests/src_modules/misc/cli_tests.rs`).

### Testing
- Built and checked the code: `./build.sh check -p gam --lib` — success (exit 0).
- Compiled tests (no-run): `./build.sh test --test misc --no-run` — success (exit 0).
- Built the CLI crate: `./build.sh build -p gam-cli` — success (exit 0).
- Installed Python bindings and built editable wheel: `maturin develop` — success (wheel built and installed).
- Ran the new pytest regression: `pytest -q tests/test_bug_hunt_cli_location_scale_uncertainty_drops_std_error.py` — 1 passed.
- Ran the added Rust writer test under the grouped misc test binary (compiled); local filtered invocation returned OK for the focused test (no failures observed).

---
Fixes #2148.

<details><summary>codex self-assessment</summary>

.0\n    Checking general-mcmc v0.9.0\n    Checking gam-model-kernels v0.3.148 (/workspace/gam/crates/gam-model-kernels)\n    Checking gam-custom-family v0.3.148 (/workspace/gam/crates/gam-custom-family)\n    Checking gam-sae v0.3.148 (/workspace/gam/crates/gam-sae)\n    Checking gam-models v0.3.148 (/workspace/gam/crates/gam-models)\n    Checking gam-inference v0.3.148 (/workspace/gam/crates/gam-inference)\n    Checking gam-test-support v0.3.148 (/workspace/gam/crates/gam-test-support)\n    Checking gam-config v0.3.148 (/workspace/gam/crates/gam-config)\n    Finished `dev` profile [unoptimized + debuginfo] target(s) in 6m 20s\n```\n\n* \u2705 `./build.sh test --test misc --no-run`\n\n```text\n[build.sh] test --test misc --no-run -> exit 0 in 657s (dedup=MISS, recompiled 6 crates)\n   Compiling gam-models v0.3.148 (/workspace/gam/crates/gam-models)\n   Compiling gam v0.3.148 (/workspace/gam)\n   Compiling gam-inference v0.3.148 (/workspace/gam/crates/gam-inference)\n   Compiling gam-test-support v0.3.148 (/workspace/gam/crates/gam-test-support)\n   Compiling gam-config v0.3.148 (/workspace/gam/crates/gam-config)\n   Compiling gam-predict v0.3.148 (/workspace/gam/crates/gam-predict)\n    Finished `test` profile [optimized + debuginfo] target(s) in 10m 56s\n  Executable tests/misc/main.rs (target/debug/deps/misc-478fed4cf4bf2e19)\n```\n\n* \u2705 `./build.sh build -p gam-cli`\n\n```text\n[build.sh] build -p gam-cli -> exit 0 in 522s (dedup=MISS, recompiled 46 crates)\n   Compiling gam-terms v0.3.148 (/workspace/gam/crates/gam-terms)\n   Compiling gam-identifiability v0.3.148 (/workspace/gam/crates/gam-identifiability)\n   Compiling gam-model-api v0.3.148 (/workspace/gam/crates/gam-model-api)\n   Compiling opt v0.5.11\n   Compiling ndarray v0.16.1\n   Compiling gam-solve v0.3.148 (/workspace/gam/crates/gam-solve)\n   Compiling burn-ir v0.18.0\n   Compiling burn-autodiff v0.18.0\n   Compiling burn-core v0.18.0\n   Compiling burn-ndarray v0.18.0\n   Compiling itertools v0.13.0\n   Compiling rustfft v6.4.1\n   Compiling ndarray-stats v0.6.0\n   Compiling burn v0.18.0\n   Compiling rustix v1.1.4\n   Compiling crossterm v0.29.0\n   Compiling general-mcmc v0.9.0\n   Compiling comfy-table v7.2.2\n   Compiling gam-report v0.3.148 (/workspace/gam/crates/gam-report)\n   Compiling gam-model-kernels v0.3.148 (/workspace/gam/crates/gam-model-kernels)\n   Compiling gam-custom-family v0.3.148 (/workspace/gam/crates/gam-custom-family)\n   Compiling gam-sae v0.3.148 (/workspace/gam/crates/gam-sae)\n   Compiling gam-models v0.3.148 (/workspace/gam/crates/gam-models)\n   Compiling gam-inference v0.3.148 (/workspace/gam/crates/gam-inference)\n   Compiling gam-test-support v0.3.148 (/workspace/gam/crates/gam-test-support)\n   Compiling gam-config v0.3.148 (/workspace/gam/crates/gam-config)\n   Compiling gam v0.3.148 (/workspace/gam)\n   Compiling gam-predict v0.3.148 (/workspace/gam/crates/gam-predict)\n   Compiling gam-cli v0.3.148 (/workspace/gam/crates/gam-cli)\n    Finished `dev` profile [unoptimized + debuginfo] target(s) in 8m 41s\n```\n\n* \u2705 `maturin develop`\n\n```text\n\ud83c\udf79 Building a mixed python/rust project\n\ud83d\udc0d Found CPython 3.12 at /workspace/gam/.venv/bin/python\n\ud83d\udd17 Found pyo3 bindings with abi3-py3.10 support\n...\n   Compiling gam-pyffi v0.1.250 (/workspace/gam/crates/gam-pyffi)\n   Compiling rustc-hash v2.1.3\n   Compiling gam-predict v0.3.148 (/workspace/gam/crates/gam-predict)\n    Finished `dev` profile [unoptimized + debuginfo] target(s) in 14m 10s\n\ud83d\udce6 Built wheel for abi3 Python \u2265 3.10 to /tmp/.tmp5hnaVC/gamfit-0.1.250-cp310-abi3-linux_x86_64.whl\n\u270f\ufe0f Setting installed package as editable\n\ud83d\udee0 Installed gamfit-0.1.250\n```\n\n* \u2705 `target/debug/gam fit --family gaussian --predict-noise \"x\" --out /tmp/ls.gam /tmp/ls.csv \"y ~ x\" && target/debug/gam predict --uncertainty --out /tmp/ls_pred.csv /tmp/ls.gam /tmp/ls.csv`\n\n```text\nmodel fit complete | family=ga
</details>

_Codex-generated; pending adversarial audit before merge._