### PR TITLE
docs: document adjudicate_atom_shape; fix harvester example dataset id + shutdown

### DIFF
--- a/docs/manifold-sae.md
+++ b/docs/manifold-sae.md
@@ -466,6 +466,66 @@ The top-level helpers `gamfit.sae_trust_diagnostics(payload)` and
 `gamfit.atom_trust_scores(diagnostics)` compute the same quantities from a raw
 fit payload / diagnostics mapping (for batch or offline analysis).
 
+## Shape adjudication: `adjudicate_atom_shape`
+
+`gamfit.adjudicate_atom_shape(coords, ...)` adjudicates the representational
+shape of a 2-D point set without forcing a topology: it races a smooth **S¹
+ring**, a **Euclidean Gaussian**, and the best **k-cluster Gaussian mixture**
+rung on held-out predictive density (deterministic cross-fitted stacking, the
+same `fit_mixture_rung` / `adjudicate_cross_class_race` machinery the
+production fit drives). The winner is whichever class predicts held-out points
+best. It is a top-level export, used throughout `tests/sae/`, and pairs
+naturally with `fit.coords[k]` from [`sae_manifold_fit`](#the-manifoldsae-result).
+
+```python
+import gamfit
+
+verdict = gamfit.adjudicate_atom_shape(coords, folds=5, seed=11)
+# coords: contiguous float64 (n, 2), n >= 4 (a few dozen points recommended);
+# k_ladder=[2, 3, ...] optionally overrides the mixture orders raced.
+```
+
+Returns a dict:
+
+| Key | Meaning |
+| --- | --- |
+| `winner` | `"circle"`, `"euclidean"`, or `"mixture_k{k}"` |
+| `circle_wins` | bool, the winner is the circle |
+| `circle_margin` | stacking-weight margin of circle over the best rival (`NaN` if weights are unavailable) |
+| `mixture_k` | the mixture order selected inside the mixture rung |
+| `candidate_names` / `stacking_weights` | per-candidate names and held-out stacking weights |
+| `negative_log_evidence` | per-candidate rank-aware negative log evidence |
+| `headline` | `"stacking"` or `"evidence"` — which criterion produced the verdict |
+| `is_cross_class` | bool, the race crossed shape classes |
+
+The mixture rung's EM can refuse to certify convergence (a `GamError`); callers
+adjudicating many groups should catch and skip, as
+`tests/sae/qwen_real_sae_pipeline.py` does.
+
+### Usage caveats on real LLM activations
+
+These were measured on real residual-stream activations (Qwen3-8B and
+OLMo-2 weekday/month token sets, plus injected synthetic controls):
+
+1. **Clusters-on-a-circle read as `mixture`, not `circle`.** Discrete concept
+   tokens arranged on a ring (weekday/month circles) typically adjudicate as a
+   cluster mixture even when the ring is real and causally validated — the
+   mixture explains clustered mass better pointwise (measured margins of
+   `-0.36` to `-0.95` on confirmed circles). A `mixture_k` verdict on a
+   discrete concept must not be read as "no manifold": pair the adjudicator
+   with a centroid-ordering test (are the mixture's own centroids arranged on
+   a circle, against a permutation null?).
+2. **Sparse non-negative codes carry a false-circle floor.** Structureless
+   controls (per-dimension-shuffled activations, covariance-matched Gaussians)
+   pushed through a sparse-SAE + per-group 2-D PCA pipeline still produce
+   adjudicator circle wins in double-digit percentages of groups. Never
+   interpret raw circle-win rates without running the byte-identical pipeline
+   on matched structureless controls.
+3. **2-D PCA masks low-relative-variance rings.** A genuine ring sharing its
+   group with a linear factor at ~1× its radius is already lost after a top-2
+   variance projection, and at 2× the adjudicator prefers a cluster mixture
+   (validated by injection). Absence of circle wins is not absence of circles.
+
 ## Supervised SAE
 
 `gamfit.sae_supervised` fits a manifold dictionary jointly with a supervised

--- a/examples/harvest_residual_activations.py
+++ b/examples/harvest_residual_activations.py
@@ -14,7 +14,7 @@ full activation matrix in memory.
 
 Example:
   python harvest_residual_activations.py --model Qwen/Qwen2.5-0.5B \
-      --dataset wikitext --config wikitext-103-raw-v1 --layer 12 \
+      --dataset Salesforce/wikitext --config wikitext-103-raw-v1 --layer 12 \
       --n-tokens 120000 --out qwen05_wikitext_l12/
 """
 from __future__ import annotations
@@ -32,7 +32,7 @@ from residual_shard_io import ShardWriter, tokenizer_hash  # noqa: E402
 def main() -> None:
     ap = argparse.ArgumentParser()
     ap.add_argument("--model", required=True)
-    ap.add_argument("--dataset", default="wikitext")
+    ap.add_argument("--dataset", default="Salesforce/wikitext")
     ap.add_argument("--config", default="wikitext-103-raw-v1")
     ap.add_argument("--split", default="train")
     ap.add_argument("--text-field", default="text")
@@ -126,6 +126,12 @@ def main() -> None:
         f"d_model={d_model}",
         flush=True,
     )
+    # Hard-exit: the `datasets` streaming iterator can leave a non-daemon
+    # background thread (e.g. retrying a dead connection), which keeps the
+    # process alive indefinitely after all outputs are flushed. Everything is
+    # on disk at this point, so exit without waiting on stray threads.
+    sys.stdout.flush()
+    os._exit(0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Documents a load-bearing public API and fixes two real-world failures in the residual-activation harvester example. AI-authored (Silico agent, run by Scott); every item below traces to an overnight study of the manifold-SAE stack on real LLM activations (Qwen3-8B layer 20 and OLMo-2 checkpoints).

## What's here

**1. `docs/manifold-sae.md`: new section for `gamfit.adjudicate_atom_shape`.**
The symbol is a top-level export (`gamfit/__init__.py`) used throughout `tests/sae/`, but appeared nowhere in `docs/`. The new section documents the current signature (`coords, folds=5, seed=11, k_ladder=None`), all return keys (verified against `crates/gam-pyffi/src/inference/inference_instruments.rs`), and three measured usage caveats:

- **Clusters-on-a-circle read as `mixture`.** On a causally-validated Qwen3-8B weekday circle (circular-linear ordering r = 0.96, permutation p = 0.001, steering-validated), the shape race preferred `mixture_k5` with circle margin −0.744; every OLMo-2 checkpoint showed the same pattern (margins −0.36 to −0.95). Discrete tokens on a ring are clumpy, and a mixture explains clumpy mass better pointwise — so the docs now say: pair a `mixture` verdict on discrete concepts with a centroid-ordering test.
- **False-circle floor on sparse codes.** Structureless controls (per-dimension shuffled activations, covariance-matched Gaussians) pushed through a byte-identical sparse-SAE + 2-D-PCA census still produced double-digit percentages of adjudicator circle wins. Raw circle-win rates are uninterpretable without matched controls.
- **2-D PCA masks low-relative-variance rings.** An injected ring sharing its group with a linear factor at 1× its radius is already lost after top-2-variance projection (ordering p = 0.16); at 2× the adjudicator prefers a 4-cluster mixture.

**2. `examples/harvest_residual_activations.py`: two fixes hit in practice.**
- The default `--dataset wikitext` id is stale on the HF Hub; updated to `Salesforce/wikitext` (docstring example too).
- The `datasets` streaming iterator can leave a non-daemon background thread retrying a dead connection, which keeps the harvester process alive indefinitely after all outputs are flushed. Added a hard exit once the manifest is written.

## Not included (checked against current main)

The overnight run also flagged `atom_basis="linear"` mapping to a Precomputed placeholder — that was true at the pinned commit the study ran on, but current main has #1221 (first-class `"linear"` topology) and the docs table already covers it, so no change was made.

## Validation

Docs-only + example-only change; `python -m py_compile` passes on the example. The caveat numbers come from the recorded experiment artifacts (census verdict JSONs, positive-control injections, steering logs), not re-run here.


---

## Second commit (854d805): census discipline, deterministic-readout guidance, source-archive builds

Added per the five-experiment synthesis ledger (L9, L10, L12):

- **`docs/manifold-sae.md` — "Running an unsupervised census honestly"** (L9): the dictionary-health gate (circle verdicts only appeared at mean L0 below ~300; 0/377 in dense dictionaries — report mean L0 next to any rate) and mandatory matched structureless controls (per-dim shuffle + covariance-matched Gaussian through the byte-identical pipeline; measured floors reached double digits).
- **`docs/manifold-sae.md` — "On real activations, lead with deterministic readouts"** (L10): the fit is a reconstruction/decoder tool; its latent angle is not a guaranteed-stable coordinate (measured: EV ≈ 0.98 fits with seed-dependent orderings 0.67–0.97 while the deterministic plane readout sat at 0.98–0.99 — see issue #2260 for the mechanism).
- **Availability note** (L12): `adjudicate_atom_shape` is absent from the released PyPI wheel; source build required until the next release.
- **`build.rs`** (L12): skip the tracked-file audits with a `cargo:warning` when `.git` is absent (source-archive/sdist builds) instead of panicking the wheel build. Audits unchanged when `.git` is present; all four audit call sites iterate the returned list, so an empty list passes vacuously. **Not build-tested in this pass** (no rust toolchain on the validation host) — flagging for CI.
- **`examples/topology_census_recipe.py`**: the validated census recipe as executable documentation (adapted from the study's PR seed), cross-referencing the in-repo pipeline and `examples/centroid_ordering.py` (PR #2257).

Docs content grounded in experiments #1 (census, controls, positive control), #5 (seed instability), and the synthesis ledger in experiment #6.