### PR TITLE
fix(tweedie): reject derivative-free power profiling (#2026)

### DIFF
--- a/crates/gam-models/src/fit_orchestration/fit.rs
+++ b/crates/gam-models/src/fit_orchestration/fit.rs
@@ -581,193 +581,15 @@ mod standard_convergence_gate_tests {
     }
 }
 
-/// **Exact** Tweedie log-likelihood of a fit at a fixed variance power `p` — the
-/// profile objective maximized to estimate `p` (#2026 / #2105).
-///
-/// Refits the mean/dispersion GLM at `Tweedie { p }` reusing the existing fit
-/// machinery (no reimplementation), reconstructs the fitted mean
-/// `μ = exp(Xβ̂ + offset)` on the log link, and evaluates the **exact** Jørgensen
-/// compound-Poisson–gamma log-density (`gam_solve::pirls::tweedie_exact_loglik_total_from_eta`)
-/// at the estimated dispersion `φ̂(p)`.
-///
-/// CRITICAL (#2105): the objective must be the *exact* EDM density, NOT the
-/// separately named saddlepoint approximation. The saddlepoint is exact
-/// only in the many-jumps (large Poisson-rate λ) limit; at the moderate λ of a
-/// typical Tweedie fit its missing `O(1/λ)` normalizer correction, summed across
-/// the sample, biases the profile maximizer **low** (e.g. `p̂ ≈ 1.33` on `p = 1.5`
-/// data). Because the reported dispersion is the Pearson estimate
-/// `φ̂ = Σw(y−μ)²/μ^p / Σw`, an under-estimated `p` inflates `φ̂` and every SE /
-/// interval scaled by `√φ̂`. mgcv's `tw()` profiles `p` on the same exact series
-/// (`ldTweedie`) for exactly this reason.
-///
-/// Returns `Err(reason)` when the refit fails or yields a non-finite objective.
-/// The profile search skips such a node rather than aborting, but it KEEPS the
-/// reason: when every node is unusable the reason is the only thing that says
-/// what actually went wrong, and collapsing it to a bare `None` is what made
-/// `estimate_tweedie_power` blame degenerate data for what is usually an outer
-/// REML refusal (and advise pinning `family="tweedie(p)"`, which does not help).
-fn tweedie_profile_loglik(request: &StandardFitRequest<'_>, p: f64) -> Result<f64, String> {
-    if !gam_spec::is_valid_tweedie_power(p) {
-        return Err(format!("p={p} is not a valid Tweedie variance power"));
-    }
-    let family = LikelihoodSpec::new(ResponseFamily::Tweedie { p }, request.family.link.clone());
-    let fitted = fit_standard_base(request, &family, &request.options)
-        .map_err(|e| format!("the mean/dispersion refit at p={p:.4} failed: {e}"))?;
-    // μ = g⁻¹(Xβ̂ + offset); the Tweedie family is fixed to the log link by
-    // `resolve_family`, so g⁻¹ = exp. `design.apply` reproduces the fitted
-    // linear predictor exactly (same contract the expectile/predict paths use).
-    // `design.apply` already folds the design's fixed affine channel (non-zero
-    // B-spline endpoint anchor, #2297) into `Xβ̂`, so only the user offset is
-    // added here; adding `affine_offset` again would double-count the pin.
-    let mut eta = fitted
-        .design
-        .apply(fitted.fit.beta.view())
-        .map_err(|e| format!("applying the refit design at p={p:.4} failed: {e}"))?;
-    if eta.len() != request.y.len() {
-        return Err(format!(
-            "the refit at p={p:.4} produced {} linear-predictor rows, expected {}",
-            eta.len(),
-            request.y.len()
-        ));
-    }
-    eta += request.offset.as_ref();
-    let mu = eta.mapv(f64::exp);
-    // Profile the dispersion out at this `p` with the SAME prior-weighted Pearson
-    // moment estimator the inner solver uses to report the Tweedie `φ̂`
-    // (`estimate_tweedie_phi_from_eta`): `φ̂ = Σ wᵢ (yᵢ − μᵢ)² / μᵢ^p / Σ wᵢ`.
-    // Computing it here from the reconstructed mean makes the profile objective
-    // independent of whether the fit retained an inference/covariance block (the
-    // seed `φ = 1` carried on `likelihood_scale` would otherwise bias every node
-    // identically-but-wrongly) and gives each `p` its own maximized dispersion —
-    // the whole point of a profile likelihood.
-    const PHI_MIN: f64 = 1e-6;
-    const PHI_MAX: f64 = 1e12;
-    let mut weighted_pearson = 0.0_f64;
-    let mut total_weight = 0.0_f64;
-    for ((&yi, &mui), &wi) in request.y.iter().zip(mu.iter()).zip(request.weights.iter()) {
-        let wi = wi.max(0.0);
-        if wi == 0.0 {
-            continue;
-        }
-        let resid = yi - mui;
-        let var_unit = mui.powf(p).max(f64::MIN_POSITIVE);
-        weighted_pearson += wi * resid * resid / var_unit;
-        total_weight += wi;
-    }
-    if total_weight <= 0.0 || !weighted_pearson.is_finite() || weighted_pearson <= 0.0 {
-        return Err(format!(
-            "the profiled dispersion at p={p:.4} is unusable: weighted Pearson statistic \
-             {weighted_pearson:.6e} over total weight {total_weight:.6e}"
-        ));
-    }
-    let phi = (weighted_pearson / total_weight).clamp(PHI_MIN, PHI_MAX);
-    // Evaluate the EXACT compound-Poisson–gamma density at φ̂(p) — the profile
-    // objective mgcv's `tw()` maximizes. Using a saddlepoint here is what biased
-    // `p̂` low and inflated `φ̂` (#2105).
-    let ll = gam_solve::pirls::tweedie_exact_loglik_total_from_eta(
-        request.y.view(),
-        eta.view(),
-        request.weights.view(),
-        p,
-        phi,
-    )
-    .map_err(|e| {
-        format!("the exact compound-Poisson-gamma density at p={p:.4}, phi={phi:.6e} failed: {e}")
-    })?;
-    if !ll.is_finite() {
-        return Err(format!(
-            "the exact compound-Poisson-gamma density at p={p:.4}, phi={phi:.6e} is non-finite"
-        ));
-    }
-    Ok(ll)
-}
-
-/// Estimate the Tweedie variance power `p ∈ (1, 2)` by profile likelihood, mgcv
-/// `tw()`-style (#2026), via a **golden-section search** over the whole open
-/// interval `(1, 2)` — NO fixed node grid (SPEC: grid search is never allowed;
-/// #2064). The profile objective [`tweedie_profile_loglik`] (a full mean/
-/// dispersion refit at each `p`) is smooth and unimodal in `p` for the
-/// compound-Poisson-gamma law, so golden section brackets the maximizer directly
-/// and contracts the bracket by the golden ratio each step. The mean fit is
-/// robust to a misspecified `p`, but the observation-interval calibration is
-/// not, so this is what makes bare `family="tweedie"` track data whose true
-/// power ≠ 1.5.
-fn estimate_tweedie_power(request: &StandardFitRequest<'_>) -> Result<f64, String> {
-    // Endpoints excluded: the Tweedie unit-deviance / saddlepoint density is
-    // singular at p = 1 (Poisson) and p = 2 (gamma).
-    const EPS: f64 = 1e-3;
-    // Converge the bracket to this width in `p`; finer than the physically
-    // meaningful precision of the variance power.
-    const TOL: f64 = 1e-3;
-    let mut a = 1.0 + EPS;
-    let mut b = 2.0 - EPS;
-    let inv_phi_gr = (5.0_f64.sqrt() - 1.0) / 2.0; // 1/φ ≈ 0.618
-    // Keep the FIRST reason a node was rejected. Every `eval` that fails feeds
-    // `NEG_INFINITY` into the bracket, which is the right thing for the search
-    // but erases why; if no node is ever usable, this is the only surviving
-    // account of the cause.
-    let mut first_rejection: Option<String> = None;
-    let mut eval = |p: f64| match tweedie_profile_loglik(request, p) {
-        Ok(ll) => ll,
-        Err(reason) => {
-            first_rejection.get_or_insert(reason);
-            f64::NEG_INFINITY
-        }
-    };
-    // Iteration count DERIVED from the tolerance (not a magic cap): each step
-    // multiplies the bracket width by `inv_phi_gr`, so `n` steps with
-    // `(b−a)·inv_phi_gr^n ≤ TOL` guarantees convergence to `TOL`.
-    let n_iter = (((TOL / (b - a)).ln() / inv_phi_gr.ln()).ceil() as i64).max(1) as usize;
-    let mut c = b - inv_phi_gr * (b - a);
-    let mut d = a + inv_phi_gr * (b - a);
-    let mut fc = eval(c);
-    let mut fd = eval(d);
-    for _ in 0..n_iter {
-        if fc >= fd {
-            b = d;
-            d = c;
-            fd = fc;
-            c = b - inv_phi_gr * (b - a);
-            fc = eval(c);
-        } else {
-            a = c;
-            c = d;
-            fc = fd;
-            d = a + inv_phi_gr * (b - a);
-            fd = eval(d);
-        }
-    }
-    let p_hat = (0.5 * (a + b)).clamp(1.0 + EPS, 2.0 - EPS);
-    // A finite profile likelihood at the maximizer certifies the search found a
-    // usable optimum (degenerate data — every `p` non-finite — fails here rather
-    // than silently returning the interval midpoint).
-    //
-    // NAME THE ACTUAL CAUSE. The old message asserted "the profile likelihood is
-    // non-finite across (1, 2)" and advised pinning `family="tweedie(p)"`. That
-    // reads as a statement about the data, and it is the wrong advice whenever
-    // the real failure is the per-node refit refusing to certify a fit at all —
-    // in which case pinning `p` changes nothing, because the pinned fit takes
-    // exactly the same refusing path. The profile likelihood cannot even be said
-    // to be "non-finite" there: it was never evaluated.
-    if let Err(at_maximizer) = tweedie_profile_loglik(request, p_hat) {
-        let cause = first_rejection.as_deref().unwrap_or(at_maximizer.as_str());
-        return Err(format!(
-            "tweedie power profiling failed: no variance power in (1, 2) yielded a usable \
-             profile likelihood, so `p` could not be estimated. First cause: {cause}. At the \
-             bracket midpoint p={p_hat:.4}: {at_maximizer}. Pinning the power via \
-             family=\"tweedie(p)\" only helps if the profile refits themselves were sound."
-        ));
-    }
-    log::info!(
-        "[tweedie#2026] estimated variance power p={p_hat:.4} by golden-section profile \
-         likelihood (bare family=\"tweedie\"); set family=\"tweedie(p)\" to pin it."
-    );
-    Ok(p_hat)
-}
-
 pub(crate) fn fit_standard_model(
     mut request: StandardFitRequest<'_>,
 ) -> Result<StandardFitResult, String> {
+    if request.estimate_tweedie_p {
+        return Err(
+            "automatic Tweedie power profiling is derivative-free hyperparameter search and is forbidden by SPEC.md; supply an explicit p strictly between 1 and 2"
+                .to_string(),
+        );
+    }
     // #2750: resolve every AUTO measure-jet representer range against the
     // response, once, before anything reads the spec.
     //
@@ -800,24 +622,6 @@ pub(crate) fn fit_standard_model(
             "[#2750] screened the representer range of {seeded} auto measure-jet term(s) against \
              the response before the standard-fit dispatch"
         );
-    }
-    // #2026: magic-by-default Tweedie power. A bare `family="tweedie"`/`"tw"`
-    // arrives with a placeholder power and `estimate_tweedie_p = true`; profile
-    // `p` over (1, 2) by likelihood and bake the estimate into `family` so the
-    // reported fit — and every observation interval derived from it — uses the
-    // data-driven power rather than the interior fallback. An explicit
-    // `tweedie(1.6)` leaves the flag `false` and skips this entirely.
-    if request.estimate_tweedie_p
-        && matches!(request.family.response, ResponseFamily::Tweedie { .. })
-    {
-        let p_hat = estimate_tweedie_power(&request)?;
-        request.family = LikelihoodSpec::new(
-            ResponseFamily::Tweedie { p: p_hat },
-            request.family.link.clone(),
-        );
-        // The power is now pinned; the final fit below is an ordinary fixed-p
-        // Tweedie fit.
-        request.estimate_tweedie_p = false;
     }
 
     // #1762: near-perfect linear separation drives the binomial REML/ARC

