### PR TITLE
#2099: Key SAE collapse guards on quotient scale

### DIFF
--- a/crates/gam-sae/src/manifold/atom.rs
+++ b/crates/gam-sae/src/manifold/atom.rs
@@ -1523,6 +1523,25 @@ impl SaeManifoldAtom {
         // penalty is decoder-magnitude-independent and must survive the peel.
     }
 
+    /// Physical atom scale in the represented contribution
+    /// `exp(s_k) · Φ_k · B_k`.
+    ///
+    /// Decoder-collapse logic must use this gauge-invariant scale once the
+    /// quotient has moved magnitude from `B_k` into `s_k`; otherwise a
+    /// unit-Frobenius decoder would make every atom look equally alive even when
+    /// its explicit amplitude has collapsed.
+    pub(crate) fn contribution_frobenius_scale(&self) -> f64 {
+        let decoder_norm = self
+            .decoder_coefficients
+            .iter()
+            .map(|v| v * v)
+            .sum::<f64>()
+            .sqrt();
+        let amplitude = self.log_amplitude.exp();
+        let scale = amplitude * decoder_norm;
+        if scale.is_finite() { scale } else { 0.0 }
+    }
+
     /// Recompute the intrinsic (gauge-invariant) roughness Gram
     /// [`Self::smooth_penalty`] from [`Self::smooth_penalty_raw`], the current
     /// basis Jacobian / second jet, and the current decoder coefficients

--- a/crates/gam-sae/src/manifold/construction_tests.rs
+++ b/crates/gam-sae/src/manifold/construction_tests.rs
@@ -880,6 +880,31 @@ mod step2_quotient_scale_tests {
         );
     }
 
+    /// #2099 — collapse guards must measure the atom's physical contribution
+    /// scale `exp(s_k)‖B_k‖_F`, not the raw decoder norm alone. After the quotient
+    /// peels both decoders to unit Frobenius, `‖B_k‖` cannot distinguish a live atom
+    /// from one whose explicit log-amplitude has collapsed.
+    #[test]
+    fn quotient_collapse_scale_tracks_log_amplitude_not_unit_decoder_norm() {
+        let (mut term, _target, _rho) = small_two_atom_periodic_term();
+        for atom in term.atoms.iter_mut() {
+            atom.absorb_decoder_norm_into_log_amplitude(f64::MIN_POSITIVE);
+        }
+        let live_scale = term.atoms[0].contribution_frobenius_scale();
+        term.atoms[1].log_amplitude = term.atoms[0].log_amplitude - 4.0_f64.ln();
+        let collapsed_scale = term.atoms[1].contribution_frobenius_scale();
+
+        assert!(
+            (frob(&term.atoms[0].decoder_coefficients) - 1.0).abs() <= 1e-9
+                && (frob(&term.atoms[1].decoder_coefficients) - 1.0).abs() <= 1e-9,
+            "fixture must exercise equal unit decoders"
+        );
+        assert!(
+            collapsed_scale < live_scale,
+            "physical scale must see the explicit-amplitude collapse: live={live_scale}, collapsed={collapsed_scale}"
+        );
+    }
+
     /// #2022 gate (i) — lever DEFAULT-OFF ⇒ the step never peels ⇒ `s` stays 0 ⇒
     /// bit-for-bit. Verified by construction: `absorb_*` is only invoked from the
     /// step under the `quotient_scale` kwarg (default false) and from the gated

