### PR TITLE
refactor(#2071): derive dense hessian-cost sentinel from MIN_DIM (was literal 22)

### DIFF
--- a/crates/gam-models/src/coefficient_cost.rs
+++ b/crates/gam-models/src/coefficient_cost.rs
@@ -90,7 +90,8 @@ mod tests {
         let p = 4;
         let n = 100;
         let mf = 11;
-        let dense = 22;
+        // #2071: derive the dense sentinel instead of hardcoding it — floor(sqrt(MIN_DIM=512))=22.
+        let dense = (MIN_DIM as f64).sqrt().floor() as u64;
         assert!(!use_joint_matrix_free_path(p as usize, n as usize));
         assert_eq!(operator_aware_hessian_cost(p, n, mf, dense), dense);
     }
@@ -101,7 +102,8 @@ mod tests {
         let p = MIN_DIM;
         let n = 1;
         let mf = 11;
-        let dense = 22;
+        // #2071: derive the dense sentinel instead of hardcoding it — floor(sqrt(MIN_DIM=512))=22.
+        let dense = (MIN_DIM as f64).sqrt().floor() as u64;
         assert!(use_joint_matrix_free_path(p as usize, n as usize));
         assert_eq!(operator_aware_hessian_cost(p, n, mf, dense), mf);
     }


### PR DESCRIPTION
Cherry-picked the one behavior-preserving, in-doctrine hunk from #2214: replace the hardcoded `let dense = 22` sentinel with `floor(sqrt(MIN_DIM=512))` (= 22, identical value). This addresses the #2071 magic-constant complaint for this sentinel **without** #2214's harmful `JUMPRELU_RELATIVE_CUTOFF 1e-3→0.0` change (which reintroduced the K·(1+d) memory blowup and broke a pinning test). Refs #2071. CI-gated.