### PR TITLE
fix(sae): accept terminal steps on objective descent (addresses #2267)

### DIFF
--- a/crates/gam-sae/src/manifold/construction.rs
+++ b/crates/gam-sae/src/manifold/construction.rs
@@ -1,4 +1,5 @@
 use super::*;
+use super::fit_drivers::GaugeOrbitDescent;
 // #2598 — `construction_quasi_laplace.rs` interpolates the refusal markers into
 // its ρ-local refusals instead of restating them, so the classifier and the
 // producer cannot disagree about the phrase again.
@@ -9,7 +10,7 @@ use crate::identifiability::{
 };
 use gam_linalg::faer_ndarray::FaerEigh;
 use gam_math::special::bessel_i0_centered_terms_from_log_abs;
-use super::fit_drivers::GaugeOrbitDescent;
+use opt::{BacktrackConfig, backtracking_line_search};
 
 // ── Theorem K: the rank charge is a RUNNING COMPLEXITY λ(n) ──────────────────
 //

--- a/crates/gam-sae/src/manifold/construction_exact_hessian.rs
+++ b/crates/gam-sae/src/manifold/construction_exact_hessian.rs
@@ -405,6 +405,55 @@ impl ExactHessianSpectralBlock {
         })
     }
 
+    /// A descent step for the scalar objective whose gradient is `residual`.
+    ///
+    /// Unlike [`Self::damped_residual_step`], this solves a shifted *Hessian*
+    /// system rather than the normal equations for `‖g‖²`.  When `A` is
+    /// indefinite, a residual-minimising step can be an ascent direction for
+    /// the objective.  Reflecting the spectrum by the smallest shift which
+    /// makes every resolved eigenvalue positive gives an objective-descent
+    /// direction while retaining the exact Newton step for positive-definite
+    /// geometry.  The caller globalizes its length against the objective.
+    fn shifted_objective_descent_step(
+        &self,
+        residual: &SaeArrowVector,
+    ) -> Result<SaeArrowVector, String> {
+        let total_t = residual.t.len();
+        let dim = total_t + residual.beta.len();
+        if self.eigenvectors.dim() != (dim, dim) || self.eigenvalues.len() != dim {
+            return Err("shifted objective step: geometry/residual dimension mismatch".to_string());
+        }
+        let mut flat = Array1::<f64>::zeros(dim);
+        flat.slice_mut(s![..total_t]).assign(&residual.t);
+        flat.slice_mut(s![total_t..]).assign(&residual.beta);
+        let coefficients = self.eigenvectors.t().dot(&flat);
+        let minimum = self
+            .eigenvalues
+            .iter()
+            .copied()
+            .fold(f64::INFINITY, f64::min);
+        let shift = if minimum < 0.0 {
+            // Twice |lambda_min| reflects the left edge to +|lambda_min|;
+            // unlike adding exactly |lambda_min|, it does not manufacture a
+            // singular system at the most informative negative-curvature mode.
+            -2.0 * minimum
+        } else {
+            0.0
+        };
+        let mut step_coefficients = Array1::<f64>::zeros(dim);
+        for index in 0..dim {
+            let denominator = self.eigenvalues[index] + shift;
+            if denominator > self.rank_floor(index) {
+                step_coefficients[index] = -coefficients[index] / denominator;
+            }
+        }
+        let solution = self.eigenvectors.dot(&step_coefficients);
+        Ok(SaeArrowVector {
+            t: solution.slice(s![..total_t]).to_owned(),
+            beta: solution.slice(s![total_t..]).to_owned(),
+        })
+    }
+
     /// Apply the symmetric Moore--Penrose inverse.  Resolved positive and
     /// negative modes are both retained; only the spectral null band
     /// `|λ| ≤ rank_floor` is removed, and that band is the ONLY null predicate

--- a/crates/gam-sae/src/manifold/construction_quasi_laplace.rs
+++ b/crates/gam-sae/src/manifold/construction_quasi_laplace.rs
@@ -2858,6 +2858,56 @@ impl SaeManifoldTerm {
                         break;
                     }
                 };
