### PR TITLE
#2132: fix(sae): honor top_k in seed LSQ and seed refinement to prevent cold-start co-collapse

### DIFF
--- a/crates/gam-pyffi/src/latent/latent_basis_and_sae_ffi.rs
+++ b/crates/gam-pyffi/src/latent/latent_basis_and_sae_ffi.rs
@@ -3267,6 +3267,13 @@ fn sae_manifold_fit_inner<'py>(
             .set_temperature_schedule(schedule)
             .map_err(py_value_error)?;
     }
+    // #2132 — the active-set cap is part of the model being optimized, so the
+    // cold routing refinement must see the same top-k softmax support as the
+    // subsequent Arrow-Schur solve. Installing it only after the EM seed let
+    // the seed decoder LSQ train every atom on every row under dense softmax
+    // responsibilities; with top_k=1 planted mixtures that reintroduced the
+    // uniform co-collapse saddle before the capped solver ever ran.
+    base_term.set_softmax_active_cap(top_k);
 
     // Cold-start routing seed refinement (#629, #630). The cold residual-logit
     // seed is computed at the cold (shared-across-atoms) coordinates and cannot
@@ -3289,6 +3296,7 @@ fn sae_manifold_fit_inner<'py>(
             tau,
             jumprelu_threshold,
             seed_refine_random_state,
+            top_k,
         )
         .map_err(py_value_error)?;
     }
@@ -3398,7 +3406,6 @@ fn sae_manifold_fit_inner<'py>(
     // atoms (the FFI's after-the-fit top-`k` projection below then collapses to a
     // no-op at the optimum). A no-op for `top_k >= K`, `None`, and non-softmax
     // modes (set_softmax_active_cap clamps to `1 <= k < K` and ignores non-softmax).
-    base_term.set_softmax_active_cap(top_k);
     let seed_dispersion = base_term
         .seed_reconstruction_dispersion(z_view)
         .map_err(py_value_error)?;
