### PR TITLE
fix(sae): pair and gate rerouted frame trials to full rerouted objective (fixes #2825)

### DIFF
--- a/crates/gam-sae/src/sparse_dict/block_stream.rs
+++ b/crates/gam-sae/src/sparse_dict/block_stream.rs
@@ -38,7 +38,10 @@
 //! uses sequential block updates; the streaming trajectory is different.
 //!
 //! EV describes the pass's measured frames with their profiled γ. Proposed frames
-//! remain an uncertified checkpoint until another pass measures them. Finalize
+//! remain an uncertified checkpoint until a paired pass reroutes both proposal
+//! and baseline and profiles a gamma for each. Only a strict full-objective
+//! improvement commits; rejection retracts halfway along the same frame direction
+//! and cannot certify stationarity. Finalize
 //! requires EV, γ, projector closure and tangent stationarity and returns the exact measured frames,
 //! γ and EV; an EV coincidence alone never certifies an unmeasured proposal.
 
@@ -126,6 +129,31 @@ fn block_row_postings(codes: &[RowBlockCode], blocks: usize) -> Vec<Vec<(usize, 
     postings
 }
 
+fn profiled_scalar(old_gamma: f32, rss: f64, numerator: f64, denominator: f64) -> (f32, f64) {
+    let gamma = if denominator == 0.0 {
+        0.0
+    } else {
+        (numerator / denominator) as f32
+    };
+    let old = old_gamma as f64;
+    let new = gamma as f64;
+    let correction = (new - old) * ((new + old) * denominator - 2.0 * numerator);
+    (gamma, (rss + correction).max(0.0))
+}
+
+/// Grassmann retraction halfway between a rejected proposal and its baseline.
+/// Repeated rejection therefore backtracks on the same proposed direction;
+/// there is no user-selected damping constant or search box.
+fn bisect_frame_trial(baseline: &Array2<f32>, proposal: &Array2<f32>, b: usize) -> Array2<f32> {
+    let mut midpoint = (baseline + proposal) * 0.5;
+    for mut block in midpoint.axis_chunks_iter_mut(Axis(0), b) {
+        let mut owned = block.to_owned();
+        gram_schmidt_rows(&mut owned);
+        block.assign(&owned);
+    }
+    midpoint
+}
+
 /// Per-shard summary returned by [`BlockSparseStreamState::partial_fit`].
 #[derive(Clone, Copy, Debug)]
 pub struct BlockShardStats {
@@ -188,6 +216,22 @@ struct PendingBlockBirth {
     baseline_second: Vec<Array2<f64>>,
 }
 
+/// A frame refresh is not committed until a second, paired streaming pass has
+/// priced both the proposal and the frame set which produced it.  Routing is
+/// repeated for both dictionaries: fixed-support descent is not evidence of
+/// descent after the top-k map changes (#2825).
+struct PendingFrameTrial {
+    baseline_decoder: Array2<f32>,
+    baseline_gamma: f32,
+    proposed_decoder: Array2<f32>,
+    baseline_rss: f64,
+    baseline_gamma_num: f64,
+    baseline_gamma_den: f64,
+    baseline_rows: usize,
+    baseline_usage: Vec<usize>,
+    baseline_second: Vec<Array2<f64>>,
+}
+
 /// Resumable state for a streaming block-sparse fit. Construct with [`Self::new`]
 /// (fit_begin), feed shards with [`Self::partial_fit`], close each epoch with
 /// [`Self::end_epoch`], and read the frames out with [`Self::finalize`]. The block
@@ -238,6 +282,7 @@ pub struct BlockSparseStreamState {
     last_rss: f64,
     last_rows: usize,
     pending_birth: Option<PendingBlockBirth>,
+    pending_frame: Option<PendingFrameTrial>,
 }
 
 /// Per-block honest-charge ledger over the last closed epoch, as parallel
@@ -340,6 +385,7 @@ impl BlockSparseStreamState {
             last_rss: 0.0,
             last_rows: 0,
             pending_birth: None,
+            pending_frame: None,
         })
     }
 
@@ -416,6 +462,7 @@ impl BlockSparseStreamState {
             last_rss: 0.0,
             last_rows: 0,
             pending_birth: None,
+            pending_frame: None,
         })
     }
 
