### PR TITLE
#1813: Clarify Duchon operator gate and add predicate + tests

### DIFF
--- a/crates/gam-terms/src/basis/duchon_thinplate.rs
+++ b/crates/gam-terms/src/basis/duchon_thinplate.rs
@@ -386,27 +386,18 @@ fn build_duchon_basis_uncached(
         // mass/tension/stiffness operator penalties): those operators build
         // their own collocation Grams in the un-rotated `Z` frame, so rotating
         // only the native penalty would desync the operator penalty columns.
-        // Operators are off for the default `duchon(x1,x2)` (the #1355 collapse),
-        // so this gate keeps the fix scoped to where it is needed and sound.
-        let operators_active = matches!(
-            spec.operator_penalties.mass,
-            OperatorPenaltySpec::Active { .. }
-        ) || matches!(
-            spec.operator_penalties.tension,
-            OperatorPenaltySpec::Active { .. }
-        ) || matches!(
-            spec.operator_penalties.stiffness,
-            OperatorPenaltySpec::Active { .. }
-        );
+        // Default Duchon terms have mass+tension active, so they deliberately
+        // bypass this fused native-only path; `all_disabled()` is the opt-in
+        // configuration that reaches it.
+        let operators_active = spec.operator_penalties.has_active_operator_penalty();
         // When the fresh data-metric reparam is computed, its `raw` (un-rotated)
         // design is built here from a full `n×k` kernel evaluation. That SAME
         // realized design is the base of the final basis — rotating it by the
         // adopted `V` gives the fit-time design without a second kernel pass —
         // so carry it forward instead of rebuilding it below (#1718). This
-        // halves the cold-build kernel work for the default `duchon(x, z)`,
-        // which is the only configuration that hits this branch (native Gram,
-        // no operators, no frozen reparam), closing the wall-time gap to
-        // `thinplate(x, z)`.
+        // halves the cold-build kernel work for explicit native-only Duchon
+        // configurations (`all_disabled()`, no frozen reparam), closing their
+        // wall-time gap to `thinplate(x, z)` without changing default terms.
         let mut prebuilt_raw_basis: Option<Array2<f64>> = None;
         if frozen_radial_reparam.is_none() && !operators_active {
             let kernel_cols = kernel_transform.ncols();
@@ -2690,6 +2681,37 @@ mod knot_selection_invariance_tests {
             canonical(&knots),
             canonical(&knots_perm),
             "reordering rows must not change the selected knot set (gh#1378)"
+        );
+    }
+}
+
+#[cfg(test)]
+mod duchon_operator_gate_tests {
+    use super::{DuchonOperatorPenaltySpec, OperatorPenaltySpec};
+
+    #[test]
+    fn default_duchon_operator_penalties_are_active() {
+        let default_spec = DuchonOperatorPenaltySpec::default();
+
+        assert!(
+            default_spec.has_active_operator_penalty(),
+            "default Duchon terms must bypass the native-only fused radial path"
+        );
+        assert!(
+            matches!(default_spec.mass, OperatorPenaltySpec::Active { .. })
+                && matches!(default_spec.tension, OperatorPenaltySpec::Active { .. })
+                && matches!(default_spec.stiffness, OperatorPenaltySpec::Disabled),
+            "the default is mass+tension active with stiffness disabled"
+        );
+    }
+
+    #[test]
+    fn all_disabled_duchon_operator_penalties_are_native_only() {
+        let native_only = DuchonOperatorPenaltySpec::all_disabled();
+
+        assert!(
+            !native_only.has_active_operator_penalty(),
+            "all_disabled() is the explicit native-Gram-only configuration"
         );
     }
 }

