### PR TITLE
#2128: Gamma-log observed curvature: closed-form weights to avoid overflow/cancellation

### DIFF
--- a/crates/gam-solve/src/pirls/curvature.rs
+++ b/crates/gam-solve/src/pirls/curvature.rs
@@ -767,6 +767,27 @@ pub fn observed_weight_gaussian_inverse(y: f64, eta: f64, phi: f64, pw: f64) -> 
     (w, c, d)
 }
 
+/// Gamma family with log link: `V(μ)=μ²`, `μ=exp(η)`.
+///
+/// For a Gamma exponential-dispersion model the negative log-likelihood
+/// second derivative with respect to `η` is exactly `y / (φ μ)`.  The generic
+/// observed-information formula computes the same value as
+/// `W_Fisher - (y - μ)·B`; with `V=μ²` and log-link derivatives this subtracts
+/// two `1/φ`-scale terms to leave the small positive `y/(φμ)` tail, and its
+/// intermediate `V²`/`V³` products overflow for large trial `η`.  This
+/// closed form is algebraically identical but cancellation- and overflow-free.
+///
+/// ```text
+/// w_obs =  ω y / (φ μ)
+/// c_obs = -ω y / (φ μ)
+/// d_obs =  ω y / (φ μ)
+/// ```
+#[inline]
+pub fn observed_weight_gamma_log(y: f64, mu: f64, phi: f64, pw: f64) -> (f64, f64, f64) {
+    let w = pw * y / (phi * mu);
+    (w, -w, w)
+}
+
 #[inline]
 pub(crate) fn observed_weight_binomial_logit_from_jet(
     n_trials: f64,
@@ -849,6 +870,9 @@ pub fn observed_weight_dispatch(
         }
         (WeightFamily::Gaussian, WeightLink::Inverse) => {
             observed_weight_gaussian_inverse(y, eta, phi, prior_weight)
+        }
+        (WeightFamily::Gamma, WeightLink::Log) => {
+            observed_weight_gamma_log(y, mu, phi, prior_weight)
         }
         (WeightFamily::Binomial, WeightLink::Logit) => {
             observed_weight_binomial_logit_from_jet(1.0, jet, prior_weight)

--- a/crates/gam-solve/src/pirls/tests.rs
+++ b/crates/gam-solve/src/pirls/tests.rs
@@ -14,12 +14,14 @@ mod tests {
     use super::reweight::madsen_lm_accept_factor;
     use super::{
         LinearInequalityConstraints, PenaltyConfig, PirlsConfig, PirlsLinearSolvePath,
-        PirlsProblem, PirlsWorkspace, WorkingDerivativeBuffersMut, bernoulli_geometry_from_jet,
-        calculate_deviance, calculate_loglikelihood, calculate_loglikelihood_omitting_constants,
-        compute_constraint_kkt_diagnostics, compute_observed_hessian_curvature_arrays,
-        fit_model_for_fixed_rho, select_active_set_release, should_log_pirls_decision_summary,
-        should_use_sparse_native_pirls, solve_newton_directionwith_linear_constraints,
-        solve_newton_directionwith_lower_bounds, tweedie_log_weight_mu_power, update_glmvectors,
+        PirlsProblem, PirlsWorkspace, WeightFamily, WeightLink, WorkingDerivativeBuffersMut,
+        bernoulli_geometry_from_jet, calculate_deviance, calculate_loglikelihood,
+        calculate_loglikelihood_omitting_constants, compute_constraint_kkt_diagnostics,
+        compute_observed_hessian_curvature_arrays, fit_model_for_fixed_rho,
+        observed_weight_dispatch, observed_weight_noncanonical, select_active_set_release,
+        should_log_pirls_decision_summary, should_use_sparse_native_pirls,
+        solve_newton_directionwith_linear_constraints, solve_newton_directionwith_lower_bounds,
+        tweedie_log_weight_mu_power, update_glmvectors, variance_jet_for_weight_family,
         write_gamma_log_working_state, write_negative_binomial_log_working_state,
         write_poisson_log_working_state, write_tweedie_log_working_state,
     };
@@ -1833,6 +1835,55 @@ mod tests {
             assert_relative_eq!(c_obs[i], -expected_w, epsilon = 1e-12, max_relative = 1e-12);
             assert_relative_eq!(d_obs[i], expected_w, epsilon = 1e-12, max_relative = 1e-12);
         }
+    }
+
+    #[test]
+    pub(crate) fn gamma_log_observed_curvature_dispatch_avoids_generic_overflow() {
+        let y = 1.25;
+        let phi = 0.5;
+        let prior_weight = 1.75;
+        let eta: f64 = 400.0;
+        let mu = eta.exp();
+        let jet = MixtureInverseLinkJet {
+            mu,
+            d1: mu,
+            d2: mu,
+            d3: mu,
+        };
+        let h4 = mu;
+
+        let generic = observed_weight_noncanonical(
+            y,
+            mu,
+            jet.d1,
+            jet.d2,
+            jet.d3,
+            h4,
+            variance_jet_for_weight_family(WeightFamily::Gamma, mu),
+            phi,
+            prior_weight,
+        );
+        assert!(
+            !generic.0.is_finite() || !generic.1.is_finite() || !generic.2.is_finite(),
+            "generic Gamma-log curvature should expose the overflow/cancellation-prone path at eta={eta}: {generic:?}"
+        );
+
+        let (w_obs, c_obs, d_obs) = observed_weight_dispatch(
+            WeightFamily::Gamma,
+            WeightLink::Log,
+            eta,
+            y,
+            mu,
+            phi,
+            prior_weight,
+            jet,
+            h4,
+        );
+        let expected_w = prior_weight * y / (phi * mu);
+        assert!(w_obs.is_finite() && c_obs.is_finite() && d_obs.is_finite());
+        assert_relative_eq!(w_obs, expected_w, epsilon = 0.0, max_relative = 1e-12);
+        assert_relative_eq!(c_obs, -expected_w, epsilon = 0.0, max_relative = 1e-12);
+        assert_relative_eq!(d_obs, expected_w, epsilon = 0.0, max_relative = 1e-12);
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- The generic noncanonical observed-information formula for Gamma + log link forms large intermediate `V²`/`V³` and subtracts two 1/φ-scale terms, which catastrophically cancels or overflows at large trial `η`, producing non-finite observed weights and destabilizing the inner P-IRLS Hessian so REML startup rejects all seeds. 
- Use the algebraically-equivalent closed-form for the Gamma-log observed curvature to eliminate cancellation/overflow and restore stable inner solves.

### Description
- Add a closed-form Gamma/log observed-information routine `observed_weight_gamma_log(y, mu, phi, pw)` that returns `w = pw * y / (phi * mu)`, `c = -w`, `d = w` to avoid cancellation/overflow (file: `crates/gam-solve/src/pirls/curvature.rs`).
- Route `(WeightFamily::Gamma, WeightLink::Log)` through the new closed-form in `observed_weight_dispatch` instead of falling back to the generic noncanonical path (file: `crates/gam-solve/src/pirls/curvature.rs`).
- Add a regression unit test `gamma_log_observed_curvature_dispatch_avoids_generic_overflow` that demonstrates the generic path becomes non-finite at an extreme but representable `η` while the dispatched closed-form is finite and exact (file: `crates/gam-solve/src/pirls/tests.rs`).

### Testing
- Built the workspace and checked the crate: `./build.sh` and `./build.sh check -p gam-solve --lib` both completed successfully (`exit 0`).
- Ran the targeted unit tests: `./build.sh test -p gam-solve gamma_log_observed_curvature -- --nocapture` — the two new/related tests passed (`2 passed; 0 failed`).
- Verified the regression that exercised the original issue: `./build.sh test -p gam --test regressions gamma_smooth_highvar_fits_with_finite_coefficients_2128 -- --nocapture` — the regression passed (`1 passed; 0 failed`).

---
Fixes #2128.

<details><summary>codex self-assessment</summary>

pirls/curvature.rs", "line_range_start": 770, "line_range_end": 789}, {"content_type": "text", "text": "\n* Routed `(WeightFamily::Gamma, WeightLink::Log)` through that closed-form path in the observed-weight dispatch. "}, {"content_type": "repo_file_citation", "path": "crates/gam-solve/src/pirls/curvature.rs", "line_range_start": 867, "line_range_end": 876}, {"content_type": "text", "text": "\n* Added a root-cause regression unit test showing the generic Gamma-log formula becomes non-finite at an extreme but representable `\u03b7`, while dispatch stays finite and matches the closed form. "}, {"content_type": "repo_file_citation", "path": "crates/gam-solve/src/pirls/tests.rs", "line_range_start": 1840, "line_range_end": 1887}, {"content_type": "text", "text": "\n\n### SPEC COMPLIANCE\n\n* Added no autodiff or finite differences in production.\n* Added no grid search, GCV, wall-clock solver budget, timeout, convergence fabrication, KKT fabrication, skipped tests, ignored tests, or penalty stuffing.\n* The new constants in the test are deterministic test data, not solver knobs; the production change is a derived analytic closed form.\n\n### TEST EVIDENCE\n\n* \u2705 `./build.sh`  \n  Output: `exit 0`, finished the workspace lib warm build successfully.\n\n* \u2705 `./build.sh check -p gam-solve --lib`  \n  Output: `exit 0`; after final formatting it checked `gam-solve` with deny-warnings successfully in 15s.\n\n* \u2705 `./build.sh test -p gam --test regressions --no-run`  \n  Output: `exit 0`; built the aggregate regression test binary successfully: `Executable tests/regressions/main.rs`.\n\n* \u2705 `./build.sh test -p gam-solve gamma_log_observed_curvature -- --nocapture`  \n  Output: `exit 0`; `2 passed; 0 failed`, including:\n  * `gamma_log_observed_curvature_dispatch_avoids_generic_overflow`\n  * `gamma_log_observed_curvature_matches_shape_one_closed_form`\n\n* \u2705 `./build.sh test -p gam --test regressions gamma_smooth_highvar_fits_with_finite_coefficients_2128 -- --nocapture`  \n  Output: `exit 0`; `1 passed; 0 failed`; the issue regression `gamma_smooth_highvar_fits_with_finite_coefficients_2128` now passes.\n\n* \u26a0\ufe0f `./build.sh test --test gamma_smooth_reml_highvar_rejects_all_seeds_2128 --no-run`  \n  Output: `exit 101`; this was the wrong integration target name for this workspace. The valid target is the aggregate `regressions` binary, which was built and run successfully above.\n\n* \u26a0\ufe0f `./build.sh fmt --check`  \n  Output: `exit 75`; wrapper reported transient failure after retries. I then ran formatting successfully with `./build.sh fmt`, reverted unrelated rustfmt changes, and re-ran the relevant compile/tests successfully.\n\n### CODE DIFF\n\nCommitted on the current branch:\n\n* Commit: `4e7c8e9 Fix gamma log observed curvature overflow`\n\nSummary of the diff:\n\n```diff\n+pub fn observed_weight_gamma_log(y: f64, mu: f64, phi: f64, pw: f64) -> (f64, f64, f64) {\n+    let w = pw * y / (phi * mu);\n+    (w, -w, w)\n+}\n...\n+        (WeightFamily::Gamma, WeightLink::Log) => {\n+            observed_weight_gamma_log(y, mu, phi, prior_weight)\n+        }\n```\n\nand a regression test that verifies the old generic Gamma-log formula becomes non-finite while dispatch remains finite and equal to the closed form. "}, {"content_type": "repo_file_citation", "path": "crates/gam-solve/src/pirls/tests.rs", "line_range_start": 1840, "line_range_end": 1887}, {"content_type": "text", "text": "\n\n### SELF-ASSESSMENT\n\n* **SOLVES THE ISSUE? SOLVED.** The issue\u2019s failing Gamma penalized-smooth regression now passes, and the fix targets the identified mechanism: non-finite / cancellation-prone Gamma-log observed curvature in the inner P-IRLS / REML startup path.\n* **NET EFFECT: NET-GOOD.** This removes an unstable generic computation for a family-link combination with a simple exact analytic form, improving numerical stability without changing solver convergence semantics or adding arbitrary knobs."}]
</details>

_Codex-generated; pending adversarial audit before merge._