### PR TITLE
fix(frontends): expose negative_binomial_theta and expectile_tau in Python fit API

### DIFF
--- a/docs/frontend-parity.md
+++ b/docs/frontend-parity.md
@@ -1,0 +1,96 @@
+# Rust, CLI, and Python surface inventory
+
+This inventory is a source-level census of the supported **user workflows**. It
+was last checked against `src/lib.rs`, `crates/gam-model-api/src/lib.rs`,
+`crates/gam-cli/src/main/cli_args.rs`, `gamfit/__init__.py`, and
+`gamfit/_api.py`. “Shared” means the frontend serializes the same
+`gam.fit-request` document or consumes the same saved-model Rust operation; it
+does not mean that a command-line program reproduces programmatic building-block
+APIs such as a matrix kernel.
+
+## User-workflow cross-tabulation
+
+| Capability / single Rust authority | Rust library | `gam` CLI | `gamfit` Python | Status |
+|---|---|---|---|---|
+| Formula fit and REML/LAML family dispatch (`FitRequest`, `fit_from_formula`, `fit_model`) | Public facade | `fit DATA FORMULA --out` or `--request` | `fit`, `fit_array`, `gaussian_reml_fit_formula` | Shared request; parity |
+| Families: auto, Gaussian, binomial (logit/probit/cloglog), Poisson, Gamma, beta, Tweedie, negative binomial, expectile | `FitConfig` / family resolver | `--family`; NB and expectile controls below | `family=` | Parity |
+| Fixed negative-binomial size | `FitConfig::negative_binomial_theta` | `--negative-binomial-theta` | `negative_binomial_theta=` | **Closed by this audit** |
+| Expectile target | `FitConfig::expectile_tau` | `--expectile-tau` | `expectile_tau=` or `expectile(tau)` family spelling | **Closed by this audit** |
+| Offset, weights, persistent warm starts | shared request fields | `--offset-column`, `--weights-column`, `--persistent-warm-start-root` | `offset=`, `weights=`, `persistent_warm_start_root=` | Parity |
+| Links and flexible link | family/link resolver | binomial family variants; complete request for `link` / `flexible_link` | `link=`, `flexible_link=` | Parity through shared request |
+| Firth binomial correction | `FitConfig::firth` | `--firth` | `firth=` | Parity |
+| Location/dispersion scale models | typed `FitRequest` variants | `--predict-noise`, `--noise-offset-column` | `noise_formula=`, `noise_offset=` | Parity |
+| CTN and calibrated marginal slope | typed requests / `CtnStage1Recipe` | `--transformation-normal`, `--ctn-stage1`, `--slope-formula`, `--z-column` | same concepts as keywords | Parity |
+| Survival (transformation, Weibull, location-scale, marginal-slope, latent) and baseline/frailty controls | typed survival requests | `Surv(...)` plus survival, time-basis, baseline, frailty flags | `survival_likelihood=`, anchor/baseline/frailty keywords; formula/config for time basis | Parity through shared request |
+| Latent coordinates, analytic penalties, smooth descriptors, precision hyperpriors | request document and term builders | JSON descriptor flags or complete request | `latents=`, `penalties=`, `smooths=`, `precision_hyperpriors=` | Parity |
+| Fit-time conformal substrate and inference retention | request document | `--precompute-conformal`, `--inference` | `config=` request fields | Parity through shared request |
+| Prediction and posterior-mean uncertainty | `gam::predict` saved-model machinery | `predict`, `--uncertainty`, `--level`, `--covariance-mode`, offsets and IDs | `Model.predict`, `predict_array`; interval, observation interval, covariance mode, IDs | Parity; Python exposes richer typed return objects |
+| CTN observed-response score | saved-model prediction machinery | `transformation-score` | `Model.transformation_score` | Parity |
+| Diagnostics / ALO | `gam::inference::alo`, saved-model ALO | `diagnose [--alo]`; report may include diagnostics | `Model.diagnose`, `check`, `basis_check`, `curvature`, `smooth_significance` | Core diagnostics shared; Python methods are programmatic views |
+| Posterior coefficient sampling | `gam::inference::sample` / `gam::hmc` | `sample --chains --samples --warmup --seed` | `Model.sample` with the same controls plus `target_accept` | Same Rust sampler |
+| Posterior predictive / response generation | `gam::predict::generative` | `generate --n-draws --seed` | `sample_replicates`, `iter_replicates`; multinomial `posterior_predict` | Same Rust generator |
+| Summary and HTML report | saved model / `gam::report` | `report` | `summary`, `report` | Parity |
+| Persistence | saved-model envelope | fit writes and all consumers read it | `save`, `load`, `loads`, `Model.save`, `dumps`, `model_from_dict` | One Rust wire format |
+| Multinomial fit/predict/inference | Rust multinomial request/model | selected by `--family multinomial` | `family="multinomial"`, `MultinomialModel` | Parity |
+| Event history | Rust event-history engine | `fit-events` | `fit_event_history`, `EventHistoryModel` | Parity |
+| Manifold crosscoder | Rust auto-fit/report engine | `crosscoder` and its override flags | `sae_crosscoder_fit` / crosscoder objects | Same Rust engine; transport-specific inputs |
+| Response geometry | Rust geometry/fitting modules | complete versioned request/artifact workflows | `fit(..., response_geometry=...)`, `ResponseGeometryModel` | Programmatic API; no duplicate CLI math |
+
+## CLI command and flag inventory
+
+Global flags are `--log-level`, `--verbose`/`-v`, and `--quiet`/`-q`.
+
+| Command | Arguments and flags |
+|---|---|
+| `fit` | `DATA`, `FORMULA`; `--request`, `--ctn-stage1`, `--precision-hyperpriors`, `--latent-coordinates`, `--analytic-penalties`, `--smooth-descriptors`, `--predict-noise`, `--slope-formula`, `--z-column`, `--weights-column`, `--offset-column`, `--noise-offset-column`, `--frailty-kind`, `--frailty-sd`, `--hazard-loading`, `--transformation-normal`, `--firth`, `--family`, `--negative-binomial-theta`, `--expectile-tau`, `--survival-likelihood`, `--survival-time-anchor`, baseline and time-basis controls, `--scale-dimensions`, `--precompute-conformal`, `--inference`, `--persistent-warm-start-root`, `--out` |
+| `predict` | `MODEL NEW_DATA --out`; offset/noise-offset/ID, `--uncertainty`, `--level`, `--covariance-mode` |
+| `transformation-score` | `MODEL LABELLED_DATA --out`; offset and ID columns |
+| `diagnose` | `MODEL DATA [--alo]` |
+| `sample` | `MODEL DATA`; `--chains`, `--samples`, `--warmup`, `--seed`, `--out` |
+| `generate` | `MODEL DATA`; `--n-draws`, `--seed`, `--out` |
+| `report` | `MODEL [DATA] [OUT]` |
+| `fit-events` | `--subjects`, `--events`, `--covariates`, `--formula`, `--marks`, `--horizons-after-exit`, `--out` |
+| `crosscoder` | named anchor/block matrices, atom/harmonic counts, sparsity/smoothness/optimizer overrides, transport-law controls, `--out` |
+
+## Python public fitting, prediction, and diagnostic inventory
+
+The formula front doors are `fit`, `fit_array`, `validate_formula`, and
+`gaussian_reml_fit_formula`. The complete `fit` model-spec keyword set is:
+
+`family`, `negative_binomial_theta`, `expectile_tau`, `offset`, `weights`,
+`persistent_warm_start_root`, `transformation_normal`,
+`transformation_normal_stage1`, `survival_likelihood`, `survival_time_anchor`,
+`baseline_target`, `baseline_scale`, `baseline_shape`, `baseline_rate`,
+`baseline_makeham`, `z_column`, `link`, `slope_formula`, `frailty_kind`,
+`frailty_sd`, `hazard_loading`, `scale_dimensions`, `firth`, `noise_formula`,
+`noise_offset`, `flexible_link`, `precision_hyperpriors`, `constraints`,
+`response_geometry`, `response_columns`, `response_coordinates`,
+`response_reference`, `fisher_rao_w`, `latents`, `penalties`, `smooths`, and
+`config`.
+
+The fitted `Model` public workflow methods/properties are `predict`,
+`predict_array`, `predict_conformal`, `transformation_score`, `summary`,
+`smoothing_parameters`, `check`, `curvature`, `smooth_significance`,
+`basis_check`, `debiased_functional`, `report`, `sample`, `sample_replicates`,
+`iter_replicates`, `design_matrix`, `design_matrix_array`, `difference_smooth`,
+`partial_dependence`, `variance_share`, `evidence`, `evidence_ratio_vs`,
+`diagnose`, `plot`, persistence methods, group extension, and model metadata.
+`MultinomialModel` exposes classes, deviance/iterations, prediction and standard
+errors, posterior prediction, smooth significance, summary, and persistence.
+
+The remaining public names in `_api.py` are programmatic Rust-kernel bindings,
+not missing CLI workflows: basis/penalty constructors; weighted-ridge helpers;
+Gaussian REML forward/backward, batched, position, latent, block, and constrained
+variants; GLM latent REML; CUDA/build diagnostics; and shared-precision updates.
+Their full signatures are the Python source of truth. They deliberately remain
+library APIs: converting arrays, derivatives, and autograd state to shell flags
+would add a second scientific configuration language rather than parity.
+
+## Audit conclusion
+
+The user-visible defect was that two fields already present in the Rust request
+and CLI—fixed negative-binomial theta and expectile tau—were available in Python
+only through the untyped `config` escape hatch. Both are now first-class Python
+keywords on `fit`, `fit_array`, and `validate_formula`, serialized without
+Python-side numerical logic. No duplicate fitter, predictor, diagnostic, family,
+or link implementation was found in a frontend.

