### PR TITLE
fix(#2372): harden derivative penalty scaling

### DIFF
--- a/crates/gam-terms/src/basis/derivative_penalty.rs
+++ b/crates/gam-terms/src/basis/derivative_penalty.rs
@@ -50,9 +50,7 @@ pub fn bspline_derivative_penalty_matrix(
     order: usize,
 ) -> Result<Array2<f64>, BasisError> {
     let factor = bspline_derivative_penalty_factor(knot_vector, degree, order)?;
-    let mut penalty = fast_ata(&factor);
-    symmetrize_in_place(&mut penalty);
-    Ok(penalty)
+    materialize_derivative_gram(&factor, "open B-spline roughness penalty")
 }
 
 /// Constructive energy factor for the exact open B-spline roughness.
@@ -258,9 +256,7 @@ pub fn cyclic_bspline_derivative_penalty_matrix(
     order: usize,
 ) -> Result<Array2<f64>, BasisError> {
     let factor = cyclic_bspline_derivative_penalty_factor(degree, num_basis, period, order)?;
-    let mut penalty = fast_ata(&factor);
-    symmetrize_in_place(&mut penalty);
-    Ok(penalty)
+    materialize_derivative_gram(&factor, "cyclic B-spline roughness penalty")
 }
 
 /// Constructive energy factor for the exact cyclic B-spline roughness.
@@ -372,6 +368,22 @@ fn validate_sobolev_knot_multiplicity(
         i = end;
     }
     Ok(())
+}
+
+/// Materialize `AᵀA` for a derivative energy factor without allowing an
+/// otherwise-finite factor to escape as a non-finite dense penalty.
+fn materialize_derivative_gram(
+    factor: &Array2<f64>,
+    context: &str,
+) -> Result<Array2<f64>, BasisError> {
+    let mut penalty = fast_ata(factor);
+    if penalty.iter().any(|value| !value.is_finite()) {
+        return Err(BasisError::InvalidInput(format!(
+            "{context} is not representable as a finite f64 Gram"
+        )));
+    }
+    symmetrize_in_place(&mut penalty);
+    Ok(penalty)
 }
 
 /// Under `x = a + c·u`, an order-`m` derivative Gram transforms as
@@ -1337,8 +1349,10 @@ mod tests {
     }
 
     /// Covariant scaling: stretching the period by `c` scales the order-`m`
-    /// roughness Gram by exactly `c^{1−2m}` (so after the builder's Frobenius
-    /// normalization the shipped penalty is unit-invariant).
+    /// roughness Gram by `c^{1−2m}` (so after the builder's Frobenius
+    /// normalization the shipped penalty is unit-invariant). Compare in matrix
+    /// max-norm: analytically zero lags carry quadrature-roundoff residues whose
+    /// entrywise relative error is undefined.
     #[test]
     fn cyclic_penalty_scales_covariantly_with_period() {
         let (degree, n, order) = (3usize, 9usize, 2usize);
@@ -1346,48 +1360,20 @@ mod tests {
         for c in [3.5_f64, 1e-13] {
             let s2 = cyclic_bspline_derivative_penalty_matrix(degree, n, c, order).unwrap();
             let factor = c.powi(1 - 2 * order as i32);
-            let max_relative_error = s1
+            let expected_scale = s1
+                .iter()
+                .map(|&base| (base * factor).abs())
+                .fold(0.0_f64, f64::max)
+                .max(1.0);
+            let max_absolute_error = s1
                 .iter()
                 .zip(s2.iter())
-                .map(|(&base, &observed)| {
-                    (base * factor - observed).abs()
-                        / observed.abs().max((base * factor).abs()).max(1.0)
-                })
+                .map(|(&base, &observed)| (base * factor - observed).abs())
                 .fold(0.0_f64, f64::max);
+            let relative_max_norm_error = max_absolute_error / expected_scale;
             assert!(
-                max_relative_error < 1e-12,
-                "period scaling must be c^(1-2m) for c={c}; rel={max_relative_error}"
-            );
-        }
-    }
-
-    /// #2372 probe: print the exact intermediates of the covariance chain at
-    /// the failing extreme scale so the 5.3% divergence names its own source.
-    #[test]
-    fn zz_measure_2372_cyclic_covariance_intermediates() {
-        let (degree, n, order) = (3usize, 9usize, 2usize);
-        let c = 1e-13_f64;
-        let s1 = cyclic_bspline_derivative_penalty_matrix(degree, n, 1.0, order).unwrap();
-        let s2 = cyclic_bspline_derivative_penalty_matrix(degree, n, c, order).unwrap();
-        let f1 = cyclic_bspline_derivative_penalty_factor(degree, n, 1.0, order).unwrap();
-        let f2 = cyclic_bspline_derivative_penalty_factor(degree, n, c, order).unwrap();
-        let factor = c.powi(1 - 2 * order as i32);
-        eprintln!(
-            "[zz2372:cyclic] c={c:e} scale=c^(1-2m)={factor:e} sqrt={:e}",
-            factor.sqrt()
-        );
-        for (i, j) in [(0usize, 0usize), (0, 1), (4, 4), (0, 8)] {
-            eprintln!(
-                "[zz2372:cyclic] S1[{i}][{j}]={:+.17e} S2[{i}][{j}]={:+.17e} S1*scale={:+.17e} ratio_err={:+.3e} F1={:+.17e} F2={:+.17e} F_ratio_err={:+.3e}",
-                s1[[i, j]],
-                s2[[i, j]],
-                s1[[i, j]] * factor,
-                (s1[[i, j]] * factor - s2[[i, j]]).abs()
-                    / s2[[i, j]].abs().max((s1[[i, j]] * factor).abs()).max(1.0),
-                f1[[i, j]],
-                f2[[i, j]],
-                (f1[[i, j]] * factor.sqrt() - f2[[i, j]]).abs()
-                    / f2[[i, j]].abs().max(1e-300),
+                relative_max_norm_error < 1e-12,
+                "period scaling must be c^(1-2m) for c={c}; max-norm rel={relative_max_norm_error}"
             );
         }
     }


### PR DESCRIPTION
## Summary
- reject dense derivative-penalty Grams when a finite energy factor overflows during `AᵀA`, instead of returning an `Ok` matrix containing infinities
- use the same checked materialization boundary for open and cyclic B-spline roughness matrices while preserving the finite constructive-factor API
- re-derive the extreme-period covariance assertion in matrix max-norm; entrywise relative error was dominated by quadrature residue at analytically zero lags (`~1e-13` at unit scale, still `~1e-16` of the scaled operator norm)
- remove the completed `zz_measure_2372_cyclic_covariance_intermediates` probe

Addresses only the derivative-penalty pair in #2372.

## Verification
- focused pair: 2 passed
- `cargo nextest run -p gam-terms --lib -E 'test(derivative_penalty)'` — 19 passed
- `cargo fmt --package gam-terms -- --check` remains red on pre-existing package formatting; the only reported `derivative_penalty.rs` diff is the unchanged `preserves_all_basis_energies` expression near line 420