--- a/crates/gam-terms/src/basis/types.rs
+++ b/crates/gam-terms/src/basis/types.rs
@@ -996,6 +996,12 @@ impl Default for DuchonOperatorPenaltySpec {
 }
 
 impl DuchonOperatorPenaltySpec {
+    pub fn has_active_operator_penalty(&self) -> bool {
+        matches!(self.mass, OperatorPenaltySpec::Active { .. })
+            || matches!(self.tension, OperatorPenaltySpec::Active { .. })
+            || matches!(self.stiffness, OperatorPenaltySpec::Active { .. })
+    }
+
     pub fn all_disabled() -> Self {
         Self {
             mass: OperatorPenaltySpec::Disabled,


### PR DESCRIPTION
### Motivation
- The Duchon builder duplicated a local "operators active" predicate and had comments that implied the default `duchon(x, z)` could hit the native-only fused radial reparam branch, which is false because the default enables mass+tension. 
- This mismatch made triage error-prone by encouraging reasoning from a stale local comment/predicate rather than from the canonical operator spec. 
- Centralizing the predicate and locking the contract with tests prevents future misattribution and documents the intended gating semantics.

### Description
- Add `has_active_operator_penalty()` to `DuchonOperatorPenaltySpec` to provide a single, tested predicate for whether any of `mass`, `tension`, or `stiffness` is `Active` (file: `crates/gam-terms/src/basis/types.rs`).
- Replace the inline `matches!` chain in the Duchon builder with the new method and correct the surrounding comment to state that default Duchon terms bypass the fused native-only path while `all_disabled()` is the explicit native-only configuration (file: `crates/gam-terms/src/basis/duchon_thinplate.rs`).
- Add unit tests that assert the default spec has mass+tension active and stiffness disabled and that `all_disabled()` is recognized as the native-only configuration (file: `crates/gam-terms/src/basis/duchon_thinplate.rs`).
- No behavioral workarounds, solver paper-overs, or forbidden patterns from `SPEC.md` were introduced; the change centralizes logic and adds regression coverage only.

### Testing
- Built the crate library with `./build.sh check -p gam-terms --lib`, which completed successfully (exit 0).
- Ran a full repository build with `./build.sh`, which completed successfully (exit 0).
- Built test binaries with `./build.sh test --test basis_smooth --no-run`, which completed successfully (exit 0).
- Ran the new unit tests via `./build.sh test -p gam-terms --lib duchon_operator_gate_tests -- --nocapture`, which ran 2 tests and both passed (exit 0).
- Re-ran the relevant regression test with `./build.sh test --test basis_smooth duchon_order1_polynomial_block_is_independent_of_the_kernel_block -- --nocapture`, which passed (exit 0).
- `./build.sh fmt --check` experienced transient environment OOM/timeout retries and reported a transient failure (exit 75) unrelated to code format; `git diff --check` shows no formatting issues.

---
Refs #1813 (partial: clarifies the operator gate + locks the default-active invariant; the umbrella tracks the remaining independent Duchon sub-causes).

<details><summary>codex self-assessment</summary>

`./build.sh`\n\n  ```text\n  [build.sh] LIB -> exit 0 in 1228s (dedup=MISS, recompiled 139 crates)\n     Compiling gam v0.3.148 (/workspace/gam)\n     Compiling gam-report v0.3.148 (/workspace/gam/crates/gam-report)\n      Finished `dev` profile [unoptimized + debuginfo] target(s) in 20m 26s\n  ```\n\n* \u2705 `./build.sh test --test basis_smooth --no-run`\n\n  ```text\n  [build.sh] test --test basis_smooth --no-run -> exit 0 in 1683s (dedup=MISS, recompiled 21 crates)\n     Compiling gam-predict v0.3.148 (/workspace/gam/crates/gam-predict)\n     Compiling num-dual v0.13.7\n     Compiling tempfile v3.27.0\n     Compiling autodiff v0.7.0\n      Finished `test` profile [optimized + debuginfo] target(s) in 28m 03s\n    Executable tests/basis_smooth/main.rs (target/debug/deps/basis_smooth-24226fcdc1a6375e)\n  ```\n\n* \u2705 `./build.sh test -p gam-terms --lib duchon_operator_gate_tests -- --nocapture`\n\n  ```text\n  [build.sh] test -p gam-terms --lib duchon_operator_gate_tests -- --nocapture -> exit 0 in 1644s (dedup=MISS, recompiled 3 crates)\n     Compiling gam-models v0.3.148 (/workspace/gam/crates/gam-models)\n     Compiling gam-test-support v0.3.148 (/workspace/gam/crates/gam-test-support)\n     Compiling gam-terms v0.3.148 (/workspace/gam/crates/gam-terms)\n      Finished `test` profile [optimized + debuginfo] target(s) in 27m 23s\n       Running unittests src/lib.rs (target/debug/deps/gam_terms-e44a500d3580d2ee)\n\n  running 2 tests\n  test basis::duchon_thinplate::duchon_operator_gate_tests::all_disabled_duchon_operator_penalties_are_native_only ... ok\n  test basis::duchon_thinplate::duchon_operator_gate_tests::default_duchon_operator_penalties_are_active ... ok\n\n  test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 688 filtered out; finished in 0.00s\n  ```\n\n* \u2705 `./build.sh test --test basis_smooth duchon_order1_polynomial_block_is_independent_of_the_kernel_block -- --nocapture`\n\n  ```text\n  [build.sh] test --test basis_smooth duchon_order1_polynomial_block_is_independent_of_the_kernel_block -- --nocapture -> exit 0 in 2s (dedup=MISS, recompiled 0 crates)\n      Finished `test` profile [optimized + debuginfo] target(s) in 1.32s\n       Running tests/basis_smooth/main.rs (target/debug/deps/basis_smooth-24226fcdc1a6375e)\n\n  running 1 test\n  test smooths::duchon_order_nullspace::duchon_order1_polynomial_block_is_independent_of_the_kernel_block ... ok\n\n  test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 299 filtered out; finished in 0.02s\n  ```\n\n* \u26a0\ufe0f `./build.sh fmt --check`\n\n  ```text\n  [build.sh] transient failure (OOM/timeout, exit 1) attempt 1/3 \u2014 retrying with CARGO_BUILD_JOBS=1 (lower peak RAM)\u2026\n  [build.sh] transient failure (OOM/timeout, exit 1) attempt 2/3 \u2014 backing off for memory, retrying\u2026\n  [build.sh] still transiently failing (exit 1) after 3 attempts \u2014 giving up this round.\n  TRANSIENT FAILURE (75, OOM/timeout) \u2014 retry\n  ```\n\n* \u2705 `git diff --check`\n\n  ```text\n  ```\n\n## CODE DIFF\n\nCommitted on the current branch:\n\n```text\n4dd18c0 Clarify Duchon operator gate\n```\n\nPR metadata was created with title:\n\n```text\nClarify Duchon operator gate\n```\n\n## SELF-ASSESSMENT\n\n* **SOLVES THE ISSUE? PARTIAL.** This fixes the concrete root-cause mechanism I found in the builder triage path: the stale local fused-branch doctrine is now corrected, centralized, and covered by tests. It does **not** claim to solve every independent Duchon quality/rotation/rank issue listed in #1813; those remain separate mechanisms by the issue\u2019s own triage.\n* **NET EFFECT: NET-GOOD.** The change is small, removes duplicated predicate logic, corrects misleading builder documentation, and adds regression coverage for the default operator gate. Risk is low because the functional branch condition is intended to be equivalent to the previous inline predicate; the main behavior change is making that predicate reusable and test-backed."}]
</details>

_Codex-generated; pending adversarial audit before merge._
