### PR TITLE
fix(steering): measure collateral in intrinsic chart units (#2234)

### DIFF
--- a/crates/gam-sae/src/inference/steering.rs
+++ b/crates/gam-sae/src/inference/steering.rs
@@ -1337,9 +1337,10 @@ fn frame_landed_norm(frame: &Array2<f64>, delta: ArrayView1<'_, f64>) -> f64 {
 /// latent `axis` over `doses`, comparing the on-manifold group action against a
 /// matched-per-row-norm flat-direction control (gam#2234 E2).
 ///
-/// For each dose `δ` the on-manifold ambient move is the fitted group-action
-/// delta [`SaeManifoldTerm::steer_rows`] (chart step `δ` on `axis`, gate held
-/// fixed). The flat control replays the SAME per-row move NORM along one fixed
+/// For each dose `δ` the on-manifold ambient move advances the atom's
+/// canonical, unit-speed chart coordinate by `δ` (gate held fixed). The raw
+/// fitted parameter is gauge-arbitrary and is deliberately not exposed as the
+/// dose axis. The flat control replays the SAME per-row move NORM along one fixed
 /// ambient direction `w` — the atom's mean decode-tangent direction along `axis`,
 /// the manifold analog of a flat SAE's single decoder column. Each move is
 /// decomposed against every atom's local decode-tangent frame at its fitted
@@ -1371,6 +1372,12 @@ pub fn collateral_curve(
     if axis >= d_k {
         return Err(format!(
             "collateral_curve: axis {axis} out of range for atom {atom_k} latent_dim {d_k}"
+        ));
+    }
+    if d_k != 1 || axis != 0 {
+        return Err(format!(
+            "collateral_curve: intrinsic doses require a one-dimensional canonical chart; \
+             atom {atom_k} has latent_dim {d_k} and axis {axis}"
         ));
     }
     if doses.is_empty() {
@@ -1486,9 +1493,7 @@ pub fn collateral_curve(
     let mut manifold_pts = Vec::with_capacity(doses.len());
     let mut flat_pts = Vec::with_capacity(doses.len());
     for &dose in doses {
-        let mut step = Array1::<f64>::zeros(d_k);
-        step[axis] = dose;
-        let on_field = model.steer_rows(atom_k, &rows, step.view())?;
+        let on_field = steer_rows_unit_speed(model, atom_k, &rows, dose)?.delta;
 
         // Matched control: same per-row move NORM, along the fixed direction w.
         let mut flat_field = Array2::<f64>::zeros((n, p));

--- a/crates/gam-sae/src/manifold/tests_collateral_e2_2234.rs
+++ b/crates/gam-sae/src/manifold/tests_collateral_e2_2234.rs
@@ -36,6 +36,17 @@ fn circle_atom(
     col_cos: usize,
     coords: &Array2<f64>,
 ) -> SaeManifoldAtom {
+    ellipse_atom(name, p, col_sin, col_cos, 1.0, coords)
+}
+
+fn ellipse_atom(
+    name: &str,
+    p: usize,
+    col_sin: usize,
+    col_cos: usize,
+    cosine_scale: f64,
+    coords: &Array2<f64>,
+) -> SaeManifoldAtom {
     let evaluator = Arc::new(
         PeriodicHarmonicEvaluator::new(3)
             .expect("an odd harmonic count is a valid periodic basis size"),
@@ -46,7 +57,7 @@ fn circle_atom(
     // PeriodicHarmonicEvaluator(3) emits [1, sin(2πt), cos(2πt)].
     let mut decoder = Array2::<f64>::zeros((3, p));
     decoder[[1, col_sin]] = 1.0;
-    decoder[[2, col_cos]] = 1.0;
+    decoder[[2, col_cos]] = cosine_scale;
     SaeManifoldAtom::new_with_provided_function_gram(
         name,
         SaeAtomBasisKind::Periodic,
@@ -58,6 +69,45 @@ fn circle_atom(
     )
     .expect("fixture atom: basis width, latent dim and decoder shape agree by construction")
     .with_basis_evaluator(evaluator)
+}
+
+#[test]
+fn collateral_dose_uses_canonical_arc_length_not_raw_chart_parameter() {
+    let n = 240usize;
+    let p = 4usize;
+    let coords = Array2::<f64>::from_shape_fn((n, 1), |(row, _)| (row as f64 + 0.5) / n as f64);
+    // An ellipse is exactly represented by the harmonic basis, but its raw
+    // phase is not unit speed. It therefore separates an intrinsic dose from a
+    // gauge-arbitrary constant raw-parameter step.
+    let atom = ellipse_atom("anisotropic-ring", p, 0, 1, 0.3, &coords);
+    let assignment = SaeAssignment::from_blocks_with_mode_and_manifolds(
+        Array2::<f64>::zeros((n, 1)),
+        vec![coords],
+        vec![LatentManifold::Circle { period: 1.0 }],
+        AssignmentMode::softmax(1.0),
+    )
+    .expect("fixture assignment");
+    let term = SaeManifoldTerm::new(vec![atom], assignment).expect("fixture term");
+    let rows: Vec<usize> = (0..n).collect();
+    let dose = 0.125;
+    let canonical = crate::inference::steering::steer_rows_unit_speed(&term, 0, &rows, dose)
+        .expect("canonical steering field");
+    let expected_rms = (canonical
+        .delta
+        .iter()
+        .map(|value| value * value)
+        .sum::<f64>()
+        / n as f64)
+        .sqrt();
+
+    let curve = collateral_curve(&term, 0, 0, &[], &[dose]).expect("collateral curve");
+    let point = &curve.manifold.points[0];
+    let observed_rms = (point.on_target_effect.powi(2) + point.collateral.powi(2)).sqrt();
+    assert!(
+        (observed_rms - expected_rms).abs() <= 1.0e-12 * expected_rms.max(1.0),
+        "collateral dose used a different coordinate gauge: observed RMS {observed_rms:e}, \
+         canonical RMS {expected_rms:e}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
### Motivation
- The E2 collateral-damage sweep used the raw fitted chart parameter as the dose axis, but the raw parameter is gauge-arbitrary and does not correspond to intrinsic arc-length, so matched-dose comparisons could be invalid. 
- The collateral curve and E2 experiments must express doses in the atom's canonical (unit-speed / arc-length) coordinate so dose is comparable across rows and charts.

### Description
- `collateral_curve` now interprets each `dose` in canonical arc-length units and builds the on-manifold field via `steer_rows_unit_speed(...)` instead of advancing the raw fitted parameter. (file: `crates/gam-sae/src/inference/steering.rs`).
- `collateral_curve` now rejects non-1D charts for intrinsic dosing with a clear error message, since canonical arc-length steering is defined only for `d = 1` charts today. (file: `crates/gam-sae/src/inference/steering.rs`).
- Added a regression test `collateral_dose_uses_canonical_arc_length_not_raw_chart_parameter` that constructs an anisotropic ellipse fixture (exactly representable by the harmonic basis) and verifies the collateral decomposition is driven by canonical arc-length, not by a raw phase increment. (file: `crates/gam-sae/src/manifold/tests_collateral_e2_2234.rs`).
- Extended the circle fixture helper to allow an anisotropic `ellipse_atom(...)` so the test can separate canonical arc-length from raw chart phase without changing existing round-circle tests. (file: `crates/gam-sae/src/manifold/tests_collateral_e2_2234.rs`).

### Testing
- Ran `rustfmt` on the modified files, which completed with no diagnostics for the edited sources; unrelated repo-wide formatting diffs exist but do not affect these changes. 
- Attempted to run the new test via `cargo test -p gam-sae collateral_dose_uses_canonical_arc_length_not_raw_chart_parameter -- --nocapture`, but the crate build failed before tests due to existing warnings-as-errors (dead-code) in unrelated methods in `gam-sae`, preventing execution of the new test. 
- Began a workspace build (`cargo build --workspace --all-targets`) but it did not finish inside this sandbox; the change itself is compile-correct for the edited files and the added test is syntactically valid, but full verification requires first resolving the pre-existing dead-code errors so the crate can compile and tests run.