--- a/gamfit/_api.py
+++ b/gamfit/_api.py
@@ -251,6 +251,8 @@ def format_cuda_diagnostics() -> str:
 def _build_fit_payload(
     *,
     family: str,
+    negative_binomial_theta: float | None,
+    expectile_tau: float | None,
     offset: str | None,
     weights: str | None,
     persistent_warm_start_root: str | Path | None,
@@ -288,6 +290,8 @@ def _build_fit_payload(
     }
     ctn_stage1_recipe = normalize_ctn_stage1(transformation_normal_stage1)
     kwarg_items: dict[str, Any] = {
+        "negative_binomial_theta": negative_binomial_theta,
+        "expectile_tau": expectile_tau,
         "transformation_normal": transformation_normal,
         "ctn_stage1": ctn_stage1_recipe.to_rust_recipe() if ctn_stage1_recipe else None,
         "survival_likelihood": survival_likelihood,
@@ -712,6 +716,8 @@ def fit(
     formula: str,
     *,
     family: str = ...,
+    negative_binomial_theta: float | None = ...,
+    expectile_tau: float | None = ...,
     offset: str | None = ...,
     weights: str | None = ...,
     persistent_warm_start_root: str | Path | None = ...,
@@ -755,6 +761,8 @@ def fit(
     formula: str,
     *,
     family: str = ...,
+    negative_binomial_theta: float | None = ...,
+    expectile_tau: float | None = ...,
     offset: str | None = ...,
     weights: str | None = ...,
     persistent_warm_start_root: str | Path | None = ...,
@@ -797,6 +805,8 @@ def fit(
     formula: str,
     *,
     family: str = "auto",
+    negative_binomial_theta: float | None = None,
+    expectile_tau: float | None = None,
     offset: str | None = None,
     weights: str | None = None,
     persistent_warm_start_root: str | Path | None = None,
@@ -865,6 +875,15 @@ def fit(
         inference — e.g. pass ``family="gaussian"`` to fit an integer rating
         column such as ``0..5`` (which matches the count signature) as a
         continuous response.
+    negative_binomial_theta:
+        Optional fixed positive size/overdispersion parameter for
+        ``family="negative-binomial"``. When omitted, Rust estimates theta.
+        This is the Python spelling of CLI ``--negative-binomial-theta`` and
+        the shared request field ``negative_binomial_theta``.
+    expectile_tau:
+        Optional target in the open interval ``(0, 1)`` for
+        ``family="expectile"``. This is the Python spelling of CLI
+        ``--expectile-tau`` and the shared request field ``expectile_tau``.
     offset:
         Name of the offset column. Corresponds to ``--offset-column``.
     weights:
@@ -1192,6 +1211,8 @@ def fit(
     )
     payload = _build_fit_payload(
         family=family,
+        negative_binomial_theta=negative_binomial_theta,
+        expectile_tau=expectile_tau,
         offset=offset,
         weights=weights,
         persistent_warm_start_root=persistent_warm_start_root,
@@ -1285,6 +1306,8 @@ def fit_array(
     formula: str,
     *,
     family: str = "auto",
+    negative_binomial_theta: float | None = None,
+    expectile_tau: float | None = None,
     offset: str | None = None,
     weights: str | None = None,
     persistent_warm_start_root: str | Path | None = None,
@@ -1351,6 +1374,8 @@ def fit_array(
     )
     payload = _build_fit_payload(
         family=family,
+        negative_binomial_theta=negative_binomial_theta,
+        expectile_tau=expectile_tau,
         offset=offset,
         weights=weights,
         persistent_warm_start_root=persistent_warm_start_root,
@@ -1595,6 +1620,8 @@ def validate_formula(
     formula: str,
     *,
     family: str = "auto",
+    negative_binomial_theta: float | None = None,
+    expectile_tau: float | None = None,
     offset: str | None = None,
     weights: str | None = None,
     persistent_warm_start_root: str | Path | None = None,
@@ -1644,6 +1671,8 @@ def validate_formula(
         rust_config.pop(key, None)
     payload = _build_fit_payload(
         family=family,
+        negative_binomial_theta=negative_binomial_theta,
+        expectile_tau=expectile_tau,
         offset=offset,
         weights=weights,
         persistent_warm_start_root=persistent_warm_start_root,

--- a/tests/test_fit_model_spec_kwargs_match_config.py
+++ b/tests/test_fit_model_spec_kwargs_match_config.py
@@ -32,6 +32,8 @@ from gamfit._api import _build_fit_payload
 
 _BASE: dict[str, typing.Any] = {
     "family": "auto",
+    "negative_binomial_theta": None,
+    "expectile_tau": None,
     "offset": None,
     "weights": None,
     "persistent_warm_start_root": None,
@@ -73,6 +75,8 @@ def _payload(**overrides: typing.Any) -> dict[str, typing.Any]:
     ("kwarg", "value", "config_key"),
     [
         ("noise_formula", "s(x)", "noise_formula"),
+        ("negative_binomial_theta", 2.5, "negative_binomial_theta"),
+        ("expectile_tau", 0.9, "expectile_tau"),
         ("noise_offset", "logvar", "noise_offset"),
         ("flexible_link", True, "flexible_link"),
         ("survival_time_anchor", 25.0, "survival_time_anchor"),

--- a/tests/test_fit_payload_keys_are_wire_config_fields.py
+++ b/tests/test_fit_payload_keys_are_wire_config_fields.py
@@ -48,6 +48,8 @@ class _Latent:
 
 _UNSET_KWARGS: dict[str, typing.Any] = {
     "family": "gaussian",
+    "negative_binomial_theta": None,
+    "expectile_tau": None,
     "offset": None,
     "weights": None,
     "persistent_warm_start_root": None,
@@ -132,6 +134,8 @@ def _fully_populated_payload() -> dict[str, typing.Any]:
             "offset": "off",
             "weights": "w",
             "transformation_normal": True,
+            "negative_binomial_theta": 2.5,
+            "expectile_tau": 0.9,
             "survival_likelihood": "location-scale",
             "survival_time_anchor": 25.0,
             "baseline_target": "weibull",


### PR DESCRIPTION
### Motivation

- Close a parity gap where the Rust/CLI supported `negative_binomial_theta` and `expectile_tau` but Python users could only pass them via the untyped `config={...}` escape hatch, hurting discoverability and ergonomics.
- Keep Python thin and forward the options to the single Rust `FitRequest` surface so behavior stays canonical in Rust rather than duplicating logic in Python.

### Description

- Add `negative_binomial_theta` and `expectile_tau` keywords to the Python `fit` API and its overloads so callers can pass them as first-class arguments; the arguments are documented in the `fit` docstring. (`gamfit/_api.py`)
- Thread the two keywords through `fit_array` and `validate_formula` and into the shared `_build_fit_payload` so they serialize as the Rust wire fields `negative_binomial_theta` and `expectile_tau` with no Python-side numerical logic. (`gamfit/_api.py`)
- Update Python regression tests to pin payload-key parity and escape-hatch equivalence for the new keywords so regressions fail if the Python payload name differs from the Rust request. (`tests/test_fit_model_spec_kwargs_match_config.py`, `tests/test_fit_payload_keys_are_wire_config_fields.py`)
- Add a source-level inventory page `docs/frontend-parity.md` enumerating the Rust, CLI, and Python public surfaces and recorded parity status.
- Commit message: `fix(frontends): close fit option parity gaps (#0)`.

### Testing

- `python -m py_compile gamfit/_api.py tests/test_fit_model_spec_kwargs_match_config.py tests/test_fit_payload_keys_are_wire_config_fields.py` — succeeded with no syntax errors.
- `git diff --check` / staged `git commit` — whitespace checks passed and the commit `bbe9aaf` was created successfully.
- Attempted `uv run pytest` and targeted `pytest` runs — could not complete collection/execution because the native `gamfit._rust` extension is not built in this sandbox and the full workspace build requires a longer native `cargo`/maturin build, so Python tests backed by the Rust extension could not be executed here (environment limitation).
- Started `cargo build --workspace --all-targets` as required by the workspace gate but the full release/LTO workspace build did not finish within the sandbox iteration window and was therefore not verified to completion.