@@ -476,6 +523,22 @@ impl BlockSparseStreamState {
             // mutating moments. Birth evidence uses a true paired full pass.
             let baseline_codes = self
                 .pending_birth
+                .as_ref()
+                .map(|pending| {
+                    route_and_code_all(
+                        rows,
+                        pending.baseline_decoder.view(),
+                        pending.baseline_gamma,
+                        self.g,
+                        b,
+                        self.k,
+                        self.config.minibatch,
+                        self.config.block_tile,
+                    )
+                })
+                .transpose()?;
+            let frame_baseline_codes = self
+                .pending_frame
                 .as_ref()
                 .map(|pending| {
                     route_and_code_all(
@@ -618,6 +681,40 @@ impl BlockSparseStreamState {
                     });
                 pending.baseline_rows += rows.nrows();
             }
+            if let (Some(pending), Some(baseline_codes)) =
+                (self.pending_frame.as_mut(), frame_baseline_codes.as_ref())
+            {
+                let baseline = project_coded_rows(
+                    rows,
+                    pending.baseline_decoder.view(),
+                    baseline_codes,
+                    b,
+                    pending.baseline_gamma,
+                );
+                for projection in &baseline {
+                    pending.baseline_rss += projection.rss;
+                    pending.baseline_gamma_num += projection.gamma_num;
+                    pending.baseline_gamma_den += projection.gamma_den;
+                }
+                let postings = block_row_postings(baseline_codes, self.g);
+                pending
+                    .baseline_second
+                    .par_iter_mut()
+                    .zip(pending.baseline_usage.par_iter_mut())
+                    .zip(postings.par_iter())
+                    .for_each(|((second, usage), entries)| {
+                        for &(row, slot) in entries {
+                            let w = &baseline_codes[row].projections[slot * b..(slot + 1) * b];
+                            for left in 0..b {
+                                for right in 0..b {
+                                    second[[left, right]] += w[left] * w[right];
+                                }
+                            }
+                        }
+                        *usage += entries.len();
+                    });
+                pending.baseline_rows += rows.nrows();
+            }
             self.row_count += rows.nrows();
             // Every completed minibatch leaves coherent accumulated state,
             // including when a later minibatch's router returns an error.
@@ -666,6 +763,54 @@ impl BlockSparseStreamState {
         for c in 0..p {
             tss += self.col_sumsq[c] - self.col_sum[c] * self.col_sum[c] / n;
         }
+        let mut rejected_frame = false;
+        if let Some(mut trial) = self.pending_frame.take() {
+            if trial.baseline_rows != self.row_count {
+                return Err(format!(
+                    "BlockSparseStream frame trial saw {} candidate rows but {} baseline rows",
+                    self.row_count, trial.baseline_rows,
+                ));
+            }
+            let (_, candidate_rss) =
+                profiled_scalar(self.gamma, self.rss, self.gamma_num, self.gamma_den);
+            let (baseline_gamma, baseline_rss) = profiled_scalar(
+                trial.baseline_gamma,
+                trial.baseline_rss,
+                trial.baseline_gamma_num,
+                trial.baseline_gamma_den,
+            );
+            // The two objectives were accumulated on identical rows.  Only a
+            // strict decrease may commit a rerouted proposal; equality has no
+            // directional information and is handled by backtracking.
+            if !(candidate_rss < baseline_rss) {
+                let midpoint =
+                    bisect_frame_trial(&trial.baseline_decoder, &trial.proposed_decoder, b);
+                self.decoder = trial.baseline_decoder.clone();
+                self.gamma = baseline_gamma;
+                self.rss = baseline_rss;
+                self.usage = std::mem::take(&mut trial.baseline_usage);
+                self.second = std::mem::take(&mut trial.baseline_second);
+                self.alive_count = self.usage.iter().filter(|&&count| count > 0).count();
+                if midpoint != self.decoder {
+                    let baseline_decoder = self.decoder.clone();
+                    self.decoder = midpoint.clone();
+                    self.pending_frame = Some(PendingFrameTrial {
+                        baseline_decoder,
+                        baseline_gamma,
+                        proposed_decoder: midpoint,
+                        baseline_rss: 0.0,
+                        baseline_gamma_num: 0.0,
+                        baseline_gamma_den: 0.0,
+                        baseline_rows: 0,
+                        baseline_usage: vec![0; self.g],
+                        baseline_second: (0..self.g)
+                            .map(|_| Array2::<f64>::zeros((b, b)))
+                            .collect(),
+                    });
+                }
+                rejected_frame = true;
+            }
+        }
         // Resolve a staged residual-row birth against the exact full-pass
         // criterion BEFORE any ordinary frame refresh consumes the candidate's
         // accumulators. A rejected proposal restores the complete baseline
@@ -711,7 +856,7 @@ impl BlockSparseStreamState {
         let mut candidate_decoder = self.decoder.clone();
         let mut gamma_residual = f64::INFINITY;
         let mut frame_residual = f64::INFINITY;
-        if !rejected_birth {
+        if !rejected_birth && !rejected_frame {
             // (γ) closed-form shared scalar from the accumulated least-squares.
             self.gamma = if self.gamma_den == 0.0 {
                 0.0
@@ -823,6 +968,7 @@ impl BlockSparseStreamState {
 
         let improve = ev - self.prev_ev;
         let stationary = !rejected_birth
+            && !rejected_frame
             && accepted_births == 0
             && improve.abs() <= self.config.tolerance
             && gamma_residual <= self.config.tolerance
@@ -835,10 +981,27 @@ impl BlockSparseStreamState {
         // Certify the frames actually measured in this pass, together with
         // their profiled gamma. A frame proposal needs the next pass before
         // it has either an EV or a gamma certificate of its own.
-        if !stationary && !rejected_birth {
-            self.decoder = candidate_decoder;
+        if !stationary && !rejected_birth && !rejected_frame {
+            let baseline_decoder = self.decoder.clone();
+            self.decoder = candidate_decoder.clone();
+            if self.decoder != baseline_decoder {
+                self.pending_frame = Some(PendingFrameTrial {
+                    baseline_decoder,
+                    baseline_gamma: self.gamma,
+                    proposed_decoder: candidate_decoder,
+                    baseline_rss: 0.0,
+                    baseline_gamma_num: 0.0,
+                    baseline_gamma_den: 0.0,
+                    baseline_rows: 0,
+                    baseline_usage: vec![0; self.g],
+                    baseline_second: (0..self.g).map(|_| Array2::<f64>::zeros((b, b))).collect(),
+                });
+            }
         }
-        let birth_pending = !rejected_birth && self.stage_birth_proposal();
+        let birth_pending = self.pending_frame.is_none()
+            && !rejected_birth
+            && !rejected_frame
+            && self.stage_birth_proposal();
         let converged = stationary && !birth_pending;
 
         self.prev_ev = ev;
@@ -963,12 +1126,12 @@ impl BlockSparseStreamState {
     /// error and the state itself remains the resumable checkpoint — stream more
     /// epochs and finalize again.
     pub fn finalize(&self) -> Result<BlockSparseStreamArtifact, String> {
-        if !self.converged || self.pending_birth.is_some() {
+        if !self.converged || self.pending_birth.is_some() || self.pending_frame.is_some() {
             return Err(format!(
                 "BlockSparseStream.finalize: streaming fit has not converged after {} epoch(s) \
                  (last EV {:.6e}, EV residual {:.3e}, gamma residual {:.3e}, frame residual {:.3e} \
                  vs tolerance {:.3e}, {} accepted block \
-                 birth(s) in the last epoch, birth pending={}); the stream state is a resumable \
+                 birth(s) in the last epoch, birth pending={}, frame trial pending={}); the stream state is a resumable \
                  checkpoint, not a model — run more epochs until end_epoch reports convergence",
                 self.epochs_run,
                 self.last_ev,
@@ -978,6 +1141,7 @@ impl BlockSparseStreamState {
                 self.config.tolerance,
                 self.last_accepted_births,
                 self.pending_birth.is_some(),
+                self.pending_frame.is_some(),
             ));
         }
         Ok(BlockSparseStreamArtifact {

--- a/crates/gam-sae/src/sparse_dict/block_stream_tests.rs
+++ b/crates/gam-sae/src/sparse_dict/block_stream_tests.rs
@@ -646,3 +646,54 @@ fn overcomplete_stream_accepts_one_evidence_birth_then_dead_tail_is_quiescent_20
     );
     assert!((artifact.explained_variance - 1.0).abs() <= f64::EPSILON);
 }
+
+#[test]
+fn rerouted_frame_trials_cannot_decrease_streamed_explained_variance_2825() {
+    // The production failure needs more than one over-complete block.  This
+    // deterministic small analogue deliberately has overlapping rank-two
+    // structure, six frames in R^8, top-k three, and no birth machinery.
+    let (rows, p, g, b) = (96usize, 8usize, 6usize, 2usize);
+    let mut bits = 0x2825_u64;
+    let x = Array2::from_shape_fn((rows, p), |(row, column)| {
+        bits = bits.wrapping_mul(6_364_136_223_846_793_005).wrapping_add(1);
+        let noise = ((bits >> 40) as f64 / (1_u64 << 24) as f64 - 0.5) * 0.05;
+        let phase = row as f64 * (column + 1) as f64 / rows as f64;
+        (phase.sin() + (phase * 2.0 + column as f64).cos() + noise) as f32
+    });
+    let config = BlockSparseConfig {
+        n_blocks: g,
+        block_size: b,
+        block_topk: 3,
+        max_epochs: 40,
+        minibatch: rows,
+        block_tile: g,
+        frame_ridge: 0.0,
+        aux_k: 0,
+        matryoshka_prefix: false,
+        tolerance: 1.0e-8,
+    };
+    let mut state = BlockSparseStreamState::new(x.slice(ndarray::s![..24, ..]), &config)
+        .expect("over-complete stream");
+    let mut previous = f64::NEG_INFINITY;
+    let mut measurable_improvements = 0usize;
+    for epoch in 0..config.max_epochs {
+        state.partial_fit(x.view()).expect("stream fixture");
+        let stats = state.end_epoch().expect("close epoch");
+        assert!(
+            stats.explained_variance >= previous,
+            "paired rerouting admitted a loss increase at epoch {epoch}: {previous:.17e} -> {:.17e}",
+            stats.explained_variance
+        );
+        if stats.explained_variance > previous && previous.is_finite() {
+            measurable_improvements += 1;
+        }
+        previous = stats.explained_variance;
+        if stats.converged {
+            break;
+        }
+    }
+    assert!(
+        measurable_improvements > 0,
+        "monotonicity would be vacuous if the frame lane never improved"
+    );
+}


### PR DESCRIPTION
### Motivation

- Prevent frame proposals from committing using a frozen-support surrogate when rerouting on the next pass can increase the true profiled reconstruction loss, which produced period-2 EV/capital γ cycling and could certify a non-fixed point. 
- Ensure the stored `explained_variance` and convergence certificate refer to the objective actually measured for the frames that are returned, not an old-gamma surrogate or a fixed-support surrogate. 

### Description

- Add a `PendingFrameTrial` record and plumbing to retain the baseline decoder/gamma and accumulate its routing moments alongside any proposed decoder so a paired comparison can be made after the next pass. 
- Compute independent profiled scalars with `profiled_scalar(...)` and compare candidate vs baseline full-pass RSS; only commit a proposed decoder when the fully rerouted objective is strictly better, and refuse commit otherwise. 
- Implement deterministic backtracking via `bisect_frame_trial(...)` that half-retracts and re-orthonormalises a rejected proposal rather than introducing damping constants or search boxes, and prevent a rejected trial from certifying convergence. 
- Expose the trial state so `finalize()` refuses to return an artifact while a frame trial is outstanding, and add the regression test `rerouted_frame_trials_cannot_decrease_streamed_explained_variance_2825` exercising an over-complete multi-block scenario with rerouting enabled. 

### Testing

- Ran the focused new regression with `RUSTFLAGS='--cap-lints allow' cargo test -p gam-sae rerouted_frame_trials_cannot_decrease_streamed_explained_variance_2825 -- --nocapture`, which reported the single test passed. 
- Ran the block-stream test suite with `RUSTFLAGS='--cap-lints allow' cargo test -p gam-sae sparse_dict::block_stream::block_stream_tests::`, which reported `11 passed, 0 failed` for the exercised tests. 
- `cargo check -p gam-sae` failed due to pre-existing dead-code warnings in unrelated files (two methods and one helper flagged as never used), so I did not force-suppress unrelated fixes in this patch. 
- A full `cargo build --workspace --all-targets` was started but could not be completed within the sandbox time budget; suggest CI/warm-cache host to run the full build and the larger Qwen-scale reproductions described in the issue.