### PR TITLE
fix(reml): scale the matrix-free rho trust region (#2735)

### DIFF
--- a/crates/gam-solve/src/rho_optimizer/bridges.rs
+++ b/crates/gam-solve/src/rho_optimizer/bridges.rs
@@ -3327,6 +3327,262 @@ pub(crate) struct OuterOperatorBridge<'a> {
     pub(crate) last_value_grad_rho: Option<Array1<f64>>,
 }
 
+/// A fixed diagonal chart for the matrix-free trust-region solve.
+///
+/// The trust region in `opt` is Euclidean.  Raw log smoothing parameters can
+/// have curvature that differs by many orders of magnitude, so using that
+/// Euclidean ball directly makes every accepted step follow the stiffest
+/// coordinate.  This chart makes the diagonal magnitudes of the seed Hessian
+/// equal while preserving their geometric-mean magnitude (and hence the
+/// overall meaning of the configured trust radius).
+#[derive(Clone, Debug)]
+pub(crate) struct OuterDiagonalChart {
+    scale: Array1<f64>,
+}
+
+impl OuterDiagonalChart {
+    pub(crate) fn from_hessian(hessian: &Array2<f64>) -> Result<Self, ObjectiveEvalError> {
+        if hessian.nrows() != hessian.ncols() || hessian.nrows() == 0 {
+            return Err(ObjectiveEvalError::fatal(
+                "outer diagonal chart requires a non-empty square Hessian",
+            ));
+        }
+        let magnitudes: Vec<f64> = hessian.diag().iter().map(|entry| entry.abs()).collect();
+        if magnitudes.iter().any(|entry| !entry.is_finite()) {
+            return Err(ObjectiveEvalError::fatal(
+                "outer diagonal chart requires finite Hessian diagonal entries",
+            ));
+        }
+        let resolved: Vec<f64> = magnitudes
+            .iter()
+            .copied()
+            .filter(|entry| *entry > 0.0)
+            .collect();
+        // A structurally flat coordinate supplies no metric information. Keep
+        // it at the typical scale of the informative coordinates rather than
+        // inventing a numerical floor. If every coordinate is flat, the chart
+        // is the identity and the downstream stationarity certificate decides.
+        let geometric_mean = if resolved.is_empty() {
+            1.0
+        } else {
+            (resolved.iter().map(|entry| entry.ln()).sum::<f64>() / resolved.len() as f64).exp()
+        };
+        let scale = Array1::from_iter(magnitudes.into_iter().map(|entry| {
+            let resolved_entry = if entry == 0.0 { geometric_mean } else { entry };
+            (0.5 * (resolved_entry.ln() - geometric_mean.ln())).exp()
+        }));
+        Ok(Self { scale })
+    }
+
+    pub(crate) fn to_solver(&self, physical: &Array1<f64>) -> Array1<f64> {
+        physical * &self.scale
+    }
+
+    pub(crate) fn to_physical(&self, solver: &Array1<f64>) -> Array1<f64> {
+        solver / &self.scale
+    }
+
+    pub(crate) fn gradient_to_solver(&self, gradient: &Array1<f64>) -> Array1<f64> {
+        gradient / &self.scale
+    }
+
+    pub(crate) fn hessian_to_solver(&self, hessian: &Array2<f64>) -> Array2<f64> {
+        let mut transformed = hessian.clone();
+        for row in 0..transformed.nrows() {
+            for col in 0..transformed.ncols() {
+                transformed[[row, col]] /= self.scale[row] * self.scale[col];
+            }
+        }
+        transformed
+    }
+
+    pub(crate) fn bounds_to_solver(
+        &self,
+        lower: &Array1<f64>,
+        upper: &Array1<f64>,
+    ) -> (Array1<f64>, Array1<f64>) {
+        (lower * &self.scale, upper * &self.scale)
+    }
+
+    pub(crate) fn gradient_tolerance_to_solver(
+        &self,
+        mut tolerance: GradientTolerance,
+    ) -> GradientTolerance {
+        // `g_physical = D g_solver`, hence this conservative scalar band
+        // guarantees that a solver-side gradient exit also clears the caller's
+        // physical-coordinate requirement. The decrement exit needs no change:
+        // it is invariant under an invertible linear chart.
+        let maximum_scale = self.scale.iter().copied().fold(0.0_f64, f64::max);
+        tolerance.abs /= maximum_scale;
+        if let Some(relative) = tolerance.rel_cost.as_mut() {
+            *relative /= maximum_scale;
+        }
+        tolerance
+    }
+
+    pub(crate) fn sample_to_solver(&self, sample: OperatorSample) -> OperatorSample {
+        let hessian = match sample.hessian {
+            HessianValue::Dense(dense) => HessianValue::Dense(self.hessian_to_solver(&dense)),
+            HessianValue::Operator(operator) => {
+                HessianValue::Operator(Arc::new(ChartedHessianOperator {
+                    inner: operator,
+                    scale: self.scale.clone(),
+                }))
+            }
+            HessianValue::Unavailable => HessianValue::Unavailable,
+        };
+        OperatorSample {
+            value: sample.value,
+            gradient: self.gradient_to_solver(&sample.gradient),
+            hessian,
+        }
+    }
+
+    pub(crate) fn solution_to_physical(&self, solution: &mut Solution) {
+        solution.final_point = self.to_physical(&solution.final_point);
+        if let Some(gradient) = solution.final_gradient.as_mut() {
+            *gradient *= &self.scale;
+            solution.final_gradient_norm = Some(gradient.dot(gradient).sqrt());
+        }
+        if let Some(hessian) = solution.final_hessian.as_mut() {
+            for row in 0..hessian.nrows() {
+                for col in 0..hessian.ncols() {
+                    hessian[[row, col]] *= self.scale[row] * self.scale[col];
+                }
+            }
+        }
+    }
+}
+
+/// Presents an [`OuterOperatorBridge`] in the curvature-balanced chart above.
+pub(crate) struct ScaledOuterOperatorBridge<'a> {
+    pub(crate) inner: OuterOperatorBridge<'a>,
+    pub(crate) chart: OuterDiagonalChart,
+}
+
+struct ChartedHessianOperator {
+    inner: Arc<dyn HessianOperator>,
+    scale: Array1<f64>,
+}
+
+impl HessianOperator for ChartedHessianOperator {
+    fn dim(&self) -> usize {
+        self.scale.len()
+    }
+
+    fn apply_into(
+        &self,
+        vector: &Array1<f64>,
+        out: &mut Array1<f64>,
+    ) -> Result<(), ObjectiveEvalError> {
+        let physical_vector = vector / &self.scale;
+        self.inner.apply_into(&physical_vector, out)?;
+        *out /= &self.scale;
+        Ok(())
+    }
+
+    fn materialization(&self) -> HessianMaterialization {
+        self.inner.materialization()
+    }
+
+    fn materialize_dense(&self) -> Result<Array2<f64>, ObjectiveEvalError> {
+        Ok(OuterDiagonalChart {
+            scale: self.scale.clone(),
+        }
+        .hessian_to_solver(&self.inner.materialize_dense()?))
+    }
+}
+
+impl ZerothOrderObjective for ScaledOuterOperatorBridge<'_> {
+    fn eval_cost(&mut self, x: &Array1<f64>) -> Result<f64, ObjectiveEvalError> {
+        self.inner.eval_cost(&self.chart.to_physical(x))
+    }
+}
+
+impl FirstOrderObjective for ScaledOuterOperatorBridge<'_> {
+    fn eval_grad(&mut self, x: &Array1<f64>) -> Result<FirstOrderSample, ObjectiveEvalError> {
+        let sample = self.inner.eval_grad(&self.chart.to_physical(x))?;
+        Ok(FirstOrderSample {
+            value: sample.value,
+            gradient: self.chart.gradient_to_solver(&sample.gradient),
+        })
+    }
+}
+
+impl OperatorObjective for ScaledOuterOperatorBridge<'_> {
+    fn eval_value_grad_op(
+        &mut self,
+        x: &Array1<f64>,
+    ) -> Result<OperatorSample, ObjectiveEvalError> {
+        let sample = self.inner.eval_value_grad_op(&self.chart.to_physical(x))?;
+        let hessian = match sample.hessian {
+            HessianValue::Dense(dense) => HessianValue::Dense(self.chart.hessian_to_solver(&dense)),
+            HessianValue::Operator(operator) => {
+                HessianValue::Operator(Arc::new(ChartedHessianOperator {
+                    inner: operator,
+                    scale: self.chart.scale.clone(),
+                }))
+            }
+            HessianValue::Unavailable => HessianValue::Unavailable,
+        };
+        Ok(OperatorSample {
+            value: sample.value,
+            gradient: self.chart.gradient_to_solver(&sample.gradient),
+            hessian,
+        })
+    }
+}
+
+#[cfg(test)]
+mod outer_diagonal_chart_tests {
+    use super::*;
+    use approx::assert_relative_eq;
+    use ndarray::{Array2, array};
+
+    #[test]
+    fn operator_trust_region_chart_equalizes_seed_curvature_2735() {
+        let hessian = Array2::from_diag(&array![1.0e-6, 1.0, 1.0e6]);
+        let chart = OuterDiagonalChart::from_hessian(&hessian)
+            .expect("a finite nonsingular analytic Hessian defines a chart");
+        let transformed = chart.hessian_to_solver(&hessian);
+
+        assert_relative_eq!(
+            transformed[[0, 0]],
+            transformed[[1, 1]],
+            max_relative = 1.0e-14
+        );
+        assert_relative_eq!(
+            transformed[[1, 1]],
+            transformed[[2, 2]],
+            max_relative = 1.0e-14
+        );
+        let physical = array![-3.0, 2.0, 7.0];
+        let solver = chart.to_solver(&physical);
+        assert_eq!(chart.to_physical(&solver), physical);
+    }
+
+    #[test]
+    fn operator_trust_region_chart_preserves_directional_derivative_2735() {
+        let hessian = Array2::from_diag(&array![0.25, 4.0]);
+        let chart = OuterDiagonalChart::from_hessian(&hessian)
+            .expect("a finite nonsingular analytic Hessian defines a chart");
+        let physical_gradient = array![3.0, -5.0];
+        let solver_gradient = chart.gradient_to_solver(&physical_gradient);
+        let solver_direction = array![0.7, -1.2];
+        let physical_direction = chart.to_physical(&solver_direction);
+
+        let solver_derivative = solver_gradient.dot(&solver_direction);
+        let physical_derivative = physical_gradient.dot(&physical_direction);
+        assert_eq!(solver_derivative, physical_derivative);
+
+        let physical_tolerance = GradientTolerance::absolute(0.25);
+        let solver_tolerance = chart.gradient_tolerance_to_solver(physical_tolerance);
+        let solver_gradient_at_band = array![solver_tolerance.abs, 0.0];
+        let physical_gradient_at_band = &solver_gradient_at_band * &chart.scale;
+        assert!(physical_gradient_at_band.dot(&physical_gradient_at_band).sqrt() <= 0.25);
+    }
+}
+
 impl ZerothOrderObjective for OuterOperatorBridge<'_> {
     fn eval_cost(&mut self, x: &Array1<f64>) -> Result<f64, ObjectiveEvalError> {
         // Uncap the inner solve for the matrix-free TR line-search cost probe.

--- a/crates/gam-solve/src/rho_optimizer/run_plan.rs
+++ b/crates/gam-solve/src/rho_optimizer/run_plan.rs
@@ -2265,14 +2265,35 @@ pub(crate) fn run_outer_with_plan(
                         "[OUTER] {context}: analytic Hessian provided as Hv operator; \
                         routing to opt::MatrixFreeTrustRegion (Steihaug-Toint CG)"
                     );
-                    let (lo, hi) = &bounds_template;
-                    let bounds_obj = outer_bounds(lo, hi)?;
+                    let seed_hessian = match &seed_eval.hessian {
+                        HessianValue::Dense(hessian) => hessian.clone(),
+                        HessianValue::Operator(operator) => operator
+                            .materialize_dense()
+                            .map_err(|error| {
+                                EstimationError::RemlOptimizationFailed(format!(
+                                    "could not construct the analytic outer curvature chart: {error}"
+                                ))
+                            })?,
+                        HessianValue::Unavailable => {
+                            return Err(EstimationError::RemlOptimizationFailed(
+                                "operator route selected without an analytic Hessian".to_string(),
+                            ));
+                        }
+                    };
+                    let chart = OuterDiagonalChart::from_hessian(&seed_hessian).map_err(|error| {
+                        EstimationError::RemlOptimizationFailed(error.to_string())
+                    })?;
+                    let (scaled_lo, scaled_hi) =
+                        chart.bounds_to_solver(&bounds_template.0, &bounds_template.1);
+                    let bounds_obj = outer_bounds(&scaled_lo, &scaled_hi)?;
                     // Scale-aware tolerance via opt 0.5.0:
                     // `relative_to_cost(τ)` = `τ * (1 + |f|)` resolved
                     // at run time from the seed cost and initial grad
                     // norm. Replaces the previous gam-side
                     // precomputed `outer_scaled_tolerance` hack.
-                    let grad_tol = outer_gradient_tolerance(config);
+                    let grad_tol = chart.gradient_tolerance_to_solver(
+                        outer_gradient_tolerance(config),
+                    );
                     let max_iter = outer_max_iterations(config.max_iter)?;
 
                     // Translate the seed_eval into an opt::OperatorSample
@@ -2281,27 +2302,31 @@ pub(crate) fn run_outer_with_plan(
                     // eval. The Hessian translation goes through the
                     // gam->opt operator adapter when the seed Hessian is
                     // an Hv operator; Analytic seeds become Dense.
-                    let initial_op_sample = OperatorSample {
+                    let initial_op_sample = chart.sample_to_solver(OperatorSample {
                         value: seed_eval.cost,
                         gradient: seed_eval.gradient.clone(),
                         hessian: seed_eval.hessian.clone(),
+                    });
+
+                    let bridge_obj = ScaledOuterOperatorBridge {
+                        chart: chart.clone(),
+                        inner: OuterOperatorBridge {
+                            obj,
+                            layout,
+                            outer_inner_cap: config.outer_inner_cap.clone(),
+                            eval_count: 0,
+                            g_norm_initial: None,
+                            last_g_norm: None,
+                            last_value_grad_rho: None,
+                        },
                     };
 
-                    let bridge_obj = OuterOperatorBridge {
-                        obj,
-                        layout,
-                        outer_inner_cap: config.outer_inner_cap.clone(),
-                        eval_count: 0,
-                        g_norm_initial: None,
-                        last_g_norm: None,
-                        last_value_grad_rho: None,
-                    };
-
-                    let mut solver = MatrixFreeTrustRegion::new(seed.clone(), bridge_obj)
+                    let scaled_seed = chart.to_solver(&seed);
+                    let mut solver = MatrixFreeTrustRegion::new(scaled_seed.clone(), bridge_obj)
                         .with_bounds(bounds_obj)
                         .with_gradient_tolerance(grad_tol)
                         .with_max_iterations(max_iter)
-                        .with_initial_sample(seed.clone(), initial_op_sample)
+                        .with_initial_sample(scaled_seed, initial_op_sample)
                         // Looser Eisenstat–Walker forcing factor on the
                         // inner Steihaug–Toint CG (default 0.1 → 0.5). The
                         // matrix-free route is reached only after
@@ -2366,7 +2391,8 @@ pub(crate) fn run_outer_with_plan(
                     }
 
                     let mf_start = std::time::Instant::now();
-                    let report = solver.run_report();
+                    let mut report = solver.run_report();
+                    chart.solution_to_physical(&mut report.solution);
                     let mf_elapsed = mf_start.elapsed().as_secs_f64();
                     let final_radius = report.diagnostics.final_trust_radius;
                     log::info!(


### PR DESCRIPTION
### Motivation

- The matrix-free outer REML solver was using an Euclidean trust region over raw log-smoothing parameters whose Hessian curvature spans many orders of magnitude, so the stiffest coordinate controlled step lengths and every accepted step was boundary-limited, preventing convergence inside the fixture's budget. 
- Rather than raising iteration budgets, the proper fix is to change the solver geometry so the trust region respects curvature scaling and allows meaningful steps in well-conditioned directions.

### Description

- Introduce a curvature-balanced diagonal chart `OuterDiagonalChart` that derives per-coordinate scales from the seed analytic Hessian while preserving geometric-mean magnitude and handling structurally flat coordinates. (new code in `crates/gam-solve/src/rho_optimizer/bridges.rs`).
- Present the matrix-free outer objective in the scaled chart via `ScaledOuterOperatorBridge`, and transform parameter vectors, gradients, dense Hessians, Hessian-operator Hv paths, bounds, solver tolerances, and returned `Solution`s consistently between physical and solver coordinates. (changes in `bridges.rs`).
- Wire the scaled bridge into the matrix-free route so the solver runs in solver-coordinates constructed from the seed Hessian and translates the solution back to physical coordinates before reporting, and adjust the solver initial-sample and gradient tolerance accordingly. (changes in `crates/gam-solve/src/rho_optimizer/run_plan.rs`).
- Add focused regressions that assert curvature equalization and directional-derivative invariance to pin the math (`operator_trust_region_chart_equalizes_seed_curvature_2735` and `operator_trust_region_chart_preserves_directional_derivative_2735`).
- The change modifies solver geometry only (no iteration-cap loosening or heuristic retries are added).

### Testing

- Ran `cargo check -p gam-solve` which completed successfully for the modified crate. 
- Ran the new focused tests with `cargo test -p gam-solve operator_trust_region_chart --lib` and observed `2 passed; 0 failed` for the added regressions. 
- Attempted `cargo build --workspace --all-targets` but the full workspace build failed due to pre-existing unrelated dead-code warnings in `crates/gam-sae` (these are not caused by the changes in this PR). 
- I did not run the long-running full stress fixture (the production `n=50_000, K=500` run), because the fixture is multi-hour and requires the performance environment used in the issue thread; I recommend a follow-up stress run to verify the end-to-end wall-clock and held-out reconstruction behavior on a converged fit.