### PR TITLE
fix(survival): use authoritative outer convergence path (#2705)

### DIFF
--- a/crates/gam-models/src/fit_orchestration/fit.rs
+++ b/crates/gam-models/src/fit_orchestration/fit.rs
@@ -187,23 +187,6 @@ const SURVIVAL_TRANSFORMATION_PIRLS_MAX_STEP_HALVING: usize = 40;
 
 const SURVIVAL_TRANSFORMATION_PIRLS_MIN_STEP_SIZE: f64 = 1e-12;
 
-/// Bounded checkpoint reseeds for the survival-transformation outer search
-/// (#2373). The transformation LAML outer runs a gradient-only BFGS (it declares
-/// no analytic outer Hessian), and `opt::Bfgs`'s flat-valley `StallPolicy` gates
-/// its flat-stall exit on `‖g‖∞ ≤ tol·(1 + ‖ρ‖∞)`. In log-λ space a baseline
-/// penalty that rails near its box edge makes `‖ρ‖∞ ≈ 10`, so that factor
-/// inflates the stall gradient gate ~10×: BFGS reports "converged (flat/stalled)"
-/// at a checkpoint whose projected gradient still exceeds the UN-inflated
-/// terminal certificate bound, and the fit is refused with genuine (unexploited)
-/// interior descent still available. The refusal is arithmetically correct, so
-/// recovery is to keep optimizing: the accumulated inverse-Hessian metric that
-/// produced the sub-tolerance steps is the stall's cause, and a fresh-metric BFGS
-/// resume seeded AT the refused `rho_checkpoint` recovers the descent — exactly
-/// the resume the refusal message advertises. This bounds how many such
-/// fresh-metric resumes are attempted before the honest non-convergence is
-/// surfaced.
-const SURVIVAL_TRANSFORMATION_OUTER_STALL_RESTARTS: usize = 10;
-
 struct SurvivalLocationScaleProfile {
     fit: SurvivalLocationScaleTermFitResult,
     inverse_link: InverseLink,
@@ -2197,92 +2180,49 @@ fn optimize_survival_transformation_smoothing(
     // in the error; a seed or best-so-far smoothing value is never promoted to
     // an estimator merely because a fixed-lambda inner solve was finite.
     //
-    // #2373 checkpoint resume: the gradient-only BFGS can bail on `opt::Bfgs`'s
-    // flat-valley `StallPolicy`, whose gradient gate is inflated by `(1 + ‖ρ‖∞)`
-    // — in log-λ space, ~10× — so it stops at a checkpoint that the un-inflated
-    // terminal certificate then rejects with real interior descent still on the
-    // table. The remedy the refusal itself advertises is to resume from
-    // `rho_checkpoint` with a fresh inverse-Hessian metric (the accumulated
-    // metric that crawled to sub-tolerance steps is the stall's cause). Each
-    // resume rebuilds the problem seeded at the prior checkpoint; `eval_at`'s
-    // warm-β cache is reused across resumes so the inner solves stay warm.
-    // Bounded so a genuine wall surfaces the honest non-convergence rather than
-    // spinning. A `run` that certifies on the first pass takes exactly one
-    // iteration of this loop, bit-for-bit as before.
-    let mut current_seed = seed_rho.clone();
-    let mut carried_iterations = 0usize;
-    let mut resumes_remaining = SURVIVAL_TRANSFORMATION_OUTER_STALL_RESTARTS;
-    let (outer_iterations, criterion_certificate, selected_rho) = loop {
-        let problem = OuterProblem::new(num_smoothing)
-            .with_gradient(Derivative::Analytic)
-            .with_hessian(gam_problem::DeclaredHessianForm::Unavailable)
-            .with_max_iter(120)
-            .with_bounds(lower.clone(), upper.clone())
-            .with_initial_rho(current_seed.clone())
-            .with_seed_config(gam_problem::SeedConfig {
-                max_seeds: 1,
-                seed_budget: 1,
-                ..Default::default()
-            });
-        let mut obj = problem.build_objective(
-            (),
-            |_: &mut (), rho: &Array1<f64>| eval_at(rho).map(|(c, _)| c),
-            |_: &mut (), rho: &Array1<f64>| {
-                let (cost, gradient) = eval_at(rho)?;
-                Ok(OuterEval {
-                    cost,
-                    gradient,
-                    hessian: HessianValue::Unavailable,
-                    inner_beta_hint: None,
-                })
-            },
-            None::<fn(&mut ())>,
-            None::<
-                fn(
-                    &mut (),
-                    &Array1<f64>,
-                )
-                    -> Result<gam_problem::EfsEval, gam_solve::estimate::EstimationError>,
-            >,
-        );
-        match problem.run(&mut obj, &context) {
-            // `run` certified the selected ρ: `iterations` (plus any carried
-            // from earlier resumes) is the true outer count and
-            // `criterion_certificate` carries the analytic stationarity bound the
-            // fit assembly gate requires (#2301 defect D).
-            Ok(result) => {
-                break (
-                    result.iterations.saturating_add(carried_iterations),
-                    result.criterion_certificate,
-                    result.rho,
-                );
-            }
-            Err(error) => {
-                // A flat-valley StallPolicy bail leaves a resumable
-                // `rho_checkpoint`; restart from it with a fresh BFGS metric
-                // while the resume budget lasts. Any other failure, or a spent
-                // budget, surfaces the honest non-convergence unchanged.
-                if resumes_remaining > 0
-                    && let gam_solve::estimate::EstimationError::RemlDidNotConverge {
-                        rho_checkpoint,
-                        iterations,
-                        ..
-                    } = &error
-                    && rho_checkpoint.len() == num_smoothing
-                {
-                    log::info!(
-                        "[OUTER] {context}: resuming from refused checkpoint {rho_checkpoint:?} \
-                         with a fresh BFGS metric ({resumes_remaining} resume(s) left)"
-                    );
-                    carried_iterations = carried_iterations.saturating_add(*iterations);
-                    resumes_remaining -= 1;
-                    current_seed = Array1::from_vec(rho_checkpoint.clone());
-                    continue;
-                }
-                return Err(error.to_string());
-            }
-        }
-    };
+    // The shared gradient-only outer route disables `opt`'s relative-stall
+    // predicate. That predicate scales its stationarity band by
+    // `(1 + ‖ρ‖∞)`, which is not the KKT contract for log smoothing
+    // parameters and used to stop this fit before the certificate's own band.
+    // Keep this caller on that single authoritative route: a refused result is
+    // non-convergence, not an invitation to rebuild BFGS with an arbitrary
+    // caller-owned retry budget.
+    let problem = OuterProblem::new(num_smoothing)
+        .with_gradient(Derivative::Analytic)
+        .with_hessian(gam_problem::DeclaredHessianForm::Unavailable)
+        .with_max_iter(120)
+        .with_bounds(lower.clone(), upper.clone())
+        .with_initial_rho(seed_rho.clone())
+        .with_seed_config(gam_problem::SeedConfig {
+            max_seeds: 1,
+            seed_budget: 1,
+            ..Default::default()
+        });
+    let mut obj = problem.build_objective(
+        (),
+        |_: &mut (), rho: &Array1<f64>| eval_at(rho).map(|(c, _)| c),
+        |_: &mut (), rho: &Array1<f64>| {
+            let (cost, gradient) = eval_at(rho)?;
+            Ok(OuterEval {
+                cost,
+                gradient,
+                hessian: HessianValue::Unavailable,
+                inner_beta_hint: None,
+            })
+        },
+        None::<fn(&mut ())>,
+        None::<
+            fn(
+                &mut (),
+                &Array1<f64>,
+            )
+                -> Result<gam_problem::EfsEval, gam_solve::estimate::EstimationError>,
+        >,
+    );
+    let result = problem.run(&mut obj, &context).map_err(|error| error.to_string())?;
+    let outer_iterations = result.iterations;
+    let criterion_certificate = result.criterion_certificate;
+    let selected_rho = result.rho;
     if selected_rho.len() != num_smoothing {
         return Err(format!(
             "survival transformation smoothing selector returned {} coordinates for \

--- a/tests/survival/survival/survival_transformation_resumes_flat_stall_checkpoint_2373.rs
+++ b/tests/survival/survival/survival_transformation_resumes_flat_stall_checkpoint_2373.rs
@@ -1,6 +1,6 @@
 //! Regression (#2373 defect A): a transformation-likelihood ("Royston-Parmar")
-//! survival fit whose gradient-only outer BFGS bails on `opt::Bfgs`'s
-//! flat-valley `StallPolicy` must still be minted.
+//! survival fit whose gradient-only outer BFGS used to bail on `opt::Bfgs`'s
+//! flat-valley `StallPolicy` must reach the actual KKT contract.
 //!
 //! Root cause: this path declares no analytic outer Hessian, so it runs
 //! `opt::Bfgs`, whose flat-stall exit gates on `‖g‖∞ ≤ tol·(1 + ‖ρ‖∞)`. In
@@ -8,10 +8,10 @@
 //! inflating that gate ~10× — so BFGS reports "converged (flat/stalled)" at a
 //! checkpoint whose projected gradient still exceeds the un-inflated terminal
 //! certificate bound, and the certificate (correctly) refuses with real
-//! interior descent remaining. `optimize_survival_transformation_smoothing` now
-//! resumes the outer search from the printed `rho_checkpoint` with a fresh BFGS
-//! inverse-Hessian metric (bounded), which recovers the descent the accumulated
-//! metric stalled on.
+//! interior descent remaining. The shared first-order outer route now disables
+//! that duplicate relative-stall predicate and lets BFGS run until the
+//! authoritative analytic certificate accepts the point. No survival-specific
+//! retry, cap, or relaxed tolerance is involved.
 //!
 //! DGP: the reporter's two-smooth Weibull cohort (shape 1.6, log-hazard slopes
 //! +0.7 / −0.5). With two smooth terms plus the baseline I-spline penalties the
@@ -78,7 +78,7 @@ fn build_two_smooth_survival_frame() -> gam::data::EncodedDataset {
 }
 
 #[test]
-fn survival_transformation_two_smooth_fit_resumes_past_flat_valley_stall() {
+fn survival_transformation_two_smooth_fit_reaches_kkt_without_relative_stall() {
     let ds = build_two_smooth_survival_frame();
     let cfg = FitConfig {
         survival_likelihood: Some("transformation".to_string()),
@@ -88,17 +88,16 @@ fn survival_transformation_two_smooth_fit_resumes_past_flat_valley_stall() {
         ..FitConfig::default()
     };
     // Before #2373A this cohort refused with a `RemlDidNotConverge` flat-valley
-    // stall; the caller-level checkpoint resume must now mint a certified fit.
+    // stall; the shared optimizer must now mint a certified fit directly.
     let result = fit_from_formula("Surv(time, event) ~ s(x1) + s(x2)", &ds, &cfg)
-        .expect("two-smooth Royston-Parmar fit must certify via the flat-stall checkpoint resume");
+        .expect("two-smooth Royston-Parmar fit must reach the analytic KKT certificate");
     let FitResult::SurvivalTransformation(fit) = result else {
         panic!("expected a survival-transformation (Royston-Parmar) fit result");
     };
 
     let evidence = fit.fit.convergence_evidence();
-    // A minted fit seals a certified `Converged` inner mode; the outer stall
-    // that produced it can only ship as a fit once the resume reaches a
-    // certified stationary rho.
+    // A minted fit seals a certified `Converged` inner mode; the old relative
+    // stall must not bypass either inner or outer certification.
     assert_eq!(
         evidence.inner_status(),
         PirlsStatus::Converged,


### PR DESCRIPTION
### Motivation

- The transformation-survival regression was being refused after a gradient-only BFGS flat/stall exit because `opt::Bfgs`'s duplicate relative-stall predicate (scaled by `(1 + ‖ρ‖∞)`) could stop the solver before the authoritative analytic projected-KKT certificate accepted the point.
- A survival-specific retry loop re-seeded BFGS up to a hard-coded budget to recover descent, which treated refusal procedurally instead of relying on the canonical outer-optimizer contract and therefore risked hiding genuine non-convergence or creating cap/ retry complexity.

### Description

- Remove the survival-specific checkpoint-resume retry loop and its hard-coded budget, and call the shared `OuterProblem` once, propagating its success or typed non-convergence up to the caller (`crates/gam-models/src/fit_orchestration/fit.rs`).
- Stop rebuilding BFGS repeatedly from a caller-owned loop; keep the outer selection/ certificate as the single authoritative path for smoothing-parameter selection and fit assembly.
- Update and rename the regression test to document the intended invariant and to assert the fit reaches the analytic KKT certificate without survival-specific retries: `survival_transformation_two_smooth_fit_reaches_kkt_without_relative_stall` (tests/survival/.../survival_transformation_resumes_flat_stall_checkpoint_2373.rs).
- Commit message: `fix(survival): use authoritative outer convergence path (#2705)` (local commit present).

### Testing

- Ran `cargo check -p gam-models --lib`, which completed successfully for the modified crate.
- Ran `git diff --check` and basic repository checks, which reported no whitespace or diff-check failures for this patch.
- Attempted to run the targeted survival regression and full build/test (`cargo build -p gam-cli --bin gam && cargo test --locked --test regressions ...`), but the workspace build failed due to unrelated existing dead-code-as-error failures in `gam-sae` (two unused-method errors), so the renamed test and full regressions binary could not be executed here; those unrelated warnings must be fixed before asserting runtime test results.
- `cargo fmt --check` was not used to gate this change (workspace-wide formatting diffs exist outside this patch), and the commit is limited to the described logical changes.