### PR TITLE
fix(custom-family): remove arbitrary eigenvalue floor from SPD fallback (#2469)

### DIFF
--- a/crates/gam-custom-family/src/blockwise_solve.rs
+++ b/crates/gam-custom-family/src/blockwise_solve.rs
@@ -2285,33 +2285,25 @@ pub(crate) const STRICT_SPD_LM_RIDGE_GROWTH: f64 = 10.0;
 // holding a second definition.
 pub(crate) use gam_problem::CUSTOM_FAMILY_RIDGE_FLOOR;
 
-/// Relative eigenvalue floor used wherever an eigendecomposition needs to
-/// distinguish "real" curvature from noise: `eps_floor = EVAL_FLOOR · max|λ|`.
-/// Applied uniformly in the strict-SPD LM eigen fallback, positive-part
-/// pseudo-inverse, and penalty-direction projection.
-pub(crate) const CUSTOM_FAMILY_EVAL_FLOOR: f64 = 1e-12;
-
-/// Absolute relative-condition guard used to prevent the eigen / spectral
-/// floors from collapsing to zero when `max|λ|` is itself tiny. Combined with
-/// `CUSTOM_FAMILY_EVAL_FLOOR · max|λ|` via `.max(...)`.
+/// Relative condition guard for rejecting genuinely negative spectrum in the
+/// penalty-direction projection.
 pub(crate) const CUSTOM_FAMILY_CONDITION_RELATIVE_FLOOR: f64 = 1e-14;
 
 /// Shared engine: try the bare strict path, fall through to an escalating
-/// LM δ-ridge Cholesky, and finally an eigen-floor fallback that clamps every
-/// eigenvalue from below at `eps_floor = 1e-12 · max|λ|`. Each caller
+/// LM δ-ridge Cholesky, and finally an eigendecomposition fallback. Each caller
 /// (solve / inverse / logdet) supplies the three operation-specific closures.
 ///
 /// Centralizing the LM/eigen scaffolding here both removes ~180 lines of
 /// near-duplicated code and guarantees the three sibling helpers stay in
 /// lockstep — any future change to the schedule, the trace_scale heuristic,
-/// or the eigen-floor logic now lives in exactly one place.
+/// or the eigenspectrum fallback now lives in exactly one place.
 pub(crate) fn strict_spd_lm_engine<R>(
     matrix: &Array2<f64>,
     op_label: &'static str,
     empty: R,
     bare_path: impl FnOnce(&Array2<f64>) -> Result<R, CustomFamilyError>,
     process_chol: impl FnOnce(&gam_linalg::faer_ndarray::FaerCholeskyFactor) -> R,
-    process_eigen: impl FnOnce(&Array1<f64>, &Array2<f64>, f64) -> R,
+    process_eigen: impl FnOnce(&Array1<f64>, &Array2<f64>) -> R,
 ) -> Result<(R, StrictSpdLmStats), CustomFamilyError> {
     if let Ok(r) = bare_path(matrix) {
         return Ok((r, StrictSpdLmStats::default()));
@@ -2352,24 +2344,20 @@ pub(crate) fn strict_spd_lm_engine<R>(
         Err(exhausted) => exhausted,
     };
 
-    // δ-ridge schedule exhausted; fall back to rank-aware eigen-floor handling.
-    // Floors every eigenvalue at `eps_floor = 1e-12 · max|λ|` so well-conditioned
-    // modes are resolved exactly and rank-deficient directions are handled with
-    // controlled curvature, preventing the spatial-adaptive pilot from collapsing
-    // to a cold full-data run.
+    // δ-ridge schedule exhausted; expose the exact spectrum to the operation.
+    // The solve consumer applies Moore–Penrose semantics on the resolved positive
+    // eigenspace rather than inventing curvature for null and negative modes.
     let max_esc = STRICT_SPD_LM_MAX_ESCALATIONS;
     let delta = exhausted.next_ridge;
     let (evals, evecs) = FaerEigh::eigh(&sym, Side::Lower).map_err(|e| {
         format!(
             "{op_label} failed even with LM δ-ridge continuation \
              (escalated {max_esc} times to δ={delta:.3e}, trace_scale={trace_scale:.3e}); \
-             eigen-floor fallback also failed: {e}"
+             eigendecomposition fallback also failed: {e}"
         )
     })?;
-    let max_abs_eval = evals.iter().fold(0.0_f64, |a, &b| a.max(b.abs()));
-    let eps_floor = (CUSTOM_FAMILY_EVAL_FLOOR * max_abs_eval).max(1e-300);
     Ok((
-        process_eigen(&evals, &evecs, eps_floor),
+        process_eigen(&evals, &evecs),
         StrictSpdLmStats {
             delta_used: delta,
             escalations: STRICT_SPD_LM_MAX_ESCALATIONS + 1,
@@ -2388,15 +2376,23 @@ pub(crate) fn strict_solve_spd_with_lm_continuation(
         Array1::<f64>::zeros(0),
         |m| strict_solve_spd(m, rhs),
         |chol| chol.solvevec(rhs),
-        |evals, evecs, eps_floor| {
-            // x = Q diag(1/Λ̃) Qᵀ rhs.
+        |evals, evecs| {
+            // The terminal fallback is the Moore–Penrose inverse on the
+            // resolved positive eigenspace. A null or negative direction
+            // contributes zero; inventing an absolute eigenvalue for it
+            // changes both the equation and its physical units.
+            let threshold = positive_eigenvalue_threshold(
+                evals.as_slice().expect("eigh returns contiguous eigenvalues"),
+            );
             let mut q_t_rhs = Array1::<f64>::zeros(p);
             for k in 0..p {
                 let mut acc = 0.0;
                 for i in 0..p {
                     acc += evecs[[i, k]] * rhs[i];
                 }
-                q_t_rhs[k] = acc / evals[k].max(eps_floor);
+                if evals[k] > threshold {
+                    q_t_rhs[k] = acc / evals[k];
+                }
             }
             let mut x = Array1::<f64>::zeros(p);
             for i in 0..p {

--- a/crates/gam-custom-family/src/tests/inner_solver_numerics.rs
+++ b/crates/gam-custom-family/src/tests/inner_solver_numerics.rs
@@ -3786,15 +3786,15 @@ pub(crate) fn pseudo_laplace_path_skips_eigendecomposition_avoiding_nan_crash() 
 /// Regression check: when `strict_solve_spd_with_lm_continuation` is given a
 /// strongly negative-definite matrix whose `|λ_min|` exceeds the LM δ-ridge
 /// schedule's terminal δ (≈ ε · trace_scale · 10¹⁶), the bare schedule can't
-/// rescue Cholesky and the terminal eigen-floor fallback must return a
-/// finite solution equal to `Q diag(1/Λ̃) Qᵀ rhs`, with
-/// `Λ̃_i = max(Λ_i, ε λ_max)`.
+/// rescue Cholesky and the terminal eigendecomposition fallback must return
+/// the positive-part Moore–Penrose solution. Negative eigendirections are
+/// outside its range and must contribute exactly zero.
 ///
 /// We also exercise the schedule-success path with a milder matrix to lock
 /// in that the eigen-floor doesn't perturb the LM-δ output for cases the
 /// schedule can already handle.
 #[test]
-pub(crate) fn strict_solve_spd_falls_back_to_eigen_floor_on_indefinite_matrix() {
+pub(crate) fn strict_solve_spd_falls_back_to_positive_pseudoinverse_on_indefinite_matrix() {
     // δ schedule from `delta0 = max(ε·tr/p, 1e-12)`, growth 10×, 16 steps.
     // With `tr = 4·1e30` we get `delta0 ≈ ε·1e30 ≈ 2.2e14`; terminal δ at
     // escalation 16 is `2.2e14 · 1e16 = 2.2e30`. Set `λ_min ≈ -1e32` to
@@ -3809,43 +3809,27 @@ pub(crate) fn strict_solve_spd_falls_back_to_eigen_floor_on_indefinite_matrix() 
     let rhs = Array1::from_vec(vec![1e30, -5e29, 2.5e29, 7.5e29]);
 
     let (x, stats) = strict_solve_spd_with_lm_continuation(&h, &rhs)
-        .expect("eigen-floor fallback must succeed on the negative-definite matrix");
+        .expect("eigendecomposition fallback must succeed on the negative-definite matrix");
     assert!(
         stats.escalations > 16,
-        "expected eigen-floor terminal fallback (escalations > MAX_ESCALATIONS), got {}",
+        "expected eigendecomposition terminal fallback (escalations > MAX_ESCALATIONS), got {}",
         stats.escalations,
     );
     for &v in x.iter() {
         assert!(
             v.is_finite(),
-            "eigen-floor solve returned non-finite component {v}"
+            "pseudo-inverse solve returned non-finite component {v}"
         );
     }
 
-    // Reconstruct the analytic floored solve and compare component-wise.
-    let mut sym = h.clone();
-    symmetrize_dense_in_place(&mut sym);
-    let (evals, evecs) = FaerEigh::eigh(&sym, Side::Lower).expect("eigh");
-    let max_abs_eval = evals.iter().fold(0.0_f64, |a, &b| a.max(b.abs()));
-    let eps_floor = (CUSTOM_FAMILY_EVAL_FLOOR * max_abs_eval).max(1e-300);
-    let mut want = Array1::<f64>::zeros(p);
-    for k in 0..p {
-        let mut q_t_rhs = 0.0;
-        for i in 0..p {
-            q_t_rhs += evecs[[i, k]] * rhs[i];
-        }
-        let scaled = q_t_rhs / evals[k].max(eps_floor);
-        for i in 0..p {
-            want[i] += evecs[[i, k]] * scaled;
-        }
-    }
-    for i in 0..p {
-        let tol = 1e-9 * want[i].abs().max(1.0) + 1e-9;
-        assert!(
-            (want[i] - x[i]).abs() <= tol,
-            "eigen-floor solve component {i}: want={:.6e}, got={:.6e}",
-            want[i],
-            x[i],
+    // A negative eigenspace is outside the range of the positive-part
+    // Moore–Penrose inverse. It contributes zero rather than an arbitrary
+    // fabricated step.
+    for (i, &value) in x.iter().enumerate() {
+        assert_eq!(
+            value.to_bits(),
+            0.0_f64.to_bits(),
+            "negative eigendirection {i} contributed {value} to the pseudo-inverse solve",
         );
     }
 }


### PR DESCRIPTION
### Motivation

- The terminal SPD fallback was inventing an absolute small eigenvalue (e.g. `…max(1e-12·max|λ|, 1e-300)`) and dividing by it, which changes the equation, can fabricate huge Newton steps in directions outside the positive eigenspace, and is an instance of an arbitrary constant on the fit path.
- The fallback must instead expose the true spectrum and let consumers apply mathematically principled Moore–Penrose / positive-part semantics so null/negative eigendirections contribute zero rather than a fabricated curvature.

### Description

- Removed the hard-coded per-eigenvalue floor from the custom-family LM/eigen terminal fallback and exposed the eigenspectrum to the consumer instead of inventing curvature. (`strict_spd_lm_engine` now passes `(&evals, &evecs)` to the consumer.)
- Replaced the floor-and-divide terminal behaviour in the SPD solve fallback with a positive-part pseudo-inverse: compute `threshold = positive_eigenvalue_threshold(evals)` and only invert eigenvalues `> threshold`, letting null and negative modes contribute zero to the solution.
- Added/retained a small relative-condition guard symbolically (`CUSTOM_FAMILY_CONDITION_RELATIVE_FLOOR`) and updated comments to document the intended Moore–Penrose semantics and rationale (language clarifies eigendecomposition fallback rather than inventing absolute floors).
- Updated the regression test to assert the precise mathematical contract: the fallback returns the positive-part Moore–Penrose solution on an indefinite matrix and negative eigendirections contribute exactly zero (test renamed to reflect this contract and its expectations).

### Testing

- Ran `cargo check -p gam-custom-family`, which completed successfully (crate type checks passed).
- Built and type-checked the modified tests and crate (`cargo check` / `cargo test` driver started for the targeted test), but the targeted `strict_solve_spd_falls_back_to_positive_pseudoinverse_on_indefinite_matrix` regression could not be observed to finish in this sandbox due to long compile time; therefore no pass/fail result for that single test is available here.
- Attempted a workspace full build (`cargo build --workspace --all-targets`) but it did not complete within the sandbox time limits, so no workspace-wide pass/fail is reported.
- Ran `git diff --check` and local repository checks (whitespace, formatting) with no errors reported.