### PR TITLE
examples: cyclic circle recovery + causal steering; centroid ring-ordering test

### DIFF
--- a/examples/centroid_ordering.py
+++ b/examples/centroid_ordering.py
@@ -1,0 +1,128 @@
+"""Centroid circular-ordering test: are a mixture's clusters arranged on a ring?
+
+Second-tier companion to ``gamfit.adjudicate_atom_shape``. The shape race
+reads discrete concept clusters ARRANGED ON a circle (weekday/month token
+sets are the measured case) as ``mixture_k``, because a Gaussian mixture
+explains clumpy mass better pointwise than a uniform ring — even when the
+ring is real and causally validated. This module asks the follow-up
+question the race cannot: *are the mixture's own centroids arranged on a
+circle, against a matched Gaussian null?*
+
+Procedure (validated in the two-tier census of real Qwen3-8B SAE features;
+the same construction rescued known calendar circles the race mislabeled and
+correctly failed rings masked past ~1x their radius):
+
+  1. Seeded k-means on the 2-D coordinates, with k = the adjudicator's
+     ``mixture_k`` (k >= 3 required for a meaningful ring test).
+  2. Ring statistic on the centroids: coefficient of variation (CV) of
+     centroid radii about the centroid mean (low CV = centroids sit on a
+     circle), plus angular coverage (max angular gap between sorted
+     centroid angles; a big gap = an arc or a clump, not a ring).
+  3. Monte-Carlo null: centroid sets drawn from a 2-D Gaussian matched to
+     the observed centroid mean/covariance; p = P(null CV <= observed CV).
+
+Caveat carried over from the census: sparse non-negative codes pushed
+through per-group 2-D PCA produce ring-like centroid arrangements on
+STRUCTURELESS controls at a double-digit rate per run. A positive here is
+"consistent with a ring", not proof — always run the byte-identical
+pipeline on matched shuffled/Gaussian controls before interpreting rates.
+
+Pure NumPy; analysis-side code in the examples/ (non-production) sense of
+SPEC.md. Import it next to this file the same way
+``harvest_residual_activations.py`` imports ``residual_shard_io``.
+"""
+from __future__ import annotations
+
+import numpy as np
+
+__all__ = ["kmeans_centroids", "ring_stats", "ring_mc_pvalue",
+           "centroid_circular_ordering"]
+
+
+def kmeans_centroids(coords: np.ndarray, k: int, seed: int = 0,
+                     iters: int = 100) -> np.ndarray:
+    """Seeded Lloyd k-means on ``(n, 2)`` coords; returns ``(k, 2)`` centers."""
+    X = np.asarray(coords, dtype=np.float64)
+    rng = np.random.default_rng(seed)
+    centers = X[rng.choice(X.shape[0], size=k, replace=False)].copy()
+    labels = np.zeros(X.shape[0], dtype=int)
+    for _ in range(iters):
+        d2 = ((X[:, None, :] - centers[None, :, :]) ** 2).sum(axis=2)
+        new = d2.argmin(axis=1)
+        if np.array_equal(new, labels):
+            break
+        labels = new
+        for c in range(k):
+            m = labels == c
+            if m.any():
+                centers[c] = X[m].mean(axis=0)
+    return centers
+
+
+def ring_stats(centers: np.ndarray) -> tuple[float, float]:
+    """Return ``(radius_cv, max_gap_deg)`` for a centroid set.
+
+    ``radius_cv`` is the coefficient of variation of centroid radii about
+    the centroid mean (0 = perfect circle). ``max_gap_deg`` is the largest
+    angular gap between sorted centroid angles (360 = degenerate).
+    """
+    c = np.asarray(centers, dtype=np.float64)
+    c = c - c.mean(axis=0, keepdims=True)
+    r = np.linalg.norm(c, axis=1)
+    if r.mean() < 1e-12:
+        return float("inf"), 360.0
+    cv = float(r.std() / r.mean())
+    ang = np.sort(np.arctan2(c[:, 1], c[:, 0]))
+    gaps = np.diff(np.concatenate([ang, [ang[0] + 2 * np.pi]]))
+    return cv, float(np.degrees(gaps.max()))
+
+
+def ring_mc_pvalue(centers: np.ndarray, observed_cv: float, n_null: int = 2000,
+                   seed: int = 0) -> float:
+    """P(null radius-CV <= observed) with null centroid sets drawn from a
+    2-D Gaussian matched to the observed centroid mean/covariance."""
+    rng = np.random.default_rng(seed)
+    c = np.asarray(centers, dtype=np.float64)
+    mu = c.mean(axis=0)
+    cov = np.cov((c - mu).T) + 1e-12 * np.eye(2)
+    L = np.linalg.cholesky(cov)
+    k = c.shape[0]
+    hits = 0
+    for _ in range(n_null):
+        z = rng.standard_normal((k, 2)) @ L.T + mu
+        cv, _ = ring_stats(z)
+        if cv <= observed_cv:
+            hits += 1
+    return (hits + 1) / (n_null + 1)
+
+
+def centroid_circular_ordering(coords: np.ndarray, k: int, *, seed: int = 0,
+                               n_null: int = 2000, p_thresh: float = 0.05,
+                               gap_thresh_deg: float = 150.0) -> dict:
+    """Full second-tier test on a ``(n, 2)`` coordinate cloud.
+
+    ``k`` should be the adjudicator's chosen ``mixture_k`` (>= 3). Returns a
+    dict with ``radius_cv``, ``max_gap_deg``, ``mc_p``, the centers, and the
+    combined verdict ``ordered_on_circle`` (p below threshold AND angular
+    coverage without a large gap).
+    """
+    coords = np.asarray(coords, dtype=np.float64)
+    if coords.ndim != 2 or coords.shape[1] != 2:
+        raise ValueError(f"coords must be (n, 2); got {coords.shape}")
+    if k < 3:
+        raise ValueError(f"need k >= 3 centroids to test a ring; got k={k}")
+    if coords.shape[0] < k:
+        raise ValueError(f"need at least k={k} rows; got {coords.shape[0]}")
+    centers = kmeans_centroids(coords, k, seed=seed)
+    cv, gap = ring_stats(centers)
+    p = ring_mc_pvalue(centers, cv, n_null=n_null, seed=seed + 202)
+    return {
+        "k": int(k),
+        "centers": centers,
+        "radius_cv": float(cv),
+        "max_gap_deg": float(gap),
+        "mc_p": float(p),
+        "ordered_on_circle": bool(p < p_thresh and gap < gap_thresh_deg),
+        "params": {"seed": seed, "n_null": n_null, "p_thresh": p_thresh,
+                   "gap_thresh_deg": gap_thresh_deg},
+    }

