### PR TITLE
#1033: fix: keep value-only kappa probes n-free

### DIFF
--- a/crates/gam-models/src/fit_orchestration/drivers/spatial_optimization.rs
+++ b/crates/gam-models/src/fit_orchestration/drivers/spatial_optimization.rs
@@ -3464,6 +3464,33 @@ impl NfreeSkipGateStatus {
     }
 }
 
+fn nfree_skip_gate_status_from_parts(
+    shape: bool,
+    covers_value: bool,
+    covers_skip: bool,
+    covers_gradient: bool,
+    penalty: bool,
+    revision: bool,
+    allow_second_order: bool,
+    require_gradient: bool,
+) -> NfreeSkipGateStatus {
+    NfreeSkipGateStatus {
+        shape,
+        // A value-only cost probe consumes only the Chebyshev Gram value; it
+        // does not expose a beta/row-space object, so the #1264 reduced-basis
+        // skip witness is not part of the value soundness certificate. Requiring
+        // `covers_skip` here forces harmless cost probes across basis-rotation
+        // seams onto `reset_surface`, reintroducing an O(n) pass into the κ
+        // trial loop. Gradient probes still require the skip witness because
+        // they return a stationary beta/gradient in the frozen reduced basis.
+        value: shape && covers_value && (!require_gradient || covers_skip),
+        gradient: shape && (!require_gradient || covers_gradient),
+        penalty,
+        revision,
+        second_order: allow_second_order,
+    }
+}
+
 impl<'d> SpatialJointContext<'d> {
     fn nfree_skip_gate_status(
         &self,
@@ -3472,24 +3499,26 @@ impl<'d> SpatialJointContext<'d> {
         require_gradient: bool,
     ) -> NfreeSkipGateStatus {
         let shape = theta.len() == self.rho_dim + 1;
-        let (value, gradient) = if shape {
+        let (covers_value, covers_skip, covers_gradient) = if shape {
             let psi = theta[self.rho_dim];
             (
-                self.evaluator.psi_gram_tensor_covers(psi)
-                    && self.evaluator.psi_gram_tensor_covers_skip(psi),
-                !require_gradient || self.evaluator.psi_gram_tensor_covers_gradient(psi),
+                self.evaluator.psi_gram_tensor_covers(psi),
+                self.evaluator.psi_gram_tensor_covers_skip(psi),
+                self.evaluator.psi_gram_tensor_covers_gradient(psi),
             )
         } else {
-            (false, false)
+            (false, false, false)
         };
-        NfreeSkipGateStatus {
+        nfree_skip_gate_status_from_parts(
             shape,
-            value,
-            gradient,
-            penalty: self.evaluator.supports_nfree_penalty_rekey(),
-            revision: self.evaluator.nfree_fast_path_revision().is_some(),
-            second_order: allow_second_order,
-        }
+            covers_value,
+            covers_skip,
+            covers_gradient,
+            self.evaluator.supports_nfree_penalty_rekey(),
+            self.evaluator.nfree_fast_path_revision().is_some(),
+            allow_second_order,
+            require_gradient,
+        )
     }
 
     fn frozen_glm_working_state(
@@ -9508,4 +9537,40 @@ fn wood_reference_df(influence: Option<&Array2<f64>>, coeff_range: &Range<usize>
     let tr2 = block.dot(&block).diag().sum();
     (tr.is_finite() && tr2.is_finite() && tr > 0.0)
         .then(|| (2.0 * tr - tr2).max(tr).max(1e-12))
+}
+
+#[cfg(test)]
+mod nfree_gate_tests {
+    use super::nfree_skip_gate_status_from_parts;
+
+    #[test]
+    fn value_only_nfree_gate_does_not_require_basis_skip_witness() {
+        let gate = nfree_skip_gate_status_from_parts(
+            true,  // shape
+            true,  // Chebyshev Gram value covers this ψ
+            false, // reduced-basis skip witness absent across a rotation seam
+            false, // gradient coverage irrelevant for a value-only cost probe
+            true,  // penalty can be re-keyed without rows
+            true,  // design revision is pinned
+            false, // no Hessian request
+            false, // value-only cost probe
+        );
+        assert!(
+            gate.would_skip(false),
+            "value-only κ cost probes must stay n-free when the Gram value is certified; \
+             the reduced-basis skip witness is required only for beta/gradient probes"
+        );
+    }
+
+    #[test]
+    fn gradient_nfree_gate_still_requires_basis_skip_witness() {
+        let gate = nfree_skip_gate_status_from_parts(
+            true, true, false, true, true, true, false, true,
+        );
+        assert!(
+            !gate.would_skip(true),
+            "gradient probes return beta/gradient objects in a reduced basis and must not \
+             skip the row lane without the reduced-basis witness"
+        );
+    }
 }


### PR DESCRIPTION
### Motivation
- The n-free κ outer-loop gate conflated two certificates: a value-only cost probe and a β/gradient probe, so value-only probes were forced through the O(n) `reset_surface` when a reduced-basis skip witness was absent across a benign basis-rotation seam.
- This reintroduced per-trial length-`n` work and broke the architectural invariant that hyperparameter trials should touch only k×k objects; the change restores the intended n-free behavior for value-only probes while preserving soundness for gradient-returning probes.

### Description
- Add a helper `nfree_skip_gate_status_from_parts(...)` that encodes the corrected gate semantics so value-only probes require only Chebyshev Gram value coverage while gradient probes still require the reduced-basis skip witness (`crates/gam-models/src/fit_orchestration/drivers/spatial_optimization.rs`).
- Update `SpatialJointContext::nfree_skip_gate_status` to query `psi_gram_tensor` coverage pieces (`covers_value`, `covers_skip`, `covers_gradient`) and route through the new helper.
- Add focused unit tests exercising both sides of the seam (`value_only_nfree_gate_does_not_require_basis_skip_witness` and `gradient_nfree_gate_still_requires_basis_skip_witness`) in the same file to guard regressions.

### Testing
- Ran `./build.sh check -p gam-models --lib`, which completed successfully (`exit 0`).
- Built perf tests with `./build.sh test --test perf_scale --no-run` (compile-only) and ran the micro κ probe `./build.sh test --test perf_scale kappa_micro_2point_n_independence -- --nocapture`; the micro test passed and reported `nfree_skip_row_touches == 0` on the exercised n ladder.
- Attempted to run the newly-added focused unit tests with `./build.sh test -p gam-models nfree_gate_tests -- --nocapture` but the environment hit heavy test-dependency rebuilds and timed out in this session; the crate-level `check` and perf-scale regression that exercise the runtime gate did pass as shown above.

---
Refs #1033. (epic — must not auto-close; changed from `Fixes` during panel review)

<details><summary>codex self-assessment</summary>

/gam-models)\n      Finished `dev` profile [unoptimized + debuginfo] target(s) in 7.86s\n  ```\n\n* \u2705 `./build.sh test --test perf_scale --no-run`\n  ```text\n  [build.sh] test --test perf_scale --no-run -> exit 0 in 1609s (dedup=MISS, recompiled 93 crates)\n     Compiling comfy-table v7.2.2\n     Compiling serde_with_macros v3.21.0\n     Compiling gam-config v0.3.148 (/workspace/gam/crates/gam-config)\n     Compiling gam-test-support v0.3.148 (/workspace/gam/crates/gam-test-support)\n     Compiling gam-report v0.3.148 (/workspace/gam/crates/gam-report)\n     Compiling cast v0.3.0\n     Compiling bevy_ptr v0.18.1\n     Compiling tinyvec_macros v0.1.1\n     Compiling bevy_ptr v0.17.3\n     Compiling same-file v1.0.6\n     Compiling walkdir v2.5.0\n     Compiling bevy_reflect v0.17.3\n     Compiling tinyvec v1.11.0\n     Compiling bevy_reflect v0.18.1\n     Compiling criterion-plot v0.8.2\n     Compiling serde_with v3.21.0\n     Compiling plotters v0.3.7\n     Compiling ciborium v0.2.2\n     Compiling tinytemplate v1.2.1\n     Compiling page_size v0.6.0\n     Compiling oorandom v11.1.5\n     Compiling anes v0.1.6\n     Compiling ad_trait v0.3.1\n     Compiling criterion v0.8.2\n     Compiling gam-predict v0.3.148 (/workspace/gam/crates/gam-predict)\n     Compiling num-dual v0.13.7\n     Compiling tempfile v3.27.0\n     Compiling autodiff v0.7.0\n      Finished `test` profile [optimized + debuginfo] target(s) in 26m 47s\n    Executable tests/perf_scale/main.rs (target/debug/deps/perf_scale-0e35117cfb33ce7a)\n  ```\n\n* \u2705 `./build.sh test --test perf_scale kappa_micro_2point_n_independence -- --nocapture`\n  ```text\n  [build.sh] test --test perf_scale kappa_micro_2point_n_independence -- --nocapture -> exit 0 in 105s (dedup=MISS, recompiled 0 crates)\n      Finished `test` profile [optimized + debuginfo] target(s) in 0.96s\n       Running tests/perf_scale/main.rs (target/debug/deps/perf_scale-0e35117cfb33ce7a)\n\n  running 1 test\n  [kappa-micro] warm-up primed caches in 32.0471s\n  [kappa-micro] n= 1000  per_callback_s=0.00605  skip_row_touches=0  resets=0  miss(shape/value/grad/pen/rev/2nd/oth)=0/0/0/0/0/0/0\n  test misc::kappa_loop_n_scaling::kappa_micro_2point_n_independence has been running for over 60 seconds\n  [kappa-micro] n= 2000  per_callback_s=0.00406  skip_row_touches=0  resets=0  miss(shape/value/grad/pen/rev/2nd/oth)=0/0/0/0/0/0/0\n  [kappa-micro] n grew 2\u00d7 ; PER-CALLBACK wall grew 0.67\u00d7 (report-only) ; skip_row_touches 0\u21920 ; resets 0\u21920\n  test misc::kappa_loop_n_scaling::kappa_micro_2point_n_independence ... ok\n\n  test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 91 filtered out; finished in 104.00s\n  ```\n\n* \u26a0\ufe0f `CARGO_BUILD_JOBS=1 GAM_BUILD_TIMEOUT=2400 ./build.sh test -p gam-models nfree_gate_tests -- --nocapture` \u2014 attempted to run the new focused unit tests, but this environment repeatedly rebuilt heavy test dependencies and did not complete in the available session; I killed the hung wrapper to avoid leaving an orphan build lock. The relevant crate library check and perf-scale regression did pass as shown above.\n\n### CODE DIFF\n\n```diff\ndiff --git a/crates/gam-models/src/fit_orchestration/drivers/spatial_optimization.rs b/crates/gam-models/src/fit_orchestration/drivers/spatial_optimization.rs\nindex 0c5b4b2..825f33e 100644\n--- a/crates/gam-models/src/fit_orchestration/drivers/spatial_optimization.rs\n+++ b/crates/gam-models/src/fit_orchestration/drivers/spatial_optimization.rs\n@@ -3464,6 +3464,33 @@ impl NfreeSkipGateStatus {\n     }\n }\n \n+fn nfree_skip_gate_status_from_parts(\n+    shape: bool,\n+    covers_value: bool,\n+    covers_skip: bool,\n+    covers_gradient: bool,\n+    penalty: bool,\n+    revision: bool,\n+    allow_second_order: bool,\n+    require_gradient: bool,\n+) -> NfreeSkipGateStatus {\n+    NfreeSkipGateStatus {\n+        shape,\n+        // A value-only cost probe consumes only the Chebyshev Gram value; it\n+        // d
</details>

_Codex-generated; pending adversarial audit before merge._