--- a/crates/gam-models/src/fit_orchestration/materialize/family.rs
+++ b/crates/gam-models/src/fit_orchestration/materialize/family.rs
@@ -174,50 +174,6 @@ fn apply_paren_link(
     Ok((LikelihoodSpec::new(base_spec.response, inverse_link), true))
 }
 
-/// #2026: whether a resolved Tweedie family should have its variance power `p`
-/// estimated by profile likelihood (mgcv `tw()` semantics) instead of held at
-/// the interior fallback baked in by [`resolve_family`].
-///
-/// mgcv's `tw()` family has no canonical `p` — it profiles `p` over the open
-/// interval `(1, 2)`. This returns `true` exactly when the user named the bare
-/// Tweedie family (`tweedie` / `tw` / `tweedie-log`, case- and separator-
-/// insensitive) WITHOUT an explicit numeric power argument. An explicit power
-/// (`tweedie(1.6)` / `tweedie(p=1.6)`) pins `p` and returns `false`; a
-/// non-numeric parenthesized argument (`tweedie(log)`) is a link, not a power,
-/// so it still estimates. The head/argument split mirrors the parser inside
-/// [`resolve_family`] so the two decisions cannot drift.
-pub fn tweedie_power_is_estimated(family: Option<&str>) -> bool {
-    let Some(name) = family else {
-        return false;
-    };
-    let lowered = name.to_ascii_lowercase().replace('_', "-");
-    let (head, arg): (&str, Option<&str>) = if let Some(open) = lowered.find('(')
-        && lowered.ends_with(')')
-    {
-        let head = lowered[..open].trim_end_matches('-').trim();
-        let inner = lowered[open + 1..lowered.len() - 1].trim();
-        if head.is_empty() || inner.is_empty() {
-            (lowered.as_str(), None)
-        } else {
-            (head, Some(inner))
-        }
-    } else {
-        (lowered.as_str(), None)
-    };
-    if !matches!(head, "tweedie" | "tw" | "tweedie-log") {
-        return false;
-    }
-    // An explicit numeric power (`1.6` or `p=1.6`) pins `p`; a missing argument
-    // or a non-numeric link argument leaves `p` to be estimated from the data.
-    match arg {
-        Some(a) => {
-            let numeric = a.strip_prefix("p=").unwrap_or(a).trim();
-            numeric.parse::<f64>().is_err()
-        }
-        None => true,
-    }
-}
-
 /// Nuisance parameters that a family NAME cannot carry on its own.
 ///
 /// The response family is fully determined by its name; `theta`, the Tweedie
