### PR TITLE
fix(sae): globalize inner solves to use objective-globalized spectral steps and pair gauge descent (#2080)

### DIFF
--- a/crates/gam-sae/src/manifold/construction_exact_hessian.rs
+++ b/crates/gam-sae/src/manifold/construction_exact_hessian.rs
@@ -405,6 +405,58 @@ impl ExactHessianSpectralBlock {
         })
     }
 
+    /// A spectrally scaled descent step for the scalar objective whose gradient
+    /// is `residual`.  Unlike `damped_residual_step`, this uses `|A|` rather
+    /// than `A`: every retained component therefore has negative directional
+    /// derivative even when the stationarity operator is indefinite.  `nu`
+    /// has the same squared-curvature units as the residual damping ladder.
+    fn damped_objective_step(
+        &self,
+        residual: &SaeArrowVector,
+        nu: f64,
+    ) -> Result<DampedResidualStep, String> {
+        let total_t = residual.t.len();
+        let dim = total_t + residual.beta.len();
+        if self.eigenvectors.dim() != (dim, dim) || self.eigenvalues.len() != dim {
+            return Err("damped objective step: geometry and residual dimensions differ".into());
+        }
+        if !(nu.is_finite() && nu >= 0.0) {
+            return Err(format!(
+                "damped objective step: damping must be finite and >= 0; got {nu}"
+            ));
+        }
+        let mut flat = Array1::<f64>::zeros(dim);
+        flat.slice_mut(s![..total_t]).assign(&residual.t);
+        flat.slice_mut(s![total_t..]).assign(&residual.beta);
+        if !flat.iter().all(|value| value.is_finite()) {
+            return Err("damped objective step: residual contains a non-finite value".into());
+        }
+        let coefficients = self.eigenvectors.t().dot(&flat);
+        let mut step_coefficients = Array1::<f64>::zeros(dim);
+        let mut retained_rank = 0;
+        for index in 0..dim {
+            let magnitude = self.eigenvalues[index].abs();
+            if magnitude > self.rank_floor(index) {
+                step_coefficients[index] = -coefficients[index] / (magnitude + nu.sqrt());
+                retained_rank += 1;
+            }
+        }
+        let solution = self.eigenvectors.dot(&step_coefficients);
+        let model = &flat + &self.operator.dot(&solution);
+        Ok(DampedResidualStep {
+            step: SaeArrowVector {
+                t: solution.slice(s![..total_t]).to_owned(),
+                beta: solution.slice(s![total_t..]).to_owned(),
+            },
+            model_residual: SaeArrowVector {
+                t: model.slice(s![..total_t]).to_owned(),
+                beta: model.slice(s![total_t..]).to_owned(),
+            },
+            step_norm_sq: solution.dot(&solution),
+            retained_rank,
+        })
+    }
+
     /// Apply the symmetric Moore--Penrose inverse.  Resolved positive and
     /// negative modes are both retained; only the spectral null band
     /// `|λ| ≤ rank_floor` is removed, and that band is the ONLY null predicate
