### PR TITLE
#2135: Fix OOS circle basis mismatch by replaying trained 2-row fundamental circle design

### DIFF
--- a/crates/gam-pyffi/src/latent/latent_basis_and_sae_ffi.rs
+++ b/crates/gam-pyffi/src/latent/latent_basis_and_sae_ffi.rs
@@ -1,3 +1,6 @@
+use gam::terms::sae::basis::{PhiEtaSplit, SaeBasisThirdJet};
+use ndarray::Array5;
+
 fn latent_basis_kind(value: &str) -> Result<&'static str, String> {
     match value.to_ascii_lowercase().replace(['_', '-'], "").as_str() {
         "duchon" | "duchonspline" => Ok("duchon"),
@@ -2019,6 +2022,7 @@ fn build_sae_basis_evaluators(
         // `with_basis_second_jet`, which is the slot the #1117 rank-revealing
         // reduction reads to reparametrize a rank-deficient decoder.
         let evaluator: Arc<dyn SaeBasisSecondJet> = match &basis_kinds[k] {
+            SaeAtomBasisKind::Periodic if d == 1 && m == 2 => Arc::new(FundamentalCircleEvaluator),
             SaeAtomBasisKind::Periodic if d == 1 && m % 2 == 1 => {
                 Arc::new(PeriodicHarmonicEvaluator::new(m)?)
             }
@@ -5147,12 +5151,87 @@ struct SaeAtomBuildPlan {
     kind: SaeAtomBasisKind,
     latent_dim: usize,
     n_harmonics: usize,
+    periodic_without_intercept: bool,
     duchon_centers: Option<Array2<f64>>,
     basis_size: usize,
 }
 
 fn sae_atom_basis_size(plan: &SaeAtomBuildPlan) -> usize {
     plan.basis_size
+}
+
+#[derive(Debug, Clone)]
+struct FundamentalCircleEvaluator;
+
+impl SaeBasisEvaluator for FundamentalCircleEvaluator {
+    fn phi_eta_split(&self, n_basis: usize) -> Result<PhiEtaSplit, String> {
+        if n_basis != 2 {
+            return Err(format!(
+                "FundamentalCircleEvaluator::phi_eta_split: expected n_basis == 2, got {n_basis}"
+            ));
+        }
+        Ok(PhiEtaSplit::all_linear(n_basis))
+    }
+
+    fn second_jet_dyn(&self, coords: ArrayView2<'_, f64>) -> Option<Result<Array4<f64>, String>> {
+        Some(<Self as SaeBasisSecondJet>::second_jet(self, coords))
+    }
+
+    fn third_jet_dyn(&self, coords: ArrayView2<'_, f64>) -> Option<Result<Array5<f64>, String>> {
+        Some(<Self as SaeBasisThirdJet>::third_jet(self, coords))
+    }
+
+    fn evaluate(&self, coords: ArrayView2<'_, f64>) -> Result<(Array2<f64>, Array3<f64>), String> {
+        if coords.ncols() != 1 {
+            return Err(format!(
+                "FundamentalCircleEvaluator::evaluate: expected latent_dim == 1, got {}",
+                coords.ncols()
+            ));
+        }
+        let t = coords.column(0).to_owned();
+        let (phi, jet, _penalty) = sae_build_periodic_atom_without_intercept(t.view())?;
+        Ok((phi, jet))
+    }
+}
+
+impl SaeBasisSecondJet for FundamentalCircleEvaluator {
+    fn second_jet(&self, coords: ArrayView2<'_, f64>) -> Result<Array4<f64>, String> {
+        if coords.ncols() != 1 {
+            return Err(format!(
+                "FundamentalCircleEvaluator::second_jet: expected latent_dim == 1, got {}",
+                coords.ncols()
+            ));
+        }
+        let n = coords.nrows();
+        let mut h = Array4::<f64>::zeros((n, 2, 1, 1));
+        let freq2 = std::f64::consts::TAU * std::f64::consts::TAU;
+        for row in 0..n {
+            let angle = std::f64::consts::TAU * coords[[row, 0]].rem_euclid(1.0);
+            h[[row, 0, 0, 0]] = -freq2 * angle.sin();
+            h[[row, 1, 0, 0]] = -freq2 * angle.cos();
+        }
+        Ok(h)
+    }
+}
+
+impl SaeBasisThirdJet for FundamentalCircleEvaluator {
+    fn third_jet(&self, coords: ArrayView2<'_, f64>) -> Result<Array5<f64>, String> {
+        if coords.ncols() != 1 {
+            return Err(format!(
+                "FundamentalCircleEvaluator::third_jet: expected latent_dim == 1, got {}",
+                coords.ncols()
+            ));
+        }
+        let n = coords.nrows();
+        let mut third = Array5::<f64>::zeros((n, 2, 1, 1, 1));
+        let freq3 = std::f64::consts::TAU * std::f64::consts::TAU * std::f64::consts::TAU;
+        for row in 0..n {
+            let angle = std::f64::consts::TAU * coords[[row, 0]].rem_euclid(1.0);
+            third[[row, 0, 0, 0, 0]] = -freq3 * angle.cos();
+            third[[row, 1, 0, 0, 0]] = freq3 * angle.sin();
+        }
+        Ok(third)
+    }
 }
 
 const SAE_MAX_PERIODIC_HARMONICS: usize = 4096;
@@ -6425,6 +6504,36 @@ fn sae_build_periodic_atom(
     Ok((phi, jet, penalty))
 }
 
+/// Evaluate the reduced fundamental circle basis `[sin(2πt), cos(2πt)]`.
+///
+/// Some trained SAE circle artifacts store the centered/fundamental chart after
+/// the constant Fourier row has been quotiented out, so the frozen decoder has
+/// exactly two rows.  OOS prediction must replay that trained design instead of
+/// inflating it to the generic three-row `[1, sin, cos]` periodic basis.
+fn sae_build_periodic_atom_without_intercept(
+    t: ArrayView1<'_, f64>,
+) -> Result<(Array2<f64>, Array3<f64>, Array2<f64>), String> {
+    if t.iter().any(|value| !value.is_finite()) {
+        return Err("sae_build_periodic_atom_without_intercept requires finite t values".to_string());
+    }
+    let n_rows = t.len();
+    let mut phi = Array2::<f64>::zeros((n_rows, 2));
+    let mut jet = Array3::<f64>::zeros((n_rows, 2, 1));
+    let mut penalty = Array2::<f64>::zeros((2, 2));
+    penalty[[0, 0]] = 1.0;
+    penalty[[1, 1]] = 1.0;
+    for row in 0..n_rows {
+        let angle = std::f64::consts::TAU * t[row].rem_euclid(1.0);
+        let sin_value = angle.sin();
+        let cos_value = angle.cos();
+        phi[[row, 0]] = sin_value;
+        phi[[row, 1]] = cos_value;
+        jet[[row, 0, 0]] = std::f64::consts::TAU * cos_value;
+        jet[[row, 1, 0]] = -std::f64::consts::TAU * sin_value;
+    }
+    Ok((phi, jet, penalty))
+}
+
 /// Compute the per-axis basis size `axis_m = (m)^(1/d)` for a torus atom and
 /// verify that `m = axis_m^d` with `axis_m` odd (i.e. `2H+1`). Returns
 /// `axis_m`.
@@ -6734,7 +6843,11 @@ fn sae_build_padded_basis_stacks(
                 } else {
                     Array1::<f64>::zeros(n_obs)
                 };
-                let (phi, jet, penalty) = sae_build_periodic_atom(t.view(), plan.n_harmonics)?;
+                let (phi, jet, penalty) = if plan.periodic_without_intercept {
+                    sae_build_periodic_atom_without_intercept(t.view())?
+                } else {
+                    sae_build_periodic_atom(t.view(), plan.n_harmonics)?
+                };
                 let m = phi.ncols();
                 if phi.nrows() != n_obs || m != basis_sizes[atom_idx] {
                     return Err(format!(

--- a/crates/gam-pyffi/src/latent/latent_basis_and_sae_ffi_tail.rs
+++ b/crates/gam-pyffi/src/latent/latent_basis_and_sae_ffi_tail.rs
@@ -58,6 +58,7 @@ fn sae_build_atom_plans(
                     kind: SaeAtomBasisKind::Periodic,
                     latent_dim: 1,
                     n_harmonics,
+                    periodic_without_intercept: false,
                     duchon_centers: None,
                     basis_size,
                 });
@@ -76,6 +77,7 @@ fn sae_build_atom_plans(
                     kind: SaeAtomBasisKind::Sphere,
                     latent_dim: 2,
                     n_harmonics: 0,
+                    periodic_without_intercept: false,
                     duchon_centers: None,
                     basis_size: SAE_SPHERE_BASIS_SIZE,
                 });
@@ -98,6 +100,7 @@ fn sae_build_atom_plans(
                     kind: SaeAtomBasisKind::Torus,
                     latent_dim: d,
                     n_harmonics: h,
+                    periodic_without_intercept: false,
                     duchon_centers: None,
                     basis_size,
                 });
@@ -150,6 +153,7 @@ fn sae_build_atom_plans(
                     kind,
                     latent_dim: d,
                     n_harmonics: 0,
+                    periodic_without_intercept: false,
                     duchon_centers: Some(centers),
                     basis_size,
                 });
@@ -734,12 +738,23 @@ fn sae_manifold_predict_oos<'py>(
                 // `n_harmonics_list[k]` is supplied. Force the optimizer
                 // latent dimension to 1 so the analytic harmonic evaluator
                 // remains live during OOS prediction.
-                let n_harmonics = n_harmonics_list[atom_idx].unwrap_or(d.max(1));
-                let basis_size = sae_periodic_basis_size(n_harmonics).map_err(py_value_error)?;
+                let trained_m = decoder_blocks[atom_idx].as_array().nrows();
+                let periodic_without_intercept = trained_m == 2;
+                let n_harmonics = if periodic_without_intercept {
+                    1
+                } else {
+                    n_harmonics_list[atom_idx].unwrap_or(d.max(1))
+                };
+                let basis_size = if periodic_without_intercept {
+                    trained_m
+                } else {
+                    sae_periodic_basis_size(n_harmonics).map_err(py_value_error)?
+                };
                 plans.push(SaeAtomBuildPlan {
                     kind: SaeAtomBasisKind::Periodic,
                     latent_dim: 1,
                     n_harmonics,
+                    periodic_without_intercept,
                     duchon_centers: None,
                     basis_size,
                 });
@@ -754,6 +769,7 @@ fn sae_manifold_predict_oos<'py>(
                     kind: SaeAtomBasisKind::Sphere,
                     latent_dim: 2,
                     n_harmonics: 0,
+                    periodic_without_intercept: false,
                     duchon_centers: None,
                     basis_size: SAE_SPHERE_BASIS_SIZE,
                 });
