### PR TITLE
fix(sae): seed overcomplete blocks from data rows (#2023)

### DIFF
--- a/crates/gam-sae/src/sparse_dict/block.rs
+++ b/crates/gam-sae/src/sparse_dict/block.rs
@@ -795,9 +795,7 @@ fn code_row(
             } else {
                 -admission_scale * own + 2.0 * gamma64 * gamma64 * overlap
             };
-            if (unconditional || gain < 0.0)
-                && best.is_none_or(|(_, incumbent)| gain < incumbent)
-            {
+            if (unconditional || gain < 0.0) && best.is_none_or(|(_, incumbent)| gain < incumbent) {
                 best = Some((index, gain));
             }
         }
@@ -1561,11 +1559,16 @@ pub(super) fn seed_frames(x: ArrayView2<'_, f32>, n_blocks: usize, b: usize) -> 
 /// How the initial `K = G·b` block frames are chosen before the alternation.
 ///
 /// The alternation (`advance_block_sparse_state`) is seed-agnostic — it reaches
-/// the same fixed point from any valid St(b,P) frame set — but the two seeds differ
+/// the same fixed point from any valid St(b,P) frame set — but the seeds differ
 /// in cost and in how coherent the starting blocks are, which matters at different
 /// `K` regimes.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum BlockSeedPolicy {
+    /// Deterministic data-row seed ([`data_row_frames`]): distribute the `K`
+    /// initial axes across the observed rows, centre them, and orthonormalize
+    /// each block.  This costs `O(N·P + K·P)` and puts capacity in the data cloud
+    /// before routing begins, rather than relying on later dead-block revival.
+    DataRows,
     /// Data-aware block-aware farthest-point pass (`seed_frames`). Each block is
     /// anchored on the row farthest from the completed frames and grown to rank `b`
     /// by uncovered-energy affinity, so unrelated subspaces never share a block.
@@ -1575,11 +1578,11 @@ pub enum BlockSeedPolicy {
     FarthestPoint,
     /// Deterministic coordinate-partition seed ([`coordinate_partition_frames`]):
     /// each block is `b` distinct signed unit coordinate axes drawn from a fixed
-    /// splitmix64 stream, `O(K·b)` with no corpus pass. The large-`K` front door —
-    /// at `K ≫ intrinsic-rank` most atoms are structurally spurious and dead-block
-    /// AuxK revival reseeds them from worst-residual ROWS during the epochs, so the
-    /// coherent farthest-point seed is neither affordable nor load-bearing; the
-    /// streaming lane already uses exactly this seed at `K ≈ 1e4`.
+    /// splitmix64 stream, `O(K·b)` with no corpus pass. This remains available
+    /// for synthetic dictionaries that deliberately must
+    /// not depend on a corpus.  It is not a fitting default: at large `K`, dead
+    /// coordinate blocks can remain dead when evidence-adjudicated revival is
+    /// deliberately conservative.
     CoordinatePartition,
 }
 
@@ -1612,6 +1615,84 @@ pub fn coordinate_partition_frames(n_blocks: usize, b: usize, p: usize) -> Array
     decoder
 }
 
+/// Seed `G` block frames from centred observations in `O(N·P + G·b·P)` work.
+///
+/// Axis `a` uses row `floor(a·N/K)`, spreading the dictionary over the corpus
+/// without a search or a caller-supplied random seed. Thus all selected rows
+/// are distinct whenever `K <= N`.
+/// Modified Gram--Schmidt makes each block a Stiefel frame.  If the selected
+/// observations do not span `b` directions, only that block falls back to the
+/// always-valid coordinate frame; degenerate data therefore cannot manufacture
+/// NaNs or an invalid initial dictionary.
+pub(super) fn data_row_frames(x: ArrayView2<'_, f32>, n_blocks: usize, b: usize) -> Array2<f32> {
+    let n = x.nrows();
+    let p = x.ncols();
+    let k = n_blocks * b;
+    let mut decoder = coordinate_partition_frames(n_blocks, b, p);
+    let mut means = vec![0.0_f64; p];
+    for row in x.rows() {
+        for (mean, &value) in means.iter_mut().zip(row.iter()) {
+            *mean += value as f64;
+        }
+    }
+    for mean in &mut means {
+        *mean /= n as f64;
+    }
+
+    for block in 0..n_blocks {
+        let mut axes: Vec<Vec<f64>> = Vec::with_capacity(b);
+        for axis in 0..b {
+            let atom = block * b + axis;
+            let row_index = ((atom as u128 * n as u128) / k as u128) as usize;
+            let mut candidate: Vec<f64> = x
+                .row(row_index)
+                .iter()
+                .zip(means.iter())
+                .map(|(&value, &mean)| value as f64 - mean)
+                .collect();
+            let input_norm = candidate
+                .iter()
+                .map(|value| value * value)
+                .sum::<f64>()
+                .sqrt();
+            for _ in 0..2 {
+                for prior in &axes {
+                    let projection: f64 = candidate
+                        .iter()
+                        .zip(prior.iter())
+                        .map(|(left, right)| left * right)
+                        .sum();
+                    for (value, direction) in candidate.iter_mut().zip(prior.iter()) {
+                        *value -= projection * direction;
+                    }
+                }
+            }
+            let norm = candidate
+                .iter()
+                .map(|value| value * value)
+                .sum::<f64>()
+                .sqrt();
+            let roundoff = f32::EPSILON as f64 * (p.max(1) as f64).sqrt() * input_norm;
+            if !norm.is_finite() || norm <= roundoff {
+                axes.clear();
+                break;
+            }
+            for value in &mut candidate {
+                *value /= norm;
+            }
+            axes.push(candidate);
+        }
+        if axes.len() == b {
+            for (axis, values) in axes.iter().enumerate() {
+                for (column, &value) in values.iter().enumerate() {
+                    decoder[[block * b + axis, column]] = value as f32;
+                }
+            }
+        }
+    }
+    decoder
+}
+
 /// splitmix64 mixing step for the deterministic coordinate seed. A local copy so
 /// the seed stream is self-contained and does not depend on any RNG crate.
 fn splitmix64_block(mut x: u64) -> u64 {
@@ -1630,6 +1711,7 @@ fn seed_frames_by_policy(
     policy: BlockSeedPolicy,
 ) -> Array2<f32> {
     match policy {
+        BlockSeedPolicy::DataRows => data_row_frames(x, n_blocks, b),
         BlockSeedPolicy::FarthestPoint => seed_frames(x, n_blocks, b),
         BlockSeedPolicy::CoordinatePartition => coordinate_partition_frames(n_blocks, b, x.ncols()),
     }
@@ -2200,15 +2282,14 @@ fn validate(x: ArrayView2<'_, f32>, config: &BlockSparseConfig) -> Result<(), Bl
 /// linear-dictionary request is a modeling choice admitted at ANY `K`, not a
 /// shape-derived demotion.
 ///
-/// Seeds with the data-aware [`BlockSeedPolicy::FarthestPoint`] pass. At `K ≫ 1`
-/// that serial `O(N·P·K)` seed dominates the fit; use
-/// [`fit_block_sparse_dictionary_with_seed`] with
-/// [`BlockSeedPolicy::CoordinatePartition`] for the large-`K` front door.
+/// Seeds from centred observations with [`BlockSeedPolicy::DataRows`].  The
+/// `O(N·P + K·P)` seed remains data-placed at large `K`, without the serial
+/// `O(N·P·K)` farthest-point pass or dependence on later dead-block revival.
 pub fn fit_block_sparse_dictionary(
     x: ArrayView2<'_, f32>,
     config: &BlockSparseConfig,
 ) -> Result<BlockSparseFit, BlockSparseFitError> {
-    fit_block_sparse_dictionary_with_seed(x, config, BlockSeedPolicy::FarthestPoint)
+    fit_block_sparse_dictionary_with_seed(x, config, BlockSeedPolicy::DataRows)
 }
 
 /// #2275/#2023 — the captured-fraction EV-plateau constants (the best-effort arm of

--- a/crates/gam-sae/src/sparse_dict/block_stream.rs
+++ b/crates/gam-sae/src/sparse_dict/block_stream.rs
@@ -45,7 +45,7 @@
 use super::BlockSparseConfig;
 use super::block::{
     RowBlockCode, block_birth_evidence_margin, frame_fixed_point_residual, gram_schmidt_rows,
-    relative_scalar_change, route_and_code_all, seed_frames, stable_rank_symmetric,
+    relative_scalar_change, route_and_code_all, stable_rank_symmetric,
 };
 use super::block_frame::polar_tied_frame_step;
 use super::residual_reservoir::ResidualReservoir;
@@ -273,8 +273,8 @@ pub struct BlockRankCharges {
 impl BlockSparseStreamState {
     /// fit_begin: seed the block frames from `seed` (a representative sample) and
     /// prime the epoch accumulators. The seed fixes `P` and the initial
-    /// orthonormal frames (`seed_frames`); the corpus is streamed later through
-    /// [`Self::partial_fit`]. γ starts at 1.
+    /// orthonormal data-row frames (`data_row_frames`); the corpus is streamed
+    /// later through [`Self::partial_fit`]. γ starts at 1.
     pub fn new(seed: ArrayView2<'_, f32>, config: &BlockSparseConfig) -> Result<Self, String> {
         validate_config(config)?;
         if seed.nrows() == 0 || seed.ncols() == 0 {
@@ -299,7 +299,7 @@ impl BlockSparseStreamState {
         let b = config.block_size;
         let k = config.block_topk.min(g).max(1);
 
-        let decoder = seed_frames(seed, g, b);
+        let decoder = super::block::data_row_frames(seed, g, b);
 
         let cap = config.aux_k.saturating_mul(b).max(1);
         Ok(Self {

--- a/crates/gam-sae/src/sparse_dict/block_stream_tests.rs
+++ b/crates/gam-sae/src/sparse_dict/block_stream_tests.rs
@@ -5,6 +5,32 @@ use super::BlockSparseStreamState;
 use crate::sparse_dict::BlockSparseConfig;
 use ndarray::{Array2, array};
 
+#[test]
+fn streaming_seed_is_data_placed_when_dictionary_is_overcomplete_2023() {
+    let direction = [1.0_f32, 2.0, 3.0, 4.0];
+    let seed = Array2::from_shape_fn((32, direction.len()), |(row, column)| {
+        (row as f32 - 15.5) * direction[column]
+    });
+    let config = BlockSparseConfig::new(16, 1);
+    let state = BlockSparseStreamState::new(seed.view(), &config).expect("valid streaming seed");
+    let direction_norm = direction
+        .iter()
+        .map(|value| value * value)
+        .sum::<f32>()
+        .sqrt();
+    for block in 0..config.n_blocks {
+        let alignment = state
+            .decoder
+            .row(block)
+            .iter()
+            .zip(direction.iter())
+            .map(|(&left, &right)| left * right / direction_norm)
+            .sum::<f32>()
+            .abs();
+        assert!((alignment - 1.0).abs() <= 8.0 * f32::EPSILON);
+    }
+}
+
 fn coupled_fixture() -> (Array2<f32>, Array2<f32>, BlockSparseConfig) {
     let x = array![[1.0_f32, 2.0], [-2.0, 1.0], [0.5, 0.2], [-0.7, -0.4]];
     let decoder = array![[1.0_f32, 0.0], [0.6, 0.8]];

--- a/crates/gam-sae/src/sparse_dict/block_tests.rs
+++ b/crates/gam-sae/src/sparse_dict/block_tests.rs
@@ -122,9 +122,15 @@ fn a_non_descent_scale_keeps_the_support_definable_2825() {
             .collect()
     };
     // NON-VACUITY: at a descent scale this row takes both blocks.
-    assert_eq!(live(&code_row(x.view(), decoder.view(), 1.0, 1, 2, &shortlist)).len(), 2);
+    assert_eq!(
+        live(&code_row(x.view(), decoder.view(), 1.0, 1, 2, &shortlist)).len(),
+        2
+    );
     for gamma in [2.0_f32, 3.5] {
-        assert!(2.0 * gamma - gamma * gamma <= 0.0, "gamma {gamma} must be non-descent");
+        assert!(
+            2.0 * gamma - gamma * gamma <= 0.0,
+            "gamma {gamma} must be non-descent"
+        );
         let selected = code_row(x.view(), decoder.view(), gamma, 1, 2, &shortlist);
         assert_eq!(
             live(&selected),
@@ -1077,8 +1083,8 @@ fn coordinate_partition_frames_are_orthonormal_and_data_independent() {
 }
 
 #[test]
-fn farthest_point_seeded_entry_matches_default_byte_for_byte() {
-    // `fit_block_sparse_dictionary` must be exactly the FarthestPoint case of the
+fn data_row_seeded_entry_matches_default_byte_for_byte_2023() {
+    // `fit_block_sparse_dictionary` must be exactly the DataRows case of the
     // seeded entry — same seed, same alternation, same fixed point.
     let (p, b, n_blocks) = (8usize, 2usize, 3usize);
     let planted = planted_frames(p, n_blocks, b);
@@ -1097,17 +1103,47 @@ fn farthest_point_seeded_entry_matches_default_byte_for_byte() {
     };
     let default_fit = fit_block_sparse_dictionary(x.view(), &config).expect("default fit");
     let seeded_fit =
-        fit_block_sparse_dictionary_with_seed(x.view(), &config, BlockSeedPolicy::FarthestPoint)
-            .expect("FarthestPoint seeded fit");
+        fit_block_sparse_dictionary_with_seed(x.view(), &config, BlockSeedPolicy::DataRows)
+            .expect("data-row seeded fit");
     assert_eq!(
         default_fit.decoder, seeded_fit.decoder,
-        "the default entry must be byte-identical to the FarthestPoint seeded entry"
+        "the default entry must be byte-identical to the data-row seeded entry"
     );
     assert_eq!(
         default_fit.explained_variance,
         seeded_fit.explained_variance
     );
     assert_eq!(default_fit.epochs, seeded_fit.epochs);
+}
+
+#[test]
+fn data_row_seed_places_every_overcomplete_block_in_the_observed_cloud_2023() {
+    // A rotated rank-one cloud is adversarial to coordinate axes.  Even with
+    // K > P, the production seed must place every scalar block on the observed
+    // direction rather than create dead blocks and hope AuxK later revives them.
+    let direction = [1.0_f32, 2.0, 3.0, 4.0];
+    let x = Array2::from_shape_fn((32, direction.len()), |(row, column)| {
+        (row as f32 - 15.5) * direction[column]
+    });
+    let frames = data_row_frames(x.view(), 16, 1);
+    let direction_norm = direction
+        .iter()
+        .map(|value| value * value)
+        .sum::<f32>()
+        .sqrt();
+    for block in 0..16 {
+        let alignment = frames
+            .row(block)
+            .iter()
+            .zip(direction.iter())
+            .map(|(&left, &right)| left * right / direction_norm)
+            .sum::<f32>()
+            .abs();
+        assert!(
+            (alignment - 1.0).abs() <= 8.0 * f32::EPSILON,
+            "block {block} was not seeded from the observed cloud: alignment={alignment}"
+        );
+    }
 }
 
 #[test]
@@ -1244,9 +1280,14 @@ fn tied_frame_stationarity_separates_normal_storage_error_from_tangent_signal_28
         action[[1, 0]] = 3.0 * current[[0, 1]] as f64;
         let scale = action.iter().map(|v| v * v).sum::<f64>().sqrt();
         let measured = super::super::block_frame::polar_tied_frame_step(
-            current.view(), action.view_mut(), second.view(), 0.0, 1.0e30,
+            current.view(),
+            action.view_mut(),
+            second.view(),
+            0.0,
+            1.0e30,
             proposal.view_mut(),
-        ).unwrap();
+        )
+        .unwrap();
         assert!((measured - tangent / scale).abs() <= 16.0 * f64::EPSILON);
     }
 }

--- a/crates/gam-sae/src/tiered/fit.rs
+++ b/crates/gam-sae/src/tiered/fit.rs
@@ -49,10 +49,9 @@ use gam_solve::rho_optimizer::OuterCriterionCertificate;
 
 use crate::front_door::{SaeFitLane, admit_topk_manifold};
 use crate::manifold::{
-    SaeSupportFixedPointReport, SaeSupportOuterRequest, SaeSupportSeedRequest,
-    SaeSupportSparseTerm, SaeSupportTermSeedRequest, build_sae_support_seed,
-    SAE_SUPPORT_INNER_FIXED_POINT_MAX_ITER, build_sae_support_term_seed,
-    run_sae_support_outer, sae_support_effective_atom_dims,
+    SAE_SUPPORT_INNER_FIXED_POINT_MAX_ITER, SaeSupportFixedPointReport, SaeSupportOuterRequest,
+    SaeSupportSeedRequest, SaeSupportSparseTerm, SaeSupportTermSeedRequest, build_sae_support_seed,
+    build_sae_support_term_seed, run_sae_support_outer, sae_support_effective_atom_dims,
 };
 use crate::migration_ledger::{BirthSeed, MoveEvidence, MoveReason, MoveStage, SaeMigrationLedger};
 use crate::sparse_dict::{
@@ -64,24 +63,13 @@ use crate::tiered::code_space::{
     CodeSpacePromotionReport, harvest_code_space_promotions, linear_distortion_floor,
 };
 
-/// Serial farthest-point block seed budget in element-ops (`N·P·G·b`). Above this
-/// the `O(N·P·K)` corpus pass dominates the whole Tier-1 fit (measured to be the
-/// scaling wall at `K ≈ 1e4`, unrelated to routing), so [`TieredSeedPolicy::Auto`]
-/// switches to the `O(K·b)` coordinate-partition seed. Below it the data-aware
-/// farthest-point seed is affordable and gives the more coherent starting blocks.
-const FARTHEST_POINT_SEED_MAX_OPS: u128 = 1_000_000_000;
-
 /// How Tier-1 seeds its `K = G·b` block frames. The default [`Auto`] keeps the
-/// data-aware farthest-point seed at small/moderate `K` and switches to the cheap
-/// coordinate-partition seed once the serial farthest-point pass would dominate —
-/// the "Tier-1 K>small" entry that makes a `K ≈ 1e4` tiered fit tractable end to end
-/// without a caller flag (#2023).
+/// seed data-placed at every width using the linear-cost data-row construction.
 ///
 /// [`Auto`]: TieredSeedPolicy::Auto
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
 pub enum TieredSeedPolicy {
-    /// Pick by the farthest-point seed cost `N·P·G·b` against
-    /// `FARTHEST_POINT_SEED_MAX_OPS`.
+    /// Use the scalable data-row seed.
     #[default]
     Auto,
     /// Force the data-aware farthest-point seed regardless of `K`.
@@ -93,21 +81,11 @@ pub enum TieredSeedPolicy {
 impl TieredSeedPolicy {
     /// Resolve to a concrete [`BlockSeedPolicy`] for a corpus of `n` rows and the
     /// Tier-1 block geometry (`G` blocks of size `b` in `ℝ^P`).
-    fn resolve(self, n: usize, p: usize, config: &BlockSparseConfig) -> BlockSeedPolicy {
+    fn resolve(self, _n: usize, _p: usize, _config: &BlockSparseConfig) -> BlockSeedPolicy {
         match self {
+            TieredSeedPolicy::Auto => BlockSeedPolicy::DataRows,
             TieredSeedPolicy::FarthestPoint => BlockSeedPolicy::FarthestPoint,
             TieredSeedPolicy::CoordinatePartition => BlockSeedPolicy::CoordinatePartition,
-            TieredSeedPolicy::Auto => {
-                let ops = (n as u128)
-                    * (p as u128)
-                    * (config.n_blocks as u128)
-                    * (config.block_size as u128);
-                if ops > FARTHEST_POINT_SEED_MAX_OPS {
-                    BlockSeedPolicy::CoordinatePartition
-                } else {
-                    BlockSeedPolicy::FarthestPoint
-                }
-            }
         }
     }
 }
@@ -177,8 +155,8 @@ pub struct TieredFitConfig {
     /// block-gate lane when the mode admits it and a runtime is present.
     pub tier1: BlockSparseConfig,
     /// How Tier-1 seeds its `K` block frames. [`TieredSeedPolicy::Auto`] (default)
-    /// switches to the cheap coordinate-partition seed once the serial
-    /// farthest-point pass would dominate, so a `K ≈ 1e4` tiered fit runs end to end.
+    /// uses the data-row seed, so a `K ≈ 1e4` fit is both linear-cost and
+    /// data-placed from its first routing pass.
     pub tier1_seed: TieredSeedPolicy,
     /// Whether to run the Tier-2 curved refinement on the Tier-1 residual
     /// (`false` ⇒ Tier-0 + Tier-1 only, the linear-bulk baseline).
@@ -791,8 +769,14 @@ mod peel_tests {
         centered: ArrayView2<'_, f64>,
         n_atoms: usize,
         support_k: usize,
-    ) -> Result<(SaeSupportSparseTerm, SaeSupportFixedPointReport, OuterCriterionCertificate), String>
-    {
+    ) -> Result<
+        (
+            SaeSupportSparseTerm,
+            SaeSupportFixedPointReport,
+            OuterCriterionCertificate,
+        ),
+        String,
+    > {
         let (n_obs, output_dim) = centered.dim();
         let atom_basis = vec!["periodic".to_string(); n_atoms];
         let atom_dim = vec![1usize; n_atoms];
@@ -841,7 +825,11 @@ mod peel_tests {
         let config = LinearPeelConfig::derive(16, 2, 3).expect("derives");
         assert_eq!(config.tier1.block_size, 2, "b = d_max");
         assert_eq!(config.tier1.n_blocks, 8, "G = P / b");
-        assert_eq!(config.tier1.n_atoms(), 16, "K_lin = P, the identifiable width");
+        assert_eq!(
+            config.tier1.n_atoms(),
+            16,
+            "K_lin = P, the identifiable width"
+        );
         assert_eq!(config.tier1.block_topk, 3, "k = support_k");
         // support_k above the block count cannot fire more blocks than exist.
         let narrow = LinearPeelConfig::derive(4, 1, 9).expect("derives");
@@ -874,7 +862,10 @@ mod peel_tests {
             fixed_point.recurred,
             "the peeled inner fixed point must have RECURRED; got {fixed_point:?}"
         );
-        assert!(term.k_atoms() >= 1, "the peeled fit must retain a curved atom");
+        assert!(
+            term.k_atoms() >= 1,
+            "the peeled fit must retain a curved atom"
+        );
     }
 
     /// Arm (b): the composition is exact. The peel's additive offset `μ + L +
@@ -969,7 +960,8 @@ mod peel_tests {
         let mut max_delta = 0.0f64;
         for row in 0..z.nrows() {
             for column in 0..z.ncols() {
-                max_delta = max_delta.max((peel.residual[[row, column]] - unpeeled[[row, column]]).abs());
+                max_delta =
+                    max_delta.max((peel.residual[[row, column]] - unpeeled[[row, column]]).abs());
             }
         }
         assert!(
@@ -1343,26 +1335,22 @@ mod fit_tests {
         assert_eq!(report.ledger.pc_reseed_events, 0);
     }
 
-    /// `TieredSeedPolicy::Auto` keeps the data-aware farthest-point seed at small
-    /// `K` and switches to the cheap coordinate-partition seed once the serial
-    /// `N·P·G·b` pass would blow the budget — the "Tier-1 K>small" entry decision.
+    /// `TieredSeedPolicy::Auto` is data-placed without a serial farthest-point
+    /// search at both small and large `K`.
     #[test]
-    fn auto_seed_switches_at_the_farthest_point_budget() {
-        // Small geometry (well under the 1e9-op budget) → farthest-point.
+    fn auto_seed_is_scalable_and_data_placed_at_every_width_2023() {
         let small = TieredFitConfig::linear_bulk(8, 2);
         assert_eq!(
             small.tier1_seed.resolve(240, 16, &small.tier1),
-            BlockSeedPolicy::FarthestPoint,
-            "small-K tiered fit must keep the data-aware seed"
+            BlockSeedPolicy::DataRows
         );
-        // K≈1e4 at the #2023 target width (N=1e5, P=64) → N·P·G·b ≫ 1e9 → cheap seed.
         let large = TieredFitConfig::linear_bulk(2_500, 4);
         assert_eq!(
             large.tier1_seed.resolve(100_000, 64, &large.tier1),
-            BlockSeedPolicy::CoordinatePartition,
-            "large-K tiered fit must switch to the coordinate-partition seed"
+            BlockSeedPolicy::DataRows,
+            "large-K tiered fit must remain data-placed"
         );
-        // Explicit overrides ignore the budget.
+        // Explicit overrides remain available for controlled comparisons.
         let mut forced = TieredFitConfig::linear_bulk(2_500, 4);
         forced.tier1_seed = TieredSeedPolicy::FarthestPoint;
         assert_eq!(

--- a/gamfit/_sparse_dictionary.py
+++ b/gamfit/_sparse_dictionary.py
@@ -1025,7 +1025,7 @@ class BlockSparseDictStream:
     ----------
     seed:
         A representative ``N_seed x P`` sample fixing ``P`` and seeding the initial
-        block frames (deterministic farthest-point + orthonormalisation).
+        block frames (centred, evenly distributed data rows + orthonormalisation).
     n_blocks, block_size, block_topk, max_epochs, minibatch, block_tile, frame_ridge, aux_k, tolerance:
         Identical hyper-parameters to :func:`block_sparse_dictionary_fit`.
     """


### PR DESCRIPTION
### Motivation
- The large-K Tier-1 path relied on a corpus-independent coordinate partition seed that left many blocks dead and the dictionary functionally undercomplete at K ≫ p; this change makes the Tier-1 seed data-placed and linear-cost so capacity is placed inside the observed cloud up-front.
- The streaming and one-shot block lanes diverged on seeding semantics; parity is required so Python/Rust surfaces behave identically.

### Description
- Add a deterministic data-row block seed `data_row_frames(...)` that centres selected rows, spreads the K axes across observations, orthonormalizes each block via two-pass Gram–Schmidt, and falls back safely for degenerate rows, with complexity `O(N·P + K·P)`; expose it for in-crate use. (`crates/gam-sae/src/sparse_dict/block.rs`)
- Introduce `BlockSeedPolicy::DataRows` and make the public one-shot `fit_block_sparse_dictionary` default to the data-row seed; keep `FarthestPoint` and `CoordinatePartition` as explicit options. (`crates/gam-sae/src/sparse_dict/block.rs`)
- Make `TieredSeedPolicy::Auto` resolve to the scalable data-row seed (so `Auto` is data-placed at any width) and leave explicit overrides available. (`crates/gam-sae/src/tiered/fit.rs`)
- Wire the streaming front-end to use the same `data_row_frames` seed so streaming and one-shot fits are behaviourally identical and avoid later reliance on AuxK revival. (`crates/gam-sae/src/sparse_dict/block_stream.rs`)
- Update Python docstring in the thin wrapper to reflect the new data-placed streaming seed. (`gamfit/_sparse_dictionary.py`)
- Add tests that pin the new behaviour and prevent regression: `data_row_seeded_entry_matches_default_byte_for_byte_2023`, `data_row_seed_places_every_overcomplete_block_in_the_observed_cloud_2023`, `streaming_seed_is_data_placed_when_dictionary_is_overcomplete_2023`, and `auto_seed_is_scalable_and_data_placed_at_every_width_2023`. (`crates/gam-sae/src/sparse_dict/block_tests.rs`, `block_stream_tests.rs`, `crates/gam-sae/src/tiered/fit.rs`)

### Testing
- Ran targeted unit tests in `gam-sae`: `sparse_dict::block::block_tests::data_row_seed_places_every_overcomplete_block_in_the_observed_cloud_2023` and `sparse_dict::block::block_tests::data_row_seeded_entry_matches_default_byte_for_byte_2023` and both passed (1/1 and 1/1 respectively in their runs).
- Ran streaming test `sparse_dict::block_stream::block_stream_tests::streaming_seed_is_data_placed_when_dictionary_is_overcomplete_2023` and Tiered policy test `tiered::fit::fit_tests::auto_seed_is_scalable_and_data_placed_at_every_width_2023`, and both passed.
- Verified `fit_block_sparse_dictionary` and streaming entry use the new seed by regression tests added, and `cargo test -p gam-sae` for the selected tests reported all new tests passed (no failures).
- Noted an unrelated pre-existing `-D warnings` issue surfaced by a workspace check: `cargo check -p gam-sae` reported unused/dead-code warnings in other `sae` modules (methods flagged as never used), which are unrelated to this change and must be addressed separately on the repo-wide CI build; the targeted tests added here are green.