### PR TITLE
fix(reml): preserve Firth structural Hessian rank (#2835)

### DIFF
--- a/crates/gam-solve/src/reml/objective.rs
+++ b/crates/gam-solve/src/reml/objective.rs
@@ -140,10 +140,7 @@ impl<'a> RemlState<'a> {
     /// actually is — is not part of that search, and charging it there would
     /// make a work guard read a covariance refinement as an outer-loop
     /// regression (#2728).
-    pub(crate) fn compute_cost_uncharged(
-        &self,
-        p: &Array1<f64>,
-    ) -> Result<f64, EstimationError> {
+    pub(crate) fn compute_cost_uncharged(&self, p: &Array1<f64>) -> Result<f64, EstimationError> {
         self.compute_cost_charging(p, 0, false)
     }
 
@@ -1352,6 +1349,40 @@ impl<'a> RemlState<'a> {
         } else {
             PseudoLogdetMode::Smooth
         };
+        let firth_structural_rank = if hessian_mode == PseudoLogdetMode::HardPseudo {
+            let design = bundle
+                .firth_dense_operator
+                .as_ref()
+                .expect("HardPseudo is selected only for a Firth operator")
+                .x_dense
+                .clone();
+            let penalties: Vec<Array2<f64>> = self
+                .canonical_penalties
+                .iter()
+                .map(|penalty| {
+                    let mut full = Array2::<f64>::zeros((penalty.total_dim, penalty.total_dim));
+                    full.slice_mut(ndarray::s![
+                        penalty.col_range.clone(),
+                        penalty.col_range.clone()
+                    ])
+                    .assign(&penalty.local);
+                    if let Some(z) = free_basis_opt.as_ref() {
+                        Self::projectwith_basis(&full, z)
+                    } else {
+                        full
+                    }
+                })
+                .collect();
+            Some(
+                DenseSpectralOperator::structural_rank_from_spans(&design, &penalties).map_err(
+                    |error| {
+                        EstimationError::InvalidInput(format!("Firth structural span: {error}"))
+                    },
+                )?,
+            )
+        } else {
+            None
+        };
 
         let c_nontrivial = pirls_result.solve_c_nontrivial;
 
@@ -1399,9 +1430,10 @@ impl<'a> RemlState<'a> {
             ) {
                 Ok(chol_op) => std::sync::Arc::new(chol_op),
                 Err(_) => std::sync::Arc::new(
-                    DenseSpectralOperator::from_symmetric_with_mode(
+                    DenseSpectralOperator::from_symmetric_with_mode_and_structural_rank(
                         h_for_operator.as_ref(),
                         hessian_mode,
+                        firth_structural_rank,
                     )
                     .map_err(|e| {
                         EstimationError::InvalidInput(format!(
@@ -1412,9 +1444,10 @@ impl<'a> RemlState<'a> {
             }
         } else {
             std::sync::Arc::new(
-                DenseSpectralOperator::from_symmetric_with_mode(
+                DenseSpectralOperator::from_symmetric_with_mode_and_structural_rank(
                     h_for_operator.as_ref(),
                     hessian_mode,
+                    firth_structural_rank,
                 )
                 .map_err(|e| {
                     EstimationError::InvalidInput(format!(
@@ -1496,17 +1529,18 @@ impl<'a> RemlState<'a> {
         // differentiates it. `InnerSolution::hessian_logdet_correction` keeps
         // its documented meaning — a uniform curvature rescale — and nothing
         // else.
-        let penalty_subspace_trace =
-            if matches!(hessian_mode, PseudoLogdetMode::Smooth) && c_nontrivial {
-                let (log_det_h_plus, kernel) =
-                    Self::intrinsic_hessian_pseudo_logdet_parts(h_for_operator.as_ref(), penalty_rank)?;
-                kernel.map(|mut kernel| {
-                    kernel.logdet_correction = log_det_h_plus - hessian_op.logdet();
-                    std::sync::Arc::new(kernel)
-                })
-            } else {
-                None
-            };
+        let penalty_subspace_trace = if matches!(hessian_mode, PseudoLogdetMode::Smooth)
+            && c_nontrivial
+        {
+            let (log_det_h_plus, kernel) =
+                Self::intrinsic_hessian_pseudo_logdet_parts(h_for_operator.as_ref(), penalty_rank)?;
+            kernel.map(|mut kernel| {
+                kernel.logdet_correction = log_det_h_plus - hessian_op.logdet();
+                std::sync::Arc::new(kernel)
+            })
+        } else {
+            None
+        };
         let hessian_logdet_correction = 0.0_f64;
 
         // #1271 diagnostic: dump the REML logdet internals at every dense
@@ -1807,6 +1841,37 @@ impl<'a> RemlState<'a> {
         } else {
             PseudoLogdetMode::Smooth
         };
+        let firth_structural_rank = if hessian_mode == PseudoLogdetMode::HardPseudo {
+            let design = bundle
+                .firth_dense_operator_original
+                .as_ref()
+                .or(bundle.firth_dense_operator.as_ref())
+                .expect("HardPseudo is selected only for a Firth operator")
+                .x_dense
+                .clone();
+            let penalties: Vec<Array2<f64>> = self
+                .canonical_penalties
+                .iter()
+                .map(|penalty| {
+                    let mut full = Array2::<f64>::zeros((penalty.total_dim, penalty.total_dim));
+                    full.slice_mut(ndarray::s![
+                        penalty.col_range.clone(),
+                        penalty.col_range.clone()
+                    ])
+                    .assign(&penalty.local);
+                    full
+                })
+                .collect();
+            Some(
+                DenseSpectralOperator::structural_rank_from_spans(&design, &penalties).map_err(
+                    |error| {
+                        EstimationError::InvalidInput(format!("Firth structural span: {error}"))
+                    },
+                )?,
+            )
+        } else {
+            None
+        };
         let c_nontrivial = pirls_result.solve_c_nontrivial;
 
         // Same Cholesky fast path as `build_dense_assembly`: for ValueOnly
@@ -1836,9 +1901,10 @@ impl<'a> RemlState<'a> {
         let hessian_op: std::sync::Arc<dyn super::reml_outer_engine::HessianFactorization> = {
             use super::reml_outer_engine::{DenseCholeskyOperator, HessianFactorization as _};
             let build_spectral = || -> Result<DenseSpectralOperator, EstimationError> {
-                let mut op = DenseSpectralOperator::from_symmetric_with_mode(
+                let mut op = DenseSpectralOperator::from_symmetric_with_mode_and_structural_rank(
                     &h_total_original,
                     hessian_mode,
+                    firth_structural_rank,
                 )
                 .map_err(|e| {
                     EstimationError::InvalidInput(format!(

--- a/crates/gam-solve/src/reml/reml_outer_engine/dense_spectral.rs
+++ b/crates/gam-solve/src/reml/reml_outer_engine/dense_spectral.rs
@@ -62,6 +62,54 @@ pub struct DenseSpectralOperator {
 }
 
 impl DenseSpectralOperator {
+    /// Rank of the union of a likelihood design span and unscaled penalty
+    /// spans.  Each source is normalized before addition, so the answer cannot
+    /// depend on a smoothing strength or on arbitrary units of one component.
+    pub(crate) fn structural_rank_from_spans(
+        design: &Array2<f64>,
+        penalties: &[Array2<f64>],
+    ) -> Result<usize, String> {
+        let p = design.ncols();
+        let mut span_gram = gam_linalg::faer_ndarray::fast_atb(design, design);
+        let design_scale = span_gram
+            .iter()
+            .map(|value| value * value)
+            .sum::<f64>()
+            .sqrt();
+        if design_scale > 0.0 {
+            span_gram.mapv_inplace(|value| value / design_scale);
+        }
+        for penalty in penalties {
+            if penalty.dim() != (p, p) {
+                return Err(format!(
+                    "structural span penalty is {}x{}, expected {p}x{p}",
+                    penalty.nrows(),
+                    penalty.ncols()
+                ));
+            }
+            let scale = penalty
+                .iter()
+                .map(|value| value * value)
+                .sum::<f64>()
+                .sqrt();
+            if scale > 0.0 {
+                span_gram.scaled_add(scale.recip(), penalty);
+            }
+        }
+        gam_linalg::matrix::symmetrize_in_place(&mut span_gram);
+        let (eigenvalues, _) = span_gram
+            .eigh(faer::Side::Lower)
+            .map_err(|error| format!("structural-span eigendecomposition failed: {error}"))?;
+        let largest = eigenvalues
+            .iter()
+            .fold(0.0_f64, |acc, &value| acc.max(value.abs()));
+        let threshold = (p.max(1) as f64) * f64::EPSILON * largest;
+        Ok(eigenvalues
+            .iter()
+            .filter(|&&value| value > threshold)
+            .count())
+    }
+
     /// Create from a symmetric matrix (may be indefinite or singular).
     ///
     /// The eigendecomposition is computed once. Eigenvalues are smoothly
@@ -82,6 +130,23 @@ impl DenseSpectralOperator {
     pub fn from_symmetric_with_mode(
         h: &Array2<f64>,
         mode: PseudoLogdetMode,
+    ) -> Result<Self, String> {
+        Self::from_symmetric_with_mode_and_structural_rank(h, mode, None)
+    }
+
+    /// Build a spectral factorization whose hard-pseudo rank is fixed by the
+    /// model's unscaled likelihood/penalty spans, rather than by the condition
+    /// number of the already-scaled Hessian.
+    ///
+    /// A smoothing strength is allowed to change eigenvalue magnitudes, but it
+    /// cannot change which coefficient directions exist in the Laplace
+    /// integral.  In particular, a `1e13` penalty must not make a second,
+    /// unit-strength smooth look structurally null merely because its Hessian
+    /// eigenvalue is less than `1e-5` of the largest one (#2835).
+    pub(crate) fn from_symmetric_with_mode_and_structural_rank(
+        h: &Array2<f64>,
+        mode: PseudoLogdetMode,
+        structural_rank: Option<usize>,
     ) -> Result<Self, String> {
         use faer::Side;
 
@@ -164,7 +229,28 @@ impl DenseSpectralOperator {
             PseudoLogdetMode::HardPseudo => {
                 let sigma_max = eigenvalues.iter().fold(0.0_f64, |acc, &s| acc.max(s.abs()));
                 let floor = epsilon.max(HARD_PSEUDO_RELATIVE_FLOOR * sigma_max);
-                eigenvalues.iter().map(|&s| s > floor).collect()
+                let mut active: Vec<bool> = eigenvalues.iter().map(|&s| s > floor).collect();
+                if let Some(rank) = structural_rank {
+                    let wanted = rank.min(n);
+                    let already = active.iter().filter(|&&keep| keep).count();
+                    if already < wanted {
+                        // `eigh` returns ascending eigenvalues.  Restore the
+                        // largest positive modes until the scale-independent
+                        // span rank is represented; exact structural aliases
+                        // remain inactive.
+                        let mut remaining = wanted - already;
+                        for index in (0..n).rev() {
+                            if remaining == 0 {
+                                break;
+                            }
+                            if !active[index] && eigenvalues[index] > 0.0 {
+                                active[index] = true;
+                                remaining -= 1;
+                            }
+                        }
+                    }
+                }
+                active
             }
         };
 

--- a/crates/gam-solve/src/reml/reml_outer_engine/tests.rs
+++ b/crates/gam-solve/src/reml/reml_outer_engine/tests.rs
@@ -7,6 +7,36 @@
 #![cfg(test)]
 
 use super::*;
+
+#[test]
+fn firth_hard_pseudo_rank_is_invariant_to_competing_smoothing_strengths() {
+    let design = array![[1.0, 0.0, 0.0]];
+    let weak_penalty = array![[0.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 0.0]];
+    let alias = Array2::<f64>::zeros((3, 3));
+    let structural_rank =
+        DenseSpectralOperator::structural_rank_from_spans(&design, &[weak_penalty.clone(), alias])
+            .expect("structural span rank");
+    assert_eq!(
+        structural_rank, 2,
+        "a true structural alias must remain absent"
+    );
+
+    for dominant_strength in [1.0, 1.0e8, 1.0e13] {
+        let h = array![
+            [dominant_strength, 0.0, 0.0],
+            [0.0, 1.0, 0.0],
+            [0.0, 0.0, 0.0]
+        ];
+        let op = DenseSpectralOperator::from_symmetric_with_mode_and_structural_rank(
+            &h,
+            PseudoLogdetMode::HardPseudo,
+            Some(structural_rank),
+        )
+        .expect("hard-pseudo factorization");
+        assert_eq!(op.active_rank(), 2);
+        assert_relative_eq!(op.trace_hinv_product(&weak_penalty), 1.0, epsilon = 1e-12);
+    }
+}
 use crate::estimate::smooth_floor_dp;
 use crate::estimate::smoothing_correction::DP_FLOOR;
 use approx::assert_relative_eq;
@@ -6686,7 +6716,8 @@ pub(crate) fn test_symmetric_eigen_diagonal() {
 pub(crate) fn test_pseudoinverse_times_vec_identity() {
     let eye = Array2::<f64>::eye(3);
     let v = Array1::from_vec(vec![1.0, 2.0, 3.0]);
-    let result = pseudoinverse_times_vec(&eye, v.as_slice().expect("contiguous test vector"), 1e-8).expect("pseudoinverse");
+    let result = pseudoinverse_times_vec(&eye, v.as_slice().expect("contiguous test vector"), 1e-8)
+        .expect("pseudoinverse");
     for i in 0..3 {
         assert!((result[i] - v[i]).abs() < 1e-12, "G=I: G⁺v should equal v");
     }
@@ -6701,7 +6732,8 @@ pub(crate) fn test_pseudoinverse_times_vec_singular() {
     g[[1, 0]] = 1.0;
     g[[1, 1]] = 1.0;
     let v = Array1::from_vec(vec![2.0, 0.0]);
-    let result = pseudoinverse_times_vec(&g, v.as_slice().expect("contiguous test vector"), 1e-8).expect("pseudoinverse");
+    let result = pseudoinverse_times_vec(&g, v.as_slice().expect("contiguous test vector"), 1e-8)
+        .expect("pseudoinverse");
     // G⁺ v = [0.25*2 + 0.25*0; 0.25*2 + 0.25*0] = [0.5; 0.5]
     assert!((result[0] - 0.5).abs() < 1e-10);
     assert!((result[1] - 0.5).abs() < 1e-10);
@@ -7020,7 +7052,8 @@ pub(crate) fn test_pseudoinverse_scalar() {
     let mut g = Array2::<f64>::zeros((1, 1));
     g[[0, 0]] = 4.0;
     let v = Array1::from_vec(vec![8.0]);
-    let result = pseudoinverse_times_vec(&g, v.as_slice().expect("contiguous test vector"), 1e-8).expect("pseudoinverse");
+    let result = pseudoinverse_times_vec(&g, v.as_slice().expect("contiguous test vector"), 1e-8)
+        .expect("pseudoinverse");
     assert!((result[0] - 2.0).abs() < 1e-12);
 }
 
@@ -8662,7 +8695,12 @@ fn trace_logdet_block_root_prices_channel_b_at_root_scale() {
 /// Build the box row `gam-terms/src/smooth/term_design.rs` assembles for
 /// `linear(x, min=LO, max=HI)`: `+e_col ≥ LO` and `−e_col ≥ −HI`, entries
 /// exactly `±1`, in ORIGINAL coefficient coordinates.
-fn box_rows_as_assembled(p: usize, col: usize, lo: f64, hi: f64) -> crate::pirls::LinearInequalityConstraints {
+fn box_rows_as_assembled(
+    p: usize,
+    col: usize,
+    lo: f64,
+    hi: f64,
+) -> crate::pirls::LinearInequalityConstraints {
     let mut a = ndarray::Array2::<f64>::zeros((2, p));
     a[[0, col]] = 1.0;
     a[[1, col]] = -1.0;
@@ -8675,7 +8713,8 @@ fn barrier_recognizes_a_box_row_that_carries_a_unit_entry() {
     // this is the case the pre-#2705 recognizer handled. It must be unchanged,
     // and unchanged BIT-FOR-BIT — the normalization divides by |val| == 1.0.
     let raw = box_rows_as_assembled(3, 1, 0.25, 4.0);
-    let cfg = BarrierConfig::from_constraints(Some(&raw)).expect("unit-entry box is a simple bound");
+    let cfg =
+        BarrierConfig::from_constraints(Some(&raw)).expect("unit-entry box is a simple bound");
     assert_eq!(cfg.constrained_indices, vec![1, 1]);
     assert_eq!(cfg.bound_signs, vec![1.0, -1.0]);
     assert_eq!(cfg.lower_bounds, vec![0.25, -4.0]);
@@ -8826,8 +8865,11 @@ impl HessianDerivativeProvider for NoDrift {
 fn spd(diagonal: [f64; 2]) -> Arc<dyn HessianFactorization> {
     let matrix = array![[diagonal[0], 0.0], [0.0, diagonal[1]]];
     Arc::new(
-        DenseSpectralOperator::from_symmetric_with_mode(&matrix, PseudoLogdetMode::PositiveDefinite)
-            .expect("SPD fixture factorizes"),
+        DenseSpectralOperator::from_symmetric_with_mode(
+            &matrix,
+            PseudoLogdetMode::PositiveDefinite,
+        )
+        .expect("SPD fixture factorizes"),
     )
 }
 
@@ -8979,7 +9021,9 @@ pub(crate) fn criterion_value_is_invariant_to_listing_a_zero_multiplier_active_r
     let mut h = xtx.clone();
     h.scaled_add(lambdas[0], &s1);
     h.scaled_add(lambdas[1], &s2);
-    let beta_hat = DenseSpectralOperator::from_symmetric(&h).unwrap().solve(&xty);
+    let beta_hat = DenseSpectralOperator::from_symmetric(&h)
+        .unwrap()
+        .solve(&xty);
     // Certify the premise rather than assume it: at this β̂ the penalized
     // gradient is zero, so every multiplier of every row is zero and no row
     // can be "binding" in any sense the criterion is entitled to price.
@@ -8997,8 +9041,8 @@ pub(crate) fn criterion_value_is_invariant_to_listing_a_zero_multiplier_active_r
             include_logdet_h: true,
             include_logdet_s: true,
         };
-        sol.active_constraints = active
-            .map(|a| std::sync::Arc::new(ActiveLinearConstraintBlock { a }));
+        sol.active_constraints =
+            active.map(|a| std::sync::Arc::new(ActiveLinearConstraintBlock { a }));
         reml_laml_evaluate(&sol, &rho, EvalMode::ValueOnly, None)
             .expect("the criterion must evaluate in both descriptions")
             .cost


### PR DESCRIPTION
### Motivation

- Firth-augmented REML was dropping legitimately identified penalty directions when a competing smoothing strength scaled Hessian eigenvalues below a relative numerical cutoff, which removed the `+½·λ_k·tr(H⁻¹S_k)` trace channel and left the constant `−½·rank(S_k)` pull that stalled outer smoothing (`firth=True` with two penalized smooths, #2835). 
- The fix ensures the Laplace integral’s effective rank is driven by the model's structural spans (likelihood + unscaled penalty spans) rather than by smoothing-magnitude-dependent spectral thresholds.

### Description

- Add `DenseSpectralOperator::structural_rank_from_spans` to compute a scale-independent structural rank from the union of a normalized design Gram and individually normalized penalty matrices. (file: `crates/gam-solve/src/reml/reml_outer_engine/dense_spectral.rs`).
- Extend the dense spectral constructor to accept an optional `structural_rank` and restore the largest positive modes up to that rank when `PseudoLogdetMode::HardPseudo` is active so competing smoothing strengths cannot delete structural directions. (file: `crates/gam-solve/src/reml/reml_outer_engine/dense_spectral.rs`).
- Wire the structural-rank computation into Firth-aware REML assembly so the HardPseudo active mask is informed by the model’s structural span (handles active-constraint projection and original-frame assembly paths). (file: `crates/gam-solve/src/reml/objective.rs`).
- Add a focused regression `firth_hard_pseudo_rank_is_invariant_to_competing_smoothing_strengths` that verifies the weaker smooth's trace survives when a dominant penalty strength grows across `1`, `1e8`, and `1e13`. (file: `crates/gam-solve/src/reml/reml_outer_engine/tests.rs`).

### Testing

- Ran `cargo check -p gam-solve`, which completed successfully for the modified crate (check passed). 
- Ran `cargo fmt --check` and `git diff --check` as lightweight hygiene checks, both passed. 
- Added the unit regression `firth_hard_pseudo_rank_is_invariant_to_competing_smoothing_strengths`; an attempt to run the focused `cargo test -p gam-solve firth_hard_pseudo_rank_is_invariant_to_competing_smoothing_strengths` was started but compilation of the workspace dependencies was still in progress in the environment and the test run did not complete in the session window. 
- A full `cargo build --workspace --all-targets` was initiated but did not complete within the available execution timeout, so full-workspace verification and the Python-wrapper seed sweep remain to be run in CI or a longer-running environment.