@@ -766,6 +782,7 @@ fn sae_manifold_predict_oos<'py>(
                     kind: SaeAtomBasisKind::Torus,
                     latent_dim: d,
                     n_harmonics: h,
+                    periodic_without_intercept: false,
                     duchon_centers: None,
                     basis_size,
                 });
@@ -822,6 +839,7 @@ fn sae_manifold_predict_oos<'py>(
                     kind,
                     latent_dim: d,
                     n_harmonics: 0,
+                    periodic_without_intercept: false,
                     duchon_centers: Some(centers),
                     basis_size,
                 });
@@ -1687,6 +1705,7 @@ fn sae_steer_delta<'py>(
                     kind: SaeAtomBasisKind::Periodic,
                     latent_dim: 1,
                     n_harmonics,
+                    periodic_without_intercept: false,
                     duchon_centers: None,
                     basis_size,
                 });
@@ -1701,6 +1720,7 @@ fn sae_steer_delta<'py>(
                     kind: SaeAtomBasisKind::Sphere,
                     latent_dim: 2,
                     n_harmonics: 0,
+                    periodic_without_intercept: false,
                     duchon_centers: None,
                     basis_size: SAE_SPHERE_BASIS_SIZE,
                 });
@@ -1713,6 +1733,7 @@ fn sae_steer_delta<'py>(
                     kind: SaeAtomBasisKind::Torus,
                     latent_dim: d,
                     n_harmonics: h,