--- a/examples/cyclic_circle_recovery_and_steering.py
+++ b/examples/cyclic_circle_recovery_and_steering.py
@@ -1,0 +1,601 @@
+#!/usr/bin/env python
+"""Recover, certify, and causally steer a cyclic concept circle in a causal LM.
+
+End-to-end recipe for weekday/month calendar circles (the measured case:
+Qwen3-8B layer 20, recovery ordering r = 0.96 against a chart-rebuilt
+permutation null, steering-validated):
+
+  1. RECOVER: harvest residual activations at the concept-token position
+     across varied mid-sentence templates; build the *day-signal chart*
+     (per-template centering + top-2 PCs of the label-class means) and read
+     each row's angle in that plane.
+  2. CERTIFY: (a) circular-linear ordering of the angles against the true
+     calendar phase, tested against a FULL-PIPELINE permutation null (the
+     label-aware chart is rebuilt for every shuffled labeling, so chart
+     construction cannot inflate the statistic); (b) the
+     ``gamfit.adjudicate_atom_shape`` race on the 2-D coords, paired with the
+     centroid circular-ordering second tier (``centroid_ordering.py`` next to
+     this file) — discrete clusters ON a ring adjudicate as ``mixture_k``, and
+     the centroid test is what rescues the real circle from that verdict.
+  3. STEER: fit a circle atom on final-position activations of calendar
+     continuation prompts (gamfit torch lane), then patch the chord of the
+     fitted decoder curve into the residual stream and measure next-token
+     calendar advance — against two matched-norm controls (random ambient
+     direction; in-chart direction orthogonal to the local circle tangent).
+
+Why the class-mean chart instead of plain top-2 PCA: the calendar circle is a
+LOW-RELATIVE-VARIANCE structure. Template/context variance dominates raw
+concept-token activations, and a top-2-variance projection loses a ring masked
+by a linear factor at >= ~1x its radius (measured by injection; ordering
+p = 0.16 at 1x, adjudicator verdict degrades to mixture at 2x). Per-template
+centering plus class-mean PCs is the label-seeded projection that reaches the
+circle. The label-awareness is exactly why the ordering null must rebuild the
+chart per permutation.
+
+Full run needs a GPU for the default 8B model (a smaller --model runs on CPU);
+--smoke shrinks everything for a fast pipeline check.
+
+Example:
+  python cyclic_circle_recovery_and_steering.py --model Qwen/Qwen3-8B \
+      --layer 20 --out-dir circle_out/
+  python cyclic_circle_recovery_and_steering.py --model Qwen/Qwen2.5-0.5B \
+      --layer 12 --smoke --allow-cpu --out-dir circle_smoke/
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import os
+import sys
+import time
+from pathlib import Path
+
+import numpy as np
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from centroid_ordering import centroid_circular_ordering  # noqa: E402
+
+TAU = 2.0 * math.pi
+
+WEEKDAYS = ("Monday", "Tuesday", "Wednesday", "Thursday", "Friday",
+            "Saturday", "Sunday")
+MONTHS = ("January", "February", "March", "April", "May", "June", "July",
+          "August", "September", "October", "November", "December")
+
+RECOVERY_TEMPLATES_DAY = (
+    "I will see you on {w}.",
+    "The meeting is scheduled for {w} morning.",
+    "She was born on a {w}.",
+    "We usually go shopping on {w}.",
+    "The package arrived last {w}.",
+    "Every {w} we have a call.",
+    "It happened on {w} afternoon.",
+    "They are leaving next {w}.",
+    "My favorite day is {w}.",
+    "The store is closed on {w}.",
+    "He starts work this {w}.",
+    "The concert is on {w} evening.",
+)
+RECOVERY_TEMPLATES_MONTH = (
+    "The conference takes place in {w} this year.",
+    "She was born in {w}.",
+    "The lease expires in {w} next year.",
+    "Every {w} the village holds a festival.",
+    "It rained heavily throughout {w}.",
+    "The project deadline is in {w}.",
+    "They got married last {w}.",
+    "The new store opens in {w}.",
+    "Harvest season peaks in {w} here.",
+    "His visa runs out in {w}.",
+    "The exam results come out in {w}.",
+    "We visited Japan in {w}.",
+)
+STEER_FIT_TEMPLATES_DAY = (
+    "Today is {w}. Tomorrow is",
+    "If today is {w}, then tomorrow is",
+    "The weekday after {w} is",
+    "On a weekly calendar, {w} is followed by",
+    "Yesterday was {w}, so today is",
+    "The day that comes right after {w} is",
+    "After {w} comes",
+    "Counting forward from {w}, the next day is",
+    "A day later than {w} is",
+    "Following {w} on the calendar is",
+)
+STEER_BASE_TEMPLATES_DAY = (
+    "Starting on {w}, the next day is",
+    "Calendar note: the day after {w} is",
+)
+STEER_FIT_TEMPLATES_MONTH = (
+    "This month is {w}. Next month is",
+    "If this month is {w}, then next month is",
+    "The month after {w} is",
+    "On the calendar, {w} is followed by",
+    "Last month was {w}, so this month is",
+    "The month that comes right after {w} is",
+    "After {w} comes the month of",
+    "Counting forward from {w}, the next month is",
+    "A month later than {w} is",
+    "Following {w} on the calendar is",
+)
+STEER_BASE_TEMPLATES_MONTH = (
+    "Starting in {w}, the next month is",
+    "Calendar note: the month after {w} is",
+)
+
+
+def log(msg: str) -> None:
+    print(f"[{time.strftime('%H:%M:%S')}] {msg}", flush=True)
+
+
+# --------------------------------------------------------------------------- #
+# Model plumbing (tuple-safe hooks; layer L means hidden_states[L], i.e. the
+# OUTPUT of model.model.layers[L-1] — capture and patch use the same site)
+# --------------------------------------------------------------------------- #
+def load_model(model_name: str, dtype_name: str):
+    import torch
+    from transformers import AutoModelForCausalLM, AutoTokenizer
+
+    dtype = {"bf16": torch.bfloat16, "fp16": torch.float16,
+             "fp32": torch.float32}[dtype_name]
+    tok = AutoTokenizer.from_pretrained(model_name)
+    model = AutoModelForCausalLM.from_pretrained(model_name, dtype=dtype)
+    model = model.to("cuda" if torch.cuda.is_available() else "cpu").eval()
+    return model, tok
+
+
+def hook_module_for_layer(model, layer: int):
+    """Module whose OUTPUT is hidden_states[layer] (layer >= 1)."""
+    return model.model.layers[layer - 1]
+
+
+def find_token_pos(tok, prompt: str, word: str) -> tuple[list[int], int]:
+    """(input_ids, index of last subtoken of ``\u0020word`` in prompt)."""
+    ids = tok(prompt, add_special_tokens=False).input_ids
+    wid = tok(" " + word, add_special_tokens=False).input_ids
+    n, m = len(ids), len(wid)
+    for i in range(n - m, -1, -1):
+        if ids[i:i + m] == wid:
+            return ids, i + m - 1
+    raise ValueError(f"could not locate {word!r} in {prompt!r}")
+
+
+def run_capture(model, tok, prompt: str, layer: int, position: int | None):
+    """Forward once; return (h[pos] at hidden_states[layer], final logits, pos)."""
+    import torch
+
+    enc = tok(prompt, return_tensors="pt", add_special_tokens=False)
+    ids = enc.input_ids.to(next(model.parameters()).device)
+    pos = ids.shape[1] - 1 if position is None else position
+    with torch.inference_mode():
+        out = model(ids, output_hidden_states=True, use_cache=False)
+    act = out.hidden_states[layer][0, pos, :].detach().float().cpu().numpy()
+    logits = out.logits[0, -1, :].detach().float().cpu()
+    return act, logits, pos
+
+
+def run_patched(model, tok, layer_mod, prompt: str, pos: int,
+                delta_ambient: np.ndarray):
+    """Forward with h[pos] += delta at the hook site; return final logits."""
+    import torch
+
+    enc = tok(prompt, return_tensors="pt", add_special_tokens=False)
+    ids = enc.input_ids.to(next(model.parameters()).device)
+    dvec = torch.from_numpy(np.asarray(delta_ambient, dtype=np.float32))
+
+    def hook(_m, _i, output):
+        hidden = output[0] if isinstance(output, tuple) else output
+        edited = hidden.clone()
+        edited[0, pos, :] = edited[0, pos, :] + dvec.to(device=edited.device,
+                                                        dtype=edited.dtype)
+        if isinstance(output, tuple):
+            return (edited,) + tuple(output[1:])
+        return edited
+
+    h = layer_mod.register_forward_hook(hook)
+    try:
+        with torch.inference_mode():
+            out = model(ids, use_cache=False)
+    finally:
+        h.remove()
+    return out.logits[0, -1, :].detach().float().cpu()
+
+
+# --------------------------------------------------------------------------- #
+# Chart + ordering statistics
+# --------------------------------------------------------------------------- #
+def per_template_center(X: np.ndarray, template_ids: np.ndarray) -> np.ndarray:
+    """Remove per-template means (uses template IDs only, never labels).
+    Kills the dominant context/template variance that swamps the circle."""
+    Xc = X.astype(np.float64).copy()
+    for t in np.unique(template_ids):
+        m = template_ids == t
+        Xc[m] -= Xc[m].mean(0, keepdims=True)
+    return Xc
+
+
+def day_signal_chart(X: np.ndarray, labels: np.ndarray,
+                     template_ids: np.ndarray, dim: int):
+    """Chart where the calendar circle lives: per-template centering, then the
+    top ``dim`` PCs of the LABEL-CLASS MEANS (rank <= period-1).
+
+    Label-aware by construction — downstream ordering tests must rebuild this
+    chart under label permutation (see ``pipeline_null``).
+
+    Returns (Z, basis, ev): rows projected into the chart, the orthonormal
+    (dim, d) ambient basis (delta_z @ basis lifts exactly), and the fraction
+    of class-mean variance kept."""
+    Xc = per_template_center(X, template_ids)
+    period = int(labels.max()) + 1
+    means = np.stack([Xc[labels == u].mean(0) for u in range(period)])
+    means = means - means.mean(0, keepdims=True)
+    _, s, vt = np.linalg.svd(means, full_matrices=False)
+    r = int(min(dim, vt.shape[0]))
+    basis = np.ascontiguousarray(vt[:r])
+    ev = float((s[:r] ** 2).sum() / max((s ** 2).sum(), 1e-30))
+    return np.ascontiguousarray(Xc @ basis.T), basis, ev
+
+
+def class_mean_plane_angles(X: np.ndarray, labels: np.ndarray,
+                            template_ids: np.ndarray) -> np.ndarray:
+    """Circle coordinate: per-row angle in the class-mean top-2 plane."""
+    Z, _b, _ev = day_signal_chart(X, labels, template_ids, 2)
+    return np.arctan2(Z[:, 1], Z[:, 0])
+
+
+def circular_linear_r(angles: np.ndarray, labels: np.ndarray,
+                      period: int) -> float:
+    """Correlation between fitted angles and the true calendar phase,
+    maximized over rotation and reflection (both gauge freedoms of a fit)."""
+    tgt = TAU * labels.astype(np.float64) / period
+    best = -1.0
+    for refl in (1.0, -1.0):
+        a = refl * angles
+        for shift in np.linspace(0.0, TAU, 144, endpoint=False):
+            aa = (a + shift) % TAU
+            sa, st = np.sin(aa - aa.mean()), np.sin(tgt - tgt.mean())
+            denom = math.sqrt(float((sa ** 2).sum() * (st ** 2).sum())) + 1e-12
+            best = max(best, float((sa * st).sum()) / denom)
+    return best
+
+
+def pipeline_null(X: np.ndarray, labels: np.ndarray, template_ids: np.ndarray,
+                  period: int, n_perm: int, seed: int) -> dict:
+    """Full-pipeline permutation null: the label-aware chart is REBUILT for
+    every shuffled labeling, so chart construction cannot inflate the
+    ordering statistic."""
+    rng = np.random.default_rng(seed)
+    obs = circular_linear_r(class_mean_plane_angles(X, labels, template_ids),
+                            labels, period)
+    null = np.empty(n_perm)
+    for i in range(n_perm):
+        lp = rng.permutation(labels)
+        null[i] = circular_linear_r(
+            class_mean_plane_angles(X, lp, template_ids), lp, period)
+    return {
+        "observed_r": obs,
+        "null_p95": float(np.quantile(null, 0.95)),
+        "p_value": float((1 + (null >= obs).sum()) / (1 + n_perm)),
+        "n_perm": n_perm,
+        "null_kind": "chart_rebuilt_per_permutation",
+    }
+
+
+def fixed_chart_null(angles: np.ndarray, labels: np.ndarray, period: int,
+                     n_perm: int, seed: int) -> dict:
+    """Weaker fixed-chart null (labels shuffled in the correlation only) for
+    coordinates that were fit WITHOUT labels, e.g. the SAE circle atom."""
+    rng = np.random.default_rng(seed)
+    obs = circular_linear_r(angles, labels, period)
+    null = np.array([circular_linear_r(angles, rng.permutation(labels), period)
+                     for _ in range(n_perm)])
+    return {
+        "observed_r": obs,
+        "null_p95": float(np.quantile(null, 0.95)),
+        "p_value": float((1 + (null >= obs).sum()) / (1 + n_perm)),
+        "n_perm": n_perm,
+        "null_kind": "fixed_chart",
+    }
+
+
+# --------------------------------------------------------------------------- #
+# Circle fit (gamfit torch lane) + explicit chord steering
+# --------------------------------------------------------------------------- #
+def torch_circle_fit(Z: np.ndarray, *, steps: int, seed: int, lr: float = 1e-2,
+                     grid: int = 720) -> dict:
+    """Single circle atom via ``gamfit.torch.manifold_sae.ManifoldSAE``.
+
+    Returns per-row angles (radians), the decoder curve over one period
+    (grid, chart_dim), and training R^2. Torch circle coordinates have
+    period 1.0; angles are converted to radians."""
+    import torch
+    from gamfit.torch.manifold_sae import ManifoldSAE, ManifoldSAEConfig
+
+    torch.manual_seed(seed)
+    cfg = ManifoldSAEConfig(input_dim=int(Z.shape[1]), n_atoms=1,
+                            intrinsic_rank=1, atom_manifold="circle")
+    mod = ManifoldSAE(cfg)
+    xt = torch.tensor(np.asarray(Z, dtype=np.float64), dtype=torch.float64)
+    opt = torch.optim.Adam(mod.parameters(), lr=lr)
+    for _ in range(steps):
+        out = mod(xt)
+        loss = ((out.x_hat - xt) ** 2).mean()
+        try:
+            loss = loss + 0.01 * mod.regularization(None)
+        except Exception:  # noqa: BLE001 — penalty optional for K=1
+            pass
+        opt.zero_grad()
+        loss.backward()
+        opt.step()
+    with torch.no_grad():
+        out = mod(xt)
+        ss_res = float(((out.x_hat - xt) ** 2).sum())
+        ss_tot = float(((xt - xt.mean(0, keepdim=True)) ** 2).sum())
+        pos = out.positions[:, 0, 0].detach().cpu().numpy()
+        curve = mod.extract_feature_curves(grid)[0].detach().cpu().numpy()
+    return {"angles": (pos % 1.0) * TAU, "curve": curve,
+            "r2": 1.0 - ss_res / max(ss_tot, 1e-30)}
+
+
+def curve_point(curve: np.ndarray, t_frac: float) -> np.ndarray:
+    """Periodic linear interpolation of the decoder curve at t in [0,1)."""
+    g = curve.shape[0]
+    x = (t_frac % 1.0) * g
+    i0 = int(np.floor(x)) % g
+    w = x - np.floor(x)
+    return (1.0 - w) * curve[i0] + w * curve[(i0 + 1) % g]
+
+
+def curve_tangent(curve: np.ndarray, t_frac: float) -> np.ndarray:
+    g = curve.shape[0]
+    eps = 1.0 / g
+    return (curve_point(curve, t_frac + eps)
+            - curve_point(curve, t_frac - eps)) / (2 * eps)
+
+
+def steer_delta(curve: np.ndarray, t_from_rad: float, t_to_rad: float,
+                basis: np.ndarray) -> tuple[np.ndarray, float]:
+    """Chord of the decoder curve from t_from to t_to, lifted to ambient space.
+
+    Returns (delta_ambient, off_manifold_norm) where off_manifold_norm is the
+    chord's residual off the local tangent line at t_from — the on-manifold
+    quality check (~0 for small steps along the fitted shape)."""
+    tf, tt = t_from_rad / TAU, t_to_rad / TAU
+    delta_z = curve_point(curve, tt) - curve_point(curve, tf)
+    tau_v = curve_tangent(curve, tf)
+    tau_hat = tau_v / max(np.linalg.norm(tau_v), 1e-30)
+    off = delta_z - (delta_z @ tau_hat) * tau_hat
+    return delta_z @ basis, float(np.linalg.norm(off))
+
+
+# --------------------------------------------------------------------------- #
+def run_concept(model, tok, gamfit_mod, concept: str, words, rec_templates,
+                fit_templates, base_templates, layer: int, *, pca_dim: int,
+                fit_steps: int, n_perm: int, ks, seed: int, out_dir: Path,
+                results: dict) -> None:
+    import torch
+
+    period = len(words)
+    layer_mod = hook_module_for_layer(model, layer)
+
+    # ---- 1. RECOVER: concept-token harvest -> class-mean chart -------------
+    log(f"=== [{concept}] recovery harvest at layer {layer} ===")
+    acts, labels, template_ids = [], [], []
+    for ti, tmpl in enumerate(rec_templates):
+        for wi, w in enumerate(words):
+            prompt = tmpl.format(w=w)
+            _ids, pos = find_token_pos(tok, prompt, w)
+            act, _lg, _p = run_capture(model, tok, prompt, layer, pos)
+            acts.append(act)
+            labels.append(wi)
+            template_ids.append(ti)
+    X = np.asarray(acts, dtype=np.float64)
+    labels = np.asarray(labels)
+    template_ids = np.asarray(template_ids)
+
+    # ---- 2. CERTIFY: ordering vs chart-rebuilt null + shape adjudication ---
+    ordering = pipeline_null(X, labels, template_ids, period, n_perm, seed)
+    log(f"  ordering r={ordering['observed_r']:.3f} "
+        f"(chart-rebuilt null p={ordering['p_value']:.4f})")
+
+    Z2, _basis2, ev2 = day_signal_chart(X, labels, template_ids, 2)
+    coords2 = np.ascontiguousarray(Z2)
+    try:
+        verdict = dict(gamfit_mod.adjudicate_atom_shape(coords2, folds=5,
+                                                        seed=seed + 11))
+        verdict.pop("negative_log_evidence", None)
+    except Exception as exc:  # noqa: BLE001
+        verdict = {"error": f"{type(exc).__name__}: {exc}"}
+    # Discrete clusters ON a ring typically adjudicate as mixture_k — run the
+    # centroid second tier at the race's own k (fall back to the period).
+    k2 = int(verdict.get("mixture_k", period)) if "error" not in verdict else period
+    tier2 = centroid_circular_ordering(coords2, max(k2, 3), seed=seed,
+                                       n_null=n_perm)
+    tier2.pop("centers", None)
+    log(f"  adjudicator: {verdict.get('winner', verdict)}; centroid tier-2: "
+        f"ordered_on_circle={tier2['ordered_on_circle']} "
+        f"(radius_cv={tier2['radius_cv']:.3f}, mc_p={tier2['mc_p']:.4f})")
+
+    # ---- 3. STEER: circle fit on continuation prompts + chord patching -----
+    log(f"=== [{concept}] steering harvest (final position) ===")
+    examples = []
+    tid = 0
+    for group, tmpls in (("fit", fit_templates), ("base", base_templates)):
+        for tmpl in tmpls:
+            for wi, w in enumerate(words):
+                prompt = tmpl.format(w=w)
+                act, logits, pos = run_capture(model, tok, prompt, layer, None)
+                examples.append({"prompt": prompt, "pos": pos, "label": wi,
+                                 "group": group, "template": tid, "act": act,
+                                 "logits": logits})
+            tid += 1
+    s_labels = np.asarray([e["label"] for e in examples])
+    s_tids = np.asarray([e["template"] for e in examples])
+    X_amb = np.stack([e["act"] for e in examples]).astype(np.float64)
+
+    chart_dim = int(min(pca_dim, period - 1))
+    Z, lift, ev = day_signal_chart(X_amb, s_labels, s_tids, chart_dim)
+    tfit = torch_circle_fit(Z, steps=fit_steps, seed=seed)
+    gate = fixed_chart_null(tfit["angles"], s_labels, period, n_perm, seed + 77)
+    log(f"  steering fit r2={tfit['r2']:.3f}; gate r={gate['observed_r']:.3f} "
+        f"(p={gate['p_value']:.4f}); chart class-mean ev={ev:.3f}")
+
+    ang = tfit["angles"]
+    curve = tfit["curve"]
+    label_phase = TAU * s_labels / period
+
+    def _concentration(sign: float) -> float:
+        d = (sign * ang - label_phase + math.pi) % TAU - math.pi
+        return float(np.abs(np.exp(1j * d).mean()))
+    orient = 1.0 if _concentration(1.0) >= _concentration(-1.0) else -1.0
+
+    cand_ids = [tok(" " + w, add_special_tokens=False).input_ids[0]
+                for w in words]
+    base_rows = [i for i, e in enumerate(examples) if e["group"] == "base"]
+    rng = np.random.default_rng(seed + 5)
+    records = []
+    for i in base_rows:
+        e = examples[i]
+        b = e["label"]
+        base_top = int(np.argmax(
+            torch.softmax(e["logits"], dim=-1)[cand_ids].numpy()))
+        t_from = float(ang[i])
+        for k in ks:
+            t_to = t_from + orient * k * TAU / period
+            delta, off_norm = steer_delta(curve, t_from, t_to, lift)
+            dn = float(np.linalg.norm(delta))
+            delta_z = delta @ lift.T
+
+            # matched-norm controls: random ambient; in-chart orthogonal to
+            # the local circle tangent (kills "any big in-chart push works")
+            g = rng.standard_normal(delta.shape[0])
+            ctrl_amb = g / np.linalg.norm(g) * dn
+            tang = delta_z / max(np.linalg.norm(delta_z), 1e-30)
+            gz = rng.standard_normal(delta_z.shape[0])
+            gz -= (gz @ tang) * tang
+            ctrl_chart = (gz / max(np.linalg.norm(gz), 1e-30)
+                          * np.linalg.norm(delta_z)) @ lift
+
+            for arm, dvec in (("manifold", delta),
+                              ("random_ambient", ctrl_amb),
+                              ("chart_orthogonal", ctrl_chart)):
+                pl = run_patched(model, tok, layer_mod, e["prompt"], e["pos"],
+                                 dvec)
+                probs_r = torch.softmax(pl, dim=-1)[cand_ids].numpy()
+                logp = torch.log_softmax(e["logits"].to(torch.float64), dim=-1)
+                logq = torch.log_softmax(pl.to(torch.float64), dim=-1)
+                kl = float((logp.exp() * (logp - logq)).sum())
+                tgt = (b + k) % period
+                records.append({
+                    "arm": arm, "k": int(k), "base_label": int(b),
+                    "target_label": int(tgt), "delta_norm": dn,
+                    "off_manifold_norm": off_norm if arm == "manifold" else None,
+                    "realized_kl": max(kl, 0.0),
+                    "top_label_realized": int(np.argmax(probs_r)),
+                    "already_correct": bool(base_top == tgt),
+                })
+
+    summary = {}
+    for arm in ("manifold", "random_ambient", "chart_orthogonal"):
+        rs = [r for r in records if r["arm"] == arm]
+        nt = [r for r in rs if not r["already_correct"]]
+        summary[arm] = {
+            "advance_accuracy": float(np.mean(
+                [r["top_label_realized"] == r["target_label"] for r in rs])),
+            "nontrivial_advance_accuracy": (float(np.mean(
+                [r["top_label_realized"] == r["target_label"] for r in nt]))
+                if nt else float("nan")),
+            "n_nontrivial": len(nt),
+            "mean_realized_kl": float(np.mean([r["realized_kl"] for r in rs])),
+        }
+    log(f"  steer advance acc: manifold="
+        f"{summary['manifold']['advance_accuracy']:.3f} vs random="
+        f"{summary['random_ambient']['advance_accuracy']:.3f} vs chart-orth="
+        f"{summary['chart_orthogonal']['advance_accuracy']:.3f}")
+
+    results[concept] = {
+        "period": period, "layer": layer,
+        "recovery_ordering": ordering,
+        "chart_class_mean_ev_2d": ev2,
+        "adjudication": verdict,
+        "centroid_tier2": tier2,
+        "steering": {"fit_r2": tfit["r2"], "gate": gate,
+                     "orientation": orient, "ks": list(ks),
+                     "summary": summary},
+    }
+    with open(out_dir / f"steer_{concept}_records.jsonl", "w") as f:
+        for r in records:
+            f.write(json.dumps(r) + "\n")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--model", default="Qwen/Qwen3-8B")
+    ap.add_argument("--layer", type=int, default=20,
+                    help="hidden_states index (1-based blocks)")
+    ap.add_argument("--dtype", default="bf16")
+    ap.add_argument("--pca-dim", type=int, default=6)
+    ap.add_argument("--fit-steps", type=int, default=600)
+    ap.add_argument("--n-perm", type=int, default=1000)
+    ap.add_argument("--max-k", type=int, default=3)
+    ap.add_argument("--seed", type=int, default=42)
+    ap.add_argument("--out-dir", required=True)
+    ap.add_argument("--smoke", action="store_true")
+    ap.add_argument("--skip-months", action="store_true")
+    ap.add_argument("--allow-cpu", action="store_true",
+                    help="permit CPU execution (small models / smoke)")
+    args = ap.parse_args()
+
+    import torch
+    if not (torch.cuda.is_available() or args.allow_cpu):
+        raise SystemExit("CUDA unavailable: pass --allow-cpu for small models "
+                         "or run on a GPU host.")
+
+    import gamfit
+    assert hasattr(gamfit, "adjudicate_atom_shape"), "gamfit missing adjudicator"
+
+    out_dir = Path(args.out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    day_rec, month_rec = RECOVERY_TEMPLATES_DAY, RECOVERY_TEMPLATES_MONTH
+    day_fit, day_base = STEER_FIT_TEMPLATES_DAY, STEER_BASE_TEMPLATES_DAY
+    month_fit, month_base = STEER_FIT_TEMPLATES_MONTH, STEER_BASE_TEMPLATES_MONTH
+    fit_steps, n_perm = args.fit_steps, args.n_perm
+    ks = list(range(1, args.max_k + 1))
+    if args.smoke:
+        day_rec, month_rec = day_rec[:4], month_rec[:4]
+        day_fit, day_base = day_fit[:4], day_base[:1]
+        month_fit, month_base = month_fit[:4], month_base[:1]
+        fit_steps, n_perm, ks = 100, 100, [1]
+
+    log(f"loading {args.model} ({args.dtype})")
+    model, tok = load_model(args.model, args.dtype)
+    n_layers = model.config.num_hidden_layers
+    assert 1 <= args.layer <= n_layers, \
+        f"--layer {args.layer} out of range for {n_layers}-block model"
+
+    results: dict = {"meta": {
+        "model": args.model, "layer": args.layer, "pca_dim": args.pca_dim,
+        "fit_steps": fit_steps, "n_perm": n_perm, "ks": ks,
+        "seed": args.seed, "smoke": args.smoke,
+        "layer_convention":
+            "hidden_states[L] = output of model.model.layers[L-1]",
+    }}
+    concepts = [("weekday", WEEKDAYS, day_rec, day_fit, day_base)]
+    if not args.skip_months:
+        concepts.append(("month", MONTHS, month_rec, month_fit, month_base))
+    for name, words, rec, fit_t, base_t in concepts:
+        run_concept(model, tok, gamfit, name, words, rec, fit_t, base_t,
+                    args.layer, pca_dim=args.pca_dim, fit_steps=fit_steps,
+                    n_perm=n_perm, ks=ks, seed=args.seed, out_dir=out_dir,
+                    results=results)
+
+    (out_dir / "results.json").write_text(
+        json.dumps(results, indent=2, default=float))
+    log(f"wrote {out_dir / 'results.json'}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/centroid_circular_ordering_test.py
+++ b/tests/centroid_circular_ordering_test.py
@@ -1,0 +1,92 @@
+"""Unit tests for examples/centroid_ordering.py (the tier-2 ring test).
+
+Three synthetic cases mirror the injections the construction was validated
+on against real-activation censuses:
+
+  * clusters arranged on a ring       -> ordered_on_circle True
+  * the same points, per-dim shuffled -> ordered_on_circle False
+  * a ring masked by a dominant linear factor, seen through top-2 PCA
+    (the census's own projection step) -> ordered_on_circle False
+    (this is the documented detection limit, not a bug in the test)
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_MOD_PATH = _REPO_ROOT / "examples" / "centroid_ordering.py"
+_SPEC = importlib.util.spec_from_file_location("centroid_ordering", _MOD_PATH)
+if _SPEC is None or _SPEC.loader is None:
+    raise RuntimeError(f"failed to load centroid_ordering from {_MOD_PATH}")
+_CO: Any = importlib.util.module_from_spec(_SPEC)
+sys.modules[_SPEC.name] = _CO
+_SPEC.loader.exec_module(_CO)
+
+
+def _clusters_on_ring(k: int = 7, per: int = 40, noise: float = 0.08,
+                      seed: int = 0) -> np.ndarray:
+    """k tight Gaussian clusters centered on a unit circle."""
+    rng = np.random.default_rng(seed)
+    pts = []
+    for i in range(k):
+        th = 2 * np.pi * i / k
+        c = np.array([np.cos(th), np.sin(th)])
+        pts.append(c + noise * rng.standard_normal((per, 2)))
+    return np.concatenate(pts, axis=0)
+
+
+def _top2_pca(X: np.ndarray) -> np.ndarray:
+    Xc = X - X.mean(axis=0, keepdims=True)
+    _, _, vt = np.linalg.svd(Xc, full_matrices=False)
+    return Xc @ vt[:2].T
+
+
+class CentroidCircularOrderingTest(unittest.TestCase):
+    def test_ring_of_clusters_passes(self) -> None:
+        coords = _clusters_on_ring(seed=0)
+        out = _CO.centroid_circular_ordering(coords, 7, seed=0, n_null=2000)
+        self.assertTrue(out["ordered_on_circle"], msg=str(out))
+        self.assertLess(out["mc_p"], 0.05)
+        self.assertLess(out["radius_cv"], 0.2)
+        self.assertLess(out["max_gap_deg"], 150.0)
+
+    def test_shuffled_ring_fails(self) -> None:
+        rng = np.random.default_rng(1)
+        coords = _clusters_on_ring(seed=1)
+        # independent per-dimension shuffle destroys the ring but preserves
+        # the marginals (the census's structureless-control construction)
+        shuffled = np.column_stack([rng.permutation(coords[:, 0]),
+                                    rng.permutation(coords[:, 1])])
+        out = _CO.centroid_circular_ordering(shuffled, 7, seed=1, n_null=2000)
+        self.assertFalse(out["ordered_on_circle"], msg=str(out))
+
+    def test_masked_ring_after_pca_fails(self) -> None:
+        # ring in dims (0, 1) + a linear factor in dim 2 at 2x the ring
+        # radius: top-2 PCA keeps the linear factor and one ring axis, so
+        # the ring is lost before the test ever sees it (measured detection
+        # limit of the census pipeline; adjudicator degrades to mixture too)
+        rng = np.random.default_rng(2)
+        ring = _clusters_on_ring(seed=2)
+        n = ring.shape[0]
+        lin = 2.0 * rng.uniform(-1.0, 1.0, size=(n, 1))
+        X3 = np.concatenate([ring, lin], axis=1)
+        coords = _top2_pca(X3)
+        out = _CO.centroid_circular_ordering(coords, 7, seed=2, n_null=2000)
+        self.assertFalse(out["ordered_on_circle"], msg=str(out))
+
+    def test_input_validation(self) -> None:
+        coords = _clusters_on_ring(seed=3)
+        with self.assertRaises(ValueError):
+            _CO.centroid_circular_ordering(coords, 2)
+        with self.assertRaises(ValueError):
+            _CO.centroid_circular_ordering(coords[:, :1], 5)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds a reproducible recover → certify → steer example for cyclic concept circles, plus the centroid circular-ordering test that makes shape adjudication honest on discrete concepts. AI-authored (Silico agent, run by Scott); ported from an overnight study on real Qwen3-8B and OLMo-2 activations.

## What's here

**1. `examples/cyclic_circle_recovery_and_steering.py`** — the full validated loop on weekday/month calendar circles:

- **Recover:** concept-token residual harvest across varied templates; class-mean chart (per-template centering + top PCs of label-class means). The chart choice is the load-bearing lesson: the calendar circle is a *low-relative-variance* structure — template/context variance dominates, and a plain top-2-PCA projection loses a ring masked by a linear factor at ≥ ~1× its radius (measured by injection). Comments carry this.
- **Certify:** circular-linear ordering against a **chart-rebuilt permutation null** (the label-aware chart is rebuilt per shuffled labeling, so chart construction can't inflate the statistic — measured on Qwen3-8B layer 20: r = 0.96, p = 0.001), plus `adjudicate_atom_shape` paired with the centroid second tier below (discrete clusters ON a ring adjudicate as `mixture_k`; the measured margin on the *confirmed* weekday circle was −0.744).
- **Steer:** circle-atom fit via the torch lane, then patching the fitted decoder curve's chord into the residual stream, with **two matched-norm controls** (random ambient; in-chart orthogonal to the local circle tangent) and realized-KL measurement. In the source experiment the manifold arm advanced the calendar where matched-norm controls did not.

**2. `examples/centroid_ordering.py`** — the tier-2 test as a small importable module (same sibling-import pattern as `residual_shard_io`): seeded k-means at the adjudicator's `mixture_k`, radius-CV ring statistic + angular-coverage gap, Monte-Carlo Gaussian null. Validated in a two-tier census of real SAE feature groups: it rescues known circles the race mislabels and correctly fails masked rings. Its docstring carries the census's control caveat (structureless controls fire at a double-digit rate per run — always run matched controls).

**3. `tests/centroid_circular_ordering_test.py`** — synthetic validation mirroring the census injections (ring of clusters passes; per-dimension shuffled ring fails; ring masked by a 2× linear factor seen through top-2 PCA fails — the documented detection limit). Follows the repo's importlib test-loading pattern (`bench_fuzz_vs_mgcv_test.py`).

## Placement note

SPEC.md keeps estimation math in Rust for production `gamfit/`, with examples/ as the carve-out — so the ordering test ships as an examples/ module here. If you'd rather fold it into the Rust shape race itself (the census finding suggests the race should *own* a cluster-on-a-circle follow-up), that's the companion issue we're filing; this module is the validated reference implementation.

## Validation

- `python -m unittest tests/centroid_circular_ordering_test.py`: 4/4 pass (CPU, seconds).
- Both example files `py_compile` clean. The full example run needs a GPU for the default 8B model (`--smoke --allow-cpu` with a small model exercises the pipeline); it was not re-run in this pass — the numbers quoted above are from the recorded source-experiment artifacts.
