### PR TITLE
fix(pyffi): make Python boundary panic-free

### DIFF
--- a/crates/gam-pyffi/src/latent/reml_latent_fit_ffi.rs
+++ b/crates/gam-pyffi/src/latent/reml_latent_fit_ffi.rs
@@ -4888,9 +4888,9 @@ fn survival_score_grid_from_times<'py>(
         return Ok(Array1::from_vec(vec![0.0, 1.0]).into_pyarray(py).unbind());
     }
     times.sort_by(|a, b| a.total_cmp(b));
-    let max_t = *times
-        .last()
-        .expect("times is non-empty; the empty case returned above");
+    let max_t = times.last().copied().ok_or_else(|| {
+        py_value_error("survival score grid requires at least one finite positive time".to_string())
+    })?;
     // Data-driven, quantile-spaced evaluation grid spanning [0, max(t)]. The old
     // grid was a fixed {0,1,2,5,10,median} set whose magic constants only made
     // sense for O(1)–O(10) survival times; on any other time scale it either ran

--- a/crates/gam-pyffi/src/manifold/geometry_ffi.rs
+++ b/crates/gam-pyffi/src/manifold/geometry_ffi.rs
@@ -8464,27 +8464,36 @@ fn affine_design_array_impl(
 
 /// Population variance (divide by `n`, matching numpy `np.var`'s default).
 fn population_variance(values: &[f64]) -> f64 {
-    population_covariance(values, values)
+    if values.is_empty() {
+        return 0.0;
+    }
+    let mean = values.iter().sum::<f64>() / values.len() as f64;
+    values
+        .iter()
+        .map(|value| (value - mean) * (value - mean))
+        .sum::<f64>()
+        / values.len() as f64
 }
 
 /// Population covariance (divide by `n`, matching `population_variance`).
-fn population_covariance(a: &[f64], b: &[f64]) -> f64 {
+fn population_covariance(a: &[f64], b: &[f64]) -> Result<f64, String> {
     let n = a.len();
-    assert_eq!(
-        n,
-        b.len(),
-        "population covariance requires equal-length slices"
-    );
+    if n != b.len() {
+        return Err(format!(
+            "population covariance requires equal-length slices, got {n} and {}",
+            b.len()
+        ));
+    }
     if n == 0 {
-        return 0.0;
+        return Ok(0.0);
     }
     let mean_a = a.iter().sum::<f64>() / n as f64;
     let mean_b = b.iter().sum::<f64>() / n as f64;
-    a.iter()
+    Ok(a.iter()
         .zip(b.iter())
         .map(|(&va, &vb)| (va - mean_a) * (vb - mean_b))
         .sum::<f64>()
-        / n as f64
+        / n as f64)
 }
 
 /// Per-term partial dependence on a grid table.
@@ -8605,7 +8614,7 @@ fn model_variance_share_encoded_impl(
             contrib[i] = s;
         }
         let share = if total_var > 0.0 {
-            population_covariance(&contrib, &eta) / total_var
+            population_covariance(&contrib, &eta)? / total_var
         } else {
             0.0
         };

--- a/crates/gam-pyffi/src/manifold/manifold_and_posterior_ffi.rs
+++ b/crates/gam-pyffi/src/manifold/manifold_and_posterior_ffi.rs
@@ -919,7 +919,12 @@ fn cross_fit_shared_precision_groups_json_impl(request_json: &str) -> Result<Str
                 dims.into_iter().collect::<Vec<_>>()
             ));
         }