+                    periodic_without_intercept: false,
                     duchon_centers: None,
                     basis_size,
                 });
@@ -1758,6 +1779,7 @@ fn sae_steer_delta<'py>(
                     kind,
                     latent_dim: d,
                     n_harmonics: 0,
+                    periodic_without_intercept: false,
                     duchon_centers: Some(centers),
                     basis_size,
                 });

--- a/tests/test_sae_manifold_synthetic_quality_ground_truth.py
+++ b/tests/test_sae_manifold_synthetic_quality_ground_truth.py
@@ -108,6 +108,35 @@ def test_periodic_basis_public_entrypoints_agree_after_wrapping() -> None:
     )
 
 
+
+def test_oos_fixed_decoder_replays_reduced_fundamental_circle_design() -> None:
+    """A trained two-row circle decoder is the authoritative OOS basis contract."""
+    t = np.linspace(0.0, 1.0, 12, endpoint=False, dtype=float)
+    x = np.column_stack([np.sin(2.0 * np.pi * t), np.cos(2.0 * np.pi * t)])
+    decoder = np.eye(2, dtype=float)
+    payload = rust_module().sae_manifold_predict_oos(
+        np.ascontiguousarray(x),
+        ["periodic"],
+        [1],
+        [np.ascontiguousarray(decoder)],
+        [None],
+        [1],
+        [2],
+        alpha=1.0,
+        tau=0.25,
+        assignment_kind="softmax",
+        sparsity_strength=0.0,
+        smoothness=0.0,
+        max_iter=3,
+        learning_rate=1.0,
+    )
+    fitted = np.asarray(payload["fitted"], dtype=float)
+
+    assert fitted.shape == x.shape
+    assert np.all(np.isfinite(fitted))
+    assert _r2(x, fitted) >= 0.98
+
+
 def test_oos_fixed_decoder_recovers_one_hot_oracle_assignments() -> None:
     """Known decoder, known one-hot atoms: OOS should recover routing."""
     x, truth, _t = _planted_one_hot_periodic(n=16, seed=0, noise=0.0)