@@ -365,6 +321,15 @@ pub fn scalar_family_from_name(
     // same validity gate as the parenthesized `tweedie(p=…)` form above, so one
     // bad power fails identically whichever surface named the family. A power
     // written into the name wins, because it is the more specific statement.
+    if matches!(head_name, "tweedie" | "tw" | "tweedie-log")
+        && tweedie_p_override.is_none()
+    {
+        return Err(WorkflowError::InvalidConfig {
+            reason: "Tweedie family requires an explicit variance power p strictly between 1 and 2 (for example, tweedie(p=1.5)); automatic power profiling is derivative-free hyperparameter search and is forbidden by SPEC.md"
+                .to_string(),
+        }
+        .into());
+    }
     if let Some(p) = tweedie_p_override
         && !gam_spec::is_valid_tweedie_power(p)
     {
@@ -513,20 +478,16 @@ pub fn scalar_family_from_name(
         ),
         // Tweedie compound-Poisson-Gamma family. The variance power p
         // must lie strictly in (1, 2). mgcv's `tw()` has NO canonical
-        // p — it *estimates* p by profile likelihood; here p can be set
-        // explicitly via the mgcv-style `tweedie(1.6)` / `tweedie(p=1.6)`
-        // parenthesized argument (parsed above into `tweedie_p_override`,
-        // #2026). Absent an explicit power we fall back to p = 1.5, a
-        // neutral interior default; the fitted mean (log-link
-        // quasi-likelihood) is robust to a misspecified p, but the
-        // observation-interval calibration depends on it, so callers on
-        // data whose true p != 1.5 should set it. The link is fixed to
+        // p — it *estimates* p by profile likelihood. We require callers to set
+        // it explicitly via `tweedie(1.6)` / `tweedie(p=1.6)`: profiling it
+        // without an analytic p-derivative would violate SPEC.md's ban on
+        // derivative-free hyperparameter search. The link is fixed to
         // log (the only link wired through the Tweedie working-response
         // and dispersion machinery). "tw" matches mgcv's family alias.
         "tweedie" | "tw" => (
             LikelihoodSpec::new(
                 ResponseFamily::Tweedie {
-                    p: tweedie_p_override.unwrap_or(1.5),
+                    p: tweedie_p_override.expect("explicit Tweedie power validated above"),
                 },
                 InverseLink::Standard(StandardLink::Log),
             ),
@@ -535,7 +496,7 @@ pub fn scalar_family_from_name(
         "tweedie-log" => (
             LikelihoodSpec::new(
                 ResponseFamily::Tweedie {
-                    p: tweedie_p_override.unwrap_or(1.5),
+                    p: tweedie_p_override.expect("explicit Tweedie power validated above"),
                 },
                 InverseLink::Standard(StandardLink::Log),
             ),
@@ -839,11 +800,20 @@ mod tweedie_power_tests {
     }
 
     #[test]
-    fn tweedie_bare_defaults_to_interior_power() {
-        // No explicit power → the neutral interior default (documented as a
-        // fallback, not a canonical value).
-        assert_eq!(tweedie_p("tweedie"), 1.5);
-        assert_eq!(tweedie_p("tw"), 1.5);
+    fn tweedie_bare_requires_explicit_power_instead_of_derivative_free_profiling() {
+        let y = array![0.0, 1.2, 3.4];
+        for family in ["tweedie", "tw", "tweedie(log)"] {
+            let error = resolve_family(
+                Some(family),
+                None,
+                None,
+                y.view(),
+                ResponseColumnKind::Numeric,
+                "y",
+            )
+            .expect_err("a bare Tweedie family must not trigger derivative-free profiling");
+            assert!(error.contains("requires an explicit variance power"), "{error}");
+        }
     }
 
     #[test]

--- a/crates/gam-models/src/fit_orchestration/materialize/mod.rs
+++ b/crates/gam-models/src/fit_orchestration/materialize/mod.rs
@@ -17,7 +17,6 @@ pub use columns::{resolve_offset_column, resolve_weight_column};
 pub(crate) use columns::resolve_continuous_column;
 pub use family::{
     FamilyNuisanceOverrides, resolve_family, response_column_kind, scalar_family_from_name,
-    tweedie_power_is_estimated,
 };
 pub use survival_time::{PreparedSurvivalTimeStack, prepare_survival_time_stack};
 pub use validation::is_binary_response;

--- a/crates/gam-models/src/fit_orchestration/materialize/standard.rs
+++ b/crates/gam-models/src/fit_orchestration/materialize/standard.rs
@@ -28,14 +28,6 @@ pub(crate) fn materialize_standard<'a>(
         y_kind,
         &parsed.response,
     )?;
-    // #2026: a bare `family="tweedie"`/`"tw"` (no explicit power) mirrors mgcv's
-    // `tw()`: the variance power `p` is estimated by profile likelihood before
-    // the reported fit, so the observation-interval calibration tracks the data
-    // rather than the interior fallback `resolve_family` baked in. An explicit
-    // `tweedie(1.6)` pins `p` and leaves this `false`.
-    let estimate_tweedie_p = matches!(family.response, ResponseFamily::Tweedie { .. })
-        && matches!(family.link, InverseLink::Standard(StandardLink::Log))
-        && tweedie_power_is_estimated(config.family.as_deref());
 
     // Per-family response-support validation (#335 Gamma requires y > 0;
     // #337 Poisson/NegativeBinomial require y ≥ 0; mirrors the Beta
@@ -341,7 +333,7 @@ pub(crate) fn materialize_standard<'a>(
             offset: Arc::new(offset),
             spec,
             family,
-            estimate_tweedie_p,
+            estimate_tweedie_p: false,
             options,
             kappa_options,
             wiggle,

--- a/crates/gam-models/src/fit_orchestration/request.rs
+++ b/crates/gam-models/src/fit_orchestration/request.rs
@@ -86,13 +86,9 @@ pub struct StandardFitRequest<'a> {
     pub offset: Arc<Array1<f64>>,
     pub spec: TermCollectionSpec,
     pub family: LikelihoodSpec,
-    /// #2026: estimate the Tweedie variance power `p` by profile likelihood
-    /// (mgcv `tw()` semantics) before the final fit, rather than trusting the
-    /// `p` baked into `family`. Set only for a bare `family="tweedie"`/`"tw"`
-    /// request that named no explicit power; an explicit `tweedie(1.6)` pins `p`
-    /// and leaves this `false`. When `true`, `family` must carry
-    /// `ResponseFamily::Tweedie` on a log link (the placeholder power is
-    /// overwritten with the estimate).
+    /// Legacy request bit retained for source compatibility. Production
+    /// materialization always sets this to `false`; automatic Tweedie power
+    /// profiling is forbidden and bare Tweedie families are rejected.
     pub estimate_tweedie_p: bool,
     pub options: FitOptions,
     pub kappa_options: SpatialLengthScaleOptimizationOptions,


### PR DESCRIPTION
### Motivation

- SPEC.md forbids derivative-free hyperparameter search and direct profiling over parameters in production code, and the code previously profiled Tweedie variance power `p` at materialization/runtime which violated that rule.
- Requiring an explicit Tweedie variance power prevents hidden golden-section/profile searches and preserves behaviour parity across surfaces while leaving an analytic restoration route for the future.

### Description

- Require callers to supply an explicit Tweedie variance power `p ∈ (1, 2)` and reject bare `tweedie`/`tw`/`tweedie-log` spellings that would have triggered automatic profiling. (changes to `materialize/family.rs`).
- Make production materialization always set `estimate_tweedie_p = false` and refuse legacy requests that set it to `true` at the fit entry point so internal request construction cannot re-enable profiling. (changes to `materialize/standard.rs`, `request.rs`, and `fit.rs`).
- Replace the prior profile/golden-section path with a hard refusal at the standard-fit boundary to keep the runtime free of derivative-free hyperparameter search until an analytic estimator is implemented. (changes to `fit.rs`).
- Add a regression test that asserts bare Tweedie names are rejected rather than launching a derivative-free profiling routine. (test added to `materialize/family.rs` tests).

### Testing

- Ran `cargo check -p gam-models` which completed successfully in the sandbox and reported the package as building in dev profile. 
- Attempted `cargo test -p gam-models tweedie_bare_requires_explicit_power_instead_of_derivative_free_profiling` but the full test compilation exceeded the interactive sandbox time window so the test execution did not complete here. 
- Started `cargo build --workspace --all-targets` as required by the workspace rules but it did not finish within the sandbox run-time; the change compiles locally under the checked package but a full workspace build was not captured to completion in this environment. 
- Performed static checks and pattern searches (audit `rg`) to confirm the removal/disablement of the profile path and that the new rejection path is reachable; these grep-based checks completed successfully.