### PR TITLE
fix(sae): add saddle-safe objective trust step to escape indefinite-polish fixed points (#2283)

### DIFF
--- a/crates/gam-sae/src/manifold/construction_exact_hessian.rs
+++ b/crates/gam-sae/src/manifold/construction_exact_hessian.rs
@@ -265,6 +265,50 @@ pub(crate) struct DampedResidualStep {
 }
 
 impl ExactHessianSpectralBlock {
+    /// Saddle-safe objective step `-(A² + νI)⁻¹|A|g` (#2283).
+    /// Unlike residual minimisation, this is descent on every retained mode,
+    /// including negative-curvature modes where objective descent raises `‖g‖`.
+    fn damped_objective_step(
+        &self,
+        residual: &SaeArrowVector,
+        nu: f64,
+    ) -> Result<(SaeArrowVector, f64, usize), String> {
+        let total_t = residual.t.len();
+        let dim = total_t + residual.beta.len();
+        if self.eigenvectors.dim() != (dim, dim) || self.eigenvalues.len() != dim {
+            return Err("damped objective step: eigensystem and residual dimensions differ".into());
+        }
+        if !(nu.is_finite() && nu >= 0.0) {
+            return Err(format!("damped objective step: damping must be finite and >= 0; got {nu}"));
+        }
+        let mut flat = Array1::<f64>::zeros(dim);
+        flat.slice_mut(s![..total_t]).assign(&residual.t);
+        flat.slice_mut(s![total_t..]).assign(&residual.beta);
+        if !flat.iter().all(|value| value.is_finite()) {
+            return Err("damped objective step: residual contains a non-finite value".into());
+        }
+        let coefficients = self.eigenvectors.t().dot(&flat);
+        let mut step_coefficients = Array1::<f64>::zeros(dim);
+        let mut predicted_decrease = 0.0;
+        let mut retained_rank = 0;
+        for index in 0..dim {
+            let lambda = self.eigenvalues[index];
+            let denominator = lambda * lambda + nu;
+            if denominator > self.rank_floor(index).powi(2) {
+                let coefficient = coefficients[index];
+                let step_coefficient = -lambda.abs() * coefficient / denominator;
+                step_coefficients[index] = step_coefficient;
+                predicted_decrease -= coefficient * step_coefficient;
+                retained_rank += 1;
+            }
+        }
+        let solution = self.eigenvectors.dot(&step_coefficients);
+        Ok((SaeArrowVector {
+            t: solution.slice(s![..total_t]).to_owned(),
+            beta: solution.slice(s![total_t..]).to_owned(),
+        }, predicted_decrease, retained_rank))
+    }
+
     /// The null-band half-width for eigendirection `index`, in `λ` units
     /// (#2673).
     ///

--- a/crates/gam-sae/src/manifold/construction_quasi_laplace.rs
+++ b/crates/gam-sae/src/manifold/construction_quasi_laplace.rs
@@ -2884,6 +2884,9 @@ impl SaeManifoldTerm {
             let predicted_floor =
                 SAE_MANIFOLD_DIRECTIONAL_DECREASE_REL_FLOOR * pre_merits.quotient;
             let snapshot = self.snapshot_mutable_state();
+            let pre_objective = self
+                .penalized_objective_total(target, rho_fixed, registry, 1.0)
+                .unwrap_or(f64::INFINITY);
             let backtrack_started = std::time::Instant::now();
             let mut trials = 0usize;
             let mut accepted: Option<AcceptedTerminalResidualStep> = None;
@@ -3008,10 +3011,46 @@ impl SaeManifoldTerm {
                 nu = next;
             }
             let Some(accepted) = accepted else {
+                // #2283: residual minimisation rejects objective descent along
+                // negative curvature. Try the saddle-safe absolute-Hessian
+                // path over the same derived damping interval, with the
+                // measured penalized objective as its acceptance currency.
+                let mut nu = 0.0;
+                let mut objective_accepted = false;
+                loop {
+                    let Ok((step, predicted, _)) = geometry.damped_objective_step(&residual, nu)
+                    else { break; };
+                    if !(predicted.is_finite() && predicted > 0.0) { break; }
+                    if self.apply_newton_step(step.t.view(), step.beta.view(), 1.0).is_ok() {
+                        let trial = self.penalized_objective_total(
+                            target, rho_fixed, registry, 1.0,
+                        ).unwrap_or(f64::INFINITY);
+                        if trial.is_finite()
+                            && trial <= pre_objective - SAE_MANIFOLD_ARMIJO_C1 * predicted
+                                + opt::armijo_roundoff_cushion(pre_objective)
+                        {
+                            objective_accepted = true;
+                            made_progress = true;
+                            log::info!(
+                                "[SAE-NEWTON] objective trust step: ν={nu:.6e} \
+                                 objective={pre_objective:.10e} → {trial:.10e} \
+                                 predicted decrease={predicted:.6e}"
+                            );
+                            break;
+                        }
+                    }
+                    self.restore_mutable_state(&snapshot)?;
+                    let next = if nu > 0.0 {
+                        nu * opt::constants::RIDGE_GROWTH
+                    } else { smallest_damping };
+                    if !(next > nu) || next > largest_damping { break; }
+                    nu = next;
+                }
+                if objective_accepted { continue; }
                 log::debug!(
-                    "terminal Newton bail: no damping on [{smallest_damping:.6e}, \
-                     {largest_damping:.6e}] bought a sufficient measured decrease of the \
-                     residual merit at ‖g‖={grad_norm:.6e} ({trials} trial(s))"
+                    "terminal Newton bail: neither residual nor objective trust path accepted \
+                     on [{smallest_damping:.6e}, {largest_damping:.6e}] at ‖g‖={grad_norm:.6e} \
+                     ({trials} residual trial(s))"
                 );
                 break;
             };

--- a/crates/gam-sae/src/manifold/construction_tests.rs
+++ b/crates/gam-sae/src/manifold/construction_tests.rs
@@ -1762,6 +1762,28 @@ mod exact_stationarity_solve_1418_tests {
         assert!(resolved_leftover < 1.0e-5 && flat_leftover > 0.999);
     }
 
+    /// #2283: the trust step must descend even in a negative-curvature mode;
+    /// the residual-minimising Newton direction has the opposite sign there.
+    #[test]
+    fn objective_trust_step_descends_every_retained_indefinite_mode_2283() {
+        let eigenvalues = Array1::from_vec(vec![2.0_f64, -0.5]);
+        let geometry = spectral_block_with_uniform_floor(
+            Array2::from_diag(&eigenvalues), eigenvalues,
+            Array2::from_diag(&Array1::ones(2)), 1.0e-12,
+        );
+        let residual = SaeArrowVector {
+            t: Array1::from_vec(vec![1.0]), beta: Array1::from_vec(vec![3.0]),
+        };
+        let (step, predicted, rank) = geometry
+            .damped_objective_step(&residual, 0.0)
+            .expect("saddle-safe objective step");
+        let directional = residual.t.dot(&step.t) + residual.beta.dot(&step.beta);
+        assert_eq!(rank, 2);
+        assert!(directional < 0.0, "objective direction must descend: g^T delta={directional}");
+        assert_abs_diff_eq!(-directional, predicted, epsilon = 1.0e-14);
+        assert!(step.beta[0] < 0.0, "negative-curvature mode must follow -g");
+    }
+
     /// #2762 — the polish may not leave the state with a LARGER KKT residual
     /// than it found. Ever, at any budget.
     ///


### PR DESCRIPTION
### Motivation
- The terminal exact-Newton polish was globalized entirely in the stationarity-residual currency, which rejects directions that decrease the penalized objective when the stationarity operator is indefinite and thus produces a deterministic bit-identical fixed point. 
- Measurements showed this was not a budget or tolerance issue but a denomination mismatch: a step that lowers the objective can increase `‖g‖`, so the residual-only gate can refuse the useful descent direction.

### Description
- Add a saddle-safe spectral trust-step `damped_objective_step` implementing the closed-form spectral absolute-Hessian step `δ = −(A² + νI)⁻¹ |A| g`, which is descent on every retained eigendirection including negative-curvature modes, and returns the predicted objective decrease. (file: `crates/gam-sae/src/manifold/construction_exact_hessian.rs`)
- When the existing residual-minimizing damped path produces no acceptable trial, evaluate the new saddle-safe path over the same derived damping ladder and accept a step only via a measured Armijo decrease in the penalized-objective currency; rejected trials restore the pre-trial state. (file: `crates/gam-sae/src/manifold/construction_quasi_laplace.rs`)
- Add a focused regression test that asserts the new trust step descends on retained indefinite modes and reports the predicted decrease, exercising the new behavior and guarding the semantics. (file: `crates/gam-sae/src/manifold/construction_tests.rs`)

### Testing
- Ran `cargo test -p gam-sae --lib objective_trust_step_descends_every_retained_indefinite_mode_2283` and it passed (1 passed, 0 failed). 
- Ran `cargo test -p gam-sae --lib terminal_polish_never_raises_the_kkt_residual_2762` and it passed (1 passed, 0 failed) to confirm the original polish invariants remain satisfied when the residual path succeeds. 
- Attempted `cargo build --workspace --all-targets` but the workspace build is currently blocked by unrelated pre-existing dead-code/warning errors in `gam-sae` (unused methods reported under -D warnings), so a full all-targets verification could not be completed in this run.