### PR TITLE
fix(atlas): refuse topology from folded covers (#2280)

### DIFF
--- a/crates/gam-sae/src/manifold/atlas_topology.rs
+++ b/crates/gam-sae/src/manifold/atlas_topology.rs
@@ -506,12 +506,22 @@ pub fn observe_atlas_topology(atlas: &LocalAtlas) -> Result<AtlasTopologyReadout
         }
     }
     let covered_rows = multiplicity.len();
-    let max_cover_multiplicity = multiplicity.values().copied().max().unwrap_or(0);
-    let mean_cover_multiplicity = if covered_rows == 0 {
+    let ambient_max_cover_multiplicity = multiplicity.values().copied().max().unwrap_or(0);
+    let ambient_mean_cover_multiplicity = if covered_rows == 0 {
         0.0
     } else {
         multiplicity.values().sum::<usize>() as f64 / covered_rows as f64
     };
+    let (intrinsic_max, intrinsic_mean) = atlas.intrinsic_cover_multiplicity();
+    let (max_cover_multiplicity, mean_cover_multiplicity) =
+        if intrinsic_max > ambient_max_cover_multiplicity {
+            (intrinsic_max, intrinsic_mean)
+        } else {
+            (
+                ambient_max_cover_multiplicity,
+                ambient_mean_cover_multiplicity,
+            )
+        };
     // Lebesgue covering dimension: a good cover of a d-manifold refines to
     // multiplicity ≤ d + 1. Applied to the realized mean rather than to 1, because
     // this cover is deliberately unrefined — the builder grows every patch past its
@@ -810,7 +820,7 @@ mod tests_2280 {
     use crate::manifold::local_charts::LocalAtlasConfig;
     use crate::manifold::tests_topology_fixtures::{
         circle, cylinder_strip, embedded_plane, mobius_strip, open_arc, sphere, spherical_band,
-        torus, trefoil_knot,
+        swiss_roll, torus, trefoil_knot,
     };
     use ndarray::{Array2, ArrayView2};
 
@@ -852,6 +862,29 @@ mod tests_2280 {
         let inv = readout.invariants();
         assert_eq!(inv.betti.b1, 0, "{readout}");
         assert_eq!(inv.euler_characteristic, 1, "{readout}");
+    }
+
+    /// Regression for the sampled-cover hole localized in the issue thread.  With
+    /// ambient-distance patches the four inner-end charts centered at rows
+    /// 0/13/131/143 formed a real `H1` representative even though the underlying
+    /// sheet is contractible.  The independent intrinsic realization exposes a
+    /// cover pile-up at that fold, so promotion is honestly refused instead of
+    /// treating the ambient cover's accidental cycle as a cylinder.
+    #[test]
+    fn dense_swiss_roll_is_never_promoted_as_cylinder_2280() {
+        let roll = swiss_roll(80, 16);
+        let first = read(roll.view(), 2);
+        let second = read(roll.view(), 2);
+
+        assert_eq!(
+            first, second,
+            "atlas construction and readout must be deterministic"
+        );
+        assert_ne!(
+            first.observed_manifold(),
+            Some(GraphCompressionKind::Cylinder),
+            "a rolled contractible sheet may be named a disk or honestly refused, but must never be promoted as a cylinder: {first}"
+        );
     }
 
     /// THE ambient-embedding test. A trefoil knot is a smooth `S¹` whose three

--- a/crates/gam-sae/src/manifold/construction_exact_hessian.rs
+++ b/crates/gam-sae/src/manifold/construction_exact_hessian.rs
@@ -1198,6 +1198,7 @@ impl SaeManifoldTerm {
     /// recovering the plain case. The softmax, ordered Beta--Bernoulli, and ARD
     /// deltas are logit/coord-space prior curvatures and carry no output metric,
     /// so they are path-independent.
+    #[cfg_attr(not(test), expect(dead_code, reason = "exercised by the exact-Hessian test target"))]
     pub(crate) fn apply_exact_hessian_minus_b(
         &self,
         rho: &SaeManifoldRho,
@@ -1956,6 +1957,7 @@ impl SaeManifoldTerm {
     /// difference — the border half of both applies is already raw, because its
     /// Schur term and its `H_βt Φ(B_tt)⁻¹ H_tβ` restoration share one conditioned
     /// factor and cancel algebraically.
+    #[cfg_attr(not(test), expect(dead_code, reason = "exercised by the matrix-free Hessian test target"))]
     pub(crate) fn apply_exact_hessian_matrix_free(
         &self,
         rho: &SaeManifoldRho,

--- a/crates/gam-sae/src/manifold/local_charts.rs
+++ b/crates/gam-sae/src/manifold/local_charts.rs
@@ -16,8 +16,8 @@
 //!      [`super::intrinsic_seed::farthest_point_landmarks`], the same greedy
 //!      coverage pattern the intrinsic seeder uses), so the patches tile the
 //!      manifold with sublinearly many charts;
-//!   2. one PATCH per center — its nearest ambient rows, at most `patch_size` of
-//!      them — sized so neighboring patches OVERLAP (controlled by
+//!   2. one PATCH per center — its nearest ambient rows, at most
+//!      `patch_size` of them — sized so neighboring patches OVERLAP (controlled by
 //!      [`LocalAtlasConfig`]). The neighborhood is the LARGEST prefix of the
 //!      distance order that yields a certified chart: a local-PCA frame is a
 //!      TANGENT plane only while the patch stays inside the local curvature scale,
@@ -76,7 +76,7 @@ use std::fmt;
 use gam_linalg::faer_ndarray::FaerSvd;
 
 use super::AtlasOrientability;
-use super::intrinsic_seed::farthest_point_landmarks;
+use super::intrinsic_seed::{farthest_point_landmarks, intrinsic_geodesic_embedding};
 
 #[cfg(test)]
 #[path = "local_chart_recovery_tests.rs"]
@@ -139,6 +139,14 @@ fn frame_angular_resolution(certificate: &ChartCertificate) -> f64 {
     let epsilon = 1.0 - captured;
     let sine = (epsilon / captured).sqrt();
     if sine.is_finite() { sine.min(1.0) } else { 1.0 }
+}
+
+fn distance_order(z: ArrayView2<'_, f64>, center: usize) -> Vec<usize> {
+    let mut scored: Vec<(f64, usize)> = (0..z.nrows())
+        .map(|row| (sq_distance(z, center, row), row))
+        .collect();
+    scored.sort_by(|a, b| a.0.total_cmp(&b.0).then_with(|| a.1.cmp(&b.1)));
+    scored.into_iter().map(|(_, row)| row).collect()
 }
 
 /// The two frames' COMBINED angular resolution, as a sine: `sin(φ_a + φ_b)`.
@@ -298,6 +306,8 @@ pub enum LocalChartError {
     },
     /// The SVD backing a chart or a transition failed to converge.
     SvdFailure { center: usize, detail: String },
+    /// The independent intrinsic realization needed to audit the cover failed.
+    IntrinsicMetricFailure { detail: String },
     /// Individually chartable centers were dropped (see [`LocalAtlas::rejected_centers`]),
     /// but the certified charts that remain cover fewer than `MIN_ATLAS_ROW_COVERAGE`
     /// of the rows — the surviving sub-atlas describes only a minority of the sample,
@@ -361,6 +371,9 @@ impl fmt::Display for LocalChartError {
                     f,
                     "local_charts: SVD failed for patch at row {center}: {detail}"
                 )
+            }
+            Self::IntrinsicMetricFailure { detail } => {
+                write!(f, "local_charts: intrinsic cover audit failed: {detail}")
             }
             Self::AtlasCoverageTooLow {
                 certified,
@@ -601,6 +614,7 @@ pub struct LocalAtlas {
     charts: Vec<LocalChart>,
     transitions: Vec<ChartTransition>,
     rejected_centers: Vec<RejectedCenter>,
+    intrinsic_cover_multiplicity: (usize, f64),
 }
 
 impl LocalAtlas {
@@ -638,9 +652,10 @@ impl LocalAtlas {
         }
         let min_overlap = config.min_overlap.max(d + 1);
 
+        let membership_coords = intrinsic_geodesic_embedding(z, d)
+            .map_err(|detail| LocalChartError::IntrinsicMetricFailure { detail })?;
         // (1) deterministic farthest-point centers (reused intrinsic-seed machinery).
         let centers = farthest_point_landmarks(z, config.patch_count.max(1).min(n));
-
         // (2)+(3) one certified local-PCA chart per patch, on the largest
         // neighborhood that certifies (see `certified_neighborhood_chart`). A center
         // whose neighborhood cannot certify at any admissible size is DROPPED with its
@@ -698,6 +713,26 @@ impl LocalAtlas {
             });
         }
 
+        // Independently realize the same cover budget in intrinsic coordinates.
+        // A fold can make the ambient cover look regular while its intrinsic
+        // realization piles many charts onto one region; topology may not be
+        // promoted from a cover that fails either coordinate-system certificate.
+        let intrinsic_centers = farthest_point_landmarks(
+            membership_coords.view(),
+            config.patch_count.max(1).min(n),
+        );
+        let mut intrinsic_counts = vec![0usize; n];
+        for center in intrinsic_centers {
+            for row in distance_order(membership_coords.view(), center)
+                .into_iter()
+                .take(patch_size)
+            {
+                intrinsic_counts[row] += 1;
+            }
+        }
+        let intrinsic_max = intrinsic_counts.iter().copied().max().unwrap_or(0);
+        let intrinsic_mean = intrinsic_counts.iter().sum::<usize>() as f64 / n as f64;
+
         // (4) orthogonal Procrustes transition per overlapping patch pair.
         let mut transitions: Vec<ChartTransition> = Vec::new();
         let mut overlap_id = 0usize;
@@ -720,6 +755,7 @@ impl LocalAtlas {
             charts,
             transitions,
             rejected_centers,
+            intrinsic_cover_multiplicity: (intrinsic_max, intrinsic_mean),
         })
     }
 
@@ -767,6 +803,10 @@ impl LocalAtlas {
     #[must_use]
     pub fn rejected_centers(&self) -> &[RejectedCenter] {
         &self.rejected_centers
+    }
+
+    pub(super) fn intrinsic_cover_multiplicity(&self) -> (usize, f64) {
+        self.intrinsic_cover_multiplicity
     }
 
     /// Numerically well-conditioned observed transition signs as
@@ -835,16 +875,6 @@ impl LocalAtlas {
     }
 }
 
-/// Every ambient row ordered by ascending Euclidean distance to `center`, ties
-/// broken by ascending row index (a TOTAL order, so the ordering is independent of
-/// the sort's stability and identical run-to-run). `center` itself is first.
-fn distance_order(z: ArrayView2<'_, f64>, center: usize) -> Vec<usize> {
-    let n = z.nrows();
-    let mut scored: Vec<(f64, usize)> = (0..n).map(|r| (sq_distance(z, center, r), r)).collect();
-    scored.sort_by(|a, b| a.0.total_cmp(&b.0).then_with(|| a.1.cmp(&b.1)));
-    scored.into_iter().map(|(_, r)| r).collect()
-}
-
 /// The chart of the LARGEST certifiable neighborhood of `center`, at most
 /// `patch_size` rows.
 ///
@@ -886,12 +916,12 @@ fn certified_neighborhood_chart(
 }
 
 fn sq_distance(z: ArrayView2<'_, f64>, a: usize, b: usize) -> f64 {
-    let mut acc = 0.0;
-    for c in 0..z.ncols() {
-        let diff = z[[a, c]] - z[[b, c]];
-        acc += diff * diff;
-    }
-    acc
+    (0..z.ncols())
+        .map(|column| {
+            let difference = z[[a, column]] - z[[b, column]];
+            difference * difference
+        })
+        .sum()
 }
 
 /// Intersection of two ascending-sorted row lists, ascending.

--- a/crates/gam-sae/src/manifold/penalties.rs
+++ b/crates/gam-sae/src/manifold/penalties.rs
@@ -2158,6 +2158,7 @@ impl SaeManifoldTerm {
     /// The smoothness Gram `λ S ⊗ I`, the data-fit β Gram (β enters the
     /// reconstruction linearly, so Gauss–Newton IS exact there), and the ARD
     /// prior (a t-tier object) install no majorizer and appear in neither side.
+    #[cfg_attr(not(test), allow(dead_code))]
     pub(crate) fn decoder_prior_beta_hvp_pair(
         &self,
         penalty_scale: f64,


### PR DESCRIPTION
### Motivation

- The swiss_roll(80,16) mislabeling as a cylinder was traced to a cover defect where ambient-nearest patches produce an accidental H1 cycle, not to the transition algebra or homology code.  A single-coordinate realization is insufficient to certify a cover. 
- Recognition should be refused when the cover fails a coordinate-system audit rather than introducing fragile thresholds or changing transition semantics; an independent intrinsic audit (Landmark‑Isomap) exposes folded-cover pile-ups without rewriting the atlas fit logic.

### Description

- Add an independent intrinsic-metric audit: compute a deterministic Landmark‑Isomap embedding at chart rank and realize the same farthest-point / patch-size budget to measure intrinsic cover multiplicity, then store `(max, mean)` multiplicity in `LocalAtlas` as an audit artifact. 
- Make the topology gate use the worse of ambient vs intrinsic cover multiplicity for the Lebesgue/multiplicity certificate so folded ambient covers are refused instead of promoted. 
- Preserve existing ambient local‑PCA charts, transitions, and orientability logic (no silent edge-filtering or sign-gated nerve changes). 
- Add a regression test `dense_swiss_roll_is_never_promoted_as_cylinder_2280` and keep the existing `manifold::local_charts`/`atlas_topology` test-suite guards; add a typed `IntrinsicMetricFailure` error and annotate a few helper methods so test-target helpers do not trigger the workspace `-D warnings` gate.

### Testing

- Ran `cargo test -p gam-sae dense_swiss_roll_is_never_promoted_as_cylinder_2280 -- --nocapture` and it passed (new regression satisfied). 
- Ran `cargo test -p gam-sae manifold::local_charts:: -- --nocapture` and all local-charts unit tests passed (14 passed; 0 failed). 
- Ran `cargo test -p gam-sae manifold::atlas_topology::tests_2280:: -- --nocapture` and the atlas topology tests passed (14 passed; 0 failed), including the new swiss-roll regression and torus/sphere/mobius controls. 
- Attempted `cargo build --workspace --all-targets`; Rust compilation of the crates succeeded, but the final pyffi test binary failed to link in this sandbox due to missing Python C symbols (environment linker/PyO3 issue), so the cross-target full-workspace link could not be verified here.