### PR TITLE
fix(sae): carry exact-A geometry through streaming Schur evidence (#2731)

### DIFF
--- a/crates/gam-sae/src/manifold/construction_quasi_laplace.rs
+++ b/crates/gam-sae/src/manifold/construction_quasi_laplace.rs
@@ -4445,6 +4445,9 @@ impl SaeManifoldTerm {
             self.beta_dim()
         };
         let mut schur_acc = Array2::<f64>::zeros((border_dim, border_dim));
+        let mut majorizer_acc = Array2::<f64>::zeros((border_dim, border_dim));
+        let mut clamp_acc = Array2::<f64>::zeros((border_dim, border_dim));
+        let mut exact_a_chunks = 0usize;
         let mut log_det_tt = 0.0_f64;
         // #2515 — same substitution as the matrix-free branch above, and for the
         // same reason: every factorization below is of `exact_a_evidence_system`'s
@@ -4503,19 +4506,44 @@ impl SaeManifoldTerm {
             // only β-side penalties, and `ΔC_ββ ≡ 0`.)
             let sys = chunk.exact_a_evidence_system(z_chunk, rho, &sys)?;
             let mut streaming = StreamingArrowSchur::from_system(&sys, sys.rows.len().max(1));
-            let (chunk_log_det_tt, chunk_schur) = streaming
-                .reduced_schur_and_log_det_tt(0.0, 0.0, &options)
+            let evidence = streaming
+                .evidence_schur_chunk(0.0, 0.0, &options)
                 .map_err(|err| format!("SaeManifoldTerm::streaming_exact_arrow_log_det: {err}"))?;
-            log_det_tt += chunk_log_det_tt;
+            log_det_tt += evidence.log_det_tt;
+            match (evidence.majorizer_metric, evidence.clamp_metric) {
+                (Some(majorizer), Some(clamp)) => {
+                    majorizer_acc += &majorizer;
+                    clamp_acc += &clamp;
+                    exact_a_chunks += 1;
+                }
+                (None, None) => {}
+                _ => {
+                    return Err("SaeManifoldTerm::streaming_exact_arrow_log_det: partial exact-A \
+                                chunk carrier is not a classification"
+                        .to_string());
+                }
+            }
             for row in 0..border_dim {
                 for col in 0..border_dim {
-                    schur_acc[[row, col]] += chunk_schur[[row, col]];
+                    schur_acc[[row, col]] += evidence.schur[[row, col]];
                 }
             }
             start = end;
         }
-        let log_det_schur = StreamingArrowSchur::reduced_schur_log_det(&schur_acc, &options)
-            .map_err(|err| format!("SaeManifoldTerm::streaming_exact_arrow_log_det: {err}"))?;
+        let expected_chunks = n_total.div_ceil(chunk_size);
+        if exact_a_chunks != 0 && exact_a_chunks != expected_chunks {
+            return Err("SaeManifoldTerm::streaming_exact_arrow_log_det: partial exact-A \
+                        chunk carrier would classify a different operator"
+                .to_string());
+        }
+        let exact_a = (exact_a_chunks == expected_chunks).then_some((&majorizer_acc, &clamp_acc));
+        let log_det_schur = StreamingArrowSchur::reduced_schur_log_det(
+            &schur_acc,
+            &options,
+            exact_a.map(|metrics| metrics.0),
+            exact_a.map(|metrics| metrics.1),
+        )
+        .map_err(|err| format!("SaeManifoldTerm::streaming_exact_arrow_log_det: {err}"))?;
         if let Some(ri) = rank_inputs.as_deref_mut() {
             ri.log_det_tt = log_det_tt;
         }

--- a/crates/gam-solve/src/arrow_schur/mod.rs
+++ b/crates/gam-solve/src/arrow_schur/mod.rs
@@ -110,6 +110,8 @@ mod system;
 #[cfg(test)]
 mod negative_curvature_2731_tests;
 #[cfg(test)]
+mod streaming_exact_a_carrier_2731_tests;
+#[cfg(test)]
 mod tests;
 #[cfg(test)]
 mod tests_device_gauge_2660;

--- a/crates/gam-solve/src/arrow_schur/streaming_exact_a_carrier_2731_tests.rs
+++ b/crates/gam-solve/src/arrow_schur/streaming_exact_a_carrier_2731_tests.rs
@@ -1,0 +1,78 @@
+//! Regression pins for #2731's chunked exact-A evidence contract.
+
+use super::*;
+use ndarray::array;
+
+fn refusing_options() -> ArrowSolveOptions {
+    ArrowSolveOptions::direct()
+        .with_indefinite_refusing_evidence_unit_deflation(SPECTRAL_DEFLATION_REL_FLOOR)
+}
+
+#[test]
+fn streaming_chunk_carries_exact_a_operands_from_the_source_system() {
+    let mut system = ArrowSchurSystem::new(1, 1, 1);
+    system.rows[0].htt[[0, 0]] = 1.0;
+    system.hbb[[0, 0]] = 2.0;
+    system.exact_a_classification = Some(ExactAClassificationGeometry {
+        rows: vec![ExactAClassificationRow {
+            delta_tt: array![[0.0]],
+            delta_tbeta: array![[0.0]],
+            clamp_diag: array![0.0],
+        }]
+        .into(),
+        border_indices: vec![0].into(),
+    });
+
+    let mut streaming = StreamingArrowSchur::from_system(&system, 1);
+    let contribution = streaming
+        .evidence_schur_chunk(0.0, 0.0, &refusing_options())
+        .expect("the streaming policy must travel with its exact-A operands");
+    assert_eq!(contribution.log_det_tt, 0.0);
+    assert_eq!(contribution.schur, array![[2.0]]);
+    assert_eq!(contribution.majorizer_metric, Some(array![[2.0]]));
+    assert_eq!(contribution.clamp_metric, Some(array![[0.0]]));
+}
+
+#[test]
+fn streaming_reduced_schur_prices_a_clamp_basin_with_its_carrier() {
+    let schur = array![[-0.5]];
+    let majorizer = array![[1.0]];
+    let clamp = array![[2.0]];
+    let value = StreamingArrowSchur::reduced_schur_log_det(
+        &schur,
+        &refusing_options(),
+        Some(&majorizer),
+        Some(&clamp),
+    )
+    .expect("the clamp restores positive basin curvature");
+    assert!((value - 1.5_f64.ln()).abs() <= 8.0 * f64::EPSILON);
+}
+
+#[test]
+fn streaming_refusing_policy_without_exact_a_carrier_still_declines() {
+    let error =
+        StreamingArrowSchur::reduced_schur_log_det(&array![[1.0]], &refusing_options(), None, None)
+            .expect_err("a verdict without its operands must remain an error");
+    assert!(error.to_string().contains("raw B/delta/clamp carrier"));
+}
+
+#[test]
+fn streaming_reduced_schur_rejects_a_partial_carrier() {
+    let error = StreamingArrowSchur::reduced_schur_log_det(
+        &array![[1.0]],
+        &refusing_options(),
+        Some(&array![[1.0]]),
+        None,
+    )
+    .expect_err("one metric cannot classify the exact operator");
+    assert!(error.to_string().contains("partial exact-A"));
+}
+
+#[test]
+fn non_refusing_unit_deflation_does_not_require_exact_a_geometry() {
+    let options =
+        ArrowSolveOptions::direct().with_evidence_unit_deflation(SPECTRAL_DEFLATION_REL_FLOOR);
+    let value = StreamingArrowSchur::reduced_schur_log_det(&array![[-0.5]], &options, None, None)
+        .expect("legacy unit deflation has no exact-A classification contract");
+    assert_eq!(value, 0.0, "unit stiffness contributes log(1) = 0");
+}

--- a/crates/gam-solve/src/arrow_schur/system.rs
+++ b/crates/gam-solve/src/arrow_schur/system.rs
@@ -1099,6 +1099,19 @@ pub struct StreamingArrowSchur {
     /// regression: #1273 wired the deflation into the dense path only). `None`
     /// for every non-evidence caller, which keeps the strict non-PD refusal.
     pub(crate) row_gauge_deflation: Option<ArrowRowGaugeDeflation>,
+    /// Raw exact-A operands used by the evidence classifier. The verdict and
+    /// operands form one contract; carrying only the refusing policy made the
+    /// streaming evidence route structurally unreachable (#2731).
+    pub(crate) exact_a_classification: Option<ExactAClassificationGeometry>,
+}
+
+/// One chunk's additive exact-evidence contribution, formed from one set of
+/// row factors so the Schur block cannot be separated from its classifier.
+pub struct StreamingEvidenceSchurChunk {
+    pub log_det_tt: f64,
+    pub schur: Array2<f64>,
+    pub majorizer_metric: Option<Array2<f64>>,
+    pub clamp_metric: Option<Array2<f64>>,
 }
 
 impl std::fmt::Debug for StreamingArrowSchur {
@@ -1145,6 +1158,7 @@ impl StreamingArrowSchur {
             evidence_factorization: false,
             refuse_resolved_indefinite: false,
             row_gauge_deflation: None,
+            exact_a_classification: None,
         }
     }
 
@@ -1208,6 +1222,7 @@ impl StreamingArrowSchur {
         // would deflate on the dense path but be refused / log-det-divergent on
         // the streaming path, breaking `streaming_logdet == full_logdet`.
         streaming.row_gauge_deflation = sys.row_gauge_deflation.clone();
+        streaming.exact_a_classification = sys.exact_a_classification.clone();
         streaming
     }
 
@@ -1226,27 +1241,34 @@ impl StreamingArrowSchur {
         di: usize,
         row_idx: usize,
     ) -> Result<Array2<f64>, ArrowSchurError> {
-        match self.row_gauge_deflation.as_ref() {
-            Some(deflation) => factor_one_row_result(
+        if self.row_gauge_deflation.is_some() || self.exact_a_classification.is_some() {
+            let gauge = self
+                .row_gauge_deflation
+                .as_ref()
+                .map(|deflation| deflation.row(row_idx))
+                .unwrap_or(&[]);
+            let exact_a = self
+                .exact_a_classification
+                .as_ref()
+                .and_then(|geometry| geometry.rows.get(row_idx));
+            factor_one_row_result(
                 row,
                 ridge_t,
                 di,
                 row_idx,
                 self.evidence_factorization,
-                deflation.row(row_idx),
+                gauge,
                 // Evidence path: opt into spectral discovery of an
                 // intrinsic-dimension-flat direction even when this row's
                 // supplied gauge list is empty/non-spanning — matching the
                 // `allow_spectral_deflation = true` the dense path passes.
                 true,
                 self.refuse_resolved_indefinite,
-                // The streaming system carries no exact-A classification
-                // geometry; the row is factored as it was before that
-                // classification existed.
-                None,
+                exact_a,
             )
-            .map(|result| result.factor),
-            None => factor_one_row(row, ridge_t, di, row_idx, self.evidence_factorization),
+            .map(|result| result.factor)
+        } else {
+            factor_one_row(row, ridge_t, di, row_idx, self.evidence_factorization)
         }
     }
 
@@ -1499,13 +1521,105 @@ impl StreamingArrowSchur {
         Ok((log_det_tt, schur))
     }
 
+    /// Form a complete chunk contribution for exact-A evidence classification.
+    pub fn evidence_schur_chunk(
+        &mut self,
+        ridge_t: f64,
+        ridge_beta: f64,
+        options: &ArrowSolveOptions,
+    ) -> Result<StreamingEvidenceSchurChunk, ArrowSchurError> {
+        if options.evidence_policy.refuses_resolved_indefinite()
+            && self.exact_a_classification.is_none()
+        {
+            return Err(ArrowSchurError::SchurFactorFailed {
+                reason: "exact-A evidence classification requires the raw B/delta/clamp carrier"
+                    .to_string(),
+            });
+        }
+        let sys = self.as_classification_system()?;
+        let backend = CpuBatchedBlockSolver;
+        let factors = factor_blocks_for_system(
+            &sys,
+            ridge_t,
+            options.evidence_policy,
+            &backend,
+            options.gpu_policy,
+        )?;
+        let mut log_det_tt = 0.0;
+        for row_idx in 0..sys.rows.len() {
+            let factor = factors.factors.factor(row_idx);
+            for axis in 0..factor.nrows() {
+                log_det_tt += 2.0 * factor[[axis, axis]].ln();
+            }
+        }
+        let schur = build_dense_schur_direct(
+            &sys,
+            &factors.factors,
+            ridge_beta,
+            &backend,
+            options.gpu_policy,
+        )?;
+        let classification = exact_a_reduced_classification(&sys, &factors.factors)?;
+        let (majorizer_metric, clamp_metric) = classification.map_or(
+            (None, None),
+            |classification| {
+                (
+                    Some(classification.majorizer_metric),
+                    Some(classification.clamp_metric),
+                )
+            },
+        );
+        Ok(StreamingEvidenceSchurChunk {
+            log_det_tt,
+            schur,
+            majorizer_metric,
+            clamp_metric,
+        })
+    }
+
+    fn as_classification_system(&self) -> Result<ArrowSchurSystem, ArrowSchurError> {
+        let mut rows = Vec::with_capacity(self.n_rows);
+        for row_idx in 0..self.n_rows {
+            let mut row = (self.row_builder)(row_idx)?;
+            let di = row.htt.nrows();
+            row.htbeta = self.row_htbeta(row_idx, &row, di);
+            rows.push(row);
+        }
+        let mut sys = ArrowSchurSystem::new_with_per_row_dims_empty_hbb_and_htbeta_cols(
+            self.row_dims.to_vec(),
+            self.k,
+            self.k,
+        );
+        sys.rows = rows;
+        sys.hbb = self.hbb.clone();
+        sys.gb = self.gb.clone();
+        sys.row_gauge_deflation = self.row_gauge_deflation.clone();
+        sys.exact_a_classification = self.exact_a_classification.clone();
+        Ok(sys)
+    }
+
     pub fn reduced_schur_log_det(
         schur: &Array2<f64>,
         options: &ArrowSolveOptions,
+        majorizer_metric: Option<&Array2<f64>>,
+        clamp_metric: Option<&Array2<f64>>,
     ) -> Result<f64, ArrowSchurError> {
-        let schur_factor =
-            factor_dense_reduced_schur(schur, options.evidence_policy.reduced_schur_policy())?
-                .factor;
+        let exact_a = match (majorizer_metric, clamp_metric) {
+            (Some(majorizer_metric), Some(clamp_metric)) => Some(ExactAReducedClassification {
+                majorizer_metric: majorizer_metric.clone(),
+                clamp_metric: clamp_metric.clone(),
+            }),
+            (None, None) => None,
+            _ => return Err(ArrowSchurError::SchurFactorFailed {
+                reason: "partial exact-A reduced-Schur carrier is not a classification".to_string(),
+            }),
+        };
+        let schur_factor = factor_dense_reduced_schur_with_exact_a(
+            schur,
+            options.evidence_policy.reduced_schur_policy(),
+            exact_a.as_ref(),
+        )?
+        .factor;
         let mut log_det_schur = 0.0_f64;
         for axis in 0..schur_factor.nrows() {
             log_det_schur += 2.0 * schur_factor[[axis, axis]].ln();


### PR DESCRIPTION
### Motivation

- Repair a contract defect that caused the chunked in-core streaming evidence route to always decline when the refusing-evidence policy was active because it carried the verdict but not the required `ExactAClassificationGeometry` operands.
- Preserve parity between the dense and streaming reduced-Schur log-determinant paths so the same classifier and factorization operate on the same operator and operands (preventing a permanently-dead route and wrong refusals at evaluation time).

### Description

- `StreamingArrowSchur` now carries the exact-A classification carrier from `ArrowSchurSystem` via `exact_a_classification`, and per-row factoring uses both the gauge and exact-A operands just like the dense path (streaming rows no longer hard-code `None`).
- Introduced `StreamingEvidenceSchurChunk` to return a chunk's `log_det_tt`, assembled `schur`, and the chunk's `majorizer_metric` and `clamp_metric` so classification and Schur assembly come from the same factorization.
- Added `evidence_schur_chunk` + `as_classification_system` helpers on `StreamingArrowSchur` to materialize per-chunk row factors, build the dense Schur for that chunk, and extract exact-A metrics for classifier use.
- Changed `StreamingArrowSchur::reduced_schur_log_det` to accept optional `majorizer_metric`/`clamp_metric` and to call `factor_dense_reduced_schur_with_exact_a` (rejecting partial carriers and refusing where the contract demands operands).
- Updated the SAE chunked criterion in `SaeManifoldTerm::streaming_exact_arrow_log_det` to accumulate Schur, majorizer and clamp per-chunk, require that the exact-A carrier either covers all chunks or none, and pass the accumulated exact-A metrics to the final reduced-Schur log-det factorization.
- Added unit tests `streaming_exact_a_carrier_2731_tests` that pin correct behavior for: a streaming chunk carrying the source exact-A operands, clamp-basin pricing when carrier is supplied, refusing the refusing-policy without operands, rejecting partial carriers, and unchanged behavior for non-refusing unit-deflation.

### Testing

- Ran `cargo test -p gam-solve streaming_exact_a_carrier_2731_tests` and the new suite passed: `5 passed; 0 failed`.
- Ran `cargo check -p gam-solve` which completed successfully on the modified tree.
- Ran `cargo check -p gam-sae` during iteration and observed `-D warnings` failures early (unused helper methods surfaced); these are pre-existing cruft unrelated to the streaming-carrier fix and were not introduced by this change.
- Started a full workspace build (`cargo build --workspace --all-targets`) in this environment; it completed but was long (~10 minutes in this sandbox) and did not expose new test regressions relevant to the streaming exact-A carrier changes.