### PR DESCRIPTION
### Motivation

- Out-of-sample frozen-decoder reconstruction was rebuilding periodic/circle atom bases from harmonic metadata instead of the trained decoder block width, which inflated a trained `M=2` decoder into a `M=3` `[1, sin, cos]` design and caused a shape-check failure on `reconstruct()`/`sae_manifold_predict_oos`.

### Description

- Make the trained decoder row-count authoritative for periodic atoms by threading a `periodic_without_intercept` flag through the atom build plan and using it during OOS basis rebuilds (`SaeAtomBuildPlan` updated). 
- Detect `trained_m == 2` in the OOS plan construction and set the flag so the rebuild uses the reduced fundamental-circle design rather than inflating harmonics. 
- Add `FundamentalCircleEvaluator` (analytic `evaluate`, `second_jet`, and `third_jet`) and `sae_build_periodic_atom_without_intercept` to generate the `[sin(2πt), cos(2πt)]` basis and jets for M=2 decoders, and register it in the evaluator factory so the OOS latent refresh stays fully analytic. 
- Use the `periodic_without_intercept` flag when building the padded `(K, N, M_max)` basis stacks and add a focused regression test `test_oos_fixed_decoder_replays_reduced_fundamental_circle_design` that exercises `sae_manifold_predict_oos` with a two-row periodic decoder block.

### Testing

- `./build.sh` completed successfully and built the workspace (lib build finished). 
- `./build.sh check -p gam-pyffi --lib` completed successfully with the `gam-pyffi` crate check passing. 
- `maturin develop` built and installed the Python wheel successfully (native extensions compiled). 
- `.venv/bin/python -m pytest tests/test_sae_manifold_synthetic_quality_ground_truth.py::test_oos_fixed_decoder_replays_reduced_fundamental_circle_design -q` passed (1 test, `1 passed`).
- I attempted `./build.sh test --test sae --no-run` to build the SAE test binary but the wrapper encountered a transient OOM/timeout during a full test binary build and was retried; I did not complete a full test-run to avoid repeated long time/OOM cycles.

---
Fixes #2135.

<details><summary>codex self-assessment</summary>

