### PR TITLE
fix(outer): continue only the exhausted ARC seed (#2817)

### DIFF
--- a/crates/gam-solve/src/rho_optimizer/run.rs
+++ b/crates/gam-solve/src/rho_optimizer/run.rs
@@ -8993,6 +8993,18 @@ pub(crate) fn run_outer_uncertified(
                     prev_attempt_grad_norm = Some(cur_grad_norm);
                     next.initial_rho = Some(result.rho.clone());
                     next.operator_initial_trust_radius = next_trust_radius;
+                    // This is a continuation of ONE exhausted trajectory, not a
+                    // new multistart search.  Leaving the original seed policy
+                    // intact caused `run_outer_with_plan` to enumerate all of
+                    // the generated seeds again after installing the checkpoint:
+                    // the three-seed standard-REML sweep therefore ran twice
+                    // whenever one candidate exhausted its budget (#2817).
+                    // Restrict the resumed plan to the checkpoint which carries
+                    // the evidence for the retry.  Besides avoiding unrelated
+                    // work, this preserves the meaning of the progress gate:
+                    // `prev_attempt_grad_norm` and the next terminal norm now
+                    // belong to the same trajectory.
+                    restrict_arc_retry_to_checkpoint(&mut next);
                     retry_config = Some(next);
                     arc_retries_left -= 1;
                     obj.reset();
@@ -9068,6 +9080,17 @@ pub(crate) fn run_outer_uncertified(
     Err(last_error.unwrap_or_else(|| {
         EstimationError::RemlOptimizationFailed(format!("all plan attempts exhausted ({context})"))
     }))
+}
+
+/// Turn an exhausted ARC plan into a single-checkpoint continuation.
+///
+/// Kept separate from the orchestration loop so the no-multistart-on-retry
+/// contract can be pinned without reproducing a full REML seed cascade.
+pub(crate) fn restrict_arc_retry_to_checkpoint(config: &mut OuterConfig) {
+    config.heuristic_lambdas = None;
+    config.seed_config.max_seeds = 1;
+    config.seed_config.seed_budget = 1;
+    config.screen_initial_rho = false;
 }
 
 // ─── Frontier ρ-scaling auto-switch (issue #986) ─────────────────────────

--- a/crates/gam-solve/src/rho_optimizer/run_plan_tests.rs
+++ b/crates/gam-solve/src/rho_optimizer/run_plan_tests.rs
@@ -5896,6 +5896,28 @@ fn run_nonconverged_arc_returns_typed_checkpoint_after_budget_retry_ladder() {
     );
 }
 
+#[test]
+fn arc_budget_retry_continues_only_the_exhausted_checkpoint() {
+    let mut config = OuterConfig::default();
+    config.heuristic_lambdas = Some(vec![0.5, 2.0, 8.0]);
+    config.seed_config.max_seeds = 7;
+    config.seed_config.seed_budget = 3;
+    config.screen_initial_rho = true;
+
+    super::super::run::restrict_arc_retry_to_checkpoint(&mut config);
+
+    assert!(
+        config.heuristic_lambdas.is_none(),
+        "a checkpoint continuation must not regenerate heuristic starts"
+    );
+    assert_eq!(config.seed_config.max_seeds, 1);
+    assert_eq!(config.seed_config.seed_budget, 1);
+    assert!(
+        !config.screen_initial_rho,
+        "the already-evaluated terminal checkpoint must be continued directly"
+    );
+}
+
 // The seed cascade: keep-best / parsimony ranking, Gaussian multistart,
 // expensive-seed screening and its cap ladder, the seed budget, and seed
 // projection before validation. Split out for the source-file length budget.


### PR DESCRIPTION
### Motivation
- The ARC budget-exhaustion retry cloned the entire plan (including multistart seed policies) when resuming an exhausted attempt, causing the generated seed sweep to be re-enumerated and re-run on retry instead of continuing the single exhausted trajectory (#2817).

### Description
- Restrict resumed ARC retries to continue only the exhausted checkpoint by clearing heuristic starts, limiting seeds to one, and disabling re-screening of the already-evaluated initial rho via `restrict_arc_retry_to_checkpoint` in `run.rs`.
- Call `restrict_arc_retry_to_checkpoint` when preparing the retry `OuterConfig` so the resumed run is a single-checkpoint continuation rather than a replay of the multistart sweep.
- Add unit test `arc_budget_retry_continues_only_the_exhausted_checkpoint` in `run_plan_tests.rs` to pin the contract that retry preparation removes multistart behavior and heuristic starts.
- Keep the existing behavior of returning a typed non-convergence checkpoint when ARC truly exhausts its budget; this change only prevents replaying unrelated seeds on retry.

### Testing
- Ran `cargo test -p gam-solve arc_budget_retry_continues_only_the_exhausted_checkpoint`, which passed (1 passed / 0 failed).
- Ran `cargo test -p gam-solve run_nonconverged_arc_returns_typed_checkpoint_after_budget_retry_ladder`, which passed (1 passed / 0 failed).
- Performed `git diff --check` with no issues and committed the change as `fix(outer): continue only the exhausted ARC seed (#2817)`.
- `cargo fmt --all -- --check` and `cargo build --workspace --all-targets` were attempted but could not be cleanly verified due to unrelated pre-existing formatting drift and unrelated `gam-sae` dead-code warnings in the workspace; these failures are not caused by the changes in this PR.