### PR TITLE
steering: use canonical arc-length for 1D row steers (#2263)

### DIFF
--- a/crates/gam-sae/src/inference/steering.rs
+++ b/crates/gam-sae/src/inference/steering.rs
@@ -1965,7 +1965,7 @@ pub fn steer_rows_unit_speed(
     let mut step = Array1::<f64>::zeros(1);
     for (out_row, &row) in rows.iter().enumerate() {
         step[0] = raw_steps[out_row];
-        let field = model.steer_rows(atom_k, &[row], step.view())?;
+        let field = model.steer_rows_raw(atom_k, &[row], step.view())?;
         for c in 0..p {
             delta[[out_row, c]] = field[[0, c]];
         }

--- a/crates/gam-sae/src/inference/tests_unit_speed_steering_2234.rs
+++ b/crates/gam-sae/src/inference/tests_unit_speed_steering_2234.rs
@@ -1,9 +1,9 @@
 //! #2234 / #2263 item 3 — **is a requested chart displacement realized as the
 //! INTRINSIC displacement it is documented to be?**
 //!
-//! [`crate::manifold::SaeManifoldTerm::steer_rows`] documents its `δ` as
-//! "radians / fraction-of-period, per the atom's manifold" and implements it as
-//! `LatentManifold::retract(t, δ)` — a raw offset of the FITTED chart parameter.
+//! The historical [`crate::manifold::SaeManifoldTerm::steer_rows`] implementation
+//! sent `δ` directly to `LatentManifold::retract(t, δ)` — a raw offset of the
+//! FITTED chart parameter.
 //! Those are the same object only when the fitted parameter is arc length. The
 //! chart parameterization is a gauge freedom (#2022 / #1019 / #2081): the fit
 //! lands on one point of the `Diff(S¹)` orbit, and
@@ -561,9 +561,18 @@ fn sweep(
             // The canonical surface picks the STEP; the ambient move is still
             // produced by the same group action, so the two arms differ in
             // nothing but the step.
-            crate::inference::steering::steer_rows_unit_speed(term, 0, &rows_idx, fraction)
-                .expect("canonical steer")
-                .raw_steps
+            let canonical = crate::inference::steering::steer_rows_unit_speed(
+                term, 0, &rows_idx, fraction,
+            )
+            .expect("canonical steer");
+            let public = term
+                .steer_rows(0, &rows_idx, array![fraction].view())
+                .expect("public steer");
+            assert_eq!(
+                public, canonical.delta,
+                "the public steer_rows surface bypassed canonical arc-length steering"
+            );
+            canonical.raw_steps
         } else {
             // What a caller passes today: the requested fraction of the period,
             // straight into the raw chart parameter.

--- a/crates/gam-sae/src/manifold/steering.rs
+++ b/crates/gam-sae/src/manifold/steering.rs
@@ -208,12 +208,16 @@ impl SaeManifoldTerm {
     /// The ambient steering DELTA `a_{ik}·(Φ_k(t_i ⊕ δ) − Φ_k(t_i))·B_k` for atom
     /// `k` on the selected `rows`, shape `(rows.len(), p)`. The caller adds this
     /// to the ambient activation `x` to move token `i` along atom `k`'s chart by
-    /// the intrinsic coordinate step `δ` (radians / fraction-of-period, per the
-    /// atom's manifold), staying on the decoded feature image by construction.
+    /// the intrinsic coordinate step `δ`, staying on the decoded feature image
+    /// by construction. For a one-dimensional periodic or interval chart, `δ`
+    /// is measured in the canonical arc-length coordinate (rescaled to the
+    /// chart's span), not in the gauge-arbitrary fitted parameter. Higher
+    /// dimensional charts retain their manifold-coordinate group action.
     ///
-    /// `δ` is a length-`d_k` chart step (the SAME `δ` applied to every selected
-    /// row). The gate `a_{ik}` is held fixed, so the delta changes content at
-    /// fixed strength. Circle closure is
+    /// `δ` is a length-`d_k` intrinsic step (the SAME intrinsic displacement
+    /// is applied to every selected row; its fitted-coordinate representation
+    /// varies with local chart speed). The gate `a_{ik}` is held fixed, so the
+    /// delta changes content at fixed strength. Circle closure is
     /// exact up to floating-point wrap: `δ = 0` is an exactly-zero delta and
     /// `δ = period` returns to the start (`|Δ| ≈ 0`).
     ///
@@ -224,6 +228,24 @@ impl SaeManifoldTerm {
     /// deltas. Use [`Self::steer_layer_delta`] / [`Self::steer_layer_decode`],
     /// which select one layer's column block and return HONEST activation units.
     pub fn steer_rows(
+        &self,
+        atom: usize,
+        rows: &[usize],
+        delta: ArrayView1<'_, f64>,
+    ) -> Result<Array2<f64>, String> {
+        if delta.len() == 1 {
+            return crate::inference::steering::steer_rows_unit_speed(
+                self, atom, rows, delta[0],
+            )
+            .map(|field| field.delta);
+        }
+        self.steer_rows_raw(atom, rows, delta)
+    }
+
+    /// Apply the fitted-coordinate group action without assigning physical units
+    /// to that coordinate. This is crate-private so all user-facing one-dimensional
+    /// steering goes through the canonical arc-length map.
+    pub(crate) fn steer_rows_raw(
         &self,
         atom: usize,
         rows: &[usize],


### PR DESCRIPTION
### Motivation
- Public one-dimensional steering previously interpreted a requested displacement `δ` as a raw fitted-chart offset, which is gauge-arbitrary and produces large per-row displacement errors when the fitted chart is not unit-speed. 
- The repository already contains canonical arc-length helpers (`canonical_chart_*` / `steer_rows_unit_speed`) so the user-facing API should deliver intrinsic (arc-length) displacements rather than exposing the fitted-parameter gauge. 

### Description
- Route the public one-dimensional API `SaeManifoldTerm::steer_rows` through the canonical arc-length map so a requested intrinsic displacement is translated per-row into the fitted-coordinate step via `canonical_chart_raw_coordinates` / `steer_rows_unit_speed`. 
- Introduce a crate-private `steer_rows_raw` that performs the original fitted-coordinate group action, and make the public `steer_rows` call the canonical path for 1-D `delta` and `steer_rows_raw` for higher-dimensional deltas. 
- Update documentation comments to state that 1-D `δ` is measured in canonical arc-length and extend the anisotropic-ring regression test to assert that the public `steer_rows` returns the canonical ambient delta rather than bypassing it. 

### Testing
- Ran `git diff --check` and formatting checks, which reported no blocking issues for the change. 
- Ran `cargo check -p gam-sae`, which reached `gam-sae` and failed due to pre-existing `dead-code` diagnostics unrelated to the steering change (two methods in other modules flagged by `-D warnings`). 
- Attempted `RUSTFLAGS='-A dead-code' cargo test -p gam-sae requested_ring_fraction_is_realized_only_in_the_canonical_chart -- --nocapture` and `cargo build --workspace --all-targets` to exercise the new regression, but the full compile/test runs did not complete within the sandbox iteration window so the new test could not be observed to finish here.