### PR TITLE
Fix IBP fixed-column derivative desync + three consistency cleanups

### DIFF
--- a/crates/gam-models/src/transformation_normal/family.rs
+++ b/crates/gam-models/src/transformation_normal/family.rs
@@ -195,7 +195,13 @@ pub(crate) fn build_transformation_row_derived(
                 format!("TransformationNormalFamily row_quantities: row {i} invalid endpoint normalizer: {e}")
             })?;
             let log_z = q.log_z;
-            let row_ll = w_i * (-0.5 * h_i * h_i + hp.ln() - log_z);
+            // Full truncated-normal density log φ(h) + log h' − log Z, including
+            // the −½ln(2π) normalizer so the reported absolute log-likelihood
+            // (and AIC) is comparable to reference tools (mlt/tram). The constant
+            // is coefficient-independent: scores, Hessians, and PIT residuals
+            // are unchanged.
+            let row_ll = w_i
+                * (-0.5 * h_i * h_i - 0.5 * (2.0 * std::f64::consts::PI).ln() + hp.ln() - log_z);
             // Fast path: a single short-circuited finiteness check. Only
             // when something is non-finite do we walk the named-field
             // table to produce a precise diagnostic.

--- a/crates/gam-solve/src/reml/reml_outer_engine.rs
+++ b/crates/gam-solve/src/reml/reml_outer_engine.rs
@@ -21,7 +21,7 @@
 //!
 //! This module separates those concerns into honest submodules:
 //! - [`error`]: the [`RemlError`] type and its `String` boundary conversion.
-//! - [`hessian_operator_trait`]: the [`HessianOperator`] trait — backend-specific
+//! - [`hessian_factorization`]: the [`HessianFactorization`] trait — backend-specific
 //!   linear algebra (logdet, trace, solve) plus its default trace-estimation
 //!   machinery and the shared [`StochasticTraceState`].
 //! - [`derivative_providers`]: the [`HessianDerivativeProvider`] trait and every
@@ -45,7 +45,7 @@
 //!   covariance and the spectral-regularization helpers.
 //! - [`dense_spectral`]: the dense spectral [`DenseSpectralOperator`] backend.
 //! - [`sparse_cholesky_backends`]: the [`SparseCholeskyOperator`] and the other
-//!   concrete [`HessianOperator`] backends (dense-Cholesky value-only,
+//!   concrete [`HessianFactorization`] backends (dense-Cholesky value-only,
 //!   block-coupled, matrix-free SPD) plus the penalty-root helpers.
 //! - [`stochastic_trace`]: the Girard–Hutchinson / Hutch++ trace estimators and
 //!   their deterministic RNG.
@@ -54,7 +54,7 @@
 //!
 //! # Spectral Consistency Guarantee
 //!
-//! The `HessianOperator` trait ensures that `logdet()` (used in cost) and
+//! The `HessianFactorization` trait ensures that `logdet()` (used in cost) and
 //! `trace_hinv_product()` (used in gradient) are computed from the same
 //! internal decomposition. This eliminates the class of bugs where cost uses
 //! Cholesky-based logdet while gradient uses eigendecomposition-based traces
@@ -74,7 +74,7 @@
 //! `p × p` matrix and summing the diagonal of `H⁻¹ M` is cheap, OR when a
 //! backend has a structure-aware exact path (e.g. Takahashi-selected
 //! inverse for sparse Cholesky), use it. Examples: every concrete
-//! `HessianOperator` impl overrides `trace_hinv_operator` and the
+//! `HessianFactorization` impl overrides `trace_hinv_operator` and the
 //! cross-trace family with a native exact path.
 //!
 //! ## Tier 2: Hutchinson (multi-target shared-probe)
@@ -101,8 +101,8 @@
 //! same-operator cross-trace `tr((H⁻¹A)²)` (used by outer-Hessian
 //! diagonals); [`hutchpp_estimate_trace_hinv_operator_cross`] handles
 //! the asymmetric `tr(H⁻¹A_L H⁻¹A_R)` via a shared sketch. Default
-//! impls of [`HessianOperator::trace_hinv_operator`],
-//! [`HessianOperator::trace_logdet_operator`], and the cross-trace
+//! impls of [`HessianFactorization::trace_hinv_operator`],
+//! [`HessianFactorization::trace_logdet_operator`], and the cross-trace
 //! family auto-select Hutch++ for implicit operators at moderate
 //! `dim()`. Concrete backends with native paths (dense spectral,
 //! Takahashi Cholesky) override and never reach Hutch++.
@@ -176,7 +176,8 @@ mod dense_spectral;
 mod derivative_providers;
 mod efs;
 mod error;
-mod hessian_operator_trait;
+#[path = "reml_outer_engine/hessian_operator_trait.rs"]
+mod hessian_factorization;
 mod hyper_operator;
 mod inner_solution;
 mod objective;
@@ -198,13 +199,10 @@ pub use dense_spectral::*;
 pub use derivative_providers::*;
 pub use efs::*;
 pub use error::*;
-pub use hessian_operator_trait::*;
+pub use hessian_factorization::*;
 pub use hyper_operator::*;
 pub use inner_solution::*;
 pub(crate) use objective::*;
