### PR TITLE
fix(#2372): restore singular Greville span diagnostic

### DIFF
--- a/crates/gam-terms/src/basis/bspline_eval.rs
+++ b/crates/gam-terms/src/basis/bspline_eval.rs
@@ -1111,7 +1111,15 @@ pub fn create_difference_penalty_matrix(
             let mut log_span_sum = 0.0_f64;
             for i in 0..nrows {
                 let span = g[i + o] - g[i];
-                if !span.is_finite() || span <= 0.0 {
+                if span == 0.0 {
+                    return Err(BasisError::InvalidKnotVector(format!(
+                        "singular divided-difference span at order {o}, row {i}: coefficient coordinates g[{}]={:.6e} and g[{i}]={:.6e} coincide",
+                        i + o,
+                        g[i + o],
+                        g[i]
+                    )));
+                }
+                if !span.is_finite() || span < 0.0 {
                     return Err(BasisError::InvalidKnotVector(format!(
                         "divided-difference coordinates must be finite and strictly increasing at order {o}, row {i}: g[{}]={:.6e}, g[{i}]={:.6e}",
                         i + o,


### PR DESCRIPTION
## Summary
- distinguish an exactly collapsed divided-difference span from other invalid coordinate orderings
- restore the explicit `singular` Greville-span diagnostic expected by the existing regression
- preserve the stricter finite/increasing diagnostic for non-finite and decreasing coordinates

Addresses only the Greville-span subtask of #2372; the other open clusters remain untouched.

## Verification
- `cargo nextest run -p gam-terms --lib -E 'test(test_penalty_matrix_rejects_singular_greville_span)'` — 1 passed
- `cargo fmt --all -- --check` remains red on unrelated pre-existing workspace formatting; the changed file produced no rustfmt diff