+            // #2267: globalize the exact-Hessian step in the objective's own
+            // currency before considering residual-norm minimization.  At an
+            // indefinite stationarity operator those are different problems:
+            // reducing ‖g‖² can reject every direction which follows negative
+            // curvature even though the penalized objective has ordinary
+            // descent.  This was the refine/polish limit cycle in the shipped
+            // 635-row example.  The residual remains the convergence gate; it
+            // is no longer (incorrectly) the step-acceptance objective.
+            let objective_before =
+                self.penalized_objective_total(target, rho_fixed, registry, 1.0)?;
+            let objective_step = geometry.shifted_objective_descent_step(&residual)?;
+            let directional =
+                -(residual.t.dot(&objective_step.t) + residual.beta.dot(&objective_step.beta));
+            if directional.is_finite() && directional > 0.0 {
+                let objective_snapshot = self.snapshot_mutable_state();
+                let accepted = backtracking_line_search::<_, String>(
+                    BacktrackConfig {
+                        initial_step: 1.0,
+                        max_steps: SAE_MANIFOLD_MAX_LINESEARCH_HALVINGS + 1,
+                        ..BacktrackConfig::default()
+                    },
+                    |alpha| {
+                        self.restore_mutable_state(&objective_snapshot)?;
+                        Ok(self
+                            .apply_newton_step(
+                                objective_step.t.view(),
+                                objective_step.beta.view(),
+                                alpha,
+                            )
+                            .and_then(|()| {
+                                self.penalized_objective_total(target, rho_fixed, registry, 1.0)
+                            })
+                            .ok()
+                            .map(|value| (value, ())))
+                    },
+                    |alpha, value| {
+                        value.is_finite()
+                            && value
+                                <= objective_before - SAE_MANIFOLD_ARMIJO_C1 * alpha * directional
+                                    + opt::armijo_roundoff_cushion(objective_before)
+                    },
+                )?;
+                if accepted.is_some() {
+                    made_progress = true;
+                    // Reassemble at the objective-descended state on the next
+                    // iteration.  Only that assembly may certify stationarity.
+                    continue;
+                }
+                self.restore_mutable_state(&objective_snapshot)?;
+            }
             let Some((curvature_min, curvature_max)) = geometry.retained_curvature_extremes()
             else {
                 log::debug!(

--- a/crates/gam-sae/src/manifold/construction_tests.rs
+++ b/crates/gam-sae/src/manifold/construction_tests.rs
@@ -1636,6 +1636,33 @@ mod exact_stationarity_solve_1418_tests {
         assert_eq!(damped.retained_rank, 2);
     }
 
+    /// #2267 — an indefinite exact stationarity operator must still produce a
+    /// descent direction for the penalized objective.  The old residual-normal
+    /// step reverses the negative mode and can therefore ascend the scalar it
+    /// is meant to optimize; the shifted Hessian step may not.
+    #[test]
+    fn indefinite_exact_hessian_step_is_objective_descent_2267() {
+        let eigenvalues = Array1::from_vec(vec![-2.0_f64, 4.0]);
+        let geometry = spectral_block_with_uniform_floor(
+            Array2::from_diag(&eigenvalues),
+            eigenvalues,
+            Array2::from_diag(&Array1::ones(2)),
+            1.0e-12,
+        );
+        let gradient = SaeArrowVector {
+            t: Array1::from_vec(vec![3.0]),
+            beta: Array1::from_vec(vec![5.0]),
+        };
+        let step = geometry
+            .shifted_objective_descent_step(&gradient)
+            .expect("indefinite geometry has an objective step");
+        let slope = gradient.t.dot(&step.t) + gradient.beta.dot(&step.beta);
+        assert!(
+            slope < 0.0,
+            "shifted exact-Hessian step must descend the objective; gᵀΔ={slope}"
+        );
+    }
+
     /// #2762 — the modeled residual the damped path reports is the EXACT linear
     /// residual `g + AΔ(ν)`, on a non-diagonal operator, at every damping.
     ///


### PR DESCRIPTION
### Motivation
- The shipped manifold-SAE example fails at the first ladder rung because the terminal polish phase accepts only residual-norm decreases, not penalized-objective decreases, producing a refine/polish limit cycle that never converges.
- At indefinite exact-stationarity Hessians a residual-minimising step can block an actual objective descent, so the acceptance currency must be the penalized objective while keeping the KKT residual as the convergence certificate.
- The change targets the algorithmic mechanism (acceptance currency) rather than tuning or time/budget workarounds so the solver can take scientifically correct descent steps and avoid the measured crawl.

### Description
- Add `shifted_objective_descent_step` to `ExactHessianSpectralBlock` (in `crates/gam-sae/src/manifold/construction_exact_hessian.rs`) which forms an objective-directed step by shifting negative eigenvalues so that retained spectral components produce an objective-descent direction. 
- In the terminal polish (`construction_quasi_laplace.rs`) attempt the shifted exact-Hessian objective step first and globalize it with the existing Armijo/backtracking machinery (`initial_step=1.0`), accepting a genuine objective decrease while leaving the residual-based gate as the convergence certificate. 
- Pin the behavior with a unit/regression test `indefinite_exact_hessian_step_is_objective_descent_2267` in `crates/gam-sae/src/manifold/construction_tests.rs` which asserts the shifted step descends the penalized objective on an indefinite spectrum and add the minimal `opt` imports needed for the line-search call. 

### Testing
- Ran `git diff --check` and code-style diffs locally which reported no lint diffs from the edits. (`git diff --check` returned clean.)
- Ran `cargo check -p gam-sae` which reached the `gam-sae` crate but failed on pre-existing `-D warnings` diagnostics (unused methods flagged as dead code: `apply_exact_hessian_minus_b` / `apply_exact_hessian_matrix_free`, and `decoder_prior_beta_hvp_pair`), so the new test could not be executed in this environment. (Outcome: compilation reached crate, then failed due to those diagnostics.)
- Attempted the focused test run `cargo test -p gam-sae indefinite_exact_hessian_step_is_objective_descent_2267 -- --exact` but it could not run because `cargo check`/build failed on the unrelated deny-warnings baseline; an uncapped workspace build (`cargo build --workspace --all-targets`) was also started but could not be completed inside the interactive sandbox window. (Outcome: test not executed; follow-up needed once baseline diagnostics are cleared.)