### PR TITLE
#2071: Fix derived SAE active-set knobs

### DIFF
--- a/crates/gam-models/src/coefficient_cost.rs
+++ b/crates/gam-models/src/coefficient_cost.rs
@@ -77,6 +77,13 @@ mod tests {
     const MIN_ROWS: u64 = 50_000;
     const MIN_DIM_AT_LARGE_N: u64 = 128;
 
+    fn dense_sentinel_cost() -> u64 {
+        // Derived from the wide-problem shape band instead of spelling out
+        // floor(sqrt(512)) as the literal `22`; this keeps the test sentinel in
+        // sync with the matrix-free gate's `MIN_DIM` boundary.
+        (MIN_DIM as f64).sqrt().floor() as u64
+    }
+
     fn spec_with_ncols(p: usize) -> ParameterBlockSpec {
         ParameterBlockSpec {
             design: DesignMatrix::Dense(DenseDesignMatrix::from(Array2::<f64>::zeros((1, p)))),
@@ -90,7 +97,7 @@ mod tests {
         let p = 4;
         let n = 100;
         let mf = 11;
-        let dense = 22;
+        let dense = dense_sentinel_cost();
         assert!(!use_joint_matrix_free_path(p as usize, n as usize));
         assert_eq!(operator_aware_hessian_cost(p, n, mf, dense), dense);
     }
@@ -101,7 +108,7 @@ mod tests {
         let p = MIN_DIM;
         let n = 1;
         let mf = 11;
-        let dense = 22;
+        let dense = dense_sentinel_cost();
         assert!(use_joint_matrix_free_path(p as usize, n as usize));
         assert_eq!(operator_aware_hessian_cost(p, n, mf, dense), mf);
     }

--- a/crates/gam-sae/src/manifold/construction_arrow_schur_assembly.rs
+++ b/crates/gam-sae/src/manifold/construction_arrow_schur_assembly.rs
@@ -226,6 +226,15 @@ impl SaeManifoldTerm {
             .collect();
         let (assignment_grad, assignment_hdiag) =
             assignment_prior_grad_hdiag(&self.assignment, rho)?;
+        // Per-atom per-axis periodicity, hoisted out of the row loop. Selects
+        // the smooth von-Mises coordinate prior on wrapped (Circle) axes and
+        // the Gaussian prior on Euclidean axes; see `ArdAxisPrior`.
+        let ard_axis_periods: Vec<Vec<Option<f64>>> = self
+            .assignment
+            .coords
+            .iter()
+            .map(|coord| coord.effective_axis_periods())
+            .collect();
 
         // #1038 softmax entropy: the exact per-row Hessian in logits is dense
         // (`H_kj = (λ/τ²) a_k[δ_kj(m−L_k−1)+a_j(L_k+L_j+1−2m)]`), not just the
@@ -346,52 +355,45 @@ impl SaeManifoldTerm {
                     threshold,
                     temperature,
                 } => {
-                    // #1801 — size the JumpReLU joint block by the HARD FORWARD GATE.
-                    // The joint (cross-coupling) row block only ever needs the atoms
-                    // that actually DATA-FIT COUPLE: a gated-off atom (`logit ≤ θ`,
-                    // `a_k = 0`) has a hard-zero reconstruction contribution and a
-                    // hard-zero data-fit logit JVP, so it never couples with the
-                    // decoder or any on atom. Its ONLY footprint is a column-
-                    // SEPARABLE diagonal prior (its own sparsity-logit + ARD-coord
-                    // gradient/curvature), which a diagonal-only atom carries without
-                    // a joint-block slot; profiling it out leaves the reduced β /
-                    // decoder Schur system and its Δβ Newton step unchanged, and the
-                    // OBJECTIVE VALUE is layout-independent (the loss sums the full
-                    // −36 optimization band regardless of this layout).
-                    //
-                    // `contribution[row, k]` is therefore the atom's DATA-FIT
-                    // coupling magnitude — the gate mass `a_{n,k}` — NOT its separable
-                    // prior gradient. `a_{n,k}` is EXACTLY zero for every gated-off
-                    // atom (the JumpReLU hard gate) and positive only above the
-                    // threshold, so `from_jumprelu`'s relative cutoff drops all
-                    // gated-off atoms and the block collapses from `K·(1+d)` to the
-                    // hard-gate `k_active·(1+d)`, independent of K. (The prior layout
-                    // scored membership by the SEPARABLE prior gradient, which is O(1)
-                    // for gated-off logits sitting near the threshold, so essentially
-                    // all K atoms were retained and the per-token block ballooned to
-                    // `K·(1+d)` — the bug pinned by
-                    // `sae_streaming_arrow_schur_contract::per_token_block_dim_is_independent_of_k_at_fixed_active`.)
-                    // PRICED (#2071), with the exact-gradient alternative stated.
-                    // `from_jumprelu` drops atoms whose contribution ≤ cutoff · (max
-                    // contribution). Gated-off atoms have `a_{n,k}` EXACTLY 0, so
-                    // ANY cutoff in `(0, min_active_contribution]` drops precisely the
-                    // gated-off set and the assembled gradient is EXACT. `1e-3`
-                    // additionally drops ACTIVE atoms whose coupling is < 0.1 % of the
-                    // row's peak — this is the gradient approximation, traded for a
-                    // per-token block bounded at `k_active·(1+d)` even when many atoms
-                    // sit just above the JumpReLU threshold with tiny mass.
-                    // Exact-gradient alternative: a numerical-zero cutoff (~a few ULP,
-                    // dropping only the exact zeros) makes the gradient exact but lets
-                    // the block grow to the FULL above-threshold set, whose size near
-                    // the threshold is not bounded independently of that near-threshold
-                    // population — a memory/exactness design choice at K = 32k scale,
-                    // not a free tuning dial, so it is left priced pending that
-                    // validation. What breaks at 10×: `1e-2` drops couplings up to 1 %
-                    // of peak (coarser gradient, smaller block); `1e-4` retains more
-                    // near-threshold atoms (finer gradient, larger block).
-                    const JUMPRELU_RELATIVE_CUTOFF: f64 = 1.0e-3;
-                    let gates = self.assignment.assignments();
-                    let contribution = gates.mapv(f64::abs);
+                    // #1801/#2071 — build the JumpReLU compact block from the
+                    // exact row-local coupling/gradient support. Hard-gated atoms
+                    // (`logit > θ`) carry data-fit coupling and are always retained.
+                    // Gated-off atoms have zero data-fit coupling, but may still carry
+                    // column-separable sparsity/ARD prior gradient over the smooth
+                    // optimization band; those atoms must be retained whenever that
+                    // omitted gradient is nonzero, otherwise the objective value and
+                    // assembled gradient describe different operators.
+                    // #2071 — exact-gradient JumpReLU layout.  `from_jumprelu`
+                    // drops atoms whose contribution is `<= relative_cutoff * row_peak`.
+                    // The production contribution is the exact row-local prior-gradient
+                    // magnitude that would otherwise leave the compact block: the
+                    // sparsity-logit gradient plus the ARD coordinate gradients.  The
+                    // only cutoff derivable without gradient approximation is zero, so
+                    // the layout drops only atoms whose omitted gradient is exactly zero;
+                    // every nonzero separable-gradient atom stays in the row block.
+                    // Hard-gated atoms are always retained separately because they carry
+                    // data-fit coupling even if their prior contribution is zero.
+                    const JUMPRELU_RELATIVE_CUTOFF: f64 = 0.0;
+                    let contribution = Array2::from_shape_fn((n, k_atoms), |(row, atom)| {
+                        let mut mag = assignment_grad[row * k_atoms + atom].abs();
+                        let coord = &self.assignment.coords[atom];
+                        let d = coord.latent_dim();
+                        if !rho.log_ard[atom].is_empty() && rho.log_ard[atom].len() == d {
+                            let row_t = coord.row(row);
+                            for axis in 0..d {
+                                let alpha = SaeManifoldRho::stable_exp_strength(
+                                    rho.log_ard[atom][axis],
+                                );
+                                let prior = ArdAxisPrior::eval(
+                                    alpha,
+                                    row_t[axis],
+                                    ard_axis_periods[atom][axis],
+                                );
+                                mag += prior.grad.abs();
+                            }
+                        }
+                        mag
+                    });
                     Some(SaeRowLayout::from_jumprelu(JumpReluLayoutParams {
                         n,
                         k_atoms,
@@ -399,9 +401,9 @@ impl SaeManifoldTerm {
                         temperature,
                         logits: &self.assignment.logits,
                         contribution: &contribution,
-                        // Cap: rely on the relative cutoff to bound the active set;
-                        // a memory-budget cap can be layered in like
-                        // `sparse_active_plan` without changing the contract.
+                        // No tuned cap in the exact-gradient JumpReLU path: retain the
+                        // full nonzero support derived above. A future memory-budget cap
+                        // would need to preserve the omitted diagonal gradient exactly.
                         k_active_cap: k_atoms,
                         relative_cutoff: JUMPRELU_RELATIVE_CUTOFF,
                         coord_dims: coord_dims.clone(),
@@ -675,15 +677,6 @@ impl SaeManifoldTerm {
         // Dense full-support index `[0, k_atoms)`, used by the row loop when no
         // compact layout is engaged so the active-atom iteration is uniform.
         let all_atoms_index: Vec<usize> = (0..k_atoms).collect();
-        // Per-atom per-axis periodicity, hoisted out of the row loop. Selects
-        // the smooth von-Mises coordinate prior on wrapped (Circle) axes and
-        // the Gaussian prior on Euclidean axes; see `ArdAxisPrior`.
-        let ard_axis_periods: Vec<Vec<Option<f64>>> = self
-            .assignment
-            .coords
-            .iter()
-            .map(|coord| coord.effective_axis_periods())
-            .collect();
         struct SaeAssemblyRow {
             pub(crate) row: usize,
             pub(crate) block: ArrowRowBlock,

--- a/crates/gam-sae/src/manifold/row_layout.rs
+++ b/crates/gam-sae/src/manifold/row_layout.rs
@@ -549,23 +549,15 @@ mod jumprelu_hard_gate_tests {
             )
             .unwrap();
         // DEFAULT path: no override → construction.rs runs the real production
-        // `ThresholdGate` wiring. #1801 — that wiring sizes the joint block by the
-        // HARD FORWARD GATE only (it scores membership by the data-fit coupling gate
-        // mass `a_k`, hard-zero for every gated-off atom), so the production block
-        // keeps ONLY the hard-gated atoms {0,1} — dropping the near-threshold gated-
-        // off atom 2 that the separable-gradient `from_jumprelu` layout above
-        // retains, and every deep atom. The production per-token cost therefore
-        // tracks `k_active` (the hard-gate count), independent of K.
+        // `ThresholdGate` wiring. #2071 changed that wiring to use the exact
+        // separable-gradient magnitude with a zero cutoff, so every in-band atom
+        // carrying nonzero prior gradient is retained. In this fixture all five
+        // atoms are in the optimization band and have nonzero sparsity gradient,
+        // so the default block matches the dense full-band row size rather than
+        // the hard-gate-only approximation.
         let default = term
             .assemble_arrow_schur_inner(target.view(), &rho, None, 1.0, probe, None)
             .unwrap();
-        // Hard-gate reference layout {0,1} (the production block dim).
-        let hard_gate = SaeRowLayout::from_active_atoms(
-            (0..n).map(|_| vec![0usize, 1usize]).collect(),
-            vec![1usize; k],
-            term.assignment.coord_offsets(),
-        );
-
         let q = term.assignment.row_block_dim();
         assert_eq!(dense.rows.len(), n);
         assert_eq!(compact.rows.len(), n);
@@ -583,22 +575,13 @@ mod jumprelu_hard_gate_tests {
                 dgt.len()
             );
             saw_drop = true;
-            // #1801 — the production default path is sized by the HARD FORWARD GATE
-            // {0,1}, strictly SMALLER than the separable-gradient `from_jumprelu`
-            // compact layout {0,1,2}: the near-threshold gated-off atom 2 (a
-            // diagonal-only atom that never data-fit-couples) is dropped from the
-            // joint block.
+            // #2071 — the production default path must no longer drop any
+            // nonzero separable-gradient in-band JumpReLU atom: in this fixture
+            // it is therefore full-band and exactly matches the dense row size.
             assert_eq!(
                 default.rows[row].gt.len(),
-                hard_gate.row_q_active(row),
-                "row {row}: default (production) path must be sized by the hard forward gate"
-            );
-            assert!(
-                default.rows[row].gt.len() < compact.rows[row].gt.len(),
-                "row {row}: production hard-gate block ({}) must be smaller than the \
-                 near-threshold-retaining from_jumprelu block ({})",
-                default.rows[row].gt.len(),
-                compact.rows[row].gt.len()
+                dgt.len(),
+                "row {row}: default production path must retain the full nonzero-gradient band"
             );
             // Expand the compact gradient to full-q and compare to dense.
             let compact_gt: Vec<f64> = compact.rows[row].gt.iter().copied().collect();

--- a/crates/gam-sae/src/manifold/tests_logdet_adjoint_780.rs
+++ b/crates/gam-sae/src/manifold/tests_logdet_adjoint_780.rs
@@ -214,20 +214,6 @@ fn dual_half_logdet_trace_2156(cache: &ArrowFactorCache, h: &Array2<f64>, dh: &A
     0.5 * report.total_derivative
 }
 
-fn dual_logdet_trace_2156(
-    label: &'static str,
-    cache: &ArrowFactorCache,
-    h: &Array2<f64>,
-    dh: &Array2<f64>,
-) -> (f64, BranchCertificate) {
-    let report = dual_trace_report_2156(
-        cache,
-        h,
-        vec![(DerivativeTraceChannel::Other(label), dh.clone())],
-    );
-    (report.total_derivative, report.certificate)
-}
-
 fn relative_error_2156(exact: f64, production: f64) -> f64 {
     (exact - production).abs() / exact.abs().max(production.abs()).max(1.0)
 }


### PR DESCRIPTION
### Motivation
- The JumpReLU compact active-set used a tuned relative cutoff (`1e-3`) and scored membership by gate mass rather than the exact row-local separable gradient, causing the assembled gradient to be approximate (objective ≠ assembled gradient).
- A test sentinel `22` duplicated `floor(sqrt(SHAPE_BAND_MAX_POINTS=512))` as a literal, risking silent desync with the matrix-free gate boundary.
- Remove an unused test helper that triggered `-D warnings` during lib-test so the test build is clean.

### Description
- Make the JumpReLU production `from_jumprelu` contribution be the exact row-local separable-gradient magnitude (sparsity-logit gradient plus per-axis ARD prior gradients) and set `JUMPRELU_RELATIVE_CUTOFF = 0.0` so only exactly-zero omitted-gradient atoms are dropped (file: `crates/gam-sae/src/manifold/construction_arrow_schur_assembly.rs`).
- Update the JumpReLU row-layout regression to assert the production path retains the full nonzero-gradient in-band support (file: `crates/gam-sae/src/manifold/row_layout.rs`).
- Replace the hardcoded `22` test sentinel with a derived helper that computes `floor(sqrt(MIN_DIM))` so the test stays in sync with the matrix-free gate (`crates/gam-models/src/coefficient_cost.rs`).
- Remove an unused test helper function from `crates/gam-sae/src/manifold/tests_logdet_adjoint_780.rs` that caused a deny-warning build failure.

### Testing
- Ran full project build with `./build.sh` and it completed successfully (lib warm and package compiles).
- Ran crate checks: `./build.sh check -p gam-sae --lib` and `./build.sh check -p gam-models --lib`, both completed with exit 0.
- Ran the SAE regression exercising the change: `./build.sh test -p gam-sae jumprelu_compact_gradient_matches_dense_full_band -- --nocapture` and it passed.
- Ran the matrix-free gate tests: `./build.sh test -p gam-models operator_aware -- --nocapture` and the three test cases passed.

---
Fixes #2071.

<details><summary>codex self-assessment</summary>

ted after fixing the mechanism: the old regression asserted the approximate hard-gate-only behavior. I updated it to assert the principled exact-gradient behavior.\n\n**Passing checks on final commit `d81f23b`**\n\n* \u2705 `./build.sh`\n\n```text\n[build.sh] LIB -> exit 0 in 1018s (dedup=MISS, recompiled 186 crates)\n...\nFinished `dev` profile [unoptimized + debuginfo] target(s) in 16m 57s\n```\n\n* \u2705 `./build.sh check -p gam-sae --lib`\n\n```text\n[build.sh] check -p gam-sae --lib -> exit 0 in 6s (dedup=MISS, recompiled 0 crates)\n    Checking gam-sae v0.3.148 (/workspace/gam/crates/gam-sae)\n    Finished `dev` profile [unoptimized + debuginfo] target(s) in 5.24s\n```\n\n* \u2705 `./build.sh check -p gam-models --lib`\n\n```text\n[build.sh] check -p gam-models --lib -> exit 0 in 0s (dedup=MISS, recompiled 0 crates)\n    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.61s\n```\n\n* \u2705 `./build.sh test -p gam-sae jumprelu_compact_gradient_matches_dense_full_band -- --nocapture`\n\n```text\n[build.sh] test -p gam-sae jumprelu_compact_gradient_matches_dense_full_band -- --nocapture -> exit 0 in 204s\n...\nrunning 1 test\ntest manifold::row_layout::jumprelu_hard_gate_tests::jumprelu_compact_gradient_matches_dense_full_band ... ok\n\ntest result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 909 filtered out\n```\n\n* \u2705 `./build.sh test -p gam-models operator_aware -- --nocapture`\n\n```text\n[build.sh] test -p gam-models operator_aware -- --nocapture -> exit 0 in 803s\n...\nrunning 3 tests\ntest coefficient_cost::tests::operator_aware_picks_dense_for_small_problem ... ok\ntest coefficient_cost::tests::operator_aware_branch_is_exactly_the_gate ... ok\ntest coefficient_cost::tests::operator_aware_picks_matrix_free_for_wide_problem ... ok\n\ntest result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 1243 filtered out\n```\n\n**Other attempted checks**\n\n* \u274c `./build.sh test -p gam-models operator_aware_picks_dense_for_small_problem operator_aware_picks_matrix_free_for_wide_problem -- --nocapture`\n\n```text\nerror: unexpected argument 'operator_aware_picks_matrix_free_for_wide_problem' found\n```\n\nThis was my command-shape error; I reran the valid `operator_aware` filter above.\n\n* \u26a0\ufe0f `./build.sh test -p gam-models operator_aware -- --nocapture`\n\n```text\n[build.sh] transient failure (OOM/timeout, exit 124) attempt 1/3 \u2014 retrying with CARGO_BUILD_JOBS=1 (lower peak RAM)\u2026\nTerminated\n[build.sh] transient failure (OOM/timeout, exit 143) attempt 2/3 \u2014 backing off for memory, retrying\u2026\n```\n\nThis first attempt hit the wrapper timeout/resource backoff and I terminated it before rerunning successfully after the full lib warm.\n\n### CODE DIFF\n\nCommitted on the current branch:\n\n```text\nd81f23b Fix derived SAE active-set knobs\n\n crates/gam-models/src/coefficient_cost.rs          |  11 ++-\n .../manifold/construction_arrow_schur_assembly.rs  | 109 ++++++++++-----------\n crates/gam-sae/src/manifold/row_layout.rs          |  39 +++-----\n .../src/manifold/tests_logdet_adjoint_780.rs       |  14 ---\n 4 files changed, 71 insertions(+), 102 deletions(-)\n```\n\n### SELF-ASSESSMENT\n\n* **SOLVES THE ISSUE? PARTIAL.** This fixes the live JumpReLU approximate-gradient knob and the bare `22 = floor(sqrt(512))` literal. It does **not** complete every item listed in #2071: the warmup constants, surplus-direction floor, promotion gates, unit-speed tolerance, and co-collapse reseed budget remain to be derived or converted into principled tolerances.\n* **NET EFFECT: NET-GOOD.** The change improves correctness by making the JumpReLU Newton gradient match the objective over the compact layout, and removes one silent-desync literal. The main tradeoff is that exact-gradient JumpReLU can retain more in-band prior-gradient atoms than the previous hard-gate-only production path; that is a deliberate correctness-over-approximation change rather than a tuned performance knob."}]
</details>

_Codex-generated; pending adversarial audit before merge._