--- a/crates/gam-sae/src/manifold/fit_drivers.rs
+++ b/crates/gam-sae/src/manifold/fit_drivers.rs
@@ -2295,16 +2295,14 @@ impl SaeManifoldTerm {
         if n == 0 || k < 2 {
             return Ok(());
         }
-        let mut norms = vec![0.0_f64; k];
-        for (atom_idx, atom) in self.atoms.iter().enumerate() {
-            let mut acc = 0.0_f64;
-            for &value in atom.decoder_coefficients.iter() {
-                acc += value * value;
-            }
-            norms[atom_idx] = acc.sqrt();
-        }
-        // Median decoder norm: the robust dictionary scale. (A mean would let a
-        // few large atoms mask a cluster of collapsed ones.)
+        let norms: Vec<f64> = self
+            .atoms
+            .iter()
+            .map(|atom| atom.contribution_frobenius_scale())
+            .collect();
+        // Median physical contribution scale: the robust dictionary scale. This is
+        // `exp(s_k)‖B_k‖_F`, not just `‖B_k‖_F`, so the same guard remains live after
+        // the quotient representation moves magnitude into `s_k`.
         let mut sorted = norms.clone();
         sorted.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
         let median = if k % 2 == 1 {

--- a/crates/gam-sae/src/manifold/gauge.rs
+++ b/crates/gam-sae/src/manifold/gauge.rs
@@ -495,17 +495,13 @@ impl SaeManifoldTerm {
         if k < 2 {
             return 0;
         }
-        let mut norms = vec![0.0_f64; k];
-        for (idx, atom) in self.atoms.iter().enumerate() {
-            norms[idx] = atom
-                .decoder_coefficients
-                .iter()
-                .map(|v| v * v)
-                .sum::<f64>()
-                .sqrt();
-        }
+        let norms: Vec<f64> = self
+            .atoms
+            .iter()
+            .map(|atom| atom.contribution_frobenius_scale())
+            .collect();
         // "Healthy dictionary scale" to measure collapse against = the MAX decoder
-        // norm (definitionally a surviving atom). NOT the median: the median is the
+        // scale (definitionally a surviving atom). NOT the median: the median is the
         // guard's statistic but it DEGENERATES whenever the MAJORITY of atoms
         // collapse, because the collapsed atoms THEMSELVES set the median. At K=3
         // with two co-vanished atoms (real IBP data: ‖B‖=[2.6, ~0, ~0]) the median
@@ -557,7 +553,9 @@ impl SaeManifoldTerm {
         // collapse at `1e-3` is retracted (`retracted>0`), a collapse at `1e-16` is
         // an `unretractable_zero` (Design B correctly no-ops → needs a backfit
         // reseed, not this). Under a healthy dictionary nothing breaches and this is
-        // a bit-for-bit no-op with a benign one-line trace.
+        // a bit-for-bit no-op with a benign one-line trace. The printed `norms` are
+        // physical contribution scales `exp(s_k)‖B_k‖_F`, so the diagnostic keeps
+        // its meaning under the scale quotient.
         let norms_fmt: Vec<String> = norms.iter().map(|v| format!("{v:.6e}")).collect();
         log::warn!(
             "[#1939 cone-atom] k={k} norms=[{}] median={median:.6e} reference={reference:.6e} \


### PR DESCRIPTION
### Motivation

- The collapse-detection and retraction code measured raw decoder Frobenius norms `‖B_k‖_F`, which becomes meaningless after the scale-quotient (magnitude moved into per-atom `log_amplitude` `s_k`) because unit `B_k` hides collapsed explicit amplitudes. 
- That mismatch blindfolded the decoder-norm guard and retraction, causing collapsed atoms to be missed or healthy fits to be destabilized when unit-`B` retractions were applied. 
- The intent is to make collapse detection gauge-invariant by measuring the atom's represented physical contribution `exp(s_k) · ‖B_k‖_F` so the guard remains correct under the quotient.

### Description

- Added `SaeManifoldAtom::contribution_frobenius_scale()` to compute the gauge-invariant contribution scale `exp(s_k) * ||B_k||_F` and return `0.0` for non-finite values (`crates/gam-sae/src/manifold/atom.rs`).
- Replaced raw-decoder-norm collections with the new contribution scale in the decoder-norm guard (`enforce_decoder_norm_guard`) so median/floor decisions use physical scale (`crates/gam-sae/src/manifold/fit_drivers.rs`).
- Switched the collapsed-decoder retraction diagnostics and thresholds to the same physical contribution scale so retraction and logging remain meaningful under quotient mode (`crates/gam-sae/src/manifold/gauge.rs`).
- Added a regression unit test `quotient_collapse_scale_tracks_log_amplitude_not_unit_decoder_norm` that verifies a lowered `log_amplitude` reduces the physical scale even when `B_k` is unit-Frobenius (`crates/gam-sae/src/manifold/construction_tests.rs`).
- Removed an unused test helper (dead function) that caused deny-warning failures in test builds (`crates/gam-sae/src/manifold/tests_logdet_adjoint_780.rs`).

### Testing

- Built the tree: ran `./build.sh` and observed a successful LIB build (`exit 0`) after compiling crates including `gam-sae`.
- Ran the scoped check: `./build.sh check -p gam-sae --lib` and it completed successfully (`exit 0`).
- Compiled the SAE test binary without running: `./build.sh test -p gam --test sae --no-run` and it succeeded (test binary produced).
- Executed the new regression and related SAE tests: `./build.sh test -p gam-sae quotient_collapse_scale_tracks_log_amplitude_not_unit_decoder_norm -- --nocapture` and `./build.sh test -p gam-sae quotient_scale_on -- --nocapture`, both finished with the relevant tests passing (unit tests reported `ok`).

---
Refs #2099 (epic — this PR addresses only scope bullet 3).

<details><summary>codex self-assessment</summary>

build.sh] check -p gam-sae --lib -> exit 0 in 1s (dedup=MISS, recompiled 0 crates)\n      Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.63s\n  ```\n\n* \u2705 `./build.sh test -p gam --test sae --no-run`  \n  Output:\n  ```text\n  [build.sh] test -p gam --test sae --no-run -> exit 0 in 121s (dedup=MISS, recompiled 2 crates)\n     Compiling gam v0.3.148 (/workspace/gam)\n     Compiling gam-predict v0.3.148 (/workspace/gam/crates/gam-predict)\n      Finished `test` profile [optimized + debuginfo] target(s) in 1m 59s\n    Executable tests/sae/main.rs (target/debug/deps/sae-581a4b8d7c9a2569)\n  ```\n\n* \u2705 `./build.sh test -p gam-sae quotient_collapse_scale_tracks_log_amplitude_not_unit_decoder_norm -- --nocapture`  \n  Output:\n  ```text\n  [build.sh] test -p gam-sae quotient_collapse_scale_tracks_log_amplitude_not_unit_decoder_norm -- --nocapture -> exit 0 in 130s (dedup=MISS, recompiled 1 crates)\n     Compiling gam-sae v0.3.148 (/workspace/gam/crates/gam-sae)\n      Finished `test` profile [optimized + debuginfo] target(s) in 2m 10s\n       Running unittests src/lib.rs (target/debug/deps/gam_sae-a2c4802d7e5c9eac)\n\n  running 1 test\n  test manifold::construction::step2_quotient_scale_tests::quotient_collapse_scale_tracks_log_amplitude_not_unit_decoder_norm ... ok\n\n  test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 910 filtered out; finished in 0.01s\n  ```\n\n* \u2705 `./build.sh test -p gam-sae quotient_scale_on -- --nocapture`  \n  Output:\n  ```text\n  [build.sh] test -p gam-sae quotient_scale_on -- --nocapture -> exit 0 in 6s (dedup=MISS, recompiled 0 crates)\n      Finished `test` profile [optimized + debuginfo] target(s) in 0.60s\n       Running unittests src/lib.rs (target/debug/deps/gam_sae-a2c4802d7e5c9eac)\n\n  running 2 tests\n  [#2100 repro] K=1 quotient_scale ON EV=0.429047 (OFF=0.429086), s=3.1091\n  test manifold::tests_cocollapse_disjoint_2027::quotient_scale_on_does_not_crash_k1_2100 ... ok\n  [#2100 repro] quotient_scale ON: EV=0.6480 (OFF=0.6533), norms=[6.3532, 35.1974]\n  test manifold::tests_cocollapse_disjoint_2027::quotient_scale_on_does_not_detonate_healthy_k2_two_circle_2100 ... ok\n\n  test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 909 filtered out; finished in 4.69s\n  ```\n\n### CODE DIFF\n\n```diff\ndiff --git a/crates/gam-sae/src/manifold/atom.rs b/crates/gam-sae/src/manifold/atom.rs\n@@\n+    /// Physical atom scale in the represented contribution\n+    /// `exp(s_k) \u00b7 \u03a6_k \u00b7 B_k`.\n+    ///\n+    /// Decoder-collapse logic must use this gauge-invariant scale once the\n+    /// quotient has moved magnitude from `B_k` into `s_k`; otherwise a\n+    /// unit-Frobenius decoder would make every atom look equally alive even when\n+    /// its explicit amplitude has collapsed.\n+    pub(crate) fn contribution_frobenius_scale(&self) -> f64 {\n+        let decoder_norm = self\n+            .decoder_coefficients\n+            .iter()\n+            .map(|v| v * v)\n+            .sum::<f64>()\n+            .sqrt();\n+        let amplitude = self.log_amplitude.exp();\n+        let scale = amplitude * decoder_norm;\n+        if scale.is_finite() { scale } else { 0.0 }\n+    }\ndiff --git a/crates/gam-sae/src/manifold/fit_drivers.rs b/crates/gam-sae/src/manifold/fit_drivers.rs\n@@\n-        let mut norms = vec![0.0_f64; k];\n-        for (atom_idx, atom) in self.atoms.iter().enumerate() {\n-            let mut acc = 0.0_f64;\n-            for &value in atom.decoder_coefficients.iter() {\n-                acc += value * value;\n-            }\n-            norms[atom_idx] = acc.sqrt();\n-        }\n-        // Median decoder norm: the robust dictionary scale. (A mean would let a\n-        // few large atoms mask a cluster of collapsed ones.)\n+        let norms: Vec<f64> = self\n+            .atoms\n+            .iter()\n+            .map(|atom| atom.contribution_frobenius_scale())\n+            .collect();\n+        // Median physical contribution 
</details>

_Codex-generated; pending adversarial audit before merge._
