### PR TITLE
#1551: Guard SAE device Direct PCG step with trust-region radius

### DIFF
--- a/crates/gam-solve/src/arrow_schur/newton_step.rs
+++ b/crates/gam-solve/src/arrow_schur/newton_step.rs
@@ -445,12 +445,14 @@ pub(crate) fn try_device_arrow_direct(
 /// device branch only fires when `radius == INFINITY` (never set in production).
 /// So every real SAE fit ran the inner arrow-Schur on the CPU (GPU 0%).
 ///
-/// Direct mode is the **exact full Newton step** — there is no trust-region
-/// truncation to honor — so the unbounded device PCG, run to tight tolerance and
-/// high iteration count, converges to the SAME step the dense Direct CPU path
-/// produces (to ~1e-8). The `radius == INFINITY` concern that gates the
-/// InexactPCG device branch therefore does not apply here: the bounded radius in
-/// the options is irrelevant because Direct never truncates.
+/// This seam is valid only when the unbounded device PCG step is also the step
+/// the dense Direct CPU path would accept. Dense Direct first factors `S` and
+/// computes the exact Newton step, but it still falls back to Steihaug-CG when
+/// that step leaves a finite trust ball. The device kernel does not implement
+/// Steihaug truncation, so after it returns the unbounded step we admit it only
+/// when [`step_inside_trust_region`] proves the β step is inside the active
+/// trust radius (or the radius is unbounded). Otherwise we transparently decline
+/// and let the existing CPU Direct path compute the principled truncated step.
 ///
 /// Returns `Some(Ok(..))` when the device produced a converged step (caller
 /// returns it), `Some(Err(..))` only for a numerical failure the LM escalation
@@ -547,10 +549,10 @@ pub(crate) fn try_device_arrow_direct_sae_pcg(
         sys.d,
         device_data.frame.is_some()
     );
-    // Direct mode = exact full step: run the unbounded device PCG to a tight
-    // tolerance and a high iteration ceiling so it converges to the same step the
-    // dense Direct factorization yields. The control floor here is independent of
-    // the (irrelevant, never-truncated) trust-region radius.
+    // First compute the unbounded Direct Newton step: when it lies inside the
+    // trust ball it is exactly the step the dense Direct path accepts. If the
+    // post-solve radius check below fails, this seam declines so CPU Direct can
+    // compute the required Steihaug boundary step.
     let max_iterations = options.pcg.max_iterations.max(sys.k.saturating_add(1));
     let relative_tolerance = options.pcg.relative_tolerance.min(1e-12);
     match crate::gpu_kernels::arrow_schur::solve_sae_matrix_free_pcg(
@@ -563,6 +565,14 @@ pub(crate) fn try_device_arrow_direct_sae_pcg(
         relative_tolerance,
     ) {
         Ok((delta_beta, mut diag)) => {
+            if !step_inside_trust_region(delta_beta.view(), options.trust_region.radius, None) {
+                trace_decline!(
+                    "unbounded device step lies outside finite trust radius {} — \
+                     CPU Direct must compute the Steihaug-truncated step",
+                    options.trust_region.radius
+                );
+                return None;
+            }
             diag.used_device_arrow = true;
             let delta_t = back_substitute_delta_t(sys, htt_factors, delta_beta.view(), backend);
             // The matrix-free device PCG returns the step ONLY (it never forms the
@@ -1821,10 +1831,10 @@ pub(crate) fn solve_arrow_newton_step_artifacts(
         ArrowSolverMode::Direct => {
             // #1551 production device seam: when the matrix-free SAE PCG frames are
             // present and the GPU admits the CG-amortised work, run the exact full
-            // Direct step on the device (no trust-region truncation in Direct mode,
-            // so the unbounded device PCG converges to the dense Direct step). On any
-            // device decline this returns `None` and the CPU dense path below runs
-            // bit-identically.
+            // Direct step on the device when that unbounded step is inside the
+            // active trust radius. If the step needs Steihaug truncation, or on any
+            // other device decline, this returns `None` and the CPU dense path below
+            // runs bit-identically.
             if let Some(device_step) = try_device_arrow_direct_sae_pcg(
                 sys,
                 &htt_factors,


### PR DESCRIPTION
### Motivation

- Production SAE inner solves were silently falling back to CPU because the device matrix-free PCG path produced an untruncated Newton step that could violate the active trust radius, and the device seam previously assumed Direct never truncates.

### Description

- Add a post-device-solve trust-region admission check in `try_device_arrow_direct_sae_pcg` so the device-returned `Δβ` is accepted only when `step_inside_trust_region(delta_beta, options.trust_region.radius, None)` holds; otherwise the device seam declines and the CPU Direct Steihaug path runs. (file: `crates/gam-solve/src/arrow_schur/newton_step.rs`, ~L552–575)
- Update comments/documentation at the device dispatch site to reflect that the device unbounded PCG step is only valid when it lies inside the active trust radius and must decline otherwise. (same file, surrounding comment edits)
- Preserve existing failure semantics: numerical failures from device kernels still surface as errors so LM ridge escalation can respond; only genuine device declines fall through transparently to CPU.

### Testing

- Ran full library build: `./build.sh` — succeeded (lib finished).  
- Ran deny-warnings check for the changed crate: `./build.sh check -p gam-solve --lib` — succeeded.  
- Built test binary: `./build.sh test --test owed_1017_phase0 --no-run` — succeeded after the build-wrapper retry; test binary produced.  
- Ran focused unit tests that exercise the changed seam: `./build.sh test -p gam-solve --lib sae_direct_inner_solve_engages_device_and_matches_cpu_1551 -- --nocapture` and `./build.sh test -p gam-solve --lib sae_inexact_pcg_inner_solve_engages_device_and_matches_cpu_1551 -- --nocapture` — both tests passed.

---
Refs #1551 (partial: adds the trust-region admission guard on the device Direct seam; does NOT resolve the open framed-matvec correctness blocker).

<details><summary>codex self-assessment</summary>

e-filter interface, so the second positional filter was rejected.\n\n  Output:\n\n  ```text\n  error: unexpected argument 'sae_inexact_pcg_inner_solve_engages_device_and_matches_cpu_1551' found\n  ```\n\n* \u2705 `./build.sh test -p gam-solve --lib sae_direct_inner_solve_engages_device_and_matches_cpu_1551 -- --nocapture`\n\n  Output excerpt:\n\n  ```text\n  [build.sh] test -p gam-solve --lib sae_direct_inner_solve_engages_device_and_matches_cpu_1551 -- --nocapture -> exit 0 in 543s (dedup=MISS, recompiled 1 crates)\n      Finished `test` profile [optimized + debuginfo] target(s) in 8m 48s\n       Running unittests src/lib.rs (target/debug/deps/gam_solve-5434b1d24a5f273e)\n\n  running 1 test\n  test arrow_schur::tests::sae_direct_inner_solve_engages_device_and_matches_cpu_1551 ... ok\n\n  test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 1198 filtered out; finished in 14.54s\n  ```\n\n* \u2705 `./build.sh test -p gam-solve --lib sae_inexact_pcg_inner_solve_engages_device_and_matches_cpu_1551 -- --nocapture`\n\n  Output:\n\n  ```text\n  [build.sh] test -p gam-solve --lib sae_inexact_pcg_inner_solve_engages_device_and_matches_cpu_1551 -- --nocapture -> exit 0 in 16s (dedup=MISS, recompiled 0 crates)\n      Finished `test` profile [optimized + debuginfo] target(s) in 0.62s\n       Running unittests src/lib.rs (target/debug/deps/gam_solve-5434b1d24a5f273e)\n\n  running 1 test\n  test arrow_schur::tests::sae_inexact_pcg_inner_solve_engages_device_and_matches_cpu_1551 ... ok\n\n  test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 1198 filtered out; finished in 14.86s\n  ```\n\n### CODE DIFF\n\n```diff\ndiff --git a/crates/gam-solve/src/arrow_schur/newton_step.rs b/crates/gam-solve/src/arrow_schur/newton_step.rs\nindex 6e6659f..513370f 100644\n--- a/crates/gam-solve/src/arrow_schur/newton_step.rs\n+++ b/crates/gam-solve/src/arrow_schur/newton_step.rs\n@@ -445,12 +445,14 @@ pub(crate) fn try_device_arrow_direct(\n /// device branch only fires when `radius == INFINITY` (never set in production).\n /// So every real SAE fit ran the inner arrow-Schur on the CPU (GPU 0%).\n ///\n-/// Direct mode is the **exact full Newton step** \u2014 there is no trust-region\n-/// truncation to honor \u2014 so the unbounded device PCG, run to tight tolerance and\n-/// high iteration count, converges to the SAME step the dense Direct CPU path\n-/// produces (to ~1e-8). The `radius == INFINITY` concern that gates the\n-/// InexactPCG device branch therefore does not apply here: the bounded radius in\n-/// the options is irrelevant because Direct never truncates.\n+/// This seam is valid only when the unbounded device PCG step is also the step\n+/// the dense Direct CPU path would accept. Dense Direct first factors `S` and\n+/// computes the exact Newton step, but it still falls back to Steihaug-CG when\n+/// that step leaves a finite trust ball. The device kernel does not implement\n+/// Steihaug truncation, so after it returns the unbounded step we admit it only\n+/// when [`step_inside_trust_region`] proves the \u03b2 step is inside the active\n+/// trust radius (or the radius is unbounded). Otherwise we transparently decline\n+/// and let the existing CPU Direct path compute the principled truncated step.\n@@ -547,10 +549,10 @@ pub(crate) fn try_device_arrow_direct_sae_pcg(\n-    // Direct mode = exact full step: run the unbounded device PCG to a tight\n-    // tolerance and a high iteration ceiling so it converges to the same step the\n-    // dense Direct factorization yields. The control floor here is independent of\n-    // the (irrelevant, never-truncated) trust-region radius.\n+    // First compute the unbounded Direct Newton step: when it lies inside the\n+    // trust ball it is exactly the step the dense Direct path accepts. If the\n+    // post-solve radius check below fails, this seam declines so CPU Direct can\n+    // compute the required Steihaug boundary step.\n@@ -563,6 +565,14 @@ pub(crate) fn try_device_arrow_direct
</details>

_Codex-generated; pending adversarial audit before merge._