-        let dimension = *dims.iter().next().expect("dimension checked above");
+        let dimension = dims.iter().next().copied().ok_or_else(|| {
+            format!(
+                "shared precision group {:?} did not establish a coefficient dimension",
+                group.name
+            )
+        })?;
         let numerator = fit_entries.len() as f64 * dimension as f64 + 2.0 * (group.shape - 1.0);
         let denominator = quadratic_sum + 2.0 * group.rate;
         if numerator <= 0.0 {

--- a/crates/gam-pyffi/src/manifold/manifold_pyclasses.rs
+++ b/crates/gam-pyffi/src/manifold/manifold_pyclasses.rs
@@ -23,15 +23,23 @@ use crate::{PyObject, py_value_error};
 )]
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) struct EuclideanManifold {
-    #[pyo3(get, set)]
+    #[pyo3(get)]
     dim: i64,
 }
 
 #[pymethods]
 impl EuclideanManifold {
     #[new]
-    fn new(dim: i64) -> Self {
-        Self { dim }
+    fn new(dim: i64) -> PyResult<Self> {
+        validate_positive_dimension("EuclideanManifold.dim", dim)?;
+        Ok(Self { dim })
+    }
+
+    #[setter]
+    fn set_dim(&mut self, dim: i64) -> PyResult<()> {
+        validate_positive_dimension("EuclideanManifold.dim", dim)?;
+        self.dim = dim;
+        Ok(())
     }
 
     fn __repr__(&self) -> String {
@@ -87,15 +95,23 @@ impl CircleManifold {
 )]
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) struct SphereManifold {
-    #[pyo3(get, set)]
+    #[pyo3(get)]
     intrinsic_dim: i64,
 }
 
 #[pymethods]
 impl SphereManifold {
     #[new]
-    fn new(intrinsic_dim: i64) -> Self {
-        Self { intrinsic_dim }
+    fn new(intrinsic_dim: i64) -> PyResult<Self> {
+        validate_positive_dimension("SphereManifold.intrinsic_dim", intrinsic_dim)?;
+        Ok(Self { intrinsic_dim })
+    }
+
+    #[setter]
+    fn set_intrinsic_dim(&mut self, intrinsic_dim: i64) -> PyResult<()> {
+        validate_positive_dimension("SphereManifold.intrinsic_dim", intrinsic_dim)?;
+        self.intrinsic_dim = intrinsic_dim;
+        Ok(())
     }
 
     fn __repr__(&self) -> String {
@@ -121,15 +137,23 @@ impl SphereManifold {
 )]
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) struct TorusManifold {
-    #[pyo3(get, set)]
+    #[pyo3(get)]
     dim: i64,
 }
 
 #[pymethods]
 impl TorusManifold {
     #[new]
-    fn new(dim: i64) -> Self {
-        Self { dim }
+    fn new(dim: i64) -> PyResult<Self> {
+        validate_positive_dimension("TorusManifold.dim", dim)?;
+        Ok(Self { dim })
+    }
+
+    #[setter]
+    fn set_dim(&mut self, dim: i64) -> PyResult<()> {
+        validate_positive_dimension("TorusManifold.dim", dim)?;
+        self.dim = dim;
+        Ok(())
     }
 
     fn __repr__(&self) -> String {
@@ -146,6 +170,15 @@ impl TorusManifold {
         out.set_item("dim", self.dim)?;
         Ok(out.into_any().unbind())
     }
+}
+
+fn validate_positive_dimension(name: &str, dimension: i64) -> PyResult<()> {
+    if dimension < 1 {
+        return Err(py_value_error(format!(
+            "{name} must be a positive integer (got {dimension})"
+        )));
+    }
+    Ok(())
 }
 
 /// Validate the `1 <= k <= n` domain shared by the constrained-frame

--- a/crates/gam-pyffi/src/model/model_ffi.rs
+++ b/crates/gam-pyffi/src/model/model_ffi.rs
@@ -3042,10 +3042,13 @@ fn basis_with_jet<'py>(
                 let (penalty, null_basis) =
                     smoothness_penalty_impl(knots_array.view(), degree, order)
                         .map_err(py_value_error)?;
-                assert!(
-                    null_basis.ncols() <= penalty.ncols(),
-                    "smoothness penalty nullspace cannot exceed coefficient count"
-                );
+                if null_basis.ncols() > penalty.ncols() {
+                    return Err(py_value_error(format!(
+                        "basis_with_jet bspline returned a nullspace with {} columns for a {}-coefficient penalty",
+                        null_basis.ncols(),
+                        penalty.ncols()
+                    )));
+                }
                 (jet, penalty)
             };
             Ok((
@@ -6869,12 +6872,8 @@ fn build_latent_duchon_design(
     // wrap = TAU for circle/torus); a `None` axis is a Euclidean (open) axis.
     // When `periodic` is `None`/all-open the basis stays byte-identical to the
     // open Euclidean construction (euclidean / sphere / matern latent fits).
-    let periodic_flags: Option<Vec<bool>> = periodic.and_then(|axes| {
-        if axes.len() == latent_dim && axes.iter().any(|p| p.is_some()) {
-            Some(axes.iter().map(|p| p.is_some()).collect())
-        } else {
-            None
-        }
+    let periodic_axes = periodic.filter(|axes| {
+        axes.len() == latent_dim && axes.iter().any(|p| p.is_some())
     });
     let spec = DuchonBasisSpec {
         radial_reparam: None,
@@ -6888,11 +6887,11 @@ fn build_latent_duchon_design(
         periodic: None,
         boundary: OneDimensionalBoundary::Open,
     };
-    let built = if let Some(flags) = periodic_flags {
+    let built = if let Some(axes) = periodic_axes {
         // `periodic` is Some with the same arity (checked above). Each periodic
         // axis carries an explicit chart period (TAU); non-periodic axes get a
         // placeholder period (unused by the builder for `!periodic` axes).
-        let axes = periodic.expect("periodic_flags is only Some when periodic is Some");
+        let flags: Vec<bool> = axes.iter().map(Option::is_some).collect();
         let periods: Vec<f64> = axes.iter().map(|p| p.unwrap_or(1.0)).collect();
         build_duchon_basis_mixed_periodicity_auto(t_mat.view(), &spec, &flags, Some(&periods))
             .map_err(|err| {
@@ -6948,7 +6947,9 @@ fn build_latent_duchon_periodic_jet(
         // collapsed centers, same domain wrap, same constant-only constraint
         // nullspace — and returns the dense `(n, kernel_cols + 1)` first
         // derivative `∂Φ/∂t` (the trailing constant column's derivative is 0).
-        let period = axes[0].expect("latent_dim == 1 periodic axis carries a period");
+        let period = axes.first().copied().flatten().ok_or_else(|| {
+            "periodic one-dimensional latent basis requires a period for its axis".to_string()
+        })?;
         let dphi_dt = create_duchon_basis_1d_derivative_dense(
             t_mat.column(0),
             centers.column(0),

--- a/tests/test_pyffi_panic_free.py
+++ b/tests/test_pyffi_panic_free.py
@@ -1,0 +1,40 @@
+"""Regression tests for invalid values crossing the public Python boundary."""
+
+from __future__ import annotations
+
+import pytest
+
+import gamfit
+
+
+@pytest.mark.parametrize(
+    ("constructor", "keyword", "value", "message"),
+    [
+        (gamfit.EuclideanManifold, "dim", 0, "EuclideanManifold.dim must be a positive integer"),
+        (gamfit.SphereManifold, "intrinsic_dim", -1, "SphereManifold.intrinsic_dim must be a positive integer"),
+        (gamfit.TorusManifold, "dim", 0, "TorusManifold.dim must be a positive integer"),
+    ],
+)
+def test_manifold_constructors_reject_nonpositive_dimensions_with_gam_error(
+    constructor: object, keyword: str, value: int, message: str
+) -> None:
+    """Bad dimensions must raise, rather than reaching indexing-heavy geometry code."""
+    with pytest.raises(gamfit.GamError, match=message):
+        constructor(**{keyword: value})
+
+
+@pytest.mark.parametrize(
+    ("manifold", "attribute"),
+    [
+        (gamfit.EuclideanManifold(2), "dim"),
+        (gamfit.SphereManifold(2), "intrinsic_dim"),
+        (gamfit.TorusManifold(2), "dim"),
+    ],
+)
+def test_manifold_dimension_setters_preserve_valid_boundary(
+    manifold: object, attribute: str
+) -> None:
+    """Mutation cannot bypass the same constructor validation."""
+    with pytest.raises(gamfit.GamError, match="must be a positive integer .*got 0"):
+        setattr(manifold, attribute, 0)
+    assert getattr(manifold, attribute) == 2


### PR DESCRIPTION
### Motivation
- Prevent Rust panics and unchecked indexing from aborting or poisoning the Python interpreter by mapping boundary invariants to Python exceptions at the FFI layer.  
- Harden public Python-visible constructors and setters (manifold descriptors) so user input cannot reach indexing-heavy geometry code without validation.  
- Keep the pyffi layer thin by surfacing engine errors as typed `gamfit.*` exceptions rather than letting `expect`/`assert`/`panic!` abort.

### Description
- Validate manifold descriptor dimensions: `EuclideanManifold`, `SphereManifold`, and `TorusManifold` now check for positive integer dimensions in constructors and setters and return `py_value_error`-mapped errors on invalid input (changes in `manifold_pyclasses.rs`).
- Replace panic-prone checks in the FFI with fallible error returns that map to Python exceptions: convert `expect`/`assert` usages to `Err(py_value_error(...))` or `Result`-style returns in `model_ffi.rs`, `manifold_and_posterior_ffi.rs`, and `reml_latent_fit_ffi.rs` with clear diagnostics.
- Make numeric helpers robust: implement a straightforward `population_variance` and make `population_covariance` return `Result<f64, String>` on shape mismatch, propagating errors at call sites (in `geometry_ffi.rs`).
- Add focused tests `tests/test_pyffi_panic_free.py` that exercise invalid public inputs via the `gamfit` API and assert `gamfit.GamError` and useful messages for both constructor and setter misuse.
- Commit message: `fix(pyffi): make Python boundary panic-free` (local commit present with the above changes across `crates/gam-pyffi` files and the new test file).

### Testing
- Static audit: counted panic-capable constructs in `crates/gam-pyffi` production code and verified the hazardous occurrences dropped from `6` (4 `expect`, 2 `assert`) to `0` after the changes.  
- Python sanity: ran `python -m py_compile tests/test_pyffi_panic_free.py` which succeeded (no syntax errors).  
- Rust check: ran `cargo check -p gam-pyffi` (crate-level) during iteration; it reached the crate and did not report panics originating from the modified boundary code (workspace-wide build was later blocked by unrelated workspace lints).  
- Pytest attempt: invoked `uv run pytest -q tests/test_pyffi_panic_free.py`, but the editable wheel / release build step did not finish within the sandbox time limit so the test run could not be completed in this environment; expected outcome on CI is the new tests to pass.  
- Workspace build: attempted `cargo build --workspace --all-targets` but the full workspace build was too slow in this sandbox and the run was aborted; a CI run is recommended to verify the complete workspace and to ensure ban-scanner/lint gates pass.