### PR TITLE
fix(python #2323): align sae_manifold_fit's sparsity_weight default with the documented and engine default

### DIFF
--- a/gamfit/_sae_manifold.py
+++ b/gamfit/_sae_manifold.py
@@ -164,7 +164,7 @@ def sae_manifold_fit(
     decoder_feature_sparsity_groups: Sequence[Sequence[int]] | None = None,
     n_iter: int = 50,
     *,
-    sparsity_weight: float = 0.0,
+    sparsity_weight: float = 1.0,
     coord_sparsity: str = "scad",
     scad_mcp_gamma: float | None = None,
     smoothness_weight: float = 1.0,

--- a/tests/sae_manifold_default_args_reach_solver_test.py
+++ b/tests/sae_manifold_default_args_reach_solver_test.py
@@ -1,0 +1,48 @@
+"""Facade defaults must pass the native front door's own validation (#2323).
+
+``sae_manifold_fit``'s keyword defaults are the documented public contract
+(``docs/manifold-sae.md`` lists ``sparsity_weight`` default ``1.0``), and the
+engine's own seed default is ``sparsity_strength: 1.0``. Before the fix, the
+facade materialized ``0.0`` and every default-argument call — including 10
+shipped examples — died at input validation with ``sparsity_strength must be
+finite and positive; got 0`` without ever reaching the solver.
+
+These tests do NOT assert the fit converges (solver behavior is owned
+elsewhere); they assert the failure mode, if any, is not the facade's own
+default failing validation.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+gamfit = pytest.importorskip("gamfit")
+
+
+def _tiny_circle(n: int = 60, seed: int = 0) -> np.ndarray:
+    rng = np.random.default_rng(seed)
+    t = rng.uniform(0.0, 2.0 * np.pi, n)
+    return np.c_[np.cos(t), np.sin(t)] + 0.05 * rng.standard_normal((n, 2))
+
+
+def test_default_arguments_pass_input_validation() -> None:
+    x = _tiny_circle()
+    try:
+        gamfit.sae_manifold_fit(x, K=1, d_atom=1, atom_topology="circle", n_iter=2)
+    except Exception as error:  # noqa: BLE001 — asserting on the message either way
+        message = str(error)
+        assert "sparsity_strength must be finite and positive" not in message, (
+            "the facade's own default failed the native front door's validation: "
+            + message
+        )
+
+
+def test_facade_default_matches_documented_and_engine_default() -> None:
+    import inspect
+
+    signature = inspect.signature(gamfit.sae_manifold_fit)
+    default = signature.parameters["sparsity_weight"].default
+    # docs/manifold-sae.md documents 1.0; SaeManifoldFitSeed's Default is
+    # sparsity_strength: 1.0. The facade must agree with both.
+    assert default == 1.0, default


### PR DESCRIPTION
Fixes #2323.

**One-line default change (`0.0` → `1.0`) plus a regression test.** The facade declared `sparsity_weight: float = 0.0` while:

- `docs/manifold-sae.md` documents the default as **`1.0`**,
- the engine's own `SaeManifoldFitSeed` default is **`sparsity_strength: 1.0`** (`crates/gam-sae/src/manifold/fit_seed.rs`),
- and the native front door rejects non-positive values outright — correctly, since the strength seeds the REML ρ vector as `ln(sparsity_strength)`, so `0` is not representable.

Result before this fix: every default-argument `sae_manifold_fit` call — including 10 shipped examples (`sae_manifold_demo.py`, `sae_ev_vs_k_olmo.py`, `cyclic_circle_recovery_and_steering.py`, `compose_tiers.py`, …) — died at input validation with `sparsity_strength must be finite and positive; got 0` without reaching the solver.

**Validation** (CPU node, provenance-verified 0.1.255 wheel with this branch's pure-Python change overlaid — the native module is untouched by this PR):

- BEFORE: default call reproduces `GamError: sparsity_strength must be finite and positive; got 0`.
- AFTER: `tests/sae_manifold_default_args_reach_solver_test.py` passes 2/2 in 141 s — the default call passes validation and reaches the solver, and `inspect.signature` agrees with the documented/engine default.

The test deliberately does **not** assert fit convergence (solver behavior is owned elsewhere, see #2258/#2322); it pins only that the facade's own defaults pass the facade's own front door.

*AI-authored (Silico agent, run by Scott), from the recorded #2323 repro.*