### PR TITLE
fix(models): preserve flexible-link response family (#2748)

### DIFF
--- a/crates/gam-models/src/fit_orchestration/fit.rs
+++ b/crates/gam-models/src/fit_orchestration/fit.rs
@@ -951,6 +951,11 @@ pub(crate) fn fit_standard_model(
     wiggle_options.compute_covariance = true;
     let wiggle_link_kind =
         resolved_wiggle_inverse_link(&request.family, &result.fit, &wiggle.link_kind)?;
+    let fitted_wiggle_family = LikelihoodSpec::try_new(
+        request.family.response.clone(),
+        wiggle_link_kind.clone(),
+    )
+    .map_err(|error| format!("invalid resolved link-wiggle likelihood: {error}"))?;
     let selected_wiggle_basis = select_binomial_mean_link_wiggle_basis_from_pilot(
         &result.design,
         &result.fit,
@@ -987,7 +992,7 @@ pub(crate) fn fit_standard_model(
     // fixed at the root by `BinomialMeanWiggleFamily::joint_jeffreys_term_required
     // = false`; the loud `Err` below catches the residual trust-region/active-set
     // non-convergence that the root fix cannot.
-    let solved = match fit_binomial_mean_wiggle_terms_with_selected_basis(
+    let mut solved = match fit_binomial_mean_wiggle_terms_with_selected_basis(
         request.data.view(),
         &result.resolvedspec,
         &result.design,
@@ -1029,6 +1034,11 @@ pub(crate) fn fit_standard_model(
                 .to_string(),
         );
     }
+    // The joint link-wiggle solver is a custom block family and therefore does
+    // not infer the observation-law metadata stored by the generic likelihood
+    // solver. Preserve the resolved response and inverse link explicitly;
+    // response-scale prediction after assembly or reload depends on it (#2748).
+    solved.fit.likelihood_family = Some(fitted_wiggle_family);
 
     Ok(StandardFitResult {
         saved_link_state: result.saved_link_state,

--- a/crates/gam-models/src/inference/model_payload_builders.rs
+++ b/crates/gam-models/src/inference/model_payload_builders.rs
@@ -517,7 +517,10 @@ pub fn assemble_standard_payload(
     let family = fit
         .likelihood_family
         .clone()
-        .unwrap_or_else(LikelihoodSpec::gaussian_identity);
+        .ok_or_else(|| {
+            "standard fit reached payload assembly without its resolved likelihood family"
+                .to_string()
+        })?;
     let estimator = expectile_tau_for_config(fit_config)
         .map_err(|error| format!("failed to persist estimator metadata: {error}"))?
         .map_or(FittedEstimator::Likelihood, |tau| {
@@ -2935,6 +2938,14 @@ mod standard_payload_penalty_topology_tests {
         else {
             panic!("flexible-link formula did not produce a standard fit");
         };
+        assert_eq!(
+            result.fit.likelihood_family,
+            Some(LikelihoodSpec::new(
+                ResponseFamily::Binomial,
+                InverseLink::Standard(StandardLink::Logit),
+            )),
+            "the custom link-wiggle solve must retain the response likelihood",
+        );
 
         let mean_dim = result.design.design.ncols();
         let raw_dim = result
@@ -2954,6 +2965,19 @@ mod standard_payload_penalty_topology_tests {
             result,
         })
         .expect("payload assembly must use the full realized raw penalty topology");
+        assert_eq!(payload.family, "binomial-logit");
+        assert_eq!(
+            payload.family_state.likelihood(),
+            LikelihoodSpec::binomial_logit(),
+        );
+        let serialized = serde_json::to_vec(&payload).expect("serialize flexible-link payload");
+        let payload: FittedModelPayload =
+            serde_json::from_slice(&serialized).expect("reload flexible-link payload");
+        assert_eq!(payload.family, "binomial-logit");
+        assert_eq!(
+            payload.family_state.likelihood(),
+            LikelihoodSpec::binomial_logit(),
+        );
         let fit = payload
             .fit_result
             .expect("standard payload must retain its canonical fit result");
@@ -2967,6 +2991,53 @@ mod standard_payload_penalty_topology_tests {
                 .null_space_logdet
                 .is_some_and(f64::is_finite),
             "the null-space Hessian log-determinant must be finite",
+        );
+    }
+
+    #[test]
+    fn flexible_probit_payload_retains_binomial_family_through_reload_2748() {
+        let dataset = six_column_flexible_binomial_fixture();
+        let formula = "y ~ x0 + x1 + x2 + x3 + x4 + link(type=flexible(probit))";
+        let config = FitConfig {
+            family: Some("binomial".to_string()),
+            ..FitConfig::default()
+        };
+        let FitResult::Standard(result) = fit_from_formula(formula, &dataset, &config)
+            .expect("the small identifiable flexible-probit fixture must fit")
+        else {
+            panic!("flexible-probit formula did not produce a standard fit");
+        };
+        assert_eq!(
+            result.fit.likelihood_family,
+            Some(LikelihoodSpec::binomial_probit()),
+        );
+
+        let payload = assemble_standard_payload(StandardPayloadInputs {
+            formula: formula.to_string(),
+            dataset: &dataset,
+            fit_config: &config,
+            result,
+        })
+        .expect("assemble flexible-probit payload");
+        assert_eq!(payload.family, "binomial-probit");
+        assert_eq!(
+            payload.family_state.likelihood(),
+            LikelihoodSpec::binomial_probit(),
+        );
+        let serialized = serde_json::to_vec(&payload).expect("serialize flexible-probit payload");
+        let reloaded: FittedModelPayload =
+            serde_json::from_slice(&serialized).expect("reload flexible-probit payload");
+        assert_eq!(reloaded.family, "binomial-probit");
+        assert_eq!(
+            reloaded.family_state.likelihood(),
+            LikelihoodSpec::binomial_probit(),
+        );
+        assert_eq!(
+            reloaded
+                .fit_result
+                .expect("reloaded payload retains fit result")
+                .likelihood_family,
+            Some(LikelihoodSpec::binomial_probit()),
         );
     }
 }


### PR DESCRIPTION
### Motivation

- A flexible-link binomial refit returned a `UnifiedFitResult` with `likelihood_family == None`, and the payload assembler silently substituted `gaussian_identity`, causing saved binomial models with learnable links to be persisted as Gaussian/Identity and producing wrong response-scale predictions (posterior_mean == linear predictor) in downstream consumers. 
- The change makes that producer omission loud and preserves the resolved binomial response + inverse-link when a link-wiggle refit succeeds so saved artifacts carry correct family/link metadata.

### Description

- In `crates/gam-models/src/fit_orchestration/fit.rs` construct a validated `LikelihoodSpec` from the original response and the resolved wiggle inverse link prior to running the link-wiggle solver and store it on the returned `solved.fit.likelihood_family` so the custom-family solver preserves observation-law metadata. 
- In `crates/gam-models/src/inference/model_payload_builders.rs` remove the silent fallback to `LikelihoodSpec::gaussian_identity()` and make payload assembly return an `Err` when `likelihood_family` is missing, preventing silent masking of the defect. 
- Add unit tests that exercise the flexible-link payload path and assert the response family/link is present before save, in the assembled payload, and after JSON serialization/reload (including a new `flexible_probit_payload_retains_binomial_family_through_reload_2748` test). 
- Commit: `fix(models): preserve flexible-link response family (#2748)` updating the two files above and the payload tests to pin the behavioural fix.

### Testing

- Ran `cargo check -p gam-models` which completed successfully and the modified crate compiles. 
- Added tests: `flexible_fit_payload_uses_the_full_six_plus_eleven_penalty_topology_2748` (extended to assert likelihood presence and payload roundtrip) and `flexible_probit_payload_retains_binomial_family_through_reload_2748` (new). 
- Attempted `cargo check -p gam-models --tests` and targeted `cargo test -p gam-models flexible_fit_payload_uses_the_full_six_plus_eleven_penalty_topology_2748`, but the test-profile compilation exceeded the interactive window and did not complete here, so the full test run could not be observed in this environment.