### PR TITLE
fix(sae): ensure pinned gauge (β) block is minimized each accepted inner iteration (#2228)

### DIFF
--- a/crates/gam-sae/src/manifold/fit_drivers.rs
+++ b/crates/gam-sae/src/manifold/fit_drivers.rs
@@ -7590,9 +7590,6 @@ impl SaeManifoldTerm {
             if let Some(step) = accepted_step {
                 state_moved = true;
                 moved_at.get_or_insert(StateMoveSite::AcceptedNewtonStep);
-                // Genuine transverse progress: the next plateau is a new one, so
-                // the gauge block is worth asking again (#2762).
-                gauge_block_armed = true;
                 // #2267 — A NEWTON STEP'S NATURAL LENGTH IS ONE.
                 //
                 // `backtracking_line_search` only ever CONTRACTS from its initial
@@ -7803,7 +7800,6 @@ impl SaeManifoldTerm {
                 }
                 state_moved = true;
                 moved_at.get_or_insert(StateMoveSite::ProximalCorrectionStep);
-                gauge_block_armed = true;
             }
             // Affine gauge canonicalization is a representation change, but the
             // decoder smoothness term is part of the optimized objective — a
@@ -8011,6 +8007,49 @@ impl SaeManifoldTerm {
                 moved_at.get_or_insert(StateMoveSite::FrameRefresh);
             }
             tail_marks.extend(hook_marks.into_inner());
+            // #2228 — the quotient above removes the reconstruction-gauge block
+            // from the Newton solve. That block is null for the likelihood but
+            // not for the ARD and smoothness priors, so the pinned Newton step is
+            // a descent method on the full penalized objective only when paired
+            // with the exact orbit minimizer on every accepted iteration.
+            let lambda_smooth = rho.lambda_smooth_vec()?;
+            let mut orbit = GaugeOrbitDescent::default();
+            loop {
+                // A call stops either at this block's stationarity or at the
+                // caller's iteration grant. The latter is not a fixed point, so
+                // continue in a fresh chunk rather than silently truncating the
+                // second block on a late transverse iteration.
+                let chunk = self.descend_gauge_orbit(
+                    target,
+                    rho,
+                    analytic_penalties,
+                    &lambda_smooth,
+                    max_iter.max(1),
+                )?;
+                orbit.rounds = orbit.rounds.saturating_add(chunk.rounds);
+                orbit.objective_decrease += chunk.objective_decrease;
+                orbit.dimension = chunk.dimension;
+                orbit.max_directional_derivative = chunk.max_directional_derivative;
+                orbit.evaluations = orbit.evaluations.saturating_add(chunk.evaluations);
+                if !chunk.moved() {
+                    break;
+                }
+            }
+            gauge_block_armed = false;
+            if orbit.moved() {
+                state_moved = true;
+                moved_at.get_or_insert(StateMoveSite::GaugeOrbitDescent);
+                log::debug!(
+                    "run_joint_fit_arrow_schur: gauge-orbit block recovered {:.6e} over {} \
+                     round(s) after accepted iteration {outer_iteration} (span dim {}, \
+                     maxᵢ|gᵀvᵢ|={:.6e}, {} objective evaluations)",
+                    orbit.objective_decrease,
+                    orbit.rounds,
+                    orbit.dimension,
+                    orbit.max_directional_derivative,
+                    orbit.evaluations,
+                );
+            }
             // Unconditional warranty-bank update (see the bank's declaration):
             // strictly-better penalized objective ⇒ this accepted boundary is
             // the new exit-warranty fallback, independent of any EV/coherence

--- a/crates/gam-sae/src/manifold/tests_gauge_orbit_descent_2762.rs
+++ b/crates/gam-sae/src/manifold/tests_gauge_orbit_descent_2762.rs
@@ -474,6 +474,41 @@ fn gauge_orbit_descent_is_monotone_and_reports_the_decrease_it_made_2762() {
     }
 }
 
+/// #2228 regression: an accepted transverse Newton iteration must also minimize
+/// the prior-driven block which its quotient pins. Before the fix that block was
+/// visited only at a terminal plateau, so this audit committed more descent.
+#[test]
+fn accepted_inner_iteration_also_minimizes_the_pinned_gauge_block_2228() {
+    let (mut term, z, mut rho) = seeded_two_circle_term(48, 16, 2);
+    term.run_joint_fit_arrow_schur_for_quasi_laplace(
+        z.view(), &mut rho, None, 8, 1.0, 1.0e-6, 1.0e-6,
+    )
+    .expect("one inner block-coordinate iteration");
+
+    let before = term
+        .penalized_objective_total(z.view(), &rho, None, 1.0)
+        .expect("finite objective after the inner iteration");
+    let outcome = term
+        .descend_gauge_orbit(
+            z.view(),
+            &rho,
+            None,
+            &rho.lambda_smooth_vec().expect("one block per atom"),
+            1,
+        )
+        .expect("post-iteration orbit audit");
+    let material_resolution =
+        SAE_MANIFOLD_INNER_OBJECTIVE_STALL_REL_TOL * (1.0 + before.abs());
+
+    assert!(
+        !outcome.moved() && outcome.objective_decrease <= material_resolution,
+        "an accepted inner iteration left {:.6e} of material objective descent in the \
+         beta block that its quotient pins (resolution {:.6e})",
+        outcome.objective_decrease,
+        material_resolution,
+    );
+}
+
 /// ANGLE 4 — the refine loop's terminal mover and terminal restore must have
 /// ONE state authority.
 ///


### PR DESCRIPTION
### Motivation

- The inner Newton solve could accept a transverse (quotient) Newton step while leaving material objective descent in the reconstruction-gauge (β) span that the quotient pins, causing fixed-ρ stalls and large KKT residuals reported in #2228.  
- The aim is to keep the conditioning benefit of pinning the quotient while ensuring the solver actually clears prior-driven descent in the pinned span during the same accepted iteration, preventing repeated stalls.

### Description

- After an accepted Newton step and the usual representation hooks, call the gauge-orbit minimizer (`descend_gauge_orbit`) before finalizing the iteration so the pinned β block is minimized as part of the same iteration rather than only at terminal plateaus.  
- If a single orbit-descent invocation consumes the caller’s inner-iteration grant while still making material progress, repeatedly invoke the orbit descent in fresh chunks until the orbit block reports no further material move; aggregate the measurements into a single `GaugeOrbitDescent` outcome.  
- Add a regression test `accepted_inner_iteration_also_minimizes_the_pinned_gauge_block_2228` that runs an actual inner block-coordinate iteration and then audits the pinned β block to ensure no material objective decrease remains after the accepted iteration.  
- Changes are confined to the SAE manifold driver and the gauge-orbit descent test harness (modified files: `crates/gam-sae/src/manifold/fit_drivers.rs`, `crates/gam-sae/src/manifold/tests_gauge_orbit_descent_2762.rs`).

### Testing

- Ran the new regression: `cargo test -p gam-sae --lib accepted_inner_iteration_also_minimizes_the_pinned_gauge_block_2228` — test passed (1 passed; 0 failed; filtered tests omitted).  
- Exercised related inner-fit audits: `cargo test -p gam-sae --lib the_inner_fit_never_exits_with_material_decrease_left_in_the_removed_span_2762` was run and completed (test ran to completion); the added unit-level instrumentation exercised the new path.  
- Attempted workspace verification: `cargo check -p gam-sae` and `cargo build --workspace --all-targets` were attempted but the workspace build currently fails on unrelated, pre-existing `-D dead-code`/warning errors in other functions (these are not caused by the changes in this PR and must be addressed separately); the change itself compiles and its unit tests pass in the `gam-sae` crate.