### PR TITLE
fix(sae): apply trust region to factored frame solves

### DIFF
--- a/crates/gam-sae/src/manifold/fit_drivers.rs
+++ b/crates/gam-sae/src/manifold/fit_drivers.rs
@@ -7288,7 +7288,7 @@ impl SaeManifoldTerm {
             }
             let mut quotient_step_norm = step_norm_sq.sqrt();
             if delta_ext_coord.len() == self.n_obs() * self.assignment.row_block_dim()
-                && delta_beta.len() == self.beta_dim()
+                && delta_beta.len() == self.factored_border_dim()
             {
                 let quotient_step_norm_sq = self.quotient_newton_step_norm_sq(
                     delta_ext_coord.view(),


### PR DESCRIPTION
Extracts the valid production fix from #2773 without its superseded diagnostic payload.

A frame-active dense solve returns `delta_beta` in the factored border layout. The existing guard compared that length with `beta_dim()`, so it skipped `quotient_newton_step_norm_sq` and the #2267 trust-region clipping whenever a decoder frame was active. The callee already validates `factored_border_dim()`, and the streaming path uses the same factored width.

This changes the guard to the layout the solver actually returns. #2773 is superseded by this focused replacement; its probes overlap the newer #2772 evidence and its framed test states that it is not red-green.