@@ -1624,15 +1676,19 @@ impl SaeManifoldTerm {
             let framed = self.last_frames_active && cache.k == self.factored_border_dim();
             if framed {
                 let lifted = projection.lift_border_vec(v.beta.view());
-                let delta = self
-                    .decoder_prior_exact_minus_majorizer_beta_hvp_prepared(prepared, lifted.view())?;
+                let delta = self.decoder_prior_exact_minus_majorizer_beta_hvp_prepared(
+                    prepared,
+                    lifted.view(),
+                )?;
                 let projected = projection.project_border_vec(delta.view());
                 for (index, &value) in projected.iter().enumerate() {
                     out.beta[index] += value;
                 }
             } else if cache.k == beta_dim {
-                let delta = self
-                    .decoder_prior_exact_minus_majorizer_beta_hvp_prepared(prepared, v.beta.view())?;
+                let delta = self.decoder_prior_exact_minus_majorizer_beta_hvp_prepared(
+                    prepared,
+                    v.beta.view(),
+                )?;
                 for (index, &value) in delta.iter().enumerate() {
                     out.beta[index] += value;
                 }
@@ -1980,13 +2036,9 @@ impl SaeManifoldTerm {
         vector: &SaeArrowVector,
         prepared: &PreparedDecoderPriorBetaCurvature,
     ) -> Result<SaeArrowVector, String> {
-        let (base_t, base_beta) = matrix_free_arrow_operator_apply(
-            system,
-            cache,
-            vector.t.view(),
-            vector.beta.view(),
-        )
-        .map_err(|error| format!("matrix-free evidence operator: {error}"))?;
+        let (base_t, base_beta) =
+            matrix_free_arrow_operator_apply(system, cache, vector.t.view(), vector.beta.view())
+                .map_err(|error| format!("matrix-free evidence operator: {error}"))?;
         let correction =
             self.apply_exact_hessian_minus_b_prepared(rho, target, cache, vector, prepared)?;
         let mut out = SaeArrowVector {
@@ -4842,7 +4894,11 @@ impl SaeManifoldTerm {
                 // (the induced ∞-norm), not a single entry: a cancellation in `C`
                 // can be as large as the whole row.
                 (0..gap.nrows())
-                    .map(|row| (0..gap.ncols()).map(|col| gap[[row, col]].abs()).sum::<f64>())
+                    .map(|row| {
+                        (0..gap.ncols())
+                            .map(|col| gap[[row, col]].abs())
+                            .sum::<f64>()
+                    })
                     .fold(0.0_f64, f64::max)
             });
         let mut inverse_values = Array1::<f64>::zeros(q);
@@ -7044,9 +7100,7 @@ mod tests_route_forced_classification_2673 {
                 .unwrap_or_else(|error| panic!("{label}: dense stationarity solve: {error}"));
             let free_solution = term
                 .solve_exact_stationarity_matrix_free(&rho, target.view(), &cache, &system, &rhs)
-                .unwrap_or_else(|error| {
-                    panic!("{label}: matrix-free stationarity solve: {error}")
-                });
+                .unwrap_or_else(|error| panic!("{label}: matrix-free stationarity solve: {error}"));
             let flatten = |x: &SaeArrowVector| -> Array1<f64> {
                 let mut out = Array1::<f64>::zeros(dim);
                 out.slice_mut(s![..total_t]).assign(&x.t);

--- a/crates/gam-sae/src/manifold/construction_quasi_laplace.rs
+++ b/crates/gam-sae/src/manifold/construction_quasi_laplace.rs
@@ -64,7 +64,7 @@ struct ResidualMerits {
 struct AcceptedTerminalResidualStep {
     damping: f64,
     trial_merits: ResidualMerits,
-    predicted_quotient_decrease: f64,
+    predicted_objective_decrease: f64,
     step: DampedResidualStep,
     system: Option<ArrowSchurSystem>,
 }
@@ -462,16 +462,14 @@ impl SaeManifoldTerm {
             let mut grams = self.empty_decoder_gram_accumulator();
             self.accumulate_decoder_gram(&mut grams)?;
             let n_eff = self.per_atom_effective_sample_size();
-            let residual_energy =
-                self.residual_energy_for_vanishing(residual.view())?;
+            let residual_energy = self.residual_energy_for_vanishing(residual.view())?;
             match self.vanished_atoms_from_signal_upper_bound(
                 &grams,
                 &n_eff,
                 residual_energy.mean_square(),
             )? {
                 VanishedAtomsProof::Certified {
-                    atoms: Some(atoms),
-                    ..
+                    atoms: Some(atoms), ..
                 } => return Err(SaeCriterionError::VanishedAtoms(atoms)),
                 VanishedAtomsProof::Certified { atoms: None, .. } => {}
                 VanishedAtomsProof::Unavailable { reason } => {
@@ -693,7 +691,7 @@ impl SaeManifoldTerm {
     /// (`exact_observed_information_log_dets`), streaming prices the Arrow–Schur
     /// majorizer `B` (`streaming_exact_arrow_log_det`). The #847 bit-identity
     /// claim held for `B` against `B` and does not survive that migration.
-     /// Freeze the collapse-prevention gates for one criterion evaluation,
+    /// Freeze the collapse-prevention gates for one criterion evaluation,
     /// returning whether they were ALREADY frozen so the caller can restore.
     ///
     /// One place, because the set has to be the same set. Before #2515 the freeze
@@ -721,7 +719,7 @@ impl SaeManifoldTerm {
         gates_were_frozen
     }
 
-   pub(crate) fn converge_inner_for_undamped_logdet(
+    pub(crate) fn converge_inner_for_undamped_logdet(
         &mut self,
         target: ArrayView2<'_, f64>,
         rho: &SaeManifoldRho,
@@ -877,9 +875,7 @@ impl SaeManifoldTerm {
         // moves beyond floating-point resolution, so it admits every useful
         // ninth-or-later rescue while a repeated plateau still terminates.
         let mut stall_polish_progress =
-            super::stall_polish_progress::StallPolishProgressCertificate::new(
-                f64::EPSILON.sqrt(),
-            );
+            super::stall_polish_progress::StallPolishProgressCertificate::new(f64::EPSILON.sqrt());
         const CERTIFICATE_ESCALATION_PROGRESS: f64 = 0.7;
         const CERTIFICATE_ESCALATION_ANTI_RUNAWAY_CAP: usize = 8;
         // #1051 — objective-stagnation convergence. On an ill-conditioned
@@ -1458,8 +1454,7 @@ impl SaeManifoldTerm {
                             final_db.view(),
                         )
                         .max(0.0);
-                        let excursion_cert =
-                            0.5 * newton_decrement_sq / final_objective_scale;
+                        let excursion_cert = 0.5 * newton_decrement_sq / final_objective_scale;
                         // #2228 — the acceptance verdict keys on the BEST-SEEN
                         // certificate, not the excursion the polish left. The
                         // band is UNCHANGED; a best-seen plateau ABOVE it is a
@@ -1467,12 +1462,9 @@ impl SaeManifoldTerm {
                         // seen ‖g‖. When best-seen clears the band we certify
                         // THERE (restore + re-factor) — the continuation is
                         // over, so nothing consumes the restore.
-                        let best_clears = best_seen
-                            .as_ref()
-                            .is_some_and(|(c, _, _)| {
-                                *c < excursion_cert
-                                    && *c <= SAE_MANIFOLD_INNER_OBJECTIVE_STALL_REL_TOL
-                            });
+                        let best_clears = best_seen.as_ref().is_some_and(|(c, _, _)| {
+                            *c < excursion_cert && *c <= SAE_MANIFOLD_INNER_OBJECTIVE_STALL_REL_TOL
+                        });
                         if best_clears {
                             let (best_cert, best_g, best_state) =
                                 best_seen.as_ref().expect("best_clears gated on Some");
@@ -1501,9 +1493,7 @@ impl SaeManifoldTerm {
                             // excursion so state + final_cache stay consistent,
                             // then fall through to the honest refusal below.
                             self.restore_mutable_state(&excursion)?;
-                        } else if excursion_cert
-                            <= SAE_MANIFOLD_INNER_OBJECTIVE_STALL_REL_TOL
-                        {
+                        } else if excursion_cert <= SAE_MANIFOLD_INNER_OBJECTIVE_STALL_REL_TOL {
                             log::debug!(
                                 "SAE inner final-gate decrement acceptance: ‖g‖={grad_norm:.6e} \
                                  (tol {grad_tolerance:.6e}) λ²={newton_decrement_sq:.6e} \
@@ -2128,23 +2118,19 @@ impl SaeManifoldTerm {
     /// already-aggregated L2 norm would retain a spurious `sqrt(K)` dependence;
     /// the max of individually scaled components is intensive in both `n` and
     /// `K`.
-    pub fn system_scaled_grad_max(
-        sys: &ArrowSchurSystem,
-    ) -> Result<f64, SaeInnerKktScaleError> {
+    pub fn system_scaled_grad_max(sys: &ArrowSchurSystem) -> Result<f64, SaeInnerKktScaleError> {
         let mut scaled_max = 0.0_f64;
         for (row_index, row) in sys.rows.iter().enumerate() {
             let gradient_len = row.gt.len();
             let (curvature_rows, curvature_cols) = row.htt.dim();
             let block = SaeInnerKktScaleBlock::CoordinateRow { row: row_index };
             if (curvature_rows, curvature_cols) != (gradient_len, gradient_len) {
-                return Err(
-                    SaeInnerKktScaleError::GradientCurvatureShapeMismatch {
-                        block,
-                        gradient_len,
-                        curvature_rows,
-                        curvature_cols,
-                    },
-                );
+                return Err(SaeInnerKktScaleError::GradientCurvatureShapeMismatch {
+                    block,
+                    gradient_len,
+                    curvature_rows,
+                    curvature_cols,
+                });
             }
             for component in 0..gradient_len {
                 let gradient = row.gt[component];
@@ -2185,14 +2171,12 @@ impl SaeManifoldTerm {
         let block = SaeInnerKktScaleBlock::SharedDecoder;
         let diagonal = sys.shared_block_diagonal();
         if sys.gb.len() != sys.k || diagonal.len() != sys.k {
-            return Err(
-                SaeInnerKktScaleError::GradientCurvatureShapeMismatch {
-                    block,
-                    gradient_len: sys.gb.len(),
-                    curvature_rows: diagonal.len(),
-                    curvature_cols: diagonal.len(),
-                },
-            );
+            return Err(SaeInnerKktScaleError::GradientCurvatureShapeMismatch {
+                block,
+                gradient_len: sys.gb.len(),
+                curvature_rows: diagonal.len(),
+                curvature_cols: diagonal.len(),
+            });
         }
         for component in 0..sys.k {
             let gradient = sys.gb[component];
@@ -2204,10 +2188,7 @@ impl SaeManifoldTerm {
                 });
             }
             let curvature = diagonal[component];
-            if !curvature.is_finite()
-                || curvature < 0.0
-                || (curvature == 0.0 && gradient != 0.0)
-            {
+            if !curvature.is_finite() || curvature < 0.0 || (curvature == 0.0 && gradient != 0.0) {
                 return Err(SaeInnerKktScaleError::InvalidCurvature {
                     block,
                     component,
@@ -2316,7 +2297,9 @@ impl SaeManifoldTerm {
         let q = self.assignment.row_block_dim();
         let dense_len = n.saturating_mul(q);
         let border_dim = self.factored_border_dim();
-        if system.rows.len() != n || system.row_offsets.len() != n + 1 || system.gb.len() != border_dim
+        if system.rows.len() != n
+            || system.row_offsets.len() != n + 1
+            || system.gb.len() != border_dim
         {
             return "orbit=unresolved(non-dense layout)".to_string();
         }
@@ -2465,7 +2448,8 @@ impl SaeManifoldTerm {
                         alpha,
                     )
                     .is_ok();
-                if applied && let Ok(trial) = self.penalized_objective_total(target, rho, registry, 1.0)
+                if applied
+                    && let Ok(trial) = self.penalized_objective_total(target, rho, registry, 1.0)
                 {
                     if (alpha - 1.0e-6).abs() < 1.0e-18 && trial.is_finite() {
                         finite_difference = (trial - base_objective) / alpha;
@@ -2608,113 +2592,22 @@ impl SaeManifoldTerm {
     /// locally quadratic and closes the same gap in O(10) steps, making the
     /// strict KKT contract REACHABLE instead of loosened.
     ///
-    /// # One merit, and it is the one the gate reads
+    /// # Objective-globalized spectral step
     ///
-    /// This phase solves `g(θ) = 0`, and the gate that judges it is a bound on
-    /// `‖g‖` (raw or gauge-quotient). So the merit here is `½‖g‖²` and nothing
-    /// else. It is a function of the STATE, not of any operator evaluated at the
-    /// state, which is what makes a comparison across two states mean something.
+    /// The KKT residual remains the convergence certificate, but it cannot be
+    /// the globalization currency: on a negative eigenmode of the exact Hessian,
+    /// objective descent increases `||g||`.  The old `(A^2 + nu) delta = -A g`
+    /// path therefore rejected the very move that left the saddle and made an
+    /// entire outer-rho neighborhood look infeasible (#2080/#2228).
     ///
-    /// The `#2762` defect was that the acceptance test compared
-    /// `gᵀB(θ₊)⁻¹g(θ₊)` — the trial state's decrement in the MAJORIZER metric —
-    /// against `gᵀA⁺g` at the pre-state, in the EXACT-Hessian metric. Same
-    /// bilinear form, two different operators, measured 67x apart on the
-    /// witness; every step passed it, `‖g‖` rose 15x–107x per accepted step, and
-    /// 482 consecutive steps were accepted after the baseline was made
-    /// self-consistent, because `gᵀB(θ)⁻¹g(θ)` can fall while `‖g‖` rises
-    /// whenever `B` stiffens.
-    ///
-    /// # Why the step is damped, and why that is the actual root cause
-    ///
-    /// Fixing the merit alone does not converge this phase, and the measurement
-    /// says why. At the `#2015` witness — `‖g‖ = 1.23e-4`, the WHOLE residual
-    /// inside the retained range — the undamped step is `‖Δ‖ = 0.44`, its full
-    /// application drives the merit `7.5e-9 → 6.1e0`, and an Armijo test on
-    /// `½‖g‖²` first passes at `α = 4.9e-4`, buying 0.03%. The step's LENGTH is
-    /// set entirely by the near-null eigendirections of `A`; the residual is
-    /// carried by the well-conditioned ones. No scalar step length separates
-    /// them — shrinking the step to keep the flat direction inside the model
-    /// shrinks the useful directions by the same factor.
-    ///
-    /// Damping does separate them. `A` is already materialized and
-    /// diagonalized here, so the whole Levenberg–Marquardt path
-    /// [`ExactHessianSpectralBlock::damped_residual_step`] is available in
-    /// closed form at one diagonal pass per point — including the modeled
-    /// residual this caller prices in its quotient merit. On the same witness
-    /// `ν = 5.7e-7` gives `‖Δ‖ = 4.6e-4`, drives
-    /// the merit `7.5e-9 → 6.2e-11` (`‖g‖ 1.23e-4 → 1.11e-5`, past a `7.1e-5`
-    /// tolerance in ONE step) at a measured/predicted ratio of `0.9992`.
-    ///
-    /// # The ladder, and why every number in it is derived
-    ///
-    /// * The first trial is `ν = 0` — the undamped step this phase has always
-    ///   taken — so the quadratic tail near a well-conditioned root is
-    ///   unchanged, and a state that never needed damping never pays for it.
-    /// * The ladder then runs from `λ_min²` to `λ_max²` over the RETAINED
-    ///   spectrum by [`opt::constants::RIDGE_GROWTH`]: below `λ_min²` a damping
-    ///   cannot move the flattest resolved direction, above `λ_max²` it has
-    ///   already flattened every direction there is.
-    /// * The accepted damping is CARRIED to the next step (divided by the same
-    ///   growth, and snapped back to `0` once it falls under `λ_min²`), so a
-    ///   converging tail walks back to the pure Newton step by itself.
-    /// * A trial is accepted when its MEASURED merit reduction is at least the
-    ///   shared Armijo fraction [`SAE_MANIFOLD_ARMIJO_C1`] of the reduction its
-    ///   own closed-form model predicted, with the shared round-off cushion.
-    ///   Model-predicted reduction is monotonically decreasing along the ladder,
-    ///   so a ladder that falls under the round-off floor
-    ///   [`SAE_MANIFOLD_DIRECTIONAL_DECREASE_REL_FLOOR`] × merit is exhausted —
-    ///   that is a proof of termination, not a cap.
-    ///
-    /// Consequences worth stating as properties:
-    ///
-    /// * every accepted step STRICTLY decreases the quantity the refusal is
-    ///   denominated in, so this phase can no longer leave the state worse than
-    ///   it found it — which is what it measurably did on both `#2762` witnesses;
-    /// * the merit is monotone across steps by construction, so no
-    ///   cross-iteration contraction bail is needed and none is kept;
-    /// * a trial costs ONE assembly. It used to cost an assembly plus a full
-    ///   arrow factorization, because the merit it evaluated needed one.
-    ///
-    /// Indefiniteness of `A` needs no special handling: `Δ(ν)` solves
-    /// `(A² + ν)Δ = −Ag`, whose operator is positive semidefinite for every
-    /// symmetric `A`, so a resolved negative mode is descended, not reflected.
-    /// Every internal failure degrades to `Ok(false)` (fall through to the
-    /// historical stall accounting), never to a new error class, and a rejected
-    /// trial restores the snapshot bit-for-bit.
-    ///
-    /// Returns `Ok(true)` when at least one step was committed (the caller
-    /// re-enters the refine loop, whose existing raw/quotient KKT gate +
-    /// idempotence certificate remain the SOLE acceptance authority — this
-    /// phase mints nothing).
-    /// A residual measured in the two currencies the inner gate speaks: the
-    /// gauge-QUOTIENT merit `½‖Π⊥null r‖²` — which is what
-    /// [`Self::quasi_laplace_kkt_stationary`] is a bound on, since the quotient
-    /// norm is clamped at or below the raw one — and the AMBIENT merit `½‖r‖²`.
-    ///
-    /// Returned together because the polish accepts on the first and holds the
-    /// second as an invariant: a step may not buy quotient progress by pumping
-    /// residual into the gauge orbit, which is the only way a projected norm can
-    /// fall without the residual falling.
-    fn residual_merits(
-        &self,
-        residual: &SaeArrowVector,
-        penalized_gram_scale: &[f64],
-    ) -> ResidualMerits {
-        let ambient_norm_sq =
-            residual.t.dot(&residual.t) + residual.beta.dot(&residual.beta);
-        let quotient_norm_sq = self
-            .quotient_gradient_norm_sq(
-                residual.t.view(),
-                residual.beta.view(),
-                ambient_norm_sq,
-                penalized_gram_scale,
-            )
-            .unwrap_or(ambient_norm_sq);
-        ResidualMerits {
-            quotient: 0.5 * quotient_norm_sq,
-            ambient: 0.5 * ambient_norm_sq,
-        }
-    }
+    /// The step now uses the absolute spectral Hessian,
+    /// `delta_i = -g_i / (|lambda_i| + sqrt(nu))`.  Thus `g^T delta < 0` on every
+    /// retained mode, irrespective of curvature sign, while it is ordinary
+    /// Newton on a positive-definite basin.  The existing derived damping ladder
+    /// controls its radius, and Armijo acceptance is measured against the actual
+    /// penalized objective.  Rejected trials restore the snapshot bit-for-bit.
+    /// No KKT tolerance changes: only the converged refine-loop gate can mint a
+    /// fit.
 
     fn terminal_exact_newton_polish(
         &mut self,
@@ -2881,15 +2774,16 @@ impl SaeManifoldTerm {
             // own units — the same relative floor the majorized Armijo lane
             // applies to its directional decrease. A prediction below it is
             // f64 noise in the quadratic model, not a step worth measuring.
+            let pre_objective = self.penalized_objective_total(target, rho_fixed, registry, 1.0)?;
             let predicted_floor =
-                SAE_MANIFOLD_DIRECTIONAL_DECREASE_REL_FLOOR * pre_merits.quotient;
+                SAE_MANIFOLD_DIRECTIONAL_DECREASE_REL_FLOOR * (1.0 + pre_objective.abs());
             let snapshot = self.snapshot_mutable_state();
             let backtrack_started = std::time::Instant::now();
             let mut trials = 0usize;
             let mut accepted: Option<AcceptedTerminalResidualStep> = None;
             let mut nu = damping;
             loop {
-                let damped = match geometry.damped_residual_step(&residual, nu) {
+                let damped = match geometry.damped_objective_step(&residual, nu) {
                     Ok(damped) => damped,
                     Err(err) => {
                         log::debug!(
@@ -2898,11 +2792,10 @@ impl SaeManifoldTerm {
                         break;
                     }
                 };
-                let model_merits = self.residual_merits(&damped.model_residual, lambda_smooth);
-                let predicted_quotient_decrease =
-                    pre_merits.quotient - model_merits.quotient;
-                if !(predicted_quotient_decrease.is_finite()
-                    && predicted_quotient_decrease > predicted_floor)
+                let predicted_objective_decrease =
+                    -(residual.t.dot(&damped.step.t) + residual.beta.dot(&damped.step.beta));
+                if !(predicted_objective_decrease.is_finite()
+                    && predicted_objective_decrease > predicted_floor)
                 {
                     // The model's predicted reduction decreases monotonically in
                     // ν, so no larger damping on this ladder can clear the floor
@@ -2910,10 +2803,8 @@ impl SaeManifoldTerm {
                     // stated reason rather than at a trial count.
                     log::debug!(
                         "terminal Newton: damping ladder exhausted at ν={nu:.6e} — predicted \
-                         quotient-merit reduction {predicted_quotient_decrease:.6e} is under the \
-                         round-off floor {predicted_floor:.6e} (quotient merit \
-                         {:.6e})",
-                        pre_merits.quotient,
+                         objective decrease {predicted_objective_decrease:.6e} is under the \
+                         round-off floor {predicted_floor:.6e}",
                     );
                     break;
                 }
@@ -2955,24 +2846,21 @@ impl SaeManifoldTerm {
                         None,
                     )
                 };
-                let sufficient = SAE_MANIFOLD_ARMIJO_C1 * predicted_quotient_decrease;
-                // Acceptance: a measured reduction of the GATE's currency worth
-                // at least the shared Armijo fraction of what this step's own
-                // model predicted. Invariant, not a second currency: the ambient
-                // residual may not GROW, so quotient progress can never be
-                // bought by pumping residual into the gauge orbit — which is the
-                // only way a projected norm falls while the residual does not.
-                if trial_merits.quotient.is_finite()
-                    && trial_merits.ambient.is_finite()
-                    && pre_merits.quotient - trial_merits.quotient
-                        >= sufficient - opt::armijo_roundoff_cushion(pre_merits.quotient)
-                    && trial_merits.ambient
-                        <= pre_merits.ambient + opt::armijo_roundoff_cushion(pre_merits.ambient)
+                let trial_objective = self
+                    .penalized_objective_total(target, rho_fixed, registry, 1.0)
+                    .unwrap_or(f64::INFINITY);
+                let sufficient = SAE_MANIFOLD_ARMIJO_C1 * predicted_objective_decrease;
+                // Acceptance is Armijo descent in the scalar objective. The residual is
+                // deliberately not constrained here: at negative curvature, genuine
+                // objective descent can and generally does increase its norm.
+                if trial_objective.is_finite()
+                    && pre_objective - trial_objective
+                        >= sufficient - opt::armijo_roundoff_cushion(pre_objective)
                 {
                     accepted = Some(AcceptedTerminalResidualStep {
                         damping: nu,
                         trial_merits,
-                        predicted_quotient_decrease,
+                        predicted_objective_decrease,
                         step: damped,
                         system: trial_system,
                     });
@@ -3010,8 +2898,8 @@ impl SaeManifoldTerm {
             let Some(accepted) = accepted else {
                 log::debug!(
                     "terminal Newton bail: no damping on [{smallest_damping:.6e}, \
-                     {largest_damping:.6e}] bought a sufficient measured decrease of the \
-                     residual merit at ‖g‖={grad_norm:.6e} ({trials} trial(s))"
+                     {largest_damping:.6e}] bought sufficient Armijo decrease of the \
+                     penalized objective at ‖g‖={grad_norm:.6e} ({trials} trial(s))"
                 );
                 break;
             };
@@ -3045,11 +2933,7 @@ impl SaeManifoldTerm {
                 let after_sq = Self::system_grad_norm_sq(system);
                 let after_gate =
                     self.quotient_gradient_norm_from_system(system, after_sq, lambda_smooth);
-                if Self::quasi_laplace_kkt_stationary(
-                    after_sq.sqrt(),
-                    after_gate,
-                    grad_tolerance,
-                ) {
+                if Self::quasi_laplace_kkt_stationary(after_sq.sqrt(), after_gate, grad_tolerance) {
                     // The step landed in the band. Say so without paying for the
                     // next loop top's assembly to rediscover it.
                     log::debug!(
@@ -3114,11 +2998,11 @@ impl SaeManifoldTerm {
                  {grad_tolerance:.6e}",
                 pre_merits.quotient,
                 accepted.trial_merits.quotient,
-                accepted.predicted_quotient_decrease,
+                accepted.predicted_objective_decrease,
                 pre_merits.quotient - accepted.trial_merits.quotient,
-                if accepted.predicted_quotient_decrease > 0.0 {
+                if accepted.predicted_objective_decrease > 0.0 {
                     (pre_merits.quotient - accepted.trial_merits.quotient)
-                        / accepted.predicted_quotient_decrease
+                        / accepted.predicted_objective_decrease
                 } else {
                     f64::NAN
                 },
@@ -3921,16 +3805,14 @@ impl SaeManifoldTerm {
             // spectral classifications of `A` and `A_tt`, so their difference is
             // `log|S_A|` only where neither PD floor deflates a direction.)
             let residual = self.reconstruction_residual(target, rho)?;
-            let residual_energy =
-                self.residual_energy_for_vanishing(residual.view())?;
+            let residual_energy = self.residual_energy_for_vanishing(residual.view())?;
             match self.vanished_atoms_from_signal_upper_bound(
                 &ri.grams,
                 &ri.n_eff,
                 residual_energy.mean_square(),
             )? {
                 VanishedAtomsProof::Certified {
-                    atoms: Some(atoms),
-                    ..
+                    atoms: Some(atoms), ..
                 } => return Err(SaeCriterionError::VanishedAtoms(atoms)),
                 VanishedAtomsProof::Certified { atoms: None, .. } => {}
                 VanishedAtomsProof::Unavailable { reason } => {
@@ -4053,8 +3935,7 @@ impl SaeManifoldTerm {
                 row_dims.len()
             ));
         }
-        let delta =
-            self.assemble_exact_hessian_minus_b_rows(rho, target, &row_dims, border_dim)?;
+        let delta = self.assemble_exact_hessian_minus_b_rows(rho, target, &row_dims, border_dim)?;
         if delta.len() != majorizer.rows.len() {
             return Err(format!(
                 "SaeManifoldTerm::exact_a_evidence_system: assembled {} exact-A correction rows \
@@ -4071,22 +3952,21 @@ impl SaeManifoldTerm {
         // conditioning, from the same row layout as ΔC.
         let clamp = self.materialize_ard_concave_clamp_diagonal_for_rows(rho, &row_dims)?;
         let mut clamp_base = 0usize;
-        let classification_rows: std::sync::Arc<
-            [gam_solve::arrow_schur::ExactAClassificationRow],
-        > = delta
-            .into_iter()
-            .zip(row_dims.iter().copied())
-            .map(|(block, q)| {
-                let clamp_diag = clamp.slice(s![clamp_base..clamp_base + q]).to_owned();
-                clamp_base += q;
-                gam_solve::arrow_schur::ExactAClassificationRow {
-                    delta_tt: block.tt,
-                    delta_tbeta: block.tbeta,
-                    clamp_diag,
-                }
-            })
-            .collect::<Vec<_>>()
-            .into();
+        let classification_rows: std::sync::Arc<[gam_solve::arrow_schur::ExactAClassificationRow]> =
+            delta
+                .into_iter()
+                .zip(row_dims.iter().copied())
+                .map(|(block, q)| {
+                    let clamp_diag = clamp.slice(s![clamp_base..clamp_base + q]).to_owned();
+                    clamp_base += q;
+                    gam_solve::arrow_schur::ExactAClassificationRow {
+                        delta_tt: block.tt,
+                        delta_tbeta: block.tbeta,
+                        clamp_diag,
+                    }
+                })
+                .collect::<Vec<_>>()
+                .into();
         let border = self.border_channels_for_border_dim(border_dim)?;
         let classification_indices: std::sync::Arc<[usize]> = border
             .iter()
@@ -4122,12 +4002,11 @@ impl SaeManifoldTerm {
             majorizer.htbeta_transpose_matvec.clone(),
         ) {
             (None, _) => {
-                for (row_idx, (row, block)) in
-                    system
-                        .rows
-                        .iter_mut()
-                        .zip(classification_rows.iter())
-                        .enumerate()
+                for (row_idx, (row, block)) in system
+                    .rows
+                    .iter_mut()
+                    .zip(classification_rows.iter())
+                    .enumerate()
                 {
                     let q = block.delta_tt.nrows();
                     if row.htbeta.dim() != (q, border_dim) {
@@ -4140,8 +4019,7 @@ impl SaeManifoldTerm {
                     }
                     for a in 0..q {
                         for (beta_pos, channel) in border.iter().enumerate() {
-                            row.htbeta[[a, channel.index]] +=
-                                block.delta_tbeta[[a, beta_pos]];
+                            row.htbeta[[a, channel.index]] += block.delta_tbeta[[a, beta_pos]];
                         }
                     }
                 }
@@ -4215,12 +4093,11 @@ impl SaeManifoldTerm {
                 );
             }
         }
-        system.exact_a_classification = Some(
-            gam_solve::arrow_schur::ExactAClassificationGeometry {
+        system.exact_a_classification =
+            Some(gam_solve::arrow_schur::ExactAClassificationGeometry {
                 rows: classification_rows,
                 border_indices: classification_indices,
-            },
-        );
+            });
         system.refresh_row_hessian_fingerprint();
         Ok(system)
     }

--- a/crates/gam-sae/src/manifold/construction_tests.rs
+++ b/crates/gam-sae/src/manifold/construction_tests.rs
@@ -95,7 +95,6 @@ mod exact_hessian_fixture_tests {
         }
         (term, target, rho)
     }
-
 }
 
 #[cfg(test)]
@@ -426,10 +425,10 @@ mod amortized_encoder_tests {
                     .expect("sparse joint logdet trace");
                 let coord = t
                     .coordinate_block_assignment_log_strength_hessian_trace(
-                    &r,
-                    &cache,
-                    EvidenceOperator::Majorizer,
-                )
+                        &r,
+                        &cache,
+                        EvidenceOperator::Majorizer,
+                    )
                     .expect("sparse coordinate-block logdet trace");
                 v[si] = joint - coord;
             }
@@ -546,8 +545,7 @@ mod amortized_encoder_tests {
                     1.0e-6,
                 )
                 .expect("diagnostic cache");
-            let per_row: Vec<usize> =
-                cache.deflated_row_directions.iter().map(Vec::len).collect();
+            let per_row: Vec<usize> = cache.deflated_row_directions.iter().map(Vec::len).collect();
             let total: usize = per_row.iter().sum();
             let spectra: Vec<(usize, f64)> = cache
                 .deflation_row_spectra
@@ -634,7 +632,12 @@ mod amortized_encoder_tests {
             let gamma = match part {
                 0 => t.logdet_theta_adjoint(&r, &cache, &solver).unwrap(),
                 1 => t
-                    .coordinate_block_logdet_theta_adjoint(&r, &cache, EvidenceOperator::Majorizer, None)
+                    .coordinate_block_logdet_theta_adjoint(
+                        &r,
+                        &cache,
+                        EvidenceOperator::Majorizer,
+                        None,
+                    )
                     .unwrap(),
                 _ => {
                     let rc = t
@@ -687,9 +690,7 @@ mod amortized_encoder_tests {
     /// (`|H·x − g|` would then be the small one). Diagnostic: prints the norms.
     #[test]
     fn third_order_ift_deflation_residual_2330() {
-        use crate::manifold::arrow_solver::{
-            SaeArrowVector, apply_cached_arrow_hessian,
-        };
+        use crate::manifold::arrow_solver::{SaeArrowVector, apply_cached_arrow_hessian};
         use ndarray::array;
         let (mut term, target, rho, _stationary_cache) =
             super::exact_hessian_fixture_tests::converged_state_with_residual();
@@ -818,7 +819,12 @@ mod amortized_encoder_tests {
             .expect("gamma_joint");
         {
             let gtt = term
-                .coordinate_block_logdet_theta_adjoint(&rho, &cache, EvidenceOperator::Majorizer, None)
+                .coordinate_block_logdet_theta_adjoint(
+                    &rho,
+                    &cache,
+                    EvidenceOperator::Majorizer,
+                    None,
+                )
                 .expect("gamma_tt");
             gamma_eff.t -= &gtt.t;
             gamma_eff.beta -= &gtt.beta;
@@ -883,7 +889,12 @@ mod amortized_encoder_tests {
                     .logdet_theta_adjoint(&r, &cache, &solver)
                     .expect("gamma_joint");
                 let gtt = t
-                    .coordinate_block_logdet_theta_adjoint(&r, &cache, EvidenceOperator::Majorizer, None)
+                    .coordinate_block_logdet_theta_adjoint(
+                        &r,
+                        &cache,
+                        EvidenceOperator::Majorizer,
+                        None,
+                    )
                     .expect("gamma_tt");
                 g.t -= &gtt.t;
                 g.beta -= &gtt.beta;
@@ -1191,7 +1202,10 @@ mod amortized_encoder_tests {
             );
             let a_tt = sym.slice(s![..total_t, ..total_t]).to_owned();
             let (eigs_tt, vecs_tt) = a_tt.eigh(Side::Lower).expect("A_tt eigendecomposition");
-            let tt_norm = eigs_tt.iter().map(|value| value.abs()).fold(0.0_f64, f64::max);
+            let tt_norm = eigs_tt
+                .iter()
+                .map(|value| value.abs())
+                .fold(0.0_f64, f64::max);
             let tt_metric = ArrowMetric::Coordinate(&cache);
             let kept_tt: f64 = eigs_tt
                 .iter()
@@ -1304,7 +1318,10 @@ mod amortized_encoder_tests {
         assert!(
             matches!(&result, Ok((value, _, _)) if value.is_finite()),
             "the E-attributable a_saddle specimen must PRICE FINITE under #2336, not refuse; got: {:?}",
-            result.as_ref().map(|(value, _, _)| *value).map_err(|e| format!("{e:?}"))
+            result
+                .as_ref()
+                .map(|(value, _, _)| *value)
+                .map_err(|e| format!("{e:?}"))
         );
     }
 
@@ -1482,7 +1499,6 @@ mod softmax_majorizer_active_entry_1410_tests {
             }
         }
     }
-
 }
 
 /// #1418: the implicit-function (IFT) back-substitution must invert the EXACT
@@ -1574,11 +1590,11 @@ mod exact_stationarity_solve_1418_tests {
     fn dense_exact_stationarity_pseudoinverse_keeps_signed_range_and_drops_null_2653() {
         let eigenvalues = Array1::from_vec(vec![4.0_f64, 1.0e-12, -2.0]);
         let geometry = spectral_block_with_uniform_floor(
-                Array2::from_diag(&eigenvalues),
-                eigenvalues,
-                Array2::from_diag(&Array1::ones(3)),
-                1.0e-9,
-            );
+            Array2::from_diag(&eigenvalues),
+            eigenvalues,
+            Array2::from_diag(&Array1::ones(3)),
+            1.0e-9,
+        );
         let rhs = SaeArrowVector {
             t: Array1::from_vec(vec![8.0, 3.0]),
             beta: Array1::from_vec(vec![6.0]),
@@ -1604,11 +1620,11 @@ mod exact_stationarity_solve_1418_tests {
     fn damped_residual_step_at_zero_damping_is_the_pseudoinverse_step_2762() {
         let eigenvalues = Array1::from_vec(vec![4.0_f64, 1.0e-12, -2.0]);
         let geometry = spectral_block_with_uniform_floor(
-                Array2::from_diag(&eigenvalues),
-                eigenvalues,
-                Array2::from_diag(&Array1::ones(3)),
-                1.0e-9,
-            );
+            Array2::from_diag(&eigenvalues),
+            eigenvalues,
+            Array2::from_diag(&Array1::ones(3)),
+            1.0e-9,
+        );
         // The damped path is stated in the RESIDUAL `g`; the pseudoinverse
         // route is stated in `rhs = −g`.
         let residual = SaeArrowVector {
@@ -1627,7 +1643,11 @@ mod exact_stationarity_solve_1418_tests {
             .expect("zero damping is the pseudoinverse point of the path");
         assert_abs_diff_eq!(damped.step.t[0], pseudoinverse.t[0], epsilon = 1.0e-15);
         assert_abs_diff_eq!(damped.step.t[1], pseudoinverse.t[1], epsilon = 1.0e-15);
-        assert_abs_diff_eq!(damped.step.beta[0], pseudoinverse.beta[0], epsilon = 1.0e-15);
+        assert_abs_diff_eq!(
+            damped.step.beta[0],
+            pseudoinverse.beta[0],
+            epsilon = 1.0e-15
+        );
         // The `1e-12` direction is inside the null band, so its whole
         // coefficient survives into the model residual and nothing else does:
         // `½·3² = 4.5`.
@@ -1659,20 +1679,14 @@ mod exact_stationarity_solve_1418_tests {
         }
         let eigenvalues = Array1::from_vec(vec![3.0_f64, -0.75, 1.0e-5, 0.25]);
         let operator = basis.dot(&Array2::from_diag(&eigenvalues)).dot(&basis.t());
-        let geometry = spectral_block_with_uniform_floor(
-                operator.clone(),
-                eigenvalues,
-                basis,
-                1.0e-12,
-            );
+        let geometry =
+            spectral_block_with_uniform_floor(operator.clone(), eigenvalues, basis, 1.0e-12);
         let residual = SaeArrowVector {
             t: Array1::from_vec(vec![0.7_f64, -1.3, 0.2]),
             beta: Array1::from_vec(vec![0.9]),
         };
         let mut flat_residual = Array1::<f64>::zeros(dim);
-        flat_residual
-            .slice_mut(s![..3])
-            .assign(&residual.t);
+        flat_residual.slice_mut(s![..3]).assign(&residual.t);
         flat_residual[3] = residual.beta[0];
         let mut previous_reduction = f64::INFINITY;
         for nu in [0.0_f64, 1.0e-10, 1.0e-6, 1.0e-2, 1.0, 1.0e3] {
@@ -1719,11 +1733,11 @@ mod exact_stationarity_solve_1418_tests {
     fn damping_separates_a_flat_direction_from_a_resolved_one_2762() {
         let eigenvalues = Array1::from_vec(vec![1.0_f64, 1.0e-6]);
         let geometry = spectral_block_with_uniform_floor(
-                Array2::from_diag(&eigenvalues),
-                eigenvalues,
-                Array2::from_diag(&Array1::ones(2)),
-                1.0e-14,
-            );
+            Array2::from_diag(&eigenvalues),
+            eigenvalues,
+            Array2::from_diag(&Array1::ones(2)),
+            1.0e-14,
+        );
         let residual = SaeArrowVector {
             t: Array1::from_vec(vec![1.0_f64]),
             beta: Array1::from_vec(vec![1.0]),
@@ -1762,23 +1776,51 @@ mod exact_stationarity_solve_1418_tests {
         assert!(resolved_leftover < 1.0e-5 && flat_leftover > 0.999);
     }
 
-    /// #2762 — the polish may not leave the state with a LARGER KKT residual
-    /// than it found. Ever, at any budget.
-    ///
-    /// This is the property the shipped acceptance test could not enforce and
-    /// measurably violated: on both #2762 witnesses EVERY step was accepted
-    /// while the raw KKT gradient rose 15x and 107x, because acceptance was
-    /// carried by a comparison between the trial state's decrement in the
-    /// MAJORIZER metric and the pre-state's decrement in the EXACT-Hessian
-    /// metric. This drives the phase directly with a tolerance no state can
-    /// meet, so it must step rather than return at its own gate, and asserts the
-    /// merit it now descends — `½‖g‖²` — is monotone across the whole budget.
-    ///
-    /// The end-to-end witnesses (`planted_1e4_column_spread…`,
-    /// `reactive_entry_reseeds…`) pin the CONVERGENCE this buys; this pins the
-    /// safety property, which holds on states where nothing converges at all.
+    /// #2080/#2228 — residual minimization and objective minimization point in
+    /// opposite directions on a negative-curvature mode.  The terminal polish
+    /// must use the latter: otherwise it rejects precisely the direction which
+    /// can leave the non-stationary inner saddle and every outer rho probe is
+    /// reported as infeasible.
     #[test]
-    fn terminal_polish_never_raises_the_kkt_residual_2762() {
+    fn terminal_objective_step_descends_resolved_negative_curvature_2080() {
+        let eigenvalues = Array1::from_vec(vec![-2.0_f64, 4.0]);
+        let geometry = spectral_block_with_uniform_floor(
+            Array2::from_diag(&eigenvalues),
+            eigenvalues,
+            Array2::from_diag(&Array1::ones(2)),
+            1.0e-12,
+        );
+        let gradient = SaeArrowVector {
+            t: Array1::from_vec(vec![3.0]),
+            beta: Array1::from_vec(vec![5.0]),
+        };
+        let residual_step = geometry
+            .damped_residual_step(&gradient, 0.0)
+            .expect("residual Gauss-Newton step");
+        let objective_step = geometry
+            .damped_objective_step(&gradient, 0.0)
+            .expect("objective trust-region step");
+        assert!(
+            gradient.t.dot(&residual_step.step.t) > 0.0,
+            "the negative-mode residual step must expose the old objective-ascent defect"
+        );
+        let directional_derivative =
+            gradient.t.dot(&objective_step.step.t) + gradient.beta.dot(&objective_step.step.beta);
+        assert!(
+            directional_derivative < 0.0,
+            "the objective step must be descent across both signs of curvature, got g dot d = {directional_derivative:.6e}"
+        );
+        assert_abs_diff_eq!(objective_step.step.t[0], -1.5, epsilon = 1.0e-14);
+        assert_abs_diff_eq!(objective_step.step.beta[0], -1.25, epsilon = 1.0e-14);
+    }
+
+    /// #2080/#2228 — the polish may not raise the penalized objective.  The
+    /// former residual-monotonicity assertion was itself wrong: objective descent
+    /// along resolved negative curvature necessarily increases `||g||`.  Driving
+    /// with an unreachable tolerance forces a real step and pins the scalar
+    /// currency on which terminal globalization is now accepted.
+    #[test]
+    fn terminal_polish_never_raises_the_penalized_objective_2080() {
         let (mut term, target, rho, _cache) =
             super::exact_hessian_fixture_tests::converged_state_with_residual();
         let lambda_smooth = rho.lambda_smooth_vec().expect("smoothness strengths");
@@ -1797,6 +1839,9 @@ mod exact_stationarity_solve_1418_tests {
             .abs()
             + 1.0;
         let before = residual_norm(&mut term);
+        let objective_before = term
+            .penalized_objective_total(target.view(), &rho, None, 1.0)
+            .expect("objective before terminal polish");
         let mut best_seen = None;
         // Tolerance `0`: `quasi_laplace_kkt_stationary` cannot fire, so the
         // phase runs its budget instead of handing straight back.
@@ -1814,18 +1859,22 @@ mod exact_stationarity_solve_1418_tests {
             )
             .expect("the polish degrades every internal failure to Ok(false)");
         let after = residual_norm(&mut term);
+        let objective_after = term
+            .penalized_objective_total(target.view(), &rho, None, 1.0)
+            .expect("objective after terminal polish");
         assert!(
-            after <= before,
-            "the polish raised the KKT residual it is judged on: {before:.6e} -> {after:.6e} \
-             (moved={moved})"
+            objective_after <= objective_before,
+            "the polish raised the scalar objective: {objective_before:.6e} -> \
+             {objective_after:.6e} (residual {before:.6e} -> {after:.6e}, moved={moved})"
         );
         // Non-vacuity: an unreachable tolerance on a state with a live residual
         // must make this phase actually step, or the assertion above is testing
         // an early return.
         assert!(
-            moved && after < before,
-            "the phase must commit at least one step at tolerance 0 on a state with a live \
-             residual: {before:.6e} -> {after:.6e} (moved={moved})"
+            moved && objective_after < objective_before,
+            "the phase must commit objective descent at tolerance 0: objective \
+             {objective_before:.6e} -> {objective_after:.6e}, residual \
+             {before:.6e} -> {after:.6e} (moved={moved})"
         );
     }
 
@@ -1835,11 +1884,11 @@ mod exact_stationarity_solve_1418_tests {
     fn retained_curvature_extremes_span_the_resolved_band_only_2762() {
         let eigenvalues = Array1::from_vec(vec![-7.0_f64, 1.0e-12, 0.5, 2.0]);
         let geometry = spectral_block_with_uniform_floor(
-                Array2::from_diag(&eigenvalues),
-                eigenvalues,
-                Array2::from_diag(&Array1::ones(4)),
-                1.0e-9,
-            );
+            Array2::from_diag(&eigenvalues),
+            eigenvalues,
+            Array2::from_diag(&Array1::ones(4)),
+            1.0e-9,
+        );
         let (smallest, largest) = geometry
             .retained_curvature_extremes()
             .expect("three directions clear the null band");
@@ -1850,11 +1899,11 @@ mod exact_stationarity_solve_1418_tests {
         // must say so rather than hand back a degenerate span.
         let null_eigenvalues = Array1::from_vec(vec![1.0e-12_f64, -2.0e-12]);
         let null_geometry = spectral_block_with_uniform_floor(
-                Array2::from_diag(&null_eigenvalues),
-                null_eigenvalues,
-                Array2::from_diag(&Array1::ones(2)),
-                1.0e-9,
-            );
+            Array2::from_diag(&null_eigenvalues),
+            null_eigenvalues,
+            Array2::from_diag(&Array1::ones(2)),
+            1.0e-9,
+        );
         assert!(null_geometry.retained_curvature_extremes().is_none());
     }
 
@@ -1920,7 +1969,6 @@ mod exact_stationarity_solve_1418_tests {
             "exact A-solve residual {exact_resid:.3e} must be far below surrogate {surrogate_resid:.3e}"
         );
     }
-
 }
 
 /// Validates the matrix-free Hutchinson stochastic-trace estimator that replaces

--- a/crates/gam-sae/src/manifold/fit_drivers.rs
+++ b/crates/gam-sae/src/manifold/fit_drivers.rs
@@ -7805,6 +7805,33 @@ impl SaeManifoldTerm {
                 moved_at.get_or_insert(StateMoveSite::ProximalCorrectionStep);
                 gauge_block_armed = true;
             }
+            // #2080/#2228 — the Newton solve deliberately quotients the
+            // reconstruction gauge to keep its Schur complement conditioned.
+            // Priors make that data-null orbit non-null for the FULL objective,
+            // however, so quotienting the step without minimizing its partner
+            // block deletes a real gradient component.  Compose both blocks at
+            // every accepted iterate; waiting for an objective-stall rescue left
+            // the orbit residual to become virtually the entire residual first.
+            if gauge_block_armed {
+                gauge_block_armed = false;
+                let orbit = self.descend_gauge_orbit(
+                    target,
+                    rho,
+                    analytic_penalties,
+                    &rho.lambda_smooth_vec()?,
+                    max_iter.saturating_sub(outer_iteration).max(1),
+                )?;
+                if orbit.moved() {
+                    state_moved = true;
+                    moved_at.get_or_insert(StateMoveSite::GaugeOrbitDescent);
+                    log::debug!(
+                        "run_joint_fit_arrow_schur: paired gauge block recovered {:.6e} over \
+                         {} round(s) after accepted iteration {outer_iteration}",
+                        orbit.objective_decrease,
+                        orbit.rounds,
+                    );
+                }
+            }
             // Affine gauge canonicalization is a representation change, but the
             // decoder smoothness term is part of the optimized objective — a
             // class-(c) objective-guarded transaction (kept move discarded: a


### PR DESCRIPTION
### Motivation
- The inner terminal Newton accepted steps by a stationarity-residual norm while the step itself was Gauss–Newton on `‖g‖²`, so on indefinite exact-Hessian modes the solver rejected objective-descending moves and handed the outer REML layer infeasible probes. 
- The conditioned Newton Schur path quotiented the reconstruction gauge but deferred orbit minimization until stove-off stalls, which deleted a genuine objective gradient component and let the orbit accumulate into the residual. 
- The acceptance rule and sequencing therefore needed to be repaired at the solver level (use the correct globalization currency and compose the orbit-block minimizer) rather than by adding time budgets or loosening tolerances.

### Description
- Add an objective-aware spectral step `damped_objective_step` to `ExactHessianSpectralBlock` that uses `|λ|`-scaled directions so every retained spectral component is descent for the scalar penalized objective even on negative curvature (`crates/gam-sae/src/manifold/construction_exact_hessian.rs`).
- Change the terminal Newton polish to predict and accept Armijo decrease in the actual penalized objective instead of a residual-only quotient currency, and thread the corresponding `predicted_objective_decrease` through the acceptance plumbing (`crates/gam-sae/src/manifold/construction_quasi_laplace.rs`).
- Compose gauge-orbit minimization immediately after accepted Newton iterations (instead of deferring it to the stall/rescue path) so the quotient-based conditioning benefit is retained while the orbit component the step removed is also minimized (`crates/gam-sae/src/manifold/fit_drivers.rs`).
- Add regression/unit tests that exercise the new behavior and the negative-curvature objective-descent property (`terminal_objective_step_descends_resolved_negative_curvature_2080` and `terminal_polish_never_raises_the_penalized_objective_2080`) and update related test scaffolding (`crates/gam-sae/src/manifold/construction_tests.rs`).

### Testing
- `cargo test -p gam-sae --lib terminal_objective_step_descends_resolved_negative_curvature_2080 -- --nocapture` — passed (1 test run, 0 failed).
- `cargo test -p gam-sae --lib terminal_polish_never_raises_the_penalized_objective_2080 -- --nocapture` — passed (1 test run, 0 failed).
- `cargo test -p gam-sae --lib terminal_gauge_descent_moves_the_state_that_best_seen_would_restore_2762 -- --nocapture` — passed (1 test run, 0 failed).
- `timeout 900s cargo test -p gam-sae --lib wide_p_outer_reml_terminates_within_probe_budget_2080 -- --nocapture` — did not complete within the sandbox wall cap (timed out); the change reduces the logical defect but the full wide-p acceptance gate could not be verified end-to-end here due to environment compile/run limits.
- `timeout 120s cargo build --workspace --all-targets` — timed out in this sandbox during dependency compilation so the full workspace all-targets build could not be validated here.