@@ -6086,6 +6093,7 @@ fn sae_decoder_lsq_init(
     alpha: f64,
     tau: f64,
     jumprelu_threshold: f64,
+    top_k: Option<usize>,
 ) -> Result<Array3<f64>, String> {
     let k_atoms = basis_sizes.len();
     let (n_obs, p_out) = z.dim();
@@ -6116,6 +6124,13 @@ fn sae_decoder_lsq_init(
     let mut a_init = Array2::<f64>::zeros((n_obs, k_atoms));
     match assignment_kind {
         "softmax" => {
+            if let Some(k_top) = top_k {
+                if k_top == 0 || k_top > k_atoms {
+                    return Err(format!(
+                        "sae_decoder_lsq_init: top_k must satisfy 1 <= top_k <= k_atoms={k_atoms}; got {k_top}"
+                    ));
+                }
+            }
             let inv_tau = 1.0 / tau;
             for row in 0..n_obs {
                 let mut max_logit = f64::NEG_INFINITY;
@@ -6135,6 +6150,38 @@ fn sae_decoder_lsq_init(
                 if sum > 0.0 && sum.is_finite() {
                     for k in 0..k_atoms {
                         a_init[[row, k]] = buf[k] / sum;
+                    }
+                }
+                if let Some(k_top) = top_k {
+                    if k_top < k_atoms {
+                        let mut paired: Vec<(f64, usize)> =
+                            (0..k_atoms).map(|k| (a_init[[row, k]], k)).collect();
+                        let cmp = |a: &(f64, usize), b: &(f64, usize)| {
+                            b.0.partial_cmp(&a.0)
+                                .unwrap_or(std::cmp::Ordering::Equal)
+                                .then(a.1.cmp(&b.1))
+                        };
+                        paired.select_nth_unstable_by(k_top - 1, cmp);
+                        let mut keep = vec![false; k_atoms];
+                        for &(_, atom_idx) in paired.iter().take(k_top) {
+                            keep[atom_idx] = true;
+                        }
+                        let kept_sum: f64 = (0..k_atoms)
+                            .filter(|&atom_idx| keep[atom_idx])
+                            .map(|atom_idx| a_init[[row, atom_idx]])
+                            .sum();
+                        if !(kept_sum.is_finite() && kept_sum > 0.0) {
+                            return Err(format!(
+                                "sae_decoder_lsq_init: top_k softmax projection has non-positive kept mass on row {row}"
+                            ));
+                        }
+                        for atom_idx in 0..k_atoms {
+                            a_init[[row, atom_idx]] = if keep[atom_idx] {
+                                a_init[[row, atom_idx]] / kept_sum
+                            } else {
+                                0.0
+                            };
+                        }
                     }
                 }
             }
@@ -6320,6 +6367,7 @@ fn sae_em_refine_routing_seed(
     tau: f64,
     jumprelu_threshold: f64,
     random_state: u64,
+    top_k: Option<usize>,
 ) -> Result<(), String> {
     const SAE_SEED_REFINE_ROUNDS: usize = 4;
     const SAE_RESIDUAL_SEED_GAIN: f64 = 4.0;
@@ -6371,6 +6419,7 @@ fn sae_em_refine_routing_seed(
             alpha,
             tau,
             jumprelu_threshold,
+            top_k,
         )?;
         for atom_idx in 0..k_atoms {
             let m_k = basis_sizes[atom_idx];

--- a/crates/gam-pyffi/src/latent/latent_basis_and_sae_ffi_tail.rs
+++ b/crates/gam-pyffi/src/latent/latent_basis_and_sae_ffi_tail.rs
@@ -529,6 +529,7 @@ fn sae_manifold_fit_minimal<'py>(
         ibp_alpha_override.unwrap_or(alpha),
         tau,
         jumprelu_threshold,
+        top_k,
     )
     .map_err(py_value_error)?;
     // `plan_latent_dim` (computed above) is the optimizer's per-atom latent

--- a/crates/gam-pyffi/tests/src_modules/lib_tests.rs
+++ b/crates/gam-pyffi/tests/src_modules/lib_tests.rs
@@ -59,6 +59,44 @@ fn pyffi_sources_use_canonical_gam_module_paths() {
 }
 
 #[test]
+fn sae_decoder_lsq_seed_honors_softmax_top_k_support_2132() {
+    let n = 4usize;
+    let k_atoms = 2usize;
+    let mut basis = ndarray::Array3::<f64>::zeros((k_atoms, n, 1));
+    for atom_idx in 0..k_atoms {
+        for row in 0..n {
+            basis[[atom_idx, row, 0]] = 1.0;
+        }
+    }
+    let z = array![[1.0], [1.0], [-1.0], [-1.0]];
+    let logits = array![[8.0, -8.0], [8.0, -8.0], [-8.0, 8.0], [-8.0, 8.0]];
+
+    let decoder = sae_decoder_lsq_init(
+        basis.view(),
+        &[1, 1],
+        z.view(),
+        logits.view(),
+        "softmax",
+        1.0,
+        1.0,
+        0.0,
+        Some(1),
+    )
+    .expect("top-k softmax seed LSQ succeeds");
+
+    assert!(
+        decoder[[0, 0, 0]] > 0.99,
+        "top_k=1 must fit atom 0 only on its selected positive rows, got {}",
+        decoder[[0, 0, 0]]
+    );
+    assert!(
+        decoder[[1, 0, 0]] < -0.99,
+        "top_k=1 must fit atom 1 only on its selected negative rows, got {}",
+        decoder[[1, 0, 0]]
+    );
+}
+
+#[test]
 fn symmetric_curvature_solve_preserves_negative_modes() {
     let matrix = array![[2.0, 0.0, 0.0], [0.0, -4.0, 0.0], [0.0, 0.0, -1.0e-15]];
     let rhs = array![8.0, -8.0, 1.0];
@@ -1435,6 +1473,7 @@ fn sae_decoder_lsq_init_produces_nontrivial_seed() {
         1.0, // alpha (IBP concentration; canonical default)
         0.7, // tau
         0.0, // jumprelu_threshold (unused for ibp_map)
+        None,
     )
     .expect("LSQ seed must succeed");
     assert_eq!(decoder.shape(), &[k, m, p]);

--- a/crates/gam-pyffi/tests/src_modules/lib_tests.rs
+++ b/crates/gam-pyffi/tests/src_modules/lib_tests.rs
@@ -69,7 +69,18 @@ fn sae_decoder_lsq_seed_honors_softmax_top_k_support_2132() {
         }
     }
     let z = array![[1.0], [1.0], [-1.0], [-1.0]];
-    let logits = array![[8.0, -8.0], [8.0, -8.0], [-8.0, 8.0], [-8.0, 8.0]];
+    // Deliberately MODERATE logits (±0.5): the dense softmax responsibilities are
+    // genuinely soft (≈[0.73, 0.27]), so every atom gets non-trivial weight on
+    // every row. That is what makes this a real regression: if the top_k support
+    // projection were a no-op, atoms 0 and 1 would remain coupled across all four
+    // rows and the joint LSQ would fit each decoder to coth(0.5) ≈ 2.16 (the
+    // symmetric dense solution), not ±1. Only projecting the responsibilities onto
+    // the top-1 support (rows 0,1 → atom 0, rows 2,3 → atom 1) decouples them so
+    // each atom fits exactly its two selected rows, giving ±1 (±the seed ridge,
+    // spectral_scale·1e-4). With near-hard logits (e.g. ±8) the dense and
+    // projected fits are indistinguishable, so such a test would pass even against
+    // a no-op projection — hence the moderate magnitude here.
+    let logits = array![[0.5, -0.5], [0.5, -0.5], [-0.5, 0.5], [-0.5, 0.5]];
 
     let decoder = sae_decoder_lsq_init(
         basis.view(),
@@ -84,15 +95,39 @@ fn sae_decoder_lsq_seed_honors_softmax_top_k_support_2132() {
     )
     .expect("top-k softmax seed LSQ succeeds");
 
+    // Projected onto top-1 support each atom fits only its two selected rows,
+    // recovering ±1 up to the tiny mean-relative seed ridge (~1e-4).
     assert!(
-        decoder[[0, 0, 0]] > 0.99,
-        "top_k=1 must fit atom 0 only on its selected positive rows, got {}",
+        (decoder[[0, 0, 0]] - 1.0).abs() < 1.0e-3,
+        "top_k=1 must fit atom 0 only on its selected positive rows (expected ≈1.0), got {}",
         decoder[[0, 0, 0]]
     );
     assert!(
-        decoder[[1, 0, 0]] < -0.99,
-        "top_k=1 must fit atom 1 only on its selected negative rows, got {}",
+        (decoder[[1, 0, 0]] + 1.0).abs() < 1.0e-3,
+        "top_k=1 must fit atom 1 only on its selected negative rows (expected ≈-1.0), got {}",
         decoder[[1, 0, 0]]
+    );
+
+    // Baseline arm: the SAME data with no top-k cap (dense softmax) keeps the
+    // atoms coupled, so the decoders land far from ±1 (≈±2.16). This proves the
+    // projection is load-bearing on this fixture — the assertions above cannot be
+    // satisfied by a no-op that ignores `top_k`.
+    let decoder_dense = sae_decoder_lsq_init(
+        basis.view(),
+        &[1, 1],
+        z.view(),
+        logits.view(),
+        "softmax",
+        1.0,
+        1.0,
+        0.0,
+        None,
+    )
+    .expect("dense softmax seed LSQ succeeds");
+    assert!(
+        (decoder_dense[[0, 0, 0]] - 1.0).abs() > 0.5,
+        "dense (no top_k) softmax seed must stay coupled and miss ±1, got {}",
+        decoder_dense[[0, 0, 0]]
     );
 }
 


### PR DESCRIPTION
### Motivation
- The cold-start seed path (decoder LSQ + EM-style routing refinement) used dense softmax responsibilities while the Arrow‑Schur solve later applied a `top_k` active-set cap, producing a different objective at init and enabling dictionary co-collapse on planted single-active mixtures.
- The change ensures the initialization sees the same capped support as the optimization so seeding cannot reintroduce the uniform-saddle that collapses atoms as K grows.

### Description
- Apply the softmax active-set cap earlier in the training pipeline by calling `base_term.set_softmax_active_cap(top_k)` before the cold routing refinement to make the seed path respect the requested `top_k` (file: `crates/gam-pyffi/src/latent/latent_basis_and_sae_ffi.rs`).
- Thread `top_k: Option<usize>` into the decoder seed helper `sae_decoder_lsq_init(...)` and project/renormalize per-row softmax responsibilities onto the top‑k support before forming the joint LSQ design (file: `crates/gam-pyffi/src/latent/latent_basis_and_sae_ffi.rs`).
- Pass `top_k` through the minimal fit / EM refinement M-step so every place that computes the seed decoder honors the active-set cap (files: `crates/gam-pyffi/src/latent/latent_basis_and_sae_ffi_tail.rs`, `crates/gam-pyffi/src/latent/latent_basis_and_sae_ffi.rs`).
- Add a focused regression test `sae_decoder_lsq_seed_honors_softmax_top_k_support_2132` that asserts `top_k=1` seed LSQ fits atoms only on their selected rows (file: `crates/gam-pyffi/tests/src_modules/lib_tests.rs`).

### Testing
- Built full tree: `./build.sh` — succeeded (library build completed).
- Scoped lib check: `./build.sh check -p gam-pyffi --lib` — succeeded (no warnings).
- Built pyffi test binary (no-run): `./build.sh test -p gam --test pyffi --no-run` — succeeded (test binary built).
- Ran the focused test binary locally where possible: `./build.sh test -p gam-pyffi --lib sae_decoder_lsq_seed_honors_softmax_top_k_support_2132 -- --nocapture` — compilation succeeded but the lib-test link failed in this environment due to missing Python/PyO3 symbols during link (linker error unrelated to the changed logic); the same test compiles in the normal crate test build and the added unit compiles against the library surface.

All changes are in Rust (no Python math), introduce no forbidden shortcuts from SPEC (no grid-search, no fabricated convergence, no hard timeouts, no magic constants without justification), and add a minimal deterministic unit that pins the `top_k` seed contract.

---
Refs #2132 (core cold-joint seed co-collapse; residual stagewise-below-PCA-floor and OOS reconstruct-shape sub-findings tracked separately in the issue).

<details><summary>codex self-assessment</summary>

rates/gam-pyffi)\n      Checking gam-predict v0.3.148 (/workspace/gam/crates/gam-predict)\n      Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 58s\n  ```\n\n* \u2705 `./build.sh test -p gam --test pyffi --no-run`  \n  Output:\n  ```text\n  [build.sh] test -p gam --test pyffi --no-run -> exit 0 in 10s (dedup=MISS, recompiled 2 crates)\n     Compiling gam v0.3.148 (/workspace/gam)\n     Compiling gam-predict v0.3.148 (/workspace/gam/crates/gam-predict)\n      Finished `test` profile [optimized + debuginfo] target(s) in 9.41s\n    Executable tests/pyffi/main.rs (target/debug/deps/pyffi-61a275d6536e0bb2)\n  ```\n\n* \u26a0\ufe0f `./build.sh test -p gam-pyffi --lib sae_decoder_lsq_seed_honors_softmax_top_k_support_2132 -- --nocapture`  \n  Output:\n  ```text\n  [build.sh] test -p gam-pyffi --lib sae_decoder_lsq_seed_honors_softmax_top_k_support_2132 -- --nocapture -> exit 101 in 265s (dedup=MISS, recompiled 3 crates)\n  FAILED (101):\n  ...\n  rust-lld: error: undefined symbol: PyExc_AttributeError\n  ...\n  rust-lld: error: undefined symbol: PyUnicode_FromStringAndSize\n  ...\n  rust-lld: error: undefined symbol: PyExc_TypeError\n  ...\n  error: could not compile `gam-pyffi` (lib test) due to 1 previous error\n  ```\n  This failed while linking the `gam-pyffi` lib-test harness against Python/PyO3 symbols, not while compiling the changed Rust code. The scoped non-test library build and relevant test binary build both passed.\n\n## CODE DIFF\n\n```diff\ndiff --git a/crates/gam-pyffi/src/latent/latent_basis_and_sae_ffi.rs b/crates/gam-pyffi/src/latent/latent_basis_and_sae_ffi.rs\nindex d43ff41..e17eaed 100644\n--- a/crates/gam-pyffi/src/latent/latent_basis_and_sae_ffi.rs\n+++ b/crates/gam-pyffi/src/latent/latent_basis_and_sae_ffi.rs\n@@ -3267,6 +3267,13 @@ fn sae_manifold_fit_inner<'py>(\n             .set_temperature_schedule(schedule)\n             .map_err(py_value_error)?;\n     }\n+    // #2132 \u2014 the active-set cap is part of the model being optimized, so the\n+    // cold routing refinement must see the same top-k softmax support as the\n+    // subsequent Arrow-Schur solve. Installing it only after the EM seed let\n+    // the seed decoder LSQ train every atom on every row under dense softmax\n+    // responsibilities; with top_k=1 planted mixtures that reintroduced the\n+    // uniform co-collapse saddle before the capped solver ever ran.\n+    base_term.set_softmax_active_cap(top_k);\n \n     // Cold-start routing seed refinement (#629, #630). The cold residual-logit\n@@ -3398,7 +3405,6 @@ fn sae_manifold_fit_inner<'py>(\n-    base_term.set_softmax_active_cap(top_k);\n     let seed_dispersion = base_term\n@@ -6086,6 +6092,7 @@ fn sae_decoder_lsq_init(\n     alpha: f64,\n     tau: f64,\n     jumprelu_threshold: f64,\n+    top_k: Option<usize>,\n ) -> Result<Array3<f64>, String> {\n@@ -6116,6 +6123,13 @@ fn sae_decoder_lsq_init(\n     match assignment_kind {\n         \"softmax\" => {\n+            if let Some(k_top) = top_k {\n+                if k_top == 0 || k_top > k_atoms {\n+                    return Err(format!(\n+                        \"sae_decoder_lsq_init: top_k must satisfy 1 <= top_k <= k_atoms={k_atoms}; got {k_top}\"\n+                    ));\n+                }\n+            }\n             let inv_tau = 1.0 / tau;\n@@ -6137,6 +6151,38 @@ fn sae_decoder_lsq_init(\n                         a_init[[row, k]] = buf[k] / sum;\n                     }\n                 }\n+                if let Some(k_top) = top_k {\n+                    if k_top < k_atoms {\n+                        let mut paired: Vec<(f64, usize)> =\n+                            (0..k_atoms).map(|k| (a_init[[row, k]], k)).collect();\n+                        let cmp = |a: &(f64, usize), b: &(f64, usize)| {\n+                            b.0.partial_cmp(&a.0)\n+                                .unwrap_or(std::cmp::Ordering::Equal)\n+                                .then(a.1.cmp(&b.1))\n+                        };\n+         
</details>

_Codex-generated; pending adversarial audit before merge._
