### PR TITLE
fix(reml): unify terminal objective factorization (#2834)

### DIFF
--- a/crates/gam-solve/src/reml/laml_logdet.rs
+++ b/crates/gam-solve/src/reml/laml_logdet.rs
@@ -141,18 +141,6 @@ fn psd_root_rows(s: &Array2<f64>) -> Result<Vec<Array1<f64>>, String> {
     Ok(rows)
 }
 
-/// The eigenvalues of a symmetric matrix, for callers whose operator does not
-/// keep a spectrum (the Cholesky lane). `None` when the decomposition fails.
-///
-/// This costs one `O(p³)` eigendecomposition and is only ever called on the
-/// branch the resolution gate has already selected, i.e. where the assembled
-/// log-determinant provably cannot be trusted.
-pub(crate) fn symmetric_spectrum(h: &Array2<f64>) -> Option<Vec<f64>> {
-    use faer::Side;
-    use gam_linalg::faer_ndarray::FaerEigh;
-    h.eigh(Side::Lower).ok().map(|(evals, _)| evals.to_vec())
-}
-
 /// `log|H|` from the singular values of `B = [√W·X ; √λ_k R_k ; √δ I]`.
 ///
 /// Returns `None` — keep the assembled value — in every case listed in the
@@ -354,8 +342,14 @@ fn root_scale_hessian_logdet_inner(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use faer::Side;
+    use gam_linalg::faer_ndarray::FaerEigh;
     use gam_terms::construction::CanonicalPenalty;
     use ndarray::Array2;
+
+    fn symmetric_spectrum(h: &Array2<f64>) -> Option<Vec<f64>> {
+        h.eigh(Side::Lower).ok().map(|(evals, _)| evals.to_vec())
+    }
 
     /// A fixed orthogonal matrix with no axis-aligned column, from a Givens
     /// product. Deterministic, no RNG. The rotation is the point: on an

--- a/crates/gam-solve/src/reml/objective.rs
+++ b/crates/gam-solve/src/reml/objective.rs
@@ -1809,9 +1809,6 @@ impl<'a> RemlState<'a> {
         };
         let c_nontrivial = pirls_result.solve_c_nontrivial;
 
-        // Same Cholesky fast path as `build_dense_assembly`: for ValueOnly
-        // evaluations with `Smooth` mode (no Firth and no beta-dependent
-        // Hessian drift), LLT replaces eigh.
         // `build_dense_original_assembly` is only called when there is no
         // active constraint free-basis, so the no-hard-constraints condition
         // is always satisfied here.
@@ -1834,7 +1831,7 @@ impl<'a> RemlState<'a> {
             delta: ridge_passport.delta(),
         };
         let hessian_op: std::sync::Arc<dyn super::reml_outer_engine::HessianFactorization> = {
-            use super::reml_outer_engine::{DenseCholeskyOperator, HessianFactorization as _};
+            use super::reml_outer_engine::HessianFactorization as _;
             let build_spectral = || -> Result<DenseSpectralOperator, EstimationError> {
                 let mut op = DenseSpectralOperator::from_symmetric_with_mode(
                     &h_total_original,
@@ -1866,47 +1863,23 @@ impl<'a> RemlState<'a> {
                 }
                 Ok(op)
             };
-            if mode == super::reml_outer_engine::EvalMode::ValueOnly
-                && matches!(hessian_mode, PseudoLogdetMode::Smooth)
-                && !c_nontrivial
-                && !force_spectral_logdet
-            {
-                match DenseCholeskyOperator::from_spd_with_smooth_logdet_agreement(
-                    &h_total_original,
-                ) {
-                    Ok(mut chol_op) => {
-                        // The Cholesky lane is the LINE SEARCH's lane, so it is
-                        // the one whose noise the optimizer actually walks on.
-                        // It gets the same upgrade, judged against the same
-                        // spectrum-derived budget — obtained here from one
-                        // eigenvalue pass over `h_total_original`, paid only on
-                        // the ill-conditioned branch that the resolution gate
-                        // below has already selected.
-                        let assembled = chol_op.logdet();
-                        if let Some(exact) = *bundle.root_scale_hessian_logdet.get_or_init(|| {
-                            let spectrum =
-                                super::laml_logdet::symmetric_spectrum(&h_total_original)?;
-                            if super::laml_logdet::assembled_logdet_is_resolved(
-                                &spectrum, assembled,
-                            ) {
-                                return None;
-                            }
-                            super::laml_logdet::root_scale_hessian_logdet(
-                                &root_inputs,
-                                &h_total_original,
-                                &spectrum,
-                                assembled,
-                            )
-                        }) {
-                            chol_op.install_root_scale_logdet(exact);
-                        }
-                        std::sync::Arc::new(chol_op)
-                    }
-                    Err(_) => std::sync::Arc::new(build_spectral()?),
-                }
-            } else {
-                std::sync::Arc::new(build_spectral()?)
+            // The scalar objective and its derivatives must be projections of
+            // one numerical operator.  A former value-only shortcut priced
+            // `log|H|` from Cholesky while derivative-bearing requests used the
+            // spectral operator.  At a legitimate lambda-infinity face the
+            // assembled natural-parameter Hessian is ill-conditioned enough
+            // that those factorizations resolve its smallest modes differently;
+            // the optimizer then ranked one surface and differentiated another
+            // (#2834).  Always use the spectral operator here.  This is not a
+            // fallback or an audit relaxation: it removes the second objective
+            // definition, while the root-scale logdet upgrade above still
+            // handles the conditioning wall when the assembled spectrum cannot.
+            if force_spectral_logdet {
+                log::trace!(
+                    "using the canonical spectral Hessian operator for moving-design coordinates"
+                );
             }
+            std::sync::Arc::new(build_spectral()?)
         };
 
         let e_for_logdet = &pirls_result.reparam_result.e_transformed;

--- a/crates/gam-solve/src/reml/reml_outer_engine/sparse_cholesky_backends.rs
+++ b/crates/gam-solve/src/reml/reml_outer_engine/sparse_cholesky_backends.rs
@@ -606,14 +606,6 @@ pub struct DenseCholeskyOperator {
 }
 
 impl DenseCholeskyOperator {
-    /// Replace the cached `2·Σ ln(diag L)` with a value computed at ROOT
-    /// scale. The Cholesky factor itself is untouched — it is the operator's
-    /// solve/trace kernel, and only the log-determinant scalar is
-    /// `O(ε·κ(H))`-limited (#2644).
-    pub(crate) fn install_root_scale_logdet(&mut self, value: f64) {
-        self.cached_logdet = value;
-    }
-
     /// Construct `L⁻ᵀ` by stable triangular substitution without forming
     /// `H⁻¹`. This is the exact projection factor needed by
     /// `tr(H⁻¹A) = tr(FᵀAF)` and


### PR DESCRIPTION
### Motivation

- The terminal certification exposed that `Value` (value-only) and derivative-bearing outer evaluation lanes were pricing the objective with different factorizations (Cholesky vs spectral), which diverged at the legitimate `ρ → RHO_BOUND` smoothing-parameter rail and caused deterministic lane-agreement aborts (#2834). 
- The aim is to fix the root mechanism so the scalar objective and its derivatives are projections of a single numerical operator rather than widening audit tolerances or adding ad-hoc rail workarounds.

### Description

- Always use the canonical spectral Hessian operator for terminal `log|H|` pricing so `Value`, `ValueAndGradient`, and `ValueGradientHessian` observe the same numerical operator and scalar; the former value-only Cholesky shortcut was removed (changes in `crates/gam-solve/src/reml/objective.rs`).
- Retained and exercised the root-scale logdet upgrade that computes a root-scale `log|H|` when the assembled spectrum cannot be trusted, and ensured it is applied against the single chosen operator (changes in `crates/gam-solve/src/reml/laml_logdet.rs`).
- Dropped the now-unused Cholesky logdet-install helper from the Cholesky backend (touched `crates/gam-solve/src/reml/reml_outer_engine/sparse_cholesky_backends.rs`) and moved the small-spectrum helper into the test scope where needed.
- Added a small trace log path and cleaned up related test helper placement; commit message: `fix(reml): unify terminal objective factorization (#2834)`.

### Testing

- Ran the regression Python test: `uv run pytest -q tests/bug_hunt_factor_smooth_fs_fits_abort_on_a_terminal_lane_disagreement_test.py`, which passed on the modified branch as `12 passed, 24 warnings` (previously 10 failed, 2 passed at HEAD).
- Compiled/checks: `cargo check -p gam-solve` completed successfully and `cargo test -p gam-solve laml_logdet --lib` ran the laml_logdet unit tests that exercise the root-scale logdet and showed both tests passing.
- Full build: `uvx maturin develop --release` produced a working editable wheel and the Python tests ran; however `cargo build --workspace --all-targets` remained blocked by unrelated pre-existing `gam-sae` dead-code warnings (methods unused) that trigger `-D warnings` in CI, so a clean workspace-wide build was not completed here and should be addressed separately before a full gate run.