### PR TITLE
#2152: test: add CLI regression to ensure pinned `curv(..., kappa=)` is honored (fixes #2152 coverage)

### DIFF
--- a/tests/bug_hunt_curv_smooth_fixed_kappa_has_no_effect_on_fit_test.py
+++ b/tests/bug_hunt_curv_smooth_fixed_kappa_has_no_effect_on_fit_test.py
@@ -48,6 +48,8 @@ from __future__ import annotations
 import contextlib
 import importlib
 import os
+import subprocess
+from pathlib import Path
 from typing import Any
 
 import numpy as np
@@ -131,4 +133,62 @@ def test_curv_fixed_kappa_changes_the_fit() -> None:
     assert flat_vs_sph > 1e-6, (
         "fixed curv() kappa= has no effect: flat kappa=0 and spherical kappa=+3 "
         f"fits are identical (max|Δ| = {flat_vs_sph:.3e})"
+    )
+
+
+def test_curv_fixed_kappa_changes_the_cli_fit(tmp_path: Path) -> None:
+    """The shared ``gam`` CLI must also preserve explicit fixed curvature.
+
+    The original report was reproduced through ``gam fit``/``gam predict``; this
+    keeps that user-visible surface pinned in addition to the Python engine path.
+    """
+    gam_bin = Path(__file__).resolve().parent.parent / "target" / "release" / "gam"
+    if not gam_bin.exists():
+        pytest.skip("release `gam` CLI binary not built (target/release/gam absent)")
+
+    train, grid = _make_data()
+    train_path = tmp_path / "ball.csv"
+    grid_path = tmp_path / "g.csv"
+    train.to_csv(train_path, index=False)
+    grid.to_csv(grid_path, index=False)
+
+    def fit_predict(kappa: float) -> np.ndarray:
+        model_path = tmp_path / f"m_{kappa}.gam"
+        pred_path = tmp_path / f"p_{kappa}.csv"
+        fit = subprocess.run(
+            [
+                str(gam_bin),
+                "fit",
+                str(train_path),
+                f"y ~ curv(x, z, kappa={kappa})",
+                "--out",
+                str(model_path),
+                "-q",
+            ],
+            capture_output=True,
+            text=True,
+        )
+        assert fit.returncode == 0, f"gam fit kappa={kappa} failed:\n{fit.stdout}\n{fit.stderr}"
+        pred = subprocess.run(
+            [
+                str(gam_bin),
+                "predict",
+                str(model_path),
+                str(grid_path),
+                "--out",
+                str(pred_path),
+                "-q",
+            ],
+            capture_output=True,
+            text=True,
+        )
+        assert pred.returncode == 0, f"gam predict kappa={kappa} failed:\n{pred.stdout}\n{pred.stderr}"
+        return pd.read_csv(pred_path)["mean"].to_numpy(dtype=float)
+
+    pred_sph = fit_predict(3.0)
+    pred_hyp = fit_predict(-3.0)
+    delta = float(np.max(np.abs(pred_sph - pred_hyp)))
+    assert delta > 1e-6, (
+        "CLI fixed curv() kappa= has no effect: kappa=+3 and kappa=-3 "
+        f"predictions are identical/indistinguishable (max|Δ| = {delta:.3e})"
     )


### PR DESCRIPTION
### Motivation
- Add a user-visible regression that exercises the original `gam fit` / `gam predict` reproduction of #2152 so the CLI surface is protected and explicit `kappa=` remains a fixed sectional curvature (spherical vs hyperbolic must produce different fits). 

### Description
- Add `test_curv_fixed_kappa_changes_the_cli_fit` to `tests/bug_hunt_curv_smooth_fixed_kappa_has_no_effect_on_fit_test.py`, importing `subprocess` and `Path`, which runs `gam fit`/`gam predict` on a small-ball dataset and asserts predictions for `kappa=+3` and `kappa=-3` differ (skips if the release `gam` binary is absent). 

### Testing
- Built the workspace and relevant crates and produced/installable Python wheels (`./build.sh`, `./build.sh check -p gam-models --lib`, `maturin build --release -o /tmp/gam-wheels`, `python -m pip install --force-reinstall /tmp/gam-wheels/gamfit-*.whl`) and ran the test file with `python -m pytest tests/bug_hunt_curv_smooth_fixed_kappa_has_no_effect_on_fit_test.py -q -s`, which reported `1 passed, 1 skipped` (the CLI test is skipped when `target/release/gam` is not present in the environment); relevant filtered Rust identifiability tests asserting pinned κ behaviour also passed when run (`pinned_kappa_is_kept_verbatim_by_the_fit` and `pinned_out_of_chart_kappa_is_rejected`).

---
Fixes #2152.

