### PR TITLE
#1561: fix: preserve explicit cs shrinkage on secondary smooths

### DIFF
--- a/crates/gam-models/src/fit_orchestration/materialize/secondary.rs
+++ b/crates/gam-models/src/fit_orchestration/materialize/secondary.rs
@@ -27,7 +27,9 @@ use super::*;
 /// bases that DEFAULT the Marra & Wood penalty on (`bspline`/`tps`/`matern`) are
 /// affected; `duchon` is excluded because it has no such penalty to disable and its
 /// builder rejects a `double_penalty=` key outright. An explicit user
-/// `double_penalty=` always wins.
+/// `double_penalty=` always wins, as does the mgcv shrinkage spline alias
+/// `bs="cs"`, because that alias is itself an explicit request for null-space
+/// shrinkage rather than a default inherited from `s()`.
 pub(super) fn apply_secondary_predictor_basis_parsimony(terms: &mut [ParsedTerm], n_rows: usize) {
     for term in terms.iter_mut() {
         if let ParsedTerm::Smooth {
@@ -47,10 +49,8 @@ pub(super) fn apply_secondary_predictor_basis_parsimony(terms: &mut [ParsedTerm]
             // reproducing-norm penalty plus a null-space ridge) and its builder
             // rejects a `double_penalty=` key outright, so injecting one here
             // would abort an otherwise-valid scale-block Duchon fit.
-            if matches!(canonical.as_str(), "bspline" | "tps" | "matern") {
-                options
-                    .entry("double_penalty".to_string())
-                    .or_insert_with(|| "false".to_string());
+            if secondary_smooth_should_disable_default_double_penalty(&canonical, options) {
+                options.insert("double_penalty".to_string(), "false".to_string());
             }
 
             if !smooth_type_uses_spatial_center_heuristic(&canonical)
@@ -61,5 +61,60 @@ pub(super) fn apply_secondary_predictor_basis_parsimony(terms: &mut [ParsedTerm]
             let cap = gam_terms::basis::conservative_secondary_centers(n_rows, vars.len());
             options.insert(SECONDARY_CENTER_CAP_OPTION.to_string(), cap.to_string());
         }
+    }
+}
+
+
+fn secondary_smooth_should_disable_default_double_penalty(
+    canonical: &str,
+    options: &BTreeMap<String, String>,
+) -> bool {
+    if options.contains_key("double_penalty") {
+        return false;
+    }
+
+    let selector = options
+        .get("bs")
+        .or_else(|| options.get("type"))
+        .map(|raw| raw.trim().to_ascii_lowercase());
+    if matches!(selector.as_deref(), Some("cs")) {
+        // `cs` is mgcv's shrinkage cubic-regression spline. It is not a silent
+        // default double penalty; it is the user's basis choice, equivalent to
+        // selecting the cubic-regression span plus null-space shrinkage.
+        return false;
+    }
+
+    matches!(canonical, "bspline" | "tps" | "matern")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn opts(pairs: &[(&str, &str)]) -> BTreeMap<String, String> {
+        pairs
+            .iter()
+            .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+            .collect()
+    }
+
+    #[test]
+    fn secondary_double_penalty_default_off_preserves_explicit_cs_shrinkage() {
+        assert!(secondary_smooth_should_disable_default_double_penalty(
+            "bspline",
+            &opts(&[])
+        ));
+        assert!(!secondary_smooth_should_disable_default_double_penalty(
+            "bspline",
+            &opts(&[("bs", "cs")])
+        ));
+        assert!(!secondary_smooth_should_disable_default_double_penalty(
+            "bspline",
+            &opts(&[("double_penalty", "true")])
+        ));
+        assert!(!secondary_smooth_should_disable_default_double_penalty(
+            "duchon",
+            &opts(&[])
+        ));
     }
 }


### PR DESCRIPTION
### Motivation
- The secondary-predictor parsimony pass injected `double_penalty=false` for many smooths which incorrectly overrode explicit user requests such as `bs="cs"`, causing shrinkage spline semantics to be lost and scale-block fits to be biased toward homoscedasticity (#1561).
- The intent is to disable only inherited default null-space double-penalties for secondary (distributional) predictors while preserving explicit user choices and the Duchon exclusion, so REML can recover genuine scale variation without mutating explicit formula semantics.

### Description
- Replace the unconditional injection of `double_penalty=false` with a helper: `secondary_smooth_should_disable_default_double_penalty(canonical, options)` in `crates/gam-models/src/fit_orchestration/materialize/secondary.rs` so only inherited defaults are suppressed.
- The helper preserves explicit `double_penalty=` options, preserves explicit mgcv `bs="cs"` shrinkage alias, excludes Duchon, and otherwise disables the inherited default for `bspline`/`tps`/`matern`.
- Update the module docstring to document that explicit `double_penalty=` and `bs="cs"` win over the default-off rule.
- Add unit test guarding the helper behavior to ensure the default-off path, explicit `bs="cs"`, explicit `double_penalty=`, and Duchon exclusion behave as intended.

### Testing
- Ran `./build.sh fmt --check -p gam-models` which passed successfully.
- Built the workspace with `./build.sh` which completed (library build exit 0) and showed `gam-models` compiled during the run.
- Ran `./build.sh check -p gam-models --lib` which passed (exit 0).
- Attempted to run the scoped test binary creation with `./build.sh test -p gam-models --lib secondary_double_penalty_default_off_preserves_explicit_cs_shrinkage --no-run` but the environment hit the build-wrapper transient OOM/timeout retry path; the wrapper retried and reported OOM/timeout attempts, so the filtered test binary could not be completed in this environment.
- Attempted `./build.sh test --test bug_hunt_duchon_scale_smooth_double_penalty_injection_1561 --no-run` similarly hit the wrapper transient OOM/timeout and could not be completed here.

---
Fixes #1561.

<details><summary>codex self-assessment</summary>

-models v0.3.148 (/workspace/gam/crates/gam-models)\n     Compiling burn v0.18.0\n     Compiling colorchoice v1.0.5\n     Compiling is_terminal_polyfill v1.70.2\n     Compiling linux-raw-sys v0.12.1\n     Compiling anstyle-query v1.1.5\n     Compiling anstyle v1.0.14\n     Compiling litrs v1.0.0\n     Compiling anstream v1.0.0\n     Compiling general-mcmc v0.9.0\n     Compiling document-features v0.2.12\n     Compiling parking_lot v0.12.5\n     Compiling gam-sae v0.3.148 (/workspace/gam/crates/gam-sae)\n     Compiling clap_lex v1.1.0\n     Compiling heck v0.5.0\n     Compiling clap_derive v4.6.1\n     Compiling clap_builder v4.6.0\n     Compiling gam-inference v0.3.148 (/workspace/gam/crates/gam-inference)\n     Compiling crossterm v0.29.0\n     Compiling gam v0.3.148 (/workspace/gam)\n     Compiling comfy-table v7.2.2\n     Compiling gam-config v0.3.148 (/workspace/gam/crates/gam-config)\n     Compiling gam-test-support v0.3.148 (/workspace/gam/crates/gam-test-support)\n     Compiling clap v4.6.1\n     Compiling gam-report v0.3.148 (/workspace/gam/crates/gam-report)\n      Finished `dev` profile [unoptimized + debuginfo] target(s) in 20m 42s\n  ```\n\n* \u2705 `./build.sh check -p gam-models --lib`\n\n  ```text\n  [build.sh] check -p gam-models --lib -> exit 0 in 0s (dedup=SUBSUMED, recompiled 0 crates)\n  ```\n\n* \u26a0\ufe0f `./build.sh test -p gam-models --lib secondary_double_penalty_default_off_preserves_explicit_cs_shrinkage --no-run`\n\n  ```text\n  [build.sh] transient failure (OOM/timeout, exit 124) attempt 1/3 \u2014 retrying with CARGO_BUILD_JOBS=1 (lower peak RAM)\u2026\n  Terminated\n  [build.sh] transient failure (OOM/timeout, exit 143) attempt 2/3 \u2014 backing off for memory, retrying\u2026\n  ./build.sh: line 394: 25117 Killed                  sleep $(( attempt * 12 ))\n  ```\n\n* \u26a0\ufe0f `./build.sh test --test bug_hunt_duchon_scale_smooth_double_penalty_injection_1561 --no-run`\n\n  ```text\n  [build.sh] transient failure (OOM/timeout, exit 124) attempt 1/3 \u2014 retrying with CARGO_BUILD_JOBS=1 (lower peak RAM)\u2026\n  ```\n\n## CODE DIFF\n\n```diff\ndiff --git a/crates/gam-models/src/fit_orchestration/materialize/secondary.rs b/crates/gam-models/src/fit_orchestration/materialize/secondary.rs\nindex 251fbce..98121d7 100644\n--- a/crates/gam-models/src/fit_orchestration/materialize/secondary.rs\n+++ b/crates/gam-models/src/fit_orchestration/materialize/secondary.rs\n@@ -27,7 +27,9 @@ use super::*;\n /// bases that DEFAULT the Marra & Wood penalty on (`bspline`/`tps`/`matern`) are\n /// affected; `duchon` is excluded because it has no such penalty to disable and its\n /// builder rejects a `double_penalty=` key outright. An explicit user\n-/// `double_penalty=` always wins.\n+/// `double_penalty=` always wins, as does the mgcv shrinkage spline alias\n+/// `bs=\"cs\"`, because that alias is itself an explicit request for null-space\n+/// shrinkage rather than a default inherited from `s()`.\n pub(super) fn apply_secondary_predictor_basis_parsimony(terms: &mut [ParsedTerm], n_rows: usize) {\n@@ -47,10 +49,8 @@ pub(super) fn apply_secondary_predictor_basis_parsimony(terms: &mut [ParsedTerm]\n             // reproducing-norm penalty plus a null-space ridge) and its builder\n             // rejects a `double_penalty=` key outright, so injecting one here\n             // would abort an otherwise-valid scale-block Duchon fit.\n-            if matches!(canonical.as_str(), \"bspline\" | \"tps\" | \"matern\") {\n-                options\n-                    .entry(\"double_penalty\".to_string())\n-                    .or_insert_with(|| \"false\".to_string());\n+            if secondary_smooth_should_disable_default_double_penalty(&canonical, options) {\n+                options.insert(\"double_penalty\".to_string(), \"false\".to_string());\n             }\n@@ -63,3 +63,58 @@ pub(super) fn apply_secondary_predictor_basis_parsimony(terms: &mut [ParsedTerm]\n         }\n     }\n }\n+\n+\n+fn secondary_smooth_sh
</details>

_Codex-generated; pending adversarial audit before merge._