### PR TITLE
fix(sae): stop refine extension on current KKT stall (#2822)

### DIFF
--- a/crates/gam-sae/src/manifold/construction_quasi_laplace.rs
+++ b/crates/gam-sae/src/manifold/construction_quasi_laplace.rs
@@ -841,7 +841,6 @@ impl SaeManifoldTerm {
             base_refine_iter
         };
         let mut previous_refine_grad_norm: Option<f64> = None;
-        let mut saw_refine_progress = false;
         // #2234 — one progress-gated extra refinement window (see the budget
         // escalation at the non-convergence refusal below). 0 until granted.
         let mut budget_escalation_extra = 0usize;
@@ -1169,7 +1168,6 @@ impl SaeManifoldTerm {
                             progress_refine_iter,
                             previous_refine_grad_norm,
                             grad_norm,
-                            saw_refine_progress,
                         );
                         if total_inner_iter >= refine_limit {
                             // #1117/#1118 — pre-stationarity genuinely-indefinite
@@ -1212,8 +1210,6 @@ impl SaeManifoldTerm {
                         }
                         let remaining = refine_limit - total_inner_iter;
                         let refine_iter = inner_max_iter.max(1).min(remaining);
-                        saw_refine_progress |=
-                            Self::refine_round_made_progress(previous_refine_grad_norm, grad_norm);
                         previous_refine_grad_norm = Some(grad_norm);
                         let refine = self.run_joint_fit_arrow_schur_for_quasi_laplace(
                             target,
@@ -1242,7 +1238,6 @@ impl SaeManifoldTerm {
                 progress_refine_iter,
                 previous_refine_grad_norm,
                 grad_norm,
-                saw_refine_progress,
             );
             let effective_refine_limit = refine_limit
                 .checked_add(budget_escalation_extra)
@@ -1259,8 +1254,8 @@ impl SaeManifoldTerm {
                 // line search sees cliffs in all directions, and the outer fit
                 // freezes at a live gradient and refuses to mint (measured
                 // fleet-wide 2026-07-10: gam-sae 126 test failures, ten-orders
-                // cost-lane disagreement at one ρ). A solve that is MEASURABLY
-                // DESCENDING (`saw_refine_progress`) is an unfinished
+                // cost-lane disagreement at one ρ). A solve whose latest KKT residual is
+                // MEASURABLY DESCENDING is an unfinished
                 // computation, not an infeasibility: grant it one additional
                 // window of the same size and keep refining. The ordinary
                 // nonstationary lane retains that single-window hang bound.
@@ -1347,7 +1342,9 @@ impl SaeManifoldTerm {
                     }
                     last_limit_certificate = Some(predicted_relative_decrease);
                 }
-                if (saw_refine_progress || gradient_stationary) && budget_escalation_extra == 0 {
+                if (refine_limit > base_refine_iter || gradient_stationary)
+                    && budget_escalation_extra == 0
+                {
                     let escalation_window = refine_limit.max(1);
                     // `refine_iteration_limit` is dynamic and may return a
                     // ceiling below the iterations already consumed.  Carry
@@ -1413,7 +1410,6 @@ impl SaeManifoldTerm {
                             polish_escalations += 1;
                             *criterion_fixed_point = false;
                             consecutive_objective_stalls = 0;
-                            saw_refine_progress = true;
                             budget_escalation_extra = total_inner_iter
                                 .saturating_sub(refine_limit)
                                 .saturating_add(refine_limit.max(1));
@@ -1613,8 +1609,6 @@ impl SaeManifoldTerm {
                 )
             })?;
             let refine_iter = inner_max_iter.max(1).min(remaining);
-            saw_refine_progress |=
-                Self::refine_round_made_progress(previous_refine_grad_norm, grad_norm);
             previous_refine_grad_norm = Some(grad_norm);
             let refine = self.run_joint_fit_arrow_schur_for_quasi_laplace(
                 target,
@@ -1880,7 +1874,6 @@ impl SaeManifoldTerm {
                     )? {
                         *criterion_fixed_point = false;
                         consecutive_objective_stalls = 0;
-                        saw_refine_progress = true;
                         continue;
                     }
                 }
@@ -1923,7 +1916,6 @@ impl SaeManifoldTerm {
                     if orbit.moved() {
                         *criterion_fixed_point = false;
                         consecutive_objective_stalls = 0;
-                        saw_refine_progress = true;
                         log::debug!(
                             "SAE inner refine loop: gauge-orbit descent recovered {:.6e} over \
                              {} round(s) at the objective-stall fixed point (span dim {}, \
@@ -2551,7 +2543,6 @@ impl SaeManifoldTerm {
         progress_refine_iter: usize,
         previous_grad_norm: Option<f64>,
         grad_norm: f64,
-        saw_refine_progress: bool,
     ) -> usize {
         // Flat affine-gauge valleys can keep crawling productively after the
         // historical base budget. Extend only when the measured KKT residual has
@@ -2559,13 +2550,12 @@ impl SaeManifoldTerm {
         // work budget (#968/#1029). Value-order probes pass the base budget as
         // their progress budget, so this branch cannot make probes expensive.
         //
-        // #2230 COST-PROPORTIONAL EXTENSION: `saw_refine_progress` is the
-        // LATEST-round verdict, not a sticky historical OR. The historical
-        // `|=` accumulation meant ONE gradient drop anywhere granted the
-        // 16×/64× extended budget for the rest of the evaluation — an
+        // #2230 COST-PROPORTIONAL EXTENSION: the latest pair of KKT residuals is
+        // the progress verdict. A historical `|=` latch meant ONE gradient drop
+        // anywhere granted the 16×/64× extended budget for the rest of the evaluation — an
         // oscillating or stalled tail then ground the full extended budget on
-        // every criterion eval (the #1094 "kept extending via
-        // saw_refine_progress from earlier rounds" pathology, and the
+        // every criterion eval (the #1094 “kept extending via progress from
+        // earlier rounds” pathology, and the
         // dominant per-eval cost of the measured multi-hour outer churn).
         // Under the per-round contract each extension round must PAY for
         // itself with a monotone KKT-residual decrease; the first
@@ -2576,7 +2566,7 @@ impl SaeManifoldTerm {
             return base_refine_iter;
         }
         let making_progress =
-            saw_refine_progress && Self::refine_round_made_progress(previous_grad_norm, grad_norm);
+            Self::refine_round_made_progress(previous_grad_norm, grad_norm);
         if making_progress && grad_norm.is_finite() {
             progress_refine_iter
         } else {

--- a/crates/gam-sae/src/manifold/tests.rs
+++ b/crates/gam-sae/src/manifold/tests.rs
@@ -3164,8 +3164,7 @@ pub(crate) fn refine_iteration_limit_probe_budget_never_extends() {
             probe_base,
             probe_base,
             Some(1.0),
-            0.5,
-            true
+            0.5
         ),
         probe_base
     );
@@ -3178,8 +3177,7 @@ pub(crate) fn refine_iteration_limit_probe_budget_never_extends() {
             accepted_base,
             accepted_progress,
             Some(1.0),
-            0.5,
-            false
+            0.5
         ),
         accepted_progress,
         "accepted-point policy: a real residual drop (prev=Some(1.0), now=0.5) must extend the \
@@ -3189,8 +3187,7 @@ pub(crate) fn refine_iteration_limit_probe_budget_never_extends() {
             accepted_base,
             accepted_progress,
             Some(1.0),
-            0.5,
-            false
+            0.5
         ),
     );
     // …a stalled residual does not…
@@ -3200,8 +3197,7 @@ pub(crate) fn refine_iteration_limit_probe_budget_never_extends() {
             accepted_base,
             accepted_progress,
             Some(1.0),
-            1.0,
-            false
+            1.0
         ),
         accepted_base
     );
@@ -3212,8 +3208,19 @@ pub(crate) fn refine_iteration_limit_probe_budget_never_extends() {
             accepted_base,
             accepted_progress,
             None,
-            1.0e9,
-            false
+            1.0e9
+        ),
+        accepted_base
+    );
+    // A drop in an earlier round cannot buy work for a later plateau. The old
+    // sticky progress latch extended this second call despite equal residuals.
+    assert_eq!(
+        SaeManifoldTerm::refine_iteration_limit(
+            accepted_base,
+            accepted_base,
+            accepted_progress,
+            Some(0.5),
+            0.5
         ),
         accepted_base
     );


### PR DESCRIPTION
### Motivation
- The SAE manifold inner-refinement loop could keep earning large progress windows based on a sticky historical progress latch, causing long-running refine loops that look like hangs and drive high memory use. 
- The intent is to make the refine-extension decision reflect the current solver state (most-recent KKT residuals) rather than a historical boolean that could be set once and never cleared. 
- A targeted change reduces runaway inner-work budgets while preserving certificate- and polish-based escalation paths used to permit genuinely-descending solves.

### Description
- Removed the historical `saw_refine_progress` latch and its updates so progress is not granted from a sticky historical flag. 
- Simplified `SaeManifoldTerm::refine_iteration_limit` to decide progress purely from the latest pair of KKT residuals via `refine_round_made_progress` rather than a passed boolean. 
- Adjusted the budget-escalation logic to use the computed `refine_limit > base_refine_iter` condition and preserved certificate- and polish-paid one-shot windows while avoiding unbounded grants from stale progress state. 
- Extended and corrected the regression `refine_iteration_limit_probe_budget_never_extends` to assert that an earlier round's drop cannot buy work for a later plateau and to exercise the new contract.

### Testing
- `cargo test -p gam-sae --lib refine_iteration_limit_probe_budget_never_extends -- --test-threads=1` ran and reported the test as passed. 
- `cargo test -p gam-sae --lib inference::layer_transport::invert_tests -- --test-threads=1` ran and all `12` tests passed. 
- `cargo test -p gam-sae --lib identifiability::tests -- --test-threads=1` ran and all `23` tests passed. 
- `cargo build --workspace --all-targets` could not be completed due to pre-existing warnings-as-errors (unused/dead-code helpers) unrelated to the refine-policy change and so the full workspace build failed on that gate.