### PR TITLE
fix(survival): reuse accepted baseline evaluations to avoid duplicate nested fits (#2714)

### DIFF
--- a/crates/gam-models/src/survival/construction.rs
+++ b/crates/gam-models/src/survival/construction.rs
@@ -847,6 +847,13 @@ where
     let target = initial.target;
     let engine_context = context.to_string();
     let objective = std::rc::Rc::new(std::cell::RefCell::new(objective));
+    // The outer engine asks for the scalar cost and then for derivatives at
+    // the same accepted point. A baseline evaluation can be a complete nested
+    // latent-survival REML fit, so retain the full result from the cost call.
+    // Taking rather than cloning also supports operator-valued Hessians.
+    let cost_eval_cache = std::rc::Rc::new(std::cell::RefCell::new(
+        None::<(Array1<f64>, gam_problem::OuterEval)>,
+    ));
     let eval_at = move |obj: &std::rc::Rc<std::cell::RefCell<F>>,
                         theta: &Array1<f64>|
           -> Result<gam_problem::OuterEval, crate::model_types::EstimationError> {
@@ -875,11 +882,25 @@ where
         Ok(eval)
     };
     let cost_objective = std::rc::Rc::clone(&objective);
+    let cost_cache = std::rc::Rc::clone(&cost_eval_cache);
     let cost_eval = eval_at.clone();
     let cost_fn = move |_: &mut (), theta: &Array1<f64>| {
-        cost_eval(&cost_objective, theta).map(|eval| eval.cost)
+        let eval = cost_eval(&cost_objective, theta)?;
+        let cost = eval.cost;
+        *cost_cache.borrow_mut() = Some((theta.clone(), eval));
+        Ok(cost)
     };
-    let eval_fn = move |_: &mut (), theta: &Array1<f64>| eval_at(&objective, theta);
+    let eval_fn = move |_: &mut (), theta: &Array1<f64>| {
+        let cached = {
+            let mut cache = cost_eval_cache.borrow_mut();
+            if cache.as_ref().is_some_and(|(cached_theta, _)| cached_theta == theta) {
+                cache.take().map(|(_, eval)| eval)
+            } else {
+                None
+            }
+        };
+        cached.map_or_else(|| eval_at(&objective, theta), Ok)
+    };
     run_baseline_theta_optimizer(initial, context, contract, cost_fn, eval_fn)
 }
 
@@ -4458,6 +4479,7 @@ fn finish_time_varying_survival_covariate_template(
 #[cfg(test)]
 mod tests {
     use super::{SURVIVAL_LIKELIHOOD_MODES, SURVIVAL_TIME_FLOOR, SurvivalBaselineConfig, SurvivalBaselineTarget, SurvivalLikelihoodMode, SurvivalMarginalSlopeFrozenOffsetChart, SurvivalTimeBasisConfig, baseline_chain_rule_gradient, baseline_offset_theta_partials, build_survival_marginal_slope_baseline_geometry, build_survival_marginal_slope_baseline_offsets, build_survival_time_basis, build_survival_timewiggle_from_baseline, evaluate_survival_baseline, evaluate_survival_marginal_slope_baseline, fitted_weibull_baseline_from_linear_time_beta, gompertz_cumulative_shape_derivative, gompertz_cumulative_shape_second_derivative, gompertz_hazard_components, marginal_slope_baseline_chain_rule_gradient, marginal_slope_baseline_offset_theta_partials, resolve_survival_time_anchor_for_mode, survival_baseline_config_from_theta, survival_baseline_theta_from_config, survival_data_is_left_truncated, survival_earliest_entry_time_anchor, survival_robust_interior_time_anchor, validate_survival_time_anchor_override};
+    use super::optimize_survival_baseline_config_with_gradient_only;
     use super::{
         center_survival_time_designs_at_anchor, evaluate_survival_time_basis_row,
         resolved_survival_time_basis_config_from_build,
@@ -5526,6 +5548,43 @@ mod tests {
              analytic={analytic:?}, fd={fd:?}, max_err={max_err:.3e}, \
              rel={rel:.3e} (analytic_inf_norm={analytic_norm:.3e})"
         );
+    }
+
+    /// gam#2714: do not execute a nested REML objective twice when the outer
+    /// engine requests cost and derivatives consecutively at one theta.
+    #[test]
+    fn baseline_optimizer_reuses_cost_evaluation_for_gradient_at_same_theta_2714() {
+        use std::cell::RefCell;
+
+        let initial = SurvivalBaselineConfig {
+            target: SurvivalBaselineTarget::Weibull,
+            scale: Some(2.0),
+            shape: Some(1.5),
+            rate: None,
+            makeham: None,
+        };
+        let previous_theta = RefCell::new(None::<Array1<f64>>);
+        let fitted = optimize_survival_baseline_config_with_gradient_only(
+            &initial,
+            "#2714 duplicate-evaluation regression",
+            |cfg| {
+                let theta = survival_baseline_theta_from_config(cfg)?
+                    .expect("Weibull baseline exposes theta");
+                assert_ne!(
+                    previous_theta.borrow().as_ref(),
+                    Some(&theta),
+                    "the adapter re-executed the expensive objective at the same theta"
+                );
+                *previous_theta.borrow_mut() = Some(theta.clone());
+                Ok((theta.dot(&theta), theta.mapv(|value| 2.0 * value)))
+            },
+        )
+        .expect("strictly convex baseline objective converges");
+
+        let theta = survival_baseline_theta_from_config(&fitted)
+            .expect("valid fitted baseline")
+            .expect("Weibull baseline exposes theta");
+        assert!(theta.iter().all(|value| value.abs() <= 1.0e-5));
     }
 
     /// Weibull (dim=2) companion to


### PR DESCRIPTION
### Motivation

- The frailty witness was spending excessive time because the baseline optimizer executed a full nested REML fit twice for the same accepted θ: once for the scalar cost call and again for the derivative call.  For latent-survival this duplicate is extremely expensive and turned a terminating run into an hour-scale hang.
- This change complements the earlier inner-solve mechanistic fixes by removing an orthogonal source of wasted work at the outer baseline level.

### Description

- Cache the `OuterEval` produced for the scalar-cost call inside `run_baseline_theta_optimizer_with_eval` and consume it on the immediately following derivative request when the requested `theta` is identical, avoiding a duplicate nested evaluation and preserving support for operator-valued Hessians by moving (not cloning) the cached value. (`crates/gam-models/src/survival/construction.rs`)
- Add a regression unit test `baseline_optimizer_reuses_cost_evaluation_for_gradient_at_same_theta_2714` which asserts the adapter does not re-run the expensive objective at the same θ and requires the optimizer to converge to the expected quadratic optimum.
- No solver tolerances, caps, or acceptance criteria were weakened; this is an efficiency/correctness change to avoid duplicate work only.

### Testing

- Ran `cargo check -p gam-models` which succeeded on this workspace snapshot (type-checked the crate).
- Added the unit test `baseline_optimizer_reuses_cost_evaluation_for_gradient_at_same_theta_2714` (present under `crates/gam-models/src/survival/construction.rs`) but an optimized full `cargo test` of the large workspace/test target did not complete inside the interactive iteration window, so I could not produce a full test-run pass/fail count for the new test here.
- Attempted focused checks (`cargo test -p gam-custom-family ...` and `cargo build --workspace --all-targets`) but these builds are heavy in this environment; compilation progressed but the full workspace/test builds were not finished, so no further automated-results are claimed from this sandbox.