### PR TITLE
test(python): fix stale double_penalty assertion left by #2219

### DIFF
--- a/tests/test_python_api.py
+++ b/tests/test_python_api.py
@@ -2353,7 +2353,13 @@ def test_smooth_dataclass_subclasses_construct_with_shape_constraint() -> None:
             )
             # Common base-class fields must default sanely.
             assert obj.by is None
-            assert obj.double_penalty is False
+            # `double_penalty` is tri-state (`bool | None`) since #2149/#2219:
+            # the default `None` means "defer to the formula/engine default"
+            # (true), so shape-reparameterized null-space columns stay penalized.
+            # An explicit `False` would be the old buggy default that left them
+            # unpenalized. None of these factories pass `double_penalty`, so the
+            # correct constructed default is `None`, not `False`.
+            assert obj.double_penalty is None
             assert obj.name is None
 
 


### PR DESCRIPTION
## What

`test_smooth_dataclass_subclasses_construct_with_shape_constraint` asserted `obj.double_penalty is False` for every `Smooth` dataclass subclass. After PR #2219 (issue #2149) made `Smooth.double_penalty` **tri-state** (`bool | None = None`), the constructed default is now `None`, so this assertion fails with `None is not False`.

## Why the new value is correct (not a weakening)

`None` means "defer to the formula/engine default" (which is `true`), so shape-reparameterized null-space columns stay penalized. The old `False` default was exactly the bug #2149 fixed (it left those columns unpenalized → pre-fit rank deficiency). None of the test's factories pass `double_penalty`, so the correct constructed default is `None`.

This updates the single stale assertion to the new correct behavior and adds an explanatory comment. The `shape_constraint`, `by`, and `name` assertions are unchanged.

Refs #2149, #2219.