### PR TITLE
#1939: Return realised cone intensities from fitted_assignment_amplitudes (include log_amplitude)

### DIFF
--- a/crates/gam-sae/src/manifold/construction.rs
+++ b/crates/gam-sae/src/manifold/construction.rs
@@ -3585,11 +3585,12 @@ impl SaeManifoldTerm {
 
     /// #1026 — the fitted per-row assignment masses `a[i,k]` (the activation
     /// amplitudes `z_k` the amortized encode recovers `t` against), as an
-    /// `n × K` matrix. These are exactly the masses
-    /// [`Self::try_fitted_with_rho`] assembles the reconstruction from, so
-    /// feeding them to [`Self::amortized_encode_target`] re-encodes the SAME
-    /// inference the dictionary was fit against — the self-consistency the
-    /// distilled encoder is supervised to approximate.
+    /// `n × K` matrix. These are the realised positive intensities
+    /// `a_{ik}·exp(s_k)` that [`Self::try_fitted_with_rho`] multiplies into each
+    /// atom's unit-shape decoded row.  The gate `a_{ik}` remains the existence
+    /// posterior/indicator, while the atom log-amplitude `s_k` is the radial
+    /// intensity scale; feeding the product to [`Self::amortized_encode_target`]
+    /// re-encodes the SAME inference the dictionary was fit against.
     pub fn fitted_assignment_amplitudes(
         &self,
         rho: &SaeManifoldRho,
@@ -3600,7 +3601,8 @@ impl SaeManifoldTerm {
         for row in 0..n {
             let a = self.assignment.try_assignments_row_for_rho(row, rho)?;
             for atom_idx in 0..k_atoms {
-                amplitudes[[row, atom_idx]] = a[atom_idx];
+                amplitudes[[row, atom_idx]] =
+                    a[atom_idx] * self.atoms[atom_idx].log_amplitude.exp();
             }
         }
         Ok(amplitudes)

--- a/crates/gam-sae/src/manifold/construction_tests.rs
+++ b/crates/gam-sae/src/manifold/construction_tests.rs
@@ -49,17 +49,21 @@ mod amortized_encoder_tests {
         }
     }
 
-    /// The fitted amplitudes the encoder derives are exactly the assignment
-    /// masses the reconstruction is assembled from — feeding them back is the
-    /// self-consistency the distilled map is supervised against.
+    /// The fitted amplitudes the encoder derives are the realised intensity
+    /// coordinates the reconstruction uses: the existence gate times the explicit
+    /// cone radial scale.  Returning the bare gate would silently re-couple
+    /// presence and intensity for amortized encoding as soon as `log_amplitude`
+    /// moves away from zero.
     #[test]
-    fn fitted_assignment_amplitudes_match_the_assignment_masses() {
-        let (term, _target, rho) = small_two_atom_periodic_term();
+    fn fitted_assignment_amplitudes_include_explicit_log_amplitude_1939() {
+        let (mut term, _target, rho) = small_two_atom_periodic_term();
+        term.atoms[0].log_amplitude = 2.0_f64.ln();
+        term.atoms[1].log_amplitude = 0.25_f64.ln();
         let n = term.n_obs();
         let k = term.k_atoms();
         let amplitudes = term
             .fitted_assignment_amplitudes(&rho)
-            .expect("fitted amplitudes derive from the assignment");
+            .expect("fitted amplitudes derive from assignment and cone scale");
         assert_eq!(amplitudes.dim(), (n, k));
         for row in 0..n {
             let a = term
@@ -67,10 +71,11 @@ mod amortized_encoder_tests {
                 .try_assignments_row_for_rho(row, &rho)
                 .expect("assignment row resolves");
             for atom_idx in 0..k {
+                let expected = a[atom_idx] * term.atoms[atom_idx].log_amplitude.exp();
                 assert_eq!(
                     amplitudes[[row, atom_idx]],
-                    a[atom_idx],
-                    "amplitude[{row},{atom_idx}] must equal the assignment mass"
+                    expected,
+                    "amplitude[{row},{atom_idx}] must equal gate times explicit cone scale"
                 );
             }
         }

--- a/crates/gam-sae/src/manifold/tests_logdet_adjoint_780.rs
+++ b/crates/gam-sae/src/manifold/tests_logdet_adjoint_780.rs
@@ -214,20 +214,6 @@ fn dual_half_logdet_trace_2156(cache: &ArrowFactorCache, h: &Array2<f64>, dh: &A
     0.5 * report.total_derivative
 }
 
-fn dual_logdet_trace_2156(
-    label: &'static str,
-    cache: &ArrowFactorCache,
-    h: &Array2<f64>,
-    dh: &Array2<f64>,
-) -> (f64, BranchCertificate) {
-    let report = dual_trace_report_2156(
-        cache,
-        h,
-        vec![(DerivativeTraceChannel::Other(label), dh.clone())],
-    );
-    (report.total_derivative, report.certificate)
-}
-
 fn relative_error_2156(exact: f64, production: f64) -> f64 {
     (exact - production).abs() / exact.abs().max(production.abs()).max(1.0)
 }


### PR DESCRIPTION
### Motivation

- The amortized-encoder surface consumed `fitted_assignment_amplitudes` but that function returned only the assignment gate `a_{ik}`, dropping the atom `log_amplitude` scale and collapsing existence vs intensity.
- This mismatch decoupled the reconstruction path (which used `a_{ik}·exp(s_k)·Φ_kB_k`) from the exported amplitudes the encoder / distilled map trained on, producing an inconsistency and making downstream code see only a bounded gate instead of the actual reconstruction intensity.

### Description

- Make `SaeManifoldTerm::fitted_assignment_amplitudes` return the realised positive intensities `a_{ik} * exp(log_amplitude_k)` instead of the bare gate; update the doc comment to describe the gate vs radial-intensity separation (`crates/gam-sae/src/manifold/construction.rs`).
- Add a regression test `fitted_assignment_amplitudes_include_explicit_log_amplitude_1939` that sets non-unit `log_amplitude` values and asserts the returned amplitudes include `exp(log_amplitude)` (`crates/gam-sae/src/manifold/construction_tests.rs`).
- Remove an unused helper that triggered `-D warnings` in the lib-test build to keep `deny(warnings)` happy (`crates/gam-sae/src/manifold/tests_logdet_adjoint_780.rs`).

### Testing

- Built the workspace: ran `./build.sh` and it completed successfully (lib build finished).
- Library check for the SAE crate: `./build.sh check -p gam-sae --lib` completed successfully.
- Prepared manifold tests: `./build.sh test --test manifolds --no-run` completed successfully.
- Ran the new regression test: `./build.sh test -p gam-sae fitted_assignment_amplitudes_include_explicit_log_amplitude_1939 -- --nocapture` and it passed after the fix.
- Ran the amortized-encoder test group: `./build.sh test -p gam-sae amortized_encoder_tests -- --nocapture` and all tests in that group passed.

All automated tests listed above passed on the modified codebase.

---
Refs #1939.

> Edited by panel review (seat 3/4): `Fixes #1939` → `Refs #1939` — #1939 is a multi-part epic with residual items, so this PR should not auto-close it.

<details><summary>codex self-assessment</summary>

 out; finished in 0.01s\n```\n\n**After-fix build/test evidence**\n\n* \u2705 `./build.sh`\n\n```text\n[build.sh] LIB -> exit 0 in 765s (dedup=MISS, recompiled 76 crates)\n...\n    Finished `dev` profile [unoptimized + debuginfo] target(s) in 12m 45s\n```\n\n* \u2705 `./build.sh check -p gam-sae --lib`\n\n```text\n[build.sh] check -p gam-sae --lib -> exit 0 in 4s (dedup=MISS, recompiled 0 crates)\n    Checking gam-sae v0.3.148 (/workspace/gam/crates/gam-sae)\n    Finished `dev` profile [unoptimized + debuginfo] target(s) in 4.01s\n```\n\n* \u2705 `./build.sh test --test manifolds --no-run`\n\n```text\n[build.sh] test --test manifolds --no-run -> exit 0 in 122s (dedup=MISS, recompiled 5 crates)\n   Compiling gam-sae v0.3.148 (/workspace/gam/crates/gam-sae)\n   Compiling gam v0.3.148 (/workspace/gam)\n   Compiling gam-inference v0.3.148 (/workspace/gam/crates/gam-inference)\n   Compiling gam-config v0.3.148 (/workspace/gam/crates/gam-config)\n   Compiling gam-predict v0.3.148 (/workspace/gam/crates/gam-predict)\n    Finished `test` profile [optimized + debuginfo] target(s) in 2m 01s\n  Executable tests/manifolds/main.rs (target/debug/deps/manifolds-829158c37384446b)\n```\n\n* \u2705 `./build.sh test -p gam-sae fitted_assignment_amplitudes_include_explicit_log_amplitude_1939 -- --nocapture`\n\n```text\n[build.sh] test -p gam-sae fitted_assignment_amplitudes_include_explicit_log_amplitude_1939 -- --nocapture -> exit 0 in 196s (dedup=MISS, recompiled 1 crates)\n   Compiling gam-sae v0.3.148 (/workspace/gam/crates/gam-sae)\n    Finished `test` profile [optimized + debuginfo] target(s) in 3m 14s\n     Running unittests src/lib.rs (target/debug/deps/gam_sae-a2c4802d7e5c9eac)\n\nrunning 1 test\ntest manifold::construction::amortized_encoder_tests::fitted_assignment_amplitudes_include_explicit_log_amplitude_1939 ... ok\n\ntest result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 909 filtered out; finished in 0.01s\n```\n\n* \u2705 `./build.sh test -p gam-sae amortized_encoder_tests -- --nocapture`\n\n```text\n[build.sh] test -p gam-sae amortized_encoder_tests -- --nocapture -> exit 0 in 1s (dedup=MISS, recompiled 0 crates)\n    Finished `test` profile [optimized + debuginfo] target(s) in 0.58s\n     Running unittests src/lib.rs (target/debug/deps/gam_sae-a2c4802d7e5c9eac)\n\nrunning 2 tests\ntest manifold::construction::amortized_encoder_tests::fitted_assignment_amplitudes_include_explicit_log_amplitude_1939 ... ok\ntest manifold::construction::amortized_encoder_tests::amortized_encode_fitted_is_reachable_and_certificate_honest ... ok\n\ntest result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 908 filtered out; finished in 0.01s\n```\n\n### CODE DIFF\n\n```diff\ndiff --git a/crates/gam-sae/src/manifold/construction.rs b/crates/gam-sae/src/manifold/construction.rs\nindex dde2957..c8d4669 100644\n--- a/crates/gam-sae/src/manifold/construction.rs\n+++ b/crates/gam-sae/src/manifold/construction.rs\n@@ -3586,9 +3586,10 @@ impl SaeManifoldTerm {\n     /// #1026 \u2014 the fitted per-row assignment masses `a[i,k]` (the activation\n     /// amplitudes `z_k` the amortized encode recovers `t` against), as an\n-    /// `n \u00d7 K` matrix. These are exactly the masses\n-    /// [`Self::try_fitted_with_rho`] assembles the reconstruction from, so\n-    /// feeding them to [`Self::amortized_encode_target`] re-encodes the SAME\n-    /// inference the dictionary was fit against \u2014 the self-consistency the\n-    /// distilled encoder is supervised to approximate.\n+    /// `n \u00d7 K` matrix. These are the realised positive intensities\n+    /// `a_{ik}\u00b7exp(s_k)` that [`Self::try_fitted_with_rho`] multiplies into each\n+    /// atom's unit-shape decoded row.  The gate `a_{ik}` remains the existence\n+    /// posterior/indicator, while the atom log-amplitude `s_k` is the radial\n+    /// intensity scale; feeding the product to [`Self::amortized_encode_target`]\n+    /// re-encodes the SAME inference the dictionary was fit against.\n     pu
</details>

_Codex-generated; pending adversarial audit before merge._
