### PR TITLE
fix(reml): derive marginal-slope strength domains (#2767)

### DIFF
--- a/crates/gam-models/src/survival/marginal_slope/fit_entry.rs
+++ b/crates/gam-models/src/survival/marginal_slope/fit_entry.rs
@@ -634,11 +634,8 @@ pub(crate) fn fit_survival_marginal_slope_terms_impl(
         }
         if influence_absorber_residualized.is_some() {
             // The absorber's single learned ridge sits at the trailing extra
-            // slot; the seed is clamped into the outer ρ box.
-            out.push(
-                crate::marginal_slope_orthogonal::influence_absorber_log_lambda(n)
-                    .clamp(-12.0, 12.0),
-            );
+            // slot; its natural scale centres its resolution-derived outer domain.
+            out.push(crate::marginal_slope_orthogonal::influence_absorber_log_lambda(n));
         }
         out
     };

--- a/crates/gam-models/src/survival/marginal_slope/fit_setup.rs
+++ b/crates/gam-models/src/survival/marginal_slope/fit_setup.rs
@@ -351,9 +351,41 @@ where
         .into_iter()
         .map(|s| {
             let penalty_scale = mean_abs(s.diag().iter().copied()).max(1.0e-8);
-            (likelihood_scale / penalty_scale).ln().clamp(-12.0, 12.0)
+            (likelihood_scale / penalty_scale).ln()
         })
         .collect()
+}
+
+/// Return the closed smoothing-strength domain centred on each block's natural
+/// scale. At either edge one curvature is `sqrt(EPSILON)` times the other, the
+/// resolution relevant to the criterion gradient consumed by the outer solver.
+fn log_lambda_domain(seeds: &Array1<f64>) -> (Array1<f64>, Array1<f64>) {
+    let radius = -0.5 * f64::EPSILON.ln();
+    (
+        seeds.mapv(|seed| seed - radius),
+        seeds.mapv(|seed| seed + radius),
+    )
+}
+
+#[cfg(test)]
+mod log_lambda_domain_tests {
+    use super::*;
+
+    /// gam#2765/gam#2767: clipping a scale-derived seed to an unrelated wall
+    /// let the projected gradient certify while REML was still descending.
+    #[test]
+    fn scale_matched_log_lambda_seed_owns_a_resolution_derived_domain_2767() {
+        let design = DesignMatrix::from(Array2::from_elem((2, 1), 1.0e4));
+        let penalty = Array2::from_elem((1, 1), 1.0e-4);
+        let seeds = Array1::from_vec(block_log_lambda_seeds(&design, [&penalty]));
+        assert!(seeds[0] > 12.0, "the fixture must cross the removed hand box");
+
+        let (lower, upper) = log_lambda_domain(&seeds);
+        let radius = -0.5 * f64::EPSILON.ln();
+        assert_eq!(lower[0], seeds[0] - radius);
+        assert_eq!(upper[0], seeds[0] + radius);
+        assert!(lower[0] < seeds[0] && seeds[0] < upper[0]);
+    }
 }
 
 pub(crate) fn joint_setup(
@@ -396,8 +428,7 @@ pub(crate) fn joint_setup(
             rho0vec[start + idx] = value;
         }
     }
-    let rho_lower = Array1::<f64>::from_elem(rho_dim, -12.0);
-    let rho_upper = Array1::<f64>::from_elem(rho_dim, 12.0);
+    let (rho_lower, rho_upper) = log_lambda_domain(&rho0vec);
     // Time block has no spatial length scales (pure B-spline on time)
     let empty_kappa = SpatialLogKappaCoords::new_with_dims(Array1::zeros(0), vec![]);
     let marginal_kappa = SpatialLogKappaCoords::from_length_scales_aniso(


### PR DESCRIPTION
### Motivation
- The REML outer search could start a scale-derived `log λ` seed exactly on a hand-coded `[-12,12]` wall, letting the projected-gradient projection zero an outward component and incorrectly certify stationarity while the criterion was still descending.
- The same hard clamp was applied to the influence-absorber seed, reproducing the defect for that trailing coordinate.
- This caused the follow-up-varying slope recovery to stall/cap even though the slope geometry and derivatives were already implemented correctly; the real problem was the smoothing-strength domain and seed policy.

### Description
- Stop clipping the per-block scale seeds produced by `block_log_lambda_seeds(...)` so seeds reflect the design/penalty scale instead of being forced into `[-12,12]` (`fit_setup.rs`).
- Introduce `log_lambda_domain(seeds: &Array1<f64>) -> (Array1<f64>, Array1<f64>)` which returns a closed, per-coordinate domain centred on the natural seed with radius `ln(1/√ε)` (i.e. `-0.5 * ln(ε)`), and use it as the outer `ρ` bounds instead of the global `[-12,12]` box (`fit_setup.rs`).
- Remove the manual clamp for the influence-absorber seed so it is seeded at its natural log-λ and thus covered by the resolution-derived domain (`fit_entry.rs`).
- Add a focused unit test `scale_matched_log_lambda_seed_owns_a_resolution_derived_domain_2767` that constructs a seed outside the former hand box and asserts the seed sits strictly inside its computed resolution-derived domain (`fit_setup.rs`).

### Testing
- Ran `cargo check -p gam-models` which completed successfully (dev profile checked). 
- Started the focused unit test run `cargo test -p gam-models scale_matched_log_lambda_seed_owns_a_resolution_derived_domain_2767 --lib -- --nocapture`, but the test binary compilation/link step did not complete within the sandbox timeout so the test run could not be observed to completion. 
- Attempted `cargo build --workspace --all-targets`, but the full workspace build timed out during dependency compilation in this environment and did not complete here.
- Local compile-and-checks of the edited crates passed where they ran; the new unit test is included and should be exercised on a warm CI/build cache (see recommended follow-ups).