<details><summary>codex self-assessment</summary>

re_smooth` is not a registered cargo test target.\n* \u26a0\ufe0f `./build.sh test --test identifiability --no-run`  \n  Output: hit the build wrapper transient timeout/retry path in this environment before completion; the relevant filtered identifiability tests passed.\n* \u26a0\ufe0f `./build.sh build -p gam-cli --release --bin gam`  \n  Output: hit the build wrapper transient timeout/retry path before producing `target/release/gam`, so the CLI pytest regression was skipped rather than run.\n\n### CODE DIFF\n\n```diff\ndiff --git a/tests/bug_hunt_curv_smooth_fixed_kappa_has_no_effect_on_fit_test.py b/tests/bug_hunt_curv_smooth_fixed_kappa_has_no_effect_on_fit_test.py\nindex 1020858..82da0e8 100644\n--- a/tests/bug_hunt_curv_smooth_fixed_kappa_has_no_effect_on_fit_test.py\n+++ b/tests/bug_hunt_curv_smooth_fixed_kappa_has_no_effect_on_fit_test.py\n@@ -48,6 +48,8 @@ from __future__ import annotations\n import contextlib\n import importlib\n import os\n+import subprocess\n+from pathlib import Path\n from typing import Any\n \n import numpy as np\n@@ -132,3 +134,61 @@ def test_curv_fixed_kappa_changes_the_fit() -> None:\n         \"fixed curv() kappa= has no effect: flat kappa=0 and spherical kappa=+3 \"\n         f\"fits are identical (max|\u0394| = {flat_vs_sph:.3e})\"\n     )\n+\n+\n+def test_curv_fixed_kappa_changes_the_cli_fit(tmp_path: Path) -> None:\n+    \"\"\"The shared ``gam`` CLI must also preserve explicit fixed curvature.\n+\n+    The original report was reproduced through ``gam fit``/``gam predict``; this\n+    keeps that user-visible surface pinned in addition to the Python engine path.\n+    \"\"\"\n+    gam_bin = Path(__file__).resolve().parent.parent / \"target\" / \"release\" / \"gam\"\n+    if not gam_bin.exists():\n+        pytest.skip(\"release `gam` CLI binary not built (target/release/gam absent)\")\n+\n+    train, grid = _make_data()\n+    train_path = tmp_path / \"ball.csv\"\n+    grid_path = tmp_path / \"g.csv\"\n+    train.to_csv(train_path, index=False)\n+    grid.to_csv(grid_path, index=False)\n+\n+    def fit_predict(kappa: float) -> np.ndarray:\n+        model_path = tmp_path / f\"m_{kappa}.gam\"\n+        pred_path = tmp_path / f\"p_{kappa}.csv\"\n+        fit = subprocess.run(\n+            [\n+                str(gam_bin),\n+                \"fit\",\n+                str(train_path),\n+                f\"y ~ curv(x, z, kappa={kappa})\",\n+                \"--out\",\n+                str(model_path),\n+                \"-q\",\n+            ],\n+            capture_output=True,\n+            text=True,\n+        )\n+        assert fit.returncode == 0, f\"gam fit kappa={kappa} failed:\\n{fit.stdout}\\n{fit.stderr}\"\n+        pred = subprocess.run(\n+            [\n+                str(gam_bin),\n+                \"predict\",\n+                str(model_path),\n+                str(grid_path),\n+                \"--out\",\n+                str(pred_path),\n+                \"-q\",\n+            ],\n+            capture_output=True,\n+            text=True,\n+        )\n+        assert pred.returncode == 0, f\"gam predict kappa={kappa} failed:\\n{pred.stdout}\\n{pred.stderr}\"\n+        return pd.read_csv(pred_path)[\"mean\"].to_numpy(dtype=float)\n+\n+    pred_sph = fit_predict(3.0)\n+    pred_hyp = fit_predict(-3.0)\n+    delta = float(np.max(np.abs(pred_sph - pred_hyp)))\n+    assert delta > 1e-6, (\n+        \"CLI fixed curv() kappa= has no effect: kappa=+3 and kappa=-3 \"\n+        f\"predictions are identical/indistinguishable (max|\u0394| = {delta:.3e})\"\n+    )\n```\n\n### SELF-ASSESSMENT\n\n* **SOLVES THE ISSUE? SOLVED.** The underlying production mechanism was already present on this branch: explicit `kappa=` is marked fixed, skipped by \u03ba re-derivation, and frozen in the joint \u03c8 coordinate. My change strengthens regression coverage for the original CLI reproduction path rather than altering production logic.\n* **NET EFFECT: NET-GOOD.** The added test directly protects the user-
</details>

_Codex-generated; pending adversarial audit before merge._