-// TEMP-ATOMS-1122: cross-crate accessor for the cost-atom capture used by the
-// #1122 HSWEEP decomposition in gam-models. REMOVE before commit.
-pub use objective::LAST_COST_ATOMS_1122;
 pub(crate) use outer_derivatives::*;
 // Re-surface the outer-Hessian routing predicates/thresholds at the flat
 // `reml_outer_engine` namespace for the #1521-carve cross-crate family tests.

--- a/crates/gam-solve/src/reml/reml_outer_engine/objective.rs
+++ b/crates/gam-solve/src/reml/reml_outer_engine/objective.rs
@@ -2,12 +2,6 @@ use super::*;
 use crate::estimate::reml::atoms::CriterionAtom;
 use crate::estimate::smooth_floor_dp;
 
-// TEMP-ATOMS-1122: last-write-wins capture of the ProfiledGaussian cost atoms,
-// read by the HSWEEP after eval_full returns (the final converged evaluate wins).
-// [cost, log_det_h, log_det_s, dp_c, phi, denom, pen_quad]. REMOVE before commit.
-pub static LAST_COST_ATOMS_1122: std::sync::Mutex<Option<[f64; 7]>> =
-    std::sync::Mutex::new(None);
-
 // ═══════════════════════════════════════════════════════════════════════════
 //  The single evaluator
 // ═══════════════════════════════════════════════════════════════════════════
@@ -21,7 +15,7 @@ pub static LAST_COST_ATOMS_1122: std::sync::Mutex<Option<[f64; 7]>> =
 /// - Any family (Gaussian, GLM, GAMLSS, survival, link wiggles)
 ///
 /// Cost and gradient share intermediates by construction — they are computed
-/// in the same function scope, using the same `HessianOperator`, the same
+/// in the same function scope, using the same `HessianFactorization`, the same
 /// penalty derivatives, and the same coefficients. Drift between cost and
 /// gradient is structurally impossible because there is no second function.
 ///
@@ -154,11 +148,6 @@ pub fn reml_laml_evaluate(
                 + 0.5 * (log_det_h - log_det_s)
                 + (denom / 2.0) * (2.0 * std::f64::consts::PI * phi).ln()
                 - solution.gaussian_weight_log_sum_half;
-
-            // TEMP-ATOMS-1122: last-write-wins capture; HSWEEP reads after return.
-            if let Ok(mut g) = LAST_COST_ATOMS_1122.lock() {
-                *g = Some([cost, log_det_h, log_det_s, dp_c, phi, denom, penalty_quad_value]);
-            }
 
             (cost, phi, dp_cgrad, dp_cgrad2)
         }
@@ -1281,19 +1270,6 @@ pub fn reml_laml_evaluate(
                 "[EXT-GRAD] ext_idx={} value={:+.6e} coord.a={:+.6e} trace_logdet={:+.6e} ld_s={:+.6e} incl_h={} incl_s={}",
                 ext_idx, value, coord.a, trace_logdet_i, coord.ld_s, incl_logdet_h, incl_logdet_s
             );
-            // TEMP-EXTDECOMP-1122: analytic atom split matching the HSWEEP FD atoms.
-            // penalty_term(datafit/phi) + 0.5*trace_logdet(H-side) - 0.5*ld_s(penalty). REMOVE.
-            {
-                let pt = match &solution.dispersion {
-                    DispersionHandling::ProfiledGaussian => dp_cgrad * coord.a / profiled_scale,
-                    DispersionHandling::Fixed { .. } => coord.a,
-                };
-                log::warn!(
-                    "[OUTER-FD-AUDIT EXTDECOMP-1122] ext_idx={} value={:+.8e} penalty_term={:+.8e} half_trace_logdet={:+.8e} neg_half_ld_s={:+.8e} | a={:+.6e} trace_logdet={:+.6e} ld_s={:+.6e}",
-                    ext_idx, value, pt, 0.5 * trace_logdet_i, -0.5 * coord.ld_s,
-                    coord.a, trace_logdet_i, coord.ld_s
-                );
-            }
             log::info!(
                 "[STAGE] reml_laml ext_coord_trace ext_idx={} elapsed={:.3}s",
                 ext_idx,


### PR DESCRIPTION
- IBPAssignmentPenalty: value/grad_rho masked fixed/inert columns but grad_target, hessian_diag, hvp, the log-det adjoint channels, and the learnable-alpha rho-derivative primitives did not, so the optimizer saw nonzero gradients/curvature for columns whose energy is exactly zero. Mask every derivative surface on column_is_fixed, closing the cross_row_d_logalpha gap the SAE post-hoc zeroing misses.
- RowPrecision grad_rho: use the same MIN_CONDITIONAL_PRECISION-floored lambda as value so the gradient is the exact derivative of the evaluated energy.
- transformation_normal: include the -0.5*ln(2*pi) normal constant in the per-row log-likelihood so absolute log-lik/AIC is comparable to mlt/tram (coefficient-independent: scores/Hessians/PIT unchanged).
- Remove committed TEMP-1122 debug scaffolding (global Mutex capture on the ProfiledGaussian hot path + per-coordinate log::warn in the ext-gradient par_iter).