### PR TITLE
test(#2372): pin nuclear-norm eigen shift

### DIFF
--- a/crates/gam-terms/src/analytic_penalties/nuclear_norm.rs
+++ b/crates/gam-terms/src/analytic_penalties/nuclear_norm.rs
@@ -486,9 +486,9 @@ impl NuclearNormPenalty {
         let mut f = Array1::<f64>::zeros(d);
         let mut df = Array1::<f64>::zeros(d);
         for i in 0..d {
-            // Same shared floor used by `value`/`grad_target` (#737): the
+            // Same shared shift used by `value`/`grad_target` (#737): the
             // right-Gram eigenvalue `raw_evals[i]` is the squared singular value
-            // `σ²`, so `regularized_sigma_sq(σ²) = max(σ²+ε², eig_floor)` keeps
+            // `σ²`, so `regularized_sigma_sq(σ²) = σ² + max(ε², 1e-15)` keeps
             // the filter on the identical regularized spectrum.
             regularized_evals[i] = self.regularized_sigma_sq(raw_evals[i]);
             if i >= active_start {

--- a/crates/gam-terms/src/analytic_penalties/tests.rs
+++ b/crates/gam-terms/src/analytic_penalties/tests.rs
@@ -1824,7 +1824,7 @@ fn nuclear_norm_wide_block_max_rank_above_true_rank_value_grad_hvp_are_finite() 
 }
 
 #[test]
-fn nuclear_norm_right_gram_divided_difference_uses_eigen_floor() {
+fn nuclear_norm_right_gram_divided_difference_uses_shared_eigen_shift() {
     let n_eff = 2usize;
     let p = 2usize;
     let target = PsiSlice {
@@ -1842,10 +1842,12 @@ fn nuclear_norm_right_gram_divided_difference_uses_eigen_floor() {
         .right_spectral_inverse_sqrt_derivative(t.view(), v.view())
         .expect("right-Gram derivative");
 
+    // The robustness floor is an additive shift, not a clamp, so the spectral
+    // value and its divided difference remain derivatives of the same function.
     let eps2 = smoothing_eps * smoothing_eps;
-    let eig_floor = eps2.max(1.0e-15);
-    let lambda0 = (a * a + eps2).max(eig_floor);
-    let lambda1 = (b * b + eps2).max(eig_floor);
+    let eigen_shift = eps2.max(1.0e-15);
+    let lambda0 = a * a + eigen_shift;
+    let lambda1 = b * b + eigen_shift;
     let f0 = lambda0.powf(-0.5);
     let f1 = lambda1.powf(-0.5);
     let expected = ((f0 - f1) / (lambda0 - lambda1)) * a;


### PR DESCRIPTION
## Summary
- re-derive the stale nuclear-norm divided-difference regression against the deliberate additive eigenvalue shift `σ² + max(ε², 1e-15)`
- rename the test so it distinguishes the shared shift from the superseded clamp
- correct the adjacent production comment to match the already-landed regularization contract

This changes no production behavior. It addresses only the nuclear-norm single-test subtask of #2372.

## Verification
- `cargo nextest run -p gam-terms --lib -E 'test(nuclear_norm_right_gram_divided_difference_uses_shared_eigen_shift)'` — 1 passed
- `cargo nextest run -p gam-terms --lib -E 'test(nuclear_norm)'` — 7 passed
- `cargo fmt --package gam-terms -- --check` remains red on pre-existing package formatting; reported `tests.rs` diffs start at line 2040 and no `nuclear_norm.rs` diff was reported