### PR TITLE
Preserve sparse PIRLS root solves with blocked TSQR

### DIFF
--- a/crates/gam-solve/src/pirls/gam_working_model.rs
+++ b/crates/gam-solve/src/pirls/gam_working_model.rs
@@ -374,6 +374,44 @@ impl<'a> GamWorkingModel<'a> {
         Ok(())
     }
 
+    fn write_scaled_sparse_design(
+        design: &SparseRowMat<usize, f64>,
+        weights: &Array1<f64>,
+        out: &mut Array2<f64>,
+    ) -> Result<(), EstimationError> {
+        if design.nrows() != weights.len()
+            || out.nrows() < design.nrows()
+            || out.ncols() != design.ncols()
+        {
+            crate::bail_invalid_estim!(
+                "PIRLS sparse square-root design shape mismatch: design={}x{}, weights={}, root={}x{}",
+                design.nrows(),
+                design.ncols(),
+                weights.len(),
+                out.nrows(),
+                out.ncols()
+            );
+        }
+        let view = design.as_ref();
+        for i in 0..design.nrows() {
+            let weight = weights[i];
+            if !(weight.is_finite() && weight >= 0.0) {
+                crate::bail_invalid_estim!(
+                    "Fisher square-root solve requires finite nonnegative weight, got {weight} at row {i}"
+                );
+            }
+            let scale = weight.sqrt();
+            for (&column, &value) in view
+                .col_idx_of_row_raw(i)
+                .iter()
+                .zip(view.val_of_row(i).iter())
+            {
+                out[[i, column.unbound()]] = scale * value;
+            }
+        }
+        Ok(())
+    }
+
     fn write_fisher_design_root(&self, out: &mut Array2<f64>) -> Result<(), EstimationError> {
         if let Some(factor) = self.firth_design_factor.as_ref() {
             return Self::write_scaled_dense_design(
@@ -390,24 +428,7 @@ impl<'a> GamWorkingModel<'a> {
                 if let Some(dense) = x_transformed.as_dense() {
                     Self::write_scaled_dense_design(dense, &self.lasthessian_weights, out)
                 } else if let Some(csr) = x_csr.as_ref() {
-                    let view = csr.as_ref();
-                    for i in 0..csr.nrows() {
-                        let weight = self.lasthessian_weights[i];
-                        if !(weight.is_finite() && weight >= 0.0) {
-                            crate::bail_invalid_estim!(
-                                "Fisher square-root solve requires finite nonnegative weight, got {weight} at row {i}"
-                            );
-                        }
-                        let scale = weight.sqrt();
-                        for (&column, &value) in view
-                            .col_idx_of_row_raw(i)
-                            .iter()
-                            .zip(view.val_of_row(i).iter())
-                        {
-                            out[[i, column.unbound()]] = scale * value;
-                        }
-                    }
-                    Ok(())
+                    Self::write_scaled_sparse_design(csr, &self.lasthessian_weights, out)
                 } else {
                     let dense = x_transformed
                         .try_to_dense_arc("PIRLS square-root solve requires the transformed design")
@@ -438,7 +459,7 @@ impl<'a> GamWorkingModel<'a> {
                 result
             }
             WorkingCoordinateDesign::OriginalSparseNative => crate::bail_invalid_estim!(
-                "dense square-root solve reached a sparse-native coordinate design"
+                "sparse-native square-root solve bypassed its tall-skinny QR route"
             ),
         }
     }
@@ -455,6 +476,85 @@ impl<'a> GamWorkingModel<'a> {
         let n = self.lasthessian_weights.len();
         let p = state.gradient.len();
         let penalty_rows = self.penalty.rank();
+        if matches!(
+            &self.coordinate_design,
+            WorkingCoordinateDesign::OriginalSparseNative
+        ) && self.firth_design_factor.is_none()
+        {
+            // Preserve the square-root problem without materializing sparse X
+            // as an n×p dense root. Blocking at p rows retains Householder QR's
+            // conditioning while bounding all live matrices by O(p²).
+            let block_rows = p.checked_mul(2).ok_or_else(|| {
+                EstimationError::InvalidInput(
+                    "PIRLS tall-skinny QR block row count overflowed usize".to_string(),
+                )
+            })?;
+            let qr_reservation = gam_runtime::resource::MemoryGovernor::global()
+                .try_reserve_dense_f64_copies(
+                    block_rows,
+                    p,
+                    4,
+                    "PIRLS sparse tall-skinny QR square-root solve",
+                )
+                .map_err(|error| EstimationError::InvalidInput(error.to_string()))?;
+            let csr = self.x_original_csr.as_ref().ok_or_else(|| {
+                EstimationError::InvalidInput(
+                    "missing CSR cache for sparse-native PIRLS square-root solve".to_string(),
+                )
+            })?;
+            let mut qr = TallSkinnyQrLeastSquares::new(p)?;
+            let mut row = Array1::<f64>::zeros(p);
+            let view = csr.as_ref();
+            for i in 0..n {
+                let weight = self.lasthessian_weights[i];
+                if !(weight.is_finite() && weight >= 0.0) {
+                    crate::bail_invalid_estim!(
+                        "Fisher square-root solve requires finite nonnegative weight, got {weight} at row {i}"
+                    );
+                }
+                let scale = weight.sqrt();
+                for (&column, &value) in view
+                    .col_idx_of_row_raw(i)
+                    .iter()
+                    .zip(view.val_of_row(i).iter())
+                {
+                    row[column.unbound()] = scale * value;
+                }
+                qr.push_row(row.view(), (state.eta[i] - self.lastz[i]) * scale)?;
+                row.fill(0.0);
+            }
+
+            let mut penalty_root = Array2::<f64>::zeros((penalty_rows, p).f());
+            let mut penalty_residual = Array1::<f64>::zeros(penalty_rows);
+            self.penalty.write_root_rows(&mut penalty_root, 0);
+            self.penalty
+                .write_root_residual(beta.as_ref(), &mut penalty_residual, 0);
+            for i in 0..penalty_rows {
+                qr.push_row(penalty_root.row(i), penalty_residual[i])?;
+            }
+            for j in 0..p {
+                let energy = state.ridge_used + loop_lambda * lm_d2[j];
+                if !(energy.is_finite() && energy >= 0.0) {
+                    crate::bail_invalid_estim!(
+                        "PIRLS square-root LM diagonal must be finite and nonnegative, got {energy} at coefficient {j}"
+                    );
+                }
+                if energy > 0.0 {
+                    let root_energy = energy.sqrt();
+                    row[j] = root_energy;
+                    qr.push_row(
+                        row.view(),
+                        state.ridge_used * beta.as_ref()[j] / root_energy,
+                    )?;
+                    row[j] = 0.0;
+                } else {
+                    qr.push_row(row.view(), 0.0)?;
+                }
+            }
+            let result = qr.solve(firth_hessian, direction_out);
+            drop(qr_reservation);
+            return result;
+        }
         let rows = n
             .checked_add(penalty_rows)
             .and_then(|value| value.checked_add(p))

--- a/crates/gam-solve/src/pirls/newton_solve.rs
+++ b/crates/gam-solve/src/pirls/newton_solve.rs
@@ -708,6 +708,208 @@ pub(super) fn solve_newton_direction_from_root_with_firth_hessian(
     Ok(projected_residual.dot(&projected_residual))
 }
 
+/// Blocked tall-skinny QR for an augmented least-squares root.
+///
+/// Every full block contains at most `p` original rows. Once a block fills,
+/// it is reduced together with the preceding `p × p` triangular factor:
+///
+/// ```text
+/// [R_previous] = Q [R_next]
+/// [A_block   ]     [   0  ]
+/// ```
+///
+/// This is algebraically the same Householder QR used by the dense root path,
+/// but its peak storage is `O(p²)` instead of `O(rows × p)`. In particular,
+/// sparse-native PIRLS designs never become a dense `n × p` allocation merely
+/// because a stiff penalty requires the numerically safer square-root solve.
+pub(super) struct TallSkinnyQrLeastSquares {
+    p: usize,
+    pending_root: Array2<f64>,
+    pending_residual: Array1<f64>,
+    pending_rows: usize,
+    triangular_root: Option<Array2<f64>>,
+    projected_residual: Array1<f64>,
+    total_rows: usize,
+    root_row_sum_max: f64,
+    root_column_sums: Array1<f64>,
+    residual_inf: f64,
+}
+
+impl TallSkinnyQrLeastSquares {
+    pub(super) fn new(p: usize) -> Result<Self, EstimationError> {
+        if p == 0 {
+            crate::bail_invalid_estim!("tall-skinny QR requires at least one coefficient");
+        }
+        Ok(Self {
+            p,
+            pending_root: Array2::zeros((p, p).f()),
+            pending_residual: Array1::zeros(p),
+            pending_rows: 0,
+            triangular_root: None,
+            projected_residual: Array1::zeros(p),
+            total_rows: 0,
+            root_row_sum_max: 0.0,
+            root_column_sums: Array1::zeros(p),
+            residual_inf: 0.0,
+        })
+    }
+
+    pub(super) fn push_row(
+        &mut self,
+        root_row: ndarray::ArrayView1<'_, f64>,
+        root_residual: f64,
+    ) -> Result<(), EstimationError> {
+        if root_row.len() != self.p {
+            crate::bail_invalid_estim!(
+                "tall-skinny QR row width {} does not match p={}",
+                root_row.len(),
+                self.p
+            );
+        }
+        if !root_residual.is_finite() || root_row.iter().any(|value| !value.is_finite()) {
+            crate::bail_invalid_estim!("tall-skinny QR received a non-finite augmented row");
+        }
+        let row_sum = root_row.iter().map(|value| value.abs()).sum::<f64>();
+        self.root_row_sum_max = self.root_row_sum_max.max(row_sum);
+        for (sum, value) in self.root_column_sums.iter_mut().zip(root_row.iter()) {
+            *sum += value.abs();
+        }
+        self.residual_inf = self.residual_inf.max(root_residual.abs());
+        self.pending_root
+            .row_mut(self.pending_rows)
+            .assign(&root_row);
+        self.pending_residual[self.pending_rows] = root_residual;
+        self.pending_rows += 1;
+        self.total_rows += 1;
+        if self.pending_rows == self.p {
+            self.flush()?;
+        }
+        Ok(())
+    }
+
+    fn flush(&mut self) -> Result<(), EstimationError> {
+        if self.pending_rows == 0 {
+            return Ok(());
+        }
+        let carried_rows = usize::from(self.triangular_root.is_some()) * self.p;
+        let rows = carried_rows + self.pending_rows;
+        if rows < self.p {
+            return Ok(());
+        }
+        let mut root = Array2::<f64>::zeros((rows, self.p).f());
+        let mut residual = Array1::<f64>::zeros(rows);
+        if let Some(previous) = self.triangular_root.as_ref() {
+            root.slice_mut(ndarray::s![..self.p, ..]).assign(previous);
+            residual
+                .slice_mut(ndarray::s![..self.p])
+                .assign(&self.projected_residual);
+        }
+        let start = carried_rows;
+        let end = start + self.pending_rows;
+        root.slice_mut(ndarray::s![start..end, ..])
+            .assign(&self.pending_root.slice(ndarray::s![..self.pending_rows, ..]));
+        residual
+            .slice_mut(ndarray::s![start..end])
+            .assign(&self.pending_residual.slice(ndarray::s![..self.pending_rows]));
+
+        let (q, r) = root
+            .qr()
+            .map_err(EstimationError::LinearSystemSolveFailed)?;
+        if r.dim() != (self.p, self.p) {
+            crate::bail_invalid_estim!(
+                "tall-skinny QR produced R={}x{} for p={}",
+                r.nrows(),
+                r.ncols(),
+                self.p
+            );
+        }
+        self.projected_residual = q.t().dot(&residual);
+        self.triangular_root = Some(r);
+        self.pending_root.fill(0.0);
+        self.pending_residual.fill(0.0);
+        self.pending_rows = 0;
+        Ok(())
+    }
+
+    pub(super) fn solve(
+        mut self,
+        firth_hessian: Option<&Array2<f64>>,
+        direction_out: &mut Array1<f64>,
+    ) -> Result<f64, EstimationError> {
+        self.flush()?;
+        let r = self.triangular_root.ok_or_else(|| {
+            EstimationError::InvalidInput(format!(
+                "tall-skinny QR has only {} rows for p={}",
+                self.total_rows, self.p
+            ))
+        })?;
+        if direction_out.len() != self.p {
+            *direction_out = Array1::zeros(self.p);
+        }
+        for reverse in 0..self.p {
+            let i = self.p - 1 - reverse;
+            let mut value = -self.projected_residual[i];
+            for k in (i + 1)..self.p {
+                value -= r[[i, k]] * direction_out[k];
+            }
+            let diagonal = r[[i, i]];
+            if !(diagonal.is_finite() && diagonal != 0.0) {
+                return Err(EstimationError::ModelIsIllConditioned {
+                    condition_number: f64::INFINITY,
+                });
+            }
+            direction_out[i] = value / diagonal;
+        }
+
+        // The block reductions are orthogonal transformations, so the compact
+        // R system has exactly the same least-squares stationarity equation as
+        // the original augmented root. Certify the triangular solve against
+        // norms accumulated from the original rows, not the reduced blocks.
+        let mut compact_residual = r.dot(direction_out);
+        compact_residual += &self.projected_residual;
+        let normal_residual = r.t().dot(&compact_residual);
+        let residual_inf = inf_norm(normal_residual.iter().copied());
+        let root_transpose_inf = inf_norm(self.root_column_sums.iter().copied());
+        let direction_inf = inf_norm(direction_out.iter().copied());
+        let scale =
+            root_transpose_inf * (self.root_row_sum_max * direction_inf + self.residual_inf);
+        let backward_error = if scale > 0.0 {
+            residual_inf / scale
+        } else {
+            residual_inf
+        };
+        let tolerance = 256.0 * f64::EPSILON * self.total_rows.max(self.p) as f64;
+        if !backward_error.is_finite() || backward_error > tolerance {
+            crate::bail_invalid_estim!(
+                "PIRLS tall-skinny square-root direction failed its backward-error certificate: \
+                 error {backward_error:.3e} exceeds {tolerance:.3e}"
+            );
+        }
+        if !array_is_finite(direction_out) {
+            crate::bail_invalid_estim!("PIRLS tall-skinny square-root direction is non-finite");
+        }
+        let decrement = self.projected_residual.dot(&self.projected_residual);
+        if let Some(hphi) = firth_hessian {
+            let fisher_direction = direction_out.clone();
+            let lower = r.t().to_owned();
+            correct_fisher_direction_for_firth_hessian_from_root_factor(
+                &lower,
+                hphi,
+                &fisher_direction,
+                direction_out,
+            )?;
+        }
+        log::info!(
+            "[STAGE] PIRLS tall-skinny newton solve backend=CPU p={} rows={} route=\"blocked Householder QR of sparse PSD root\" backward_error={:.3e} damped_decrement_sq={:.3e}",
+            self.p,
+            self.total_rows,
+            backward_error,
+            decrement,
+        );
+        Ok(decrement)
+    }
+}
+
 /// Convert the cancellation-safe Fisher/penalty direction into the exact
 /// Firth-Newton direction without ever reconstructing the cancelled score.
 ///
@@ -862,6 +1064,41 @@ mod square_root_solve_tests {
         .expect("stationary least-squares root certificate");
         assert!(stationary_direction.dot(&stationary_direction) <= 1.0e-28);
         assert!(stationary_decrement <= 1.0e-28);
+    }
+
+    #[test]
+    fn tall_skinny_qr_matches_dense_qr_for_a_stiff_root() {
+        let root = array![
+            [1.0e8, 1.0e8],
+            [1.0, -1.0],
+            [0.0, 1.0],
+            [2.0, 0.0],
+            [0.0, 3.0]
+        ];
+        let expected = array![0.25, -0.25];
+        let residual = -root.dot(&expected);
+        let mut dense_direction = Array1::<f64>::zeros(2);
+        let dense_decrement =
+            solve_newton_direction_from_root(&root, &residual, &mut dense_direction)
+                .expect("dense square-root solve");
+
+        let mut blocked = TallSkinnyQrLeastSquares::new(2).expect("blocked QR");
+        for i in 0..root.nrows() {
+            blocked
+                .push_row(root.row(i), residual[i])
+                .expect("append augmented row");
+        }
+        let mut blocked_direction = Array1::<f64>::zeros(2);
+        let blocked_decrement = blocked
+            .solve(None, &mut blocked_direction)
+            .expect("blocked square-root solve");
+
+        for (&blocked_value, &dense_value) in
+            blocked_direction.iter().zip(dense_direction.iter())
+        {
+            assert!((blocked_value - dense_value).abs() < 1.0e-10);
+        }
+        assert!((blocked_decrement - dense_decrement).abs() < 1.0e-8);
     }
 
     #[test]

--- a/crates/gam-solve/src/pirls/tests.rs
+++ b/crates/gam-solve/src/pirls/tests.rs
@@ -1263,6 +1263,117 @@ mod tests {
         assert_eq!(decision.reason, "constraints_present");
     }
 
+    /// Regression for #2401: the cancellation-safe PSD-root solve introduced
+    /// for stiff P-IRLS systems must accept the sparse-native coordinate frame.
+    /// Before the fix, the routing oracle correctly chose `SparseNative`, the
+    /// disparate penalty energies correctly chose the augmented root solve, and
+    /// `write_fisher_design_root` then aborted solely because those two valid
+    /// choices had no shared implementation.
+    #[test]
+    pub(crate) fn sparse_native_stiff_penalty_uses_psd_root_2401() {
+        use gam_terms::construction::CanonicalPenalty;
+
+        let p = 64usize;
+        let n = 3 * p;
+        let triplets: Vec<_> = (0..n).map(|row| Triplet::new(row, row / 3, 1.0)).collect();
+        let x = SparseColMat::try_new_from_triplets(n, p, &triplets)
+            .expect("one-hot sparse design should build");
+        let x_design = DesignMatrix::from(x.clone());
+
+        let mut low_energy_root = Array2::<f64>::zeros((1, p));
+        low_energy_root[[0, 0]] = 1.0;
+        let mut high_energy_root = Array2::<f64>::zeros((p - 1, p));
+        for coefficient in 1..p {
+            high_energy_root[[coefficient - 1, coefficient]] = 1.0;
+        }
+        let canonical: Vec<_> = [low_energy_root, high_energy_root]
+            .into_iter()
+            .map(|root| {
+                let rank = root.nrows();
+                CanonicalPenalty {
+                    local: root.t().dot(&root),
+                    root,
+                    col_range: 0..p,
+                    total_dim: p,
+                    nullity: p - rank,
+                    prior_mean: Array1::zeros(p),
+                    positive_eigenvalues: vec![1.0; rank],
+                    op: None,
+                }
+            })
+            .collect();
+
+        let rho = array![-12.0, 12.0];
+        let lambdas = rho.mapv(f64::exp);
+        let weighted_penalty = &canonical[0].local * lambdas[0] + &canonical[1].local * lambdas[1];
+        let mut routing_workspace = PirlsWorkspace::new(n, p, 0, 0);
+        let decision = should_use_sparse_native_pirls(
+            &mut routing_workspace,
+            &x_design,
+            &weighted_penalty,
+            None,
+            None,
+        );
+        assert_eq!(
+            decision.path,
+            PirlsLinearSolvePath::SparseNative,
+            "fixture must exercise the sparse-native coordinate frame; reason={}",
+            decision.reason
+        );
+        assert!(
+            lambdas[1] / lambdas[0] > f64::EPSILON.sqrt().recip(),
+            "fixture must exceed the PSD-root stiffness threshold"
+        );
+
+        let y = Array1::from_shape_fn(n, |row| if row % 3 == 2 { 1.0 } else { 0.0 });
+        let weights = Array1::ones(n);
+        let offset = Array1::zeros(n);
+        let config = PirlsConfig {
+            likelihood: GlmLikelihoodSpec::canonical(LikelihoodSpec::new(
+                ResponseFamily::Binomial,
+                InverseLink::Standard(StandardLink::Logit),
+            )),
+            link_kind: InverseLink::Standard(StandardLink::Logit),
+            max_iterations: 100,
+            convergence_tolerance: 1e-8,
+            firth_bias_reduction: false,
+            initial_lm_lambda: None,
+            arrow_schur: None,
+        };
+
+        let (fit, _) = fit_model_for_fixed_rho(
+            LogSmoothingParamsView::new(rho.view())
+                .expect("test rho lies in the smoothing-strength domain"),
+            PirlsProblem {
+                x,
+                offset: offset.view(),
+                y: y.view(),
+                priorweights: weights.view(),
+                covariate_se: None,
+                gaussian_fixed_cache: None,
+                glm_first_step_gram: None,
+            },
+            PenaltyConfig {
+                canonical_penalties: &canonical,
+                balanced_penalty_root: None,
+                reparam_invariant: None,
+                p,
+                coefficient_lower_bounds: None,
+                linear_constraints_original: None,
+                penalty_shrinkage_floor: None,
+                kronecker_factored: None,
+            },
+            &config,
+            None,
+        )
+        .expect("stiff sparse-native binomial P-IRLS fit must use the PSD root");
+
+        assert!(
+            fit.beta_transformed.iter().all(|value| value.is_finite()),
+            "sparse-native PSD-root fit must return finite coefficients"
+        );
+    }
+
     /// Regression for the sparse-native vs dense REML λ-selection divergence
     /// (#1266 class): the sparse-native reparam result MUST carry the same
     /// penalty (with the `penalty_shrinkage_floor` ridge folded in) that the


### PR DESCRIPTION
Refs #2401.

## Root cause

Stiff penalties correctly select the cancellation-safe augmented square-root solve, while sparse model matrices correctly select the sparse-native coordinate frame. Their intersection was deliberately rejected because the only square-root implementation materialized the entire augmented root as a dense `(n + rank + p) × p` matrix.

Densifying CSR would remove the exception but violate the no-OOM/large-scale contract. This change instead implements blocked tall-skinny Householder QR. Each source block is reduced with the preceding `p × p` triangular factor, preserving the original least-squares problem and QR conditioning while bounding live matrix storage by `O(p²)`.

## Invariants

- Never forms `AᵀA`; the stiff-root path therefore does not square the represented condition number.
- Transforms the root-space residual alongside every orthogonal reduction.
- Retains the existing backward-error certificate and Firth congruence correction interface.
- Explicitly rejects any sparse-native call that bypasses the TSQR route, preventing accidental full-root densification.
- Uses the memory governor for the complete bounded QR working set.

## Regression coverage

- Dense QR versus blocked TSQR on a deliberately stiff rotated root.
- A fixed-rho sparse-native binomial P-IRLS fit with a penalty-energy ratio above the PSD-root threshold (the exact branch that previously aborted).

## Validation status

MSI validation was intentionally stopped because every available named target predated the July 19–20 dependency upgrade. The nominal shared target began rebuilding Arrow/faer/Parquet instead of reaching the touched crate; three attempts were cancelled promptly (74 s, 63 s, and 105 s), and the queue was left empty. This draft PR is the next cache-backed compiler/test signal. It must remain draft until focused tests and repository checks pass.