### PR TITLE
#2162: Make curv() terminal κ-polish retreat on NaN covariance and add regression test

### DIFF
--- a/crates/gam-models/src/fit_orchestration/drivers/spatial_optimization.rs
+++ b/crates/gam-models/src/fit_orchestration/drivers/spatial_optimization.rs
@@ -8646,23 +8646,30 @@ pub fn fit_term_collectionwith_spatial_length_scale_optimization(
             (fit, score)
         })
     });
-    // #1074: when the multi-start pre-scan already placed the seed in a good,
-    // finite basin, a HARD joint-solve failure (e.g. a NaN covariance from κ
-    // railing into the kernel-collapse corner during the local polish) must not
-    // sink the whole fit — the pre-scan geometry is itself a valid κ-optimized
-    // result (ρ profiled at the best-scoring fixed κ). Fall back to it, exactly
-    // as the NonConverged / worsened-score gates inside the joint solver already
-    // fall back to the frozen baseline. Only the local polish (a fraction of a
-    // REML nat) is forgone. Scoped to the pre-scan-improved case so ordinary
-    // joint failures keep raising as before.
-    let exact_joint = if prescan_improved && !matches!(joint_result, Ok(Some(_))) {
+    // #1074 / #2162: when the fixed-κ profiled seed is in a good, finite basin,
+    // a HARD joint-solve failure caused only by inference-matrix finiteness (for
+    // example a NaN frequentist covariance from κ railing into the
+    // kernel-collapse corner during local polish) must not sink the whole fit.
+    // The trial-evaluation path already classifies that exact condition as a
+    // recoverable infeasible κ point and retreats; apply the same semantics to
+    // the terminal polish by returning the finite frozen/pre-scan geometry with
+    // ρ profiled at fixed κ. Keep unrelated errors fatal, and keep the older
+    // pre-scan-improved rescue for cases where the multi-start scan found a
+    // strictly better fixed-κ basin but the final polish produced no candidate.
+    let terminal_joint_recoverable = matches!(
+        &joint_result,
+        Err(err) if is_recoverable_trial_point_error(err)
+    );
+    let exact_joint = if (prescan_improved && !matches!(joint_result, Ok(Some(_))))
+        || terminal_joint_recoverable
+    {
         let reason = match &joint_result {
             Err(e) => format!("error: {e}"),
             _ => "unavailable".to_string(),
         };
         log::info!(
-            "[spatial-kappa] #1074 joint polish yielded no usable candidate \
-             ({reason}); returning the multi-start pre-scan geometry (REML {initial_score:.5})"
+            "[spatial-kappa] #1074/#2162 joint polish yielded no usable candidate \
+             ({reason}); returning the fixed-κ profiled geometry (REML {initial_score:.5})"
         );
         FittedTermCollectionWithSpec {
             fit: best.fit,

--- a/tests/bug_hunt_curv_smooth_aborts_nan_covariance_low_signal_test.py
+++ b/tests/bug_hunt_curv_smooth_aborts_nan_covariance_low_signal_test.py
@@ -1,0 +1,42 @@
+"""Regression for #2162: terminal curv() κ polish must retreat on NaN covariance.
+
+The data are deliberately low-signal Gaussian noise. Peer 2-D smooths can fit it,
+so the constant-curvature smooth must not abort just because the terminal local
+κ polish reaches an inference-only NaN covariance at an infeasible trial point.
+"""
+
+import numpy as np
+import pandas as pd
+
+import gamfit
+
+
+def _low_signal_frame() -> pd.DataFrame:
+    rng = np.random.default_rng(3)
+    return pd.DataFrame(
+        {
+            "x": rng.uniform(0.01, 0.99, 400),
+            "z": rng.uniform(0.01, 0.99, 400),
+            "y": rng.standard_normal(400),
+        }
+    )
+
+
+def test_peer_2d_smooths_fit_the_same_low_signal_data():
+    df = _low_signal_frame()
+
+    for formula in ("y ~ te(x, z)", "y ~ mjs(x, z)", "y ~ s(x) + s(z)"):
+        model = gamfit.fit(df, formula, family="gaussian")
+        pred = np.asarray(model.predict(df))
+        assert pred.shape[0] == len(df)
+        assert np.all(np.isfinite(pred))
+
+
+def test_curv_smooth_fits_low_signal_data_without_aborting():
+    df = _low_signal_frame()
+
+    model = gamfit.fit(df, "y ~ curv(x, z)", family="gaussian")
+    pred = np.asarray(model.predict(df))
+
+    assert pred.shape[0] == len(df)
+    assert np.all(np.isfinite(pred))


### PR DESCRIPTION
### Motivation
- The terminal spatial-κ joint-polish path converted a recoverable inference-only NaN covariance into a fatal REML failure because the pre-scan fallback was gated on `prescan_improved`, which is false for many flat/low-signal fits. 
- Trial-evaluation code already treats the identical `fit_result.beta_covariance_frequentist … must be finite` error as a recoverable trial-point and retreats, so terminal and trial semantics needed to be consistent. 

### Description
- Apply the existing recoverable-trial-point classifier by introducing `terminal_joint_recoverable = matches!(&joint_result, Err(err) if is_recoverable_trial_point_error(err))` and include it in the `exact_joint` fallback condition in `crates/gam-models/src/fit_orchestration/drivers/spatial_optimization.rs`. 
- When the terminal joint polish fails only due to inference-matrix non-finiteness, return the finite frozen/pre-scan fixed-κ profiled geometry instead of aborting, while leaving unrelated errors fatal. 
- Update the fallback log message and add a deterministic Python regression `tests/bug_hunt_curv_smooth_aborts_nan_covariance_low_signal_test.py` that reproduces the low-signal `curv(x, z)` abort and asserts peer 2-D smooths and `curv()` produce finite predictions. 

### Testing
- Built the tree with `./build.sh` and the release Python extension with `PATH=$HOME/.local/bin:$PATH ./build.sh maturin`, both completed successfully. 
- Ran a scoped check `./build.sh check -p gam-models --lib` which completed successfully. 
- Ran the new pytest regression with `python -m pytest tests/bug_hunt_curv_smooth_aborts_nan_covariance_low_signal_test.py` and it passed (`2 passed`). 
- Ran the Rust unit-suite gate `./build.sh test -p gam-models spatial_trial_recovery_tests --lib -- --nocapture` and the existing recovery tests passed (`2 passed`).

---
Fixes #2162.

<details><summary>codex self-assessment</summary>

 v0.3.148 (/workspace/gam/crates/gam-config)\n   Compiling comfy-table v7.2.2\n   Compiling clap v4.6.1\n   Compiling gam-test-support v0.3.148 (/workspace/gam/crates/gam-test-support)\n   Compiling gam-report v0.3.148 (/workspace/gam/crates/gam-report)\n    Finished `dev` profile [unoptimized + debuginfo] target(s) in 20m 17s\n```\n\n* \u2705 `./build.sh check -p gam-models --lib`\n\n```text\n[build.sh] check -p gam-models --lib -> exit 0 in 10s (dedup=MISS, recompiled 0 crates)\n    Checking gam-models v0.3.148 (/workspace/gam/crates/gam-models)\n    Finished `dev` profile [unoptimized + debuginfo] target(s) in 9.49s\n```\n\n* \u2705 `PATH=$HOME/.local/bin:$PATH ./build.sh maturin`\n\n```text\n[build.sh] maturin develop --release  -> exit 0 in 1662s (dedup=n/a, recompiled 89 crates)\n   Compiling document-features v0.2.12\n   Compiling general-mcmc v0.9.0\n   Compiling parking_lot v0.12.5\n   Compiling strsim v0.11.1\n   Compiling clap_lex v1.1.0\n   Compiling clap_builder v4.6.0\n   Compiling crossterm v0.29.0\n   Compiling clap_derive v4.6.1\n   Compiling gam-model-kernels v0.3.148 (/workspace/gam/crates/gam-model-kernels)\n   Compiling gam-custom-family v0.3.148 (/workspace/gam/crates/gam-custom-family)\n   Compiling gam-sae v0.3.148 (/workspace/gam/crates/gam-sae)\n   Compiling gam-models v0.3.148 (/workspace/gam/crates/gam-models)\n   Compiling pyo3-macros-backend v0.29.0\n   Compiling gam v0.3.148 (/workspace/gam)\n   Compiling unicode-segmentation v1.13.3\n   Compiling comfy-table v7.2.2\n   Compiling gam-inference v0.3.148 (/workspace/gam/crates/gam-inference)\n   Compiling gam-config v0.3.148 (/workspace/gam/crates/gam-config)\n   Compiling gam-test-support v0.3.148 (/workspace/gam/crates/gam-test-support)\n   Compiling pyo3-macros v0.29.0\n   Compiling clap v4.6.1\n   Compiling numpy v0.29.0\n   Compiling gam-report v0.3.148 (/workspace/gam/crates/gam-report)\n   Compiling rustc-hash v2.1.3\n   Compiling gam-pyffi v0.1.250 (/workspace/gam/crates/gam-pyffi)\n   Compiling gam-predict v0.3.148 (/workspace/gam/crates/gam-predict)\n    Finished `release` profile [optimized] target(s) in 27m 34s\n\ud83d\udce6 Built wheel for abi3 Python \u2265 3.10 to /tmp/.tmp4mnAFx/gamfit-0.1.250-cp310-abi3-linux_x86_64.whl\n\u270f\ufe0f Setting installed package as editable\n\ud83d\udee0 Installed gamfit-0.1.250\n```\n\n* \u2705 `.venv/bin/python -m pytest tests/bug_hunt_curv_smooth_aborts_nan_covariance_low_signal_test.py -v --tb=short`\n\n```text\n============================= test session starts ==============================\nplatform linux -- Python 3.12.13, pytest-9.1.1, pluggy-1.6.0 -- /workspace/gam/.venv/bin/python\ncachedir: .pytest_cache\nrootdir: /workspace/gam\nconfigfile: pyproject.toml\ncollecting ... collected 2 items\n\ntests/bug_hunt_curv_smooth_aborts_nan_covariance_low_signal_test.py::test_peer_2d_smooths_fit_the_same_low_signal_data PASSED [ 50%]\ntests/bug_hunt_curv_smooth_aborts_nan_covariance_low_signal_test.py::test_curv_smooth_fits_low_signal_data_without_aborting PASSED [100%]\n\n=============================== warnings summary ===============================\ntests/bug_hunt_curv_smooth_aborts_nan_covariance_low_signal_test.py::test_peer_2d_smooths_fit_the_same_low_signal_data\n  /workspace/gam/gamfit/_api.py:660: GamInferenceWarning: Automatically set per-margin basis sizes [7, 7] for tensor smooth 'x,z' (dimension-aware tensor budget: total \u220fk kept near the mgcv-te default and within the data support, distributed geometrically across margins and capped per margin by each column's resolution). Override with k=<int> or k=[k0,k1,...].\n    return fn(*args, **kwargs)\n\ntests/bug_hunt_curv_smooth_aborts_nan_covariance_low_signal_test.py::test_peer_2d_smooths_fit_the_same_low_signal_data\n  /workspace/gam/gamfit/_api.py:660: GamInferenceWarning: Automatically set 8 internal knots for smooth 'x' from 400 unique values (rule: clamp(unique/4, 4..max(20, cbrt(unique))) = clamp(unique/4, 4..20)). Override with 
</details>

_Codex-generated; pending adversarial audit before merge._