### PR TITLE
#2149: Make descriptor `double_penalty` tri-state so shape-constrained BSpline descriptors defer to formula defaults (fix #2149)

### DIFF
--- a/gamfit/smooth.py
+++ b/gamfit/smooth.py
@@ -98,10 +98,10 @@ class Smooth(_BasisDescriptor):
         layer). Mathematically equivalent to ``by · s(x)`` in the additive
         model. When the underlying basis is a column-block of the joint
         design, ``by`` multiplies every column in the block per row.
-    double_penalty : if True, add a ridge-shrinkage penalty on the null
-        space of the main penalty (mgcv ``bs="..."`` ``select=TRUE`` style).
-        Useful when the smooth might be entirely redundant and you want
-        REML to shrink it out.
+    double_penalty : optional bool. ``None`` (the default) defers to the
+        Rust/formula default for the smooth kind, keeping descriptor lowering
+        bit-identical to the formula DSL. Pass ``True`` or ``False`` to
+        explicitly enable or disable the null-space shrinkage penalty.
     shape_constraint : optional shape constraint on the fitted function.
         One of ``None`` / ``"none"`` (unconstrained, the default),
         ``"monotone_increasing"`` (f'(x) ≥ 0 everywhere on the data range),
@@ -126,7 +126,7 @@ class Smooth(_BasisDescriptor):
 
     name: str | None = None
     by: Any | None = None
-    double_penalty: bool = False
+    double_penalty: bool | None = None
     shape_constraint: ShapeConstraintLiteral | None = None
     _gamfit_topology_dim: int | None = field(default=None, init=False, repr=False)
     _gamfit_tensor_k: tuple[int, int] | None = field(default=None, init=False, repr=False)
@@ -167,13 +167,10 @@ class Smooth(_BasisDescriptor):
             out["name"] = str(self.name)
         if self.shape_constraint is not None:
             out["shape_constraint"] = str(self.shape_constraint)
-        # Emit ``double_penalty`` for BOTH True and False so the flag is
-        # actually toggle-able through the ``smooths={}`` descriptor bridge
-        # (issue #1565). A plain-``bool`` field (base, BSpline, …) is never
-        # None, so it always emits its concrete value; subclasses that
-        # redefine the field as ``bool | None`` (e.g. MeasureJet) keep their
-        # tri-state semantics — ``None`` means "defer to engine" and emits
-        # no key.
+        # Emit ``double_penalty`` only when the user explicitly pins it.
+        # ``None`` means "defer to the Rust/formula default", which keeps the
+        # descriptor bridge bit-identical to the formula DSL while preserving
+        # issue #1565's ability to transmit an explicit ``False``.
         if self.double_penalty is not None:
             out["double_penalty"] = bool(self.double_penalty)
         if self.by is not None:
@@ -526,9 +523,6 @@ class MeasureJet(Smooth):
     scales: int | None = None
     length_scale: float | None = None
     learn_length_scale: bool | None = None
-    # Tri-state override of the base ``bool = False`` field: the engine
-    # default for measure-jet is double-penalty ON, so ``None`` must mean
-    # "defer to the engine" and an explicit ``False`` must be emitted.
     double_penalty: bool | None = None
 
     def to_rust_descriptor(self) -> dict[str, Any]:

--- a/tests/bug_hunt_shape_constrained_bspline_descriptor_default_unfittable_test.py
+++ b/tests/bug_hunt_shape_constrained_bspline_descriptor_default_unfittable_test.py
@@ -1,0 +1,82 @@
+"""Regression test for #2149: shape-constrained BSpline descriptor defaults.
+
+The formula DSL and the ``smooths={}`` descriptor bridge are documented to lower
+an equivalent smooth identically. A shape-constrained ``BSpline`` descriptor used
+to emit ``double_penalty=False`` from its Python default, while formula
+``s(x, shape=...)`` inherits the Rust/formula default ``double_penalty=True``.
+For the shape reparameterization this left null-space directions unpenalized and
+collinear with lower-order model columns, causing a pre-fit rank deficiency.
+"""
+
+from __future__ import annotations
+
+import importlib
+from typing import Any
+
+import numpy as np
+import pandas as pd
+
+pytest: Any = importlib.import_module("pytest")
+pytest.importorskip("gamfit._rust")
+
+import gamfit
+from gamfit.smooth import BSpline
+
+
+def _data(seed: int = 4, n: int = 300) -> pd.DataFrame:
+    rng = np.random.default_rng(seed)
+    x = rng.uniform(0.0, 1.0, n)
+    y = np.sqrt(x) + rng.normal(0.0, 0.03, n)
+    return pd.DataFrame({"x": x, "y": y})
+
+
+def _grid(df: pd.DataFrame, n: int = 160) -> pd.DataFrame:
+    return pd.DataFrame({"x": np.linspace(df["x"].min(), df["x"].max(), n)})
+
+
+def test_bspline_descriptor_double_penalty_tristate_serialization() -> None:
+    default_descriptor = BSpline(shape_constraint="monotone_increasing").to_rust_descriptor()
+    assert "double_penalty" not in default_descriptor
+
+    explicit_false = BSpline(double_penalty=False).to_rust_descriptor()
+    assert explicit_false["double_penalty"] is False
+
+    explicit_true = BSpline(double_penalty=True).to_rust_descriptor()
+    assert explicit_true["double_penalty"] is True
+
+
+def test_bspline_descriptor_monotone_fits_and_matches_formula() -> None:
+    df = _data()
+    formula = gamfit.fit(df, "y ~ s(x, shape='monotone_increasing')")
+    descriptor = gamfit.fit(
+        df,
+        "y ~ s(x)",
+        smooths={"x": BSpline(shape_constraint="monotone_increasing")},
+    )
+
+    pred_formula = np.asarray(formula.predict(_grid(df)), dtype=float)
+    pred_descriptor = np.asarray(descriptor.predict(_grid(df)), dtype=float)
+
+    assert np.all(np.diff(pred_descriptor) >= -1e-6)
+    np.testing.assert_array_equal(pred_descriptor, pred_formula)
+
+
+def test_bspline_descriptor_convex_and_concave_fit() -> None:
+    df = _data()
+    grid = _grid(df)
+
+    convex = gamfit.fit(
+        df,
+        "y ~ s(x)",
+        smooths={"x": BSpline(shape_constraint="convex")},
+    )
+    convex_pred = np.asarray(convex.predict(grid), dtype=float)
+    assert np.all(np.diff(convex_pred, 2) >= -1e-5)
+
+    concave = gamfit.fit(
+        df,
+        "y ~ s(x)",
+        smooths={"x": BSpline(shape_constraint="concave")},
+    )
+    concave_pred = np.asarray(concave.predict(grid), dtype=float)
+    assert np.all(np.diff(concave_pred, 2) <= 1e-5)


### PR DESCRIPTION
### Motivation

- The Python descriptor path was forcing `double_penalty=False` by default while the formula DSL/engine default is `true`, producing a silent mismatch that made shape-constrained `BSpline` descriptors pre-fit rank-deficient. 
- For shape reparameterizations the null-space shrinkage (double-penalty) is required to avoid aliasing the unpenalized intercept/low-order directions, so omitted-descriptor semantics must inherit the Rust/formula default. 

### Description

- Change `Smooth.double_penalty` from `bool = False` to tri-state `bool | None = None` so an omitted field defers to the Rust/formula default. (file: `gamfit/smooth.py`) 
- Update `Smooth.to_rust_descriptor()` to emit `double_penalty` only when the user explicitly pins it, preserving explicit `True`/`False` toggles while restoring descriptor↔formula parity. (file: `gamfit/smooth.py` lines around the field and serialization) 
- Keep `MeasureJet` tri-state semantics and rely on the base emission guard so per-kind overrides still behave as intended. (file: `gamfit/smooth.py`) 
- Add a regression test that asserts default descriptor omission, explicit serialization, and that shape-constrained `BSpline` descriptors fit and match the formula DSL for monotone/convex/concave cases. (file: `tests/bug_hunt_shape_constrained_bspline_descriptor_default_unfittable_test.py`) 

### Testing

- Built and installed the Python extension with `PATH=/workspace/gam/.venv/bin:$PATH ./build.sh maturin` which completed successfully and produced an editable wheel. 
- Built the tree with `./build.sh` and ran `./build.sh check -p gam-pyffi --lib`; both returned success. 
- Ran the new regression test with `.venv/bin/python -m pytest tests/bug_hunt_shape_constrained_bspline_descriptor_default_unfittable_test.py` and it passed (`3 passed, 4 warnings`). 
- Exercised related shape-constrained test suites with `.venv/bin/python -m pytest tests/bug_hunt_shape_constrained_smooth_python_fit_unfittable_test.py tests/test_bug_hunt_smooths_descriptor_by_dropped.py` and they passed (`12 passed, 5 warnings`).

---
Fixes #2149.

<details><summary>codex self-assessment</summary>

aint': 'monotone_increasing', 'double_penalty': False, 'degree': 3, ...}\n__________ test_bspline_descriptor_monotone_fits_and_matches_formula ___________\n...\nE   gamfit._rust.IntegrationError: Pre-fit rank deficiency detected in the realized unpenalized design: rank 1 < 2 unpenalized columns (min eigenvalue 0.000e0, tolerance 3.997e-11, columns [0, 1]). Remove/reparameterize the aliased columns or add an explicit penalty/constraint before fitting.\n...\n________________ test_bspline_descriptor_convex_and_concave_fit ________________\n...\nE   gamfit._rust.IntegrationError: Pre-fit rank deficiency detected in the realized unpenalized design: rank 2 < 3 unpenalized columns (min eigenvalue -7.524e-14, tolerance 4.626e-11, columns [0, 1, 2]). Remove/reparameterize the aliased columns or add an explicit penalty/constraint before fitting.\n=========================== short test summary info ============================\nFAILED tests/bug_hunt_shape_constrained_bspline_descriptor_default_unfittable_test.py::test_bspline_descriptor_double_penalty_tristate_serialization\nFAILED tests/bug_hunt_shape_constrained_bspline_descriptor_default_unfittable_test.py::test_bspline_descriptor_monotone_fits_and_matches_formula\nFAILED tests/bug_hunt_shape_constrained_bspline_descriptor_default_unfittable_test.py::test_bspline_descriptor_convex_and_concave_fit\n3 failed, 1 warning in 1.65s\n```\n\n**After fix**\n\n* \u2705 `PATH=/workspace/gam/.venv/bin:$PATH ./build.sh maturin`\n\n```text\n[build.sh] maturin develop --release  -> exit 0 in 1420s (dedup=n/a, recompiled 3 crates)\n...\n   Compiling gam v0.3.148 (/workspace/gam)\n   Compiling gam-predict v0.3.148 (/workspace/gam/crates/gam-predict)\n   Compiling gam-pyffi v0.1.250 (/workspace/gam/crates/gam-pyffi)\n    Finished `release` profile [optimized] target(s) in 23m 28s\n\ud83d\udce6 Built wheel for abi3 Python \u2265 3.10 to /tmp/.tmpgD3akR/gamfit-0.1.250-cp310-abi3-linux_x86_64.whl\n\u270f\ufe0f Setting installed package as editable\n\ud83d\udee0 Installed gamfit-0.1.250\n```\n\n* \u2705 `./build.sh`\n\n```text\n[build.sh] LIB -> exit 0 in 470s (dedup=MISS, recompiled 5 crates)\n   Compiling gam-models v0.3.148 (/workspace/gam/crates/gam-models)\n   Compiling gam-inference v0.3.148 (/workspace/gam/crates/gam-inference)\n   Compiling gam v0.3.148 (/workspace/gam)\n   Compiling gam-config v0.3.148 (/workspace/gam/crates/gam-config)\n   Compiling gam-test-support v0.3.148 (/workspace/gam/crates/gam-test-support)\n    Finished `dev` profile [unoptimized + debuginfo] target(s) in 7m 48s\n```\n\n* \u2705 `./build.sh check -p gam-pyffi --lib`\n\n```text\n[build.sh] check -p gam-pyffi --lib -> exit 0 in 0s (dedup=SUBSUMED, recompiled 0 crates)\n```\n\n* \u2705 `.venv/bin/python -m py_compile gamfit/smooth.py tests/bug_hunt_shape_constrained_bspline_descriptor_default_unfittable_test.py`\n\n```text\n# no output; exited 0\n```\n\n* \u2705 `.venv/bin/python -m pytest tests/bug_hunt_shape_constrained_bspline_descriptor_default_unfittable_test.py -q --tb=short --disable-warnings`\n\n```text\n...                                                                      [100%]\n3 passed, 4 warnings in 3.38s\n```\n\n* \u2705 `.venv/bin/python -m pytest tests/bug_hunt_shape_constrained_smooth_python_fit_unfittable_test.py tests/test_bug_hunt_smooths_descriptor_by_dropped.py -q --tb=short --disable-warnings`\n\n```text\n............                                                             [100%]\n12 passed, 5 warnings in 3.84s\n```\n\n### CODE DIFF\n\n```diff\ndiff --git a/gamfit/smooth.py b/gamfit/smooth.py\nindex 3030514..b394938 100644\n--- a/gamfit/smooth.py\n+++ b/gamfit/smooth.py\n@@ -98,10 +98,10 @@ class Smooth(_BasisDescriptor):\n         layer). Mathematically equivalent to ``by \u00b7 s(x)`` in the additive\n         model. When the underlying basis is a column-block of the joint\n         design, ``by`` multiplies every column in the block per row.\n-    double_penalty : if True, add a ridge-shrink
</details>

_Codex-generated; pending adversarial audit before merge._