d_truth.py::test_oos_fixed_decoder_replays_reduced_fundamental_circle_design -q`\n\n```text\nF                                                                        [100%]\n=================================== FAILURES ===================================\n_______ test_oos_fixed_decoder_replays_reduced_fundamental_circle_design _______\n\nE       gamfit._rust.GamError: build_sae_basis_evaluators: Periodic atom 0 requires latent_dim == 1 and odd basis size; got dim=1, m=2\n\n1 failed in 0.69s\n```\n\n**After fix**\n\n* \u2705 `./build.sh`\n\n```text\n[build.sh] LIB -> exit 0 in 1155s (dedup=MISS, recompiled 268 crates)\nFinished `dev` profile [unoptimized + debuginfo] target(s) in 19m 14s\n```\n\n* \u2705 `./build.sh check -p gam-pyffi --lib`\n\n```text\n[build.sh] check -p gam-pyffi --lib -> exit 0 in 125s (dedup=MISS, recompiled 2 crates)\n   Compiling gam v0.3.148 (/workspace/gam)\n   Compiling gam-pyffi v0.1.250 (/workspace/gam/crates/gam-pyffi)\n    Checking gam-predict v0.3.148 (/workspace/gam/crates/gam-predict)\n    Finished `dev` profile [unoptimized + debuginfo] target(s) in 2m 04s\n```\n\n* \u2705 `maturin develop`\n\n```text\n\ud83c\udf79 Building a mixed python/rust project\n\ud83d\udc0d Found CPython 3.12 at /workspace/gam/.venv/bin/python\n\ud83d\udd17 Found pyo3 bindings with abi3-py3.10 support\nFinished `dev` profile [unoptimized + debuginfo] target(s) in 49.55s\n\ud83d\udce6 Built wheel for abi3 Python \u2265 3.10 to /tmp/.tmpSvvqiF/gamfit-0.1.250-cp310-abi3-linux_x86_64.whl\n\u270f\ufe0f Setting installed package as editable\n\ud83d\udee0 Installed gamfit-0.1.250\n```\n\n* \u2705 `.venv/bin/python -m pytest tests/test_sae_manifold_synthetic_quality_ground_truth.py::test_oos_fixed_decoder_replays_reduced_fundamental_circle_design -q`\n\n```text\n.                                                                        [100%]\n1 passed in 0.53s\n```\n\n* \u26a0\ufe0f `./build.sh test --test sae --no-run`\n\n```text\n[build.sh] transient failure (OOM/timeout, exit 124) attempt 1/3 \u2014 retrying with CARGO_BUILD_JOBS=1 (lower peak RAM)\u2026\n```\n\nI stopped the retry to avoid another long timeout after the wrapper had already hit its transient OOM/timeout lane.\n\n### CODE DIFF\n\nCommitted on the current branch:\n\n```text\n2d9f059 Fix OOS reduced circle basis replay\n```\n\nSummary of the committed diff:\n\n```text\ncrates/gam-pyffi/src/latent/latent_basis_and_sae_ffi.rs\n  + imports PhiEtaSplit / SaeBasisThirdJet / Array5\n  + registers FundamentalCircleEvaluator for periodic M=2\n  + adds periodic_without_intercept to SaeAtomBuildPlan\n  + adds FundamentalCircleEvaluator with analytic evaluate/second_jet/third_jet\n  + adds sae_build_periodic_atom_without_intercept([sin, cos])\n  + uses reduced circle builder in padded OOS basis stacks\n\ncrates/gam-pyffi/src/latent/latent_basis_and_sae_ffi_tail.rs\n  + threads periodic_without_intercept through plan construction\n  + derives the OOS periodic basis width from decoder_blocks[atom].nrows()\n    when trained_m == 2\n\ntests/test_sae_manifold_synthetic_quality_ground_truth.py\n  + adds test_oos_fixed_decoder_replays_reduced_fundamental_circle_design\n```\n\n### SELF-ASSESSMENT\n\n* **SOLVES THE ISSUE? SOLVED.** The reported failure mechanism is specifically `decoder_blocks[0] has M=2 but rebuilt basis has M=3` for held-out OOS reconstruction of a fitted circle atom. The OOS planner now detects the trained `M=2` periodic decoder and rebuilds/evaluates the corresponding two-column fundamental circle design, so it no longer inflates the basis to `M=3`.\n* **NET EFFECT: NET-GOOD.** This improves the codebase by making frozen-decoder prediction replay the trained design contract instead of relying on lossy harmonic metadata. The main risk is scope-limited: `M=2` periodic atoms are now treated as a reduced fundamental circle basis, which matches the observed trained artifact and the explicit regression test; odd-width periodic designs remain on the existing path."}]
</details>

_Codex-generated; pending adversarial audit before merge._