### PR TITLE
test(pyffi): initialize Python interpreter before Python::attach in bare cargo/nextest

### DIFF
--- a/crates/gam-pyffi/src/latent/sae_spectral_ffi.rs
+++ b/crates/gam-pyffi/src/latent/sae_spectral_ffi.rs
@@ -1218,6 +1218,7 @@ mod sae_spectral_ffi_tests {
 
     #[test]
     fn audit_sae_round_trip_surfaces_external_dictionary_diagnostics() {
+        pyo3::prepare_freethreaded_python();
         Python::attach(|py| {
             let decoder = ndarray::array![[1.0_f32, 0.0_f32], [0.0_f32, 1.0_f32]];
             let codes = ndarray::array![

--- a/crates/gam-pyffi/src/latent/topology_persistence_ffi.rs
+++ b/crates/gam-pyffi/src/latent/topology_persistence_ffi.rs
@@ -88,6 +88,7 @@ mod tests {
 
     #[test]
     fn topology_persistence_payload_surfaces_covering_side() {
+        pyo3::prepare_freethreaded_python();
         Python::attach(|py| {
             let report = AtomTopologyPersistence {
                 raced_kind: SaeAtomBasisKind::Periodic,


### PR DESCRIPTION
## Problem

Two `gam-pyffi` Rust unit tests panic under `cargo nextest` (CI "gam-pyffi unit tests" job) with:

> The Python interpreter is not initialized and the \`auto-initialize\` feature is not enabled

- `sae_spectral_ffi_tests::audit_sae_round_trip_surfaces_external_dictionary_diagnostics`
- `topology_persistence_ffi::tests::topology_persistence_payload_surfaces_covering_side`

They pass under maturin/pytest because the host Python interpreter is already initialized there, but the CI archive is built with `--no-default-features` (extension-module OFF, libpython linked) and run by nextest with no interpreter initialized. `Python::attach` requires an initialized interpreter.

## Fix

Call `pyo3::prepare_freethreaded_python()` (idempotent) as the first statement of each test, before `Python::attach`. This is the canonical PyO3 pattern for tests that hold the GIL without the (deliberately-unset, extension-module-incompatible) `auto-initialize` feature. The production lib is untouched — no feature change, so the published wheel is unchanged.

- Not `auto-initialize`: it is incompatible with the default-on `extension-module` feature and would be wrong for the wheel.
- Not `#[ignore]`/XFAIL: the tests exercise real payload surfaces and must run.

## Verification

`prepare_freethreaded_python()` initializes the interpreter under the `--no-default-features` (libpython-linked) config CI uses to build the gam-pyffi test archive, so both tests can now acquire the GIL and run their existing assertions unchanged.

Refs #954 #964 #965 #966