### PR TITLE
test(docs): execute Python and CLI documentation examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ overcomplete hard-TopK support lane (`K > p`, per-token active set solved
 against the frozen dictionary, memory `O(N·top_k)` — the LLM-scale path).
 Fits mint only from a converged, certificate-checked optimization.
 
-```python
+```python no-exec
 fit = gamfit.sae_manifold_fit(X=acts, K=32_000, d_atom=1,
                               assignment="topk", top_k=8)   # K >> p, topology=auto
 census = Counter(fit.atom_topologies)     # which shapes the evidence kept
@@ -220,7 +220,7 @@ with on-demand `S(t)`, `h(t)`, `H(t)` on any time grid:
 pred = model.predict(test_df)
 S = pred.survival_at([1, 5, 10, 20])
 H = pred.cumulative_hazard_at([10])
-pred.write_survival_at_csv("surv.csv", times=[...])  # streamed
+pred.write_survival_at_csv("surv.csv", times=[1, 5, 10])  # streamed
 ```
 
 Event histories. `gam_models::event_history` fits marked counting
@@ -304,8 +304,8 @@ matrices, the Grassmann and Stiefel manifolds, and the hyperbolic
 the responses:
 
 ```python
-gamfit.fit(df, "y ~ s(x)", response_geometry="poincare", response_columns=[...])
-gamfit.fit(df, "y ~ s(x)", response_geometry="constant_curvature", response_columns=[...])
+gamfit.fit(df, "y ~ s(x)", response_geometry="poincare", response_columns=["sand", "silt", "clay"])
+gamfit.fit(df, "y ~ s(x)", response_geometry="constant_curvature", response_columns=["nx", "ny", "nz"])
 ```
 
 Model comparison. `compare_models` reports AIC and approximate

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -5,7 +5,7 @@ model blobs, prediction CSVs, posterior draws, generated responses, or HTML
 reports.
 
 ```bash
-gam <command> --help
+gam --help
 ```
 
 ## Commands

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -136,7 +136,7 @@ that combination produces a confidently significant false association. Read
 
 ## diagnose()
 
-```python
+```text
 diag = model.diagnose(data, *, y=None, interval=0.95)
 ```
 

--- a/docs/manifold-sae.md
+++ b/docs/manifold-sae.md
@@ -13,7 +13,7 @@ Each atom answers **where it lives** (a typed manifold embedded in ambient
 space), **what shape it is** (the topology and its fitted curve), and **how
 confident** that shape is (a posterior band).
 
-```python
+```python no-exec
 import numpy as np
 import gamfit
 
@@ -178,7 +178,7 @@ is not normalized LAML, REML, or model evidence. Each piece plays a distinct rol
   (a `GumbelTemperatureSchedule` or a mapping). Three constructors are
   top-level exports:
 
-  ```python
+  ```python no-exec
   from gamfit import (gumbel_geometric_schedule, gumbel_linear_schedule,
                       gumbel_reciprocal_iter_schedule)
   # geometric decay τ_start → τ_min at the given multiplicative rate
@@ -305,7 +305,7 @@ The fitted band is stored directly on each Rust-owned atom, evaluated along the
 atom's own coordinates (so it reports uncertainty exactly where the data
 lives):
 
-```python
+```python no-exec
 atom = fit.atoms[0]
 atom.decoder_covariance   # (M_k*p, M_k*p), row-major (basis, channel) flat layout
 atom.shape_band_coords    # (G, d_k)
@@ -358,7 +358,7 @@ equivalently `fit.atoms[k].coords`). The **observed extent** — where on the
 shape the tokens actually land — is read directly off it. Combined with the
 shape band, you get the curve *across the range the atom is used over*:
 
-```python
+```python no-exec
 coords_k = fit.coords[0]                       # (N, d_k) per-token coordinate
 lo, hi   = coords_k.min(0), coords_k.max(0)    # full observed extent per axis
 p5, p95  = np.percentile(coords_k, [5, 95], 0) # robust central range
@@ -380,7 +380,7 @@ percentile calculation applies to new data.
 
 Fresh SAE fits also carry a first-class per-atom curvature report:
 
-```python
+```python no-exec
 curv = fit.curvature_report
 curv["atoms"][0]["kappa_hat"]  # fitted estimate, when present in the report
 ```
@@ -420,7 +420,7 @@ warm-start tensors, or a second training objective.
 
 The out-of-sample surface:
 
-```python
+```python no-exec
 reconstruction = fit.predict(X)       # (N, p), same operation as reconstruct(X)
 gates = fit.encode(X)                 # (N, K)
 latents = fit.converged_latents(X)    # one coherent solve
@@ -439,7 +439,7 @@ Call `converged_latents` when several outputs are needed; separate
 plan** at a requested measured KL dose. The callback applies the supplied plan to
 the real downstream model and returns one atomic mapping:
 
-```python
+```python no-exec
 def patched_forward_kl(steer_plan):
     effective_delta = apply_exact_plan(steer_plan)
     return {
@@ -453,7 +453,7 @@ def patched_forward_kl(steer_plan):
 
 The request then controls the bracket solve:
 
-```python
+```python no-exec
 plan = fit.steer_to_target(
     {
         "atom_k": 3,
@@ -548,7 +548,7 @@ It is a top-level export, used throughout `tests/sae/`, and pairs naturally with
 `fit.coords[k]` from
 [`sae_manifold_fit`](#the-manifoldsae-result).
 
-```python
+```python no-exec
 import gamfit
 
 verdict = gamfit.adjudicate_atom_shape(
@@ -642,7 +642,7 @@ entry. It invokes the exact same deterministic `(matrix, seed)` callback on the
 observed activations and both controls, isolates callback mutation with private
 matrix copies, and retains only one control matrix at a time:
 
-```python
+```python no-exec
 def complete_pipeline(matrix, seed):
     # Fresh fit: SAE -> grouping -> projection/search -> adjudication.
     return run_census(matrix, seed=seed)
@@ -680,7 +680,7 @@ verdict. Consequently neither a chart-fixed permutation nor one shuffled draw
 is a false-positive floor. Rebuild the chart for every draw and compare the
 observed **circular margin** with the full shuffle-margin distribution:
 
-```python
+```python no-exec
 def labeled_chart_pipeline(matrix, labels, seed):
     # Recompute class means, select/refit the chart, then adjudicate it.
     coords = build_class_mean_chart(matrix, labels)
@@ -723,7 +723,7 @@ native fit and verify cross-seed concordance explicitly.
 Across seeds, stack corresponding fitted coordinates as `(replicates, rows)` and
 report their exact rotation/reflection-quotiented agreement:
 
-```python
+```python no-exec
 report = circular_concordance(torch.stack(seed_coordinates), period=1.0)
 print(report.minimum_aligned_score)
 print(report.pairs)
@@ -748,7 +748,7 @@ audits with a warning.
 GLM head, so the learned atoms are predictive of a label on the rows where one
 is available (semi-supervised: `supervised_mask` selects them):
 
-```python
+```python no-exec
 fit = gamfit.sae_supervised(
     X, Y, supervised_mask,        # (N, p) data, (N,) labels, (N,) bool mask
     K=16, d_atom=2,
@@ -778,7 +778,7 @@ descriptive changes; the grid does not supply sampling uncertainty or a
 statistical stability test. The shared coordinates fix the correspondence
 without fitting a transport.
 
-```python
+```python no-exec
 dyn = gamfit.sae_checkpoint_dynamics(
     decoder_grid,                 # decoder evaluations across checkpoints
     checkpoint_ids=["step10k", "step20k", ...],
@@ -791,7 +791,7 @@ dyn = gamfit.sae_checkpoint_dynamics(
 and `gamfit.layer_transport_ladder` chains the pairwise transports across a
 sequence of layers:
 
-```python
+```python no-exec
 t = gamfit.layer_transport_fit(coords_from, coords_to,
                                topology_from="circle", topology_to="circle",
                                layer_from=0, layer_to=1)
@@ -808,7 +808,7 @@ ladder = gamfit.layer_transport_ladder(coords, topology="circle", layers=None)
 The Torch surface wraps a converged native fit; it does not define or train a
 second SAE objective.
 
-```python
+```python no-exec
 import torch
 import gamfit
 from gamfit.torch import ManifoldSAE

--- a/docs/posterior-sampling.md
+++ b/docs/posterior-sampling.md
@@ -27,7 +27,7 @@ bands = posterior.predict(test_df, level=0.95)
 
 ## Model.sample
 
-```python
+```text
 model.sample(
     data,
     *,

--- a/docs/predictions.md
+++ b/docs/predictions.md
@@ -6,7 +6,7 @@ shape depends on the fitted model class and on the keyword arguments
 
 ## Signature
 
-```python
+```text
 model.predict(
     data,
     *,

--- a/docs/reml_scaling.md
+++ b/docs/reml_scaling.md
@@ -72,7 +72,7 @@ uses the shared-scale block estimator: the coefficient problems decouple,
 the residual scale remains global, autograd flows through the differentiable
 block solves, and memory stays linear in F. A representative architecture is:
 
-```python
+```python no-exec
 codes = encoder(x)               # (B, F)
 positions = codes                # (B, F)
 amps = topk_amps(codes)          # (B, F), sparse

--- a/docs/sklearn.md
+++ b/docs/sklearn.md
@@ -27,7 +27,7 @@ r2    = est.score(X, y)       # r2_score
 
 ### Constructor
 
-```python
+```text
 GAMRegressor(
     formula: str,
     family: str = "auto",

--- a/docs/torch.md
+++ b/docs/torch.md
@@ -25,7 +25,7 @@ The closed-form Gaussian REML primitives have analytic Rust VJPs.
 `GaussianRemlOutput` (`coefficients`, `fitted`, `lam`, `reml_score`, `edf`)
 and route upstream gradients into the matching Rust backward:
 
-```python
+```python no-exec
 import torch
 import gamfit.torch as gt
 
@@ -51,7 +51,7 @@ in-place mutation between forward and backward raises `RuntimeError`.
 
 `from_fitted` wraps a fitted `gamfit.Model` as a frozen `nn.Module`:
 
-```python
+```python no-exec
 import gamfit
 import gamfit.torch as gt
 
@@ -100,7 +100,7 @@ can support reverse AD while lacking the forward-mode JVP these two harvests
 require. For Hugging Face models, select the differentiable attention path when
 the model is loaded:
 
-```python
+```python no-exec
 model = AutoModelForCausalLM.from_pretrained(
     model_id,
     attn_implementation="eager",

--- a/tests/test_documentation_examples.py
+++ b/tests/test_documentation_examples.py
@@ -1,0 +1,133 @@
+"""Executable contracts for the Markdown examples shipped to users.
+
+A ``python`` fence is executable documentation, not pseudocode.  API signatures
+belong in ``text`` fences.  Examples which require external models, accelerators,
+or large user-owned activation arrays use ``python no-exec`` and therefore are
+not executable examples.
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import re
+import subprocess
+
+import numpy as np
+import pandas as pd
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+DOCS = (ROOT / "README.md", *sorted((ROOT / "docs").glob("*.md")))
+FENCE = re.compile(r"^```(?P<language>python|bash|sh)[ \t]*\n(?P<body>.*?)^```[ \t]*$", re.MULTILINE | re.DOTALL)
+
+
+def examples(language: str):
+    for path in DOCS:
+        source = path.read_text(encoding="utf-8")
+        for match in FENCE.finditer(source):
+            if match["language"] != language:
+                continue
+            line = source.count("\n", 0, match.start()) + 2
+            yield pytest.param(path, line, match["body"], id=f"{path.relative_to(ROOT)}:{line}")
+
+
+def synthetic_data() -> pd.DataFrame:
+    """One small, deterministic frame covering names used by introductory snippets."""
+    n = 40
+    x = np.linspace(0.1, 4.0, n)
+    frame = pd.DataFrame({
+        "x": x, "x1": x, "x2": np.sin(x), "x3": np.cos(x), "x4": x / 4,
+        "age": 30 + x * 10, "bmi": 20 + x, "hba1c": 4 + x / 2,
+        "dose": x / 4, "prop": x / 5, "dow": np.arange(n) % 7,
+        "hour": np.arange(n) % 24, "theta": np.linspace(0, 2 * np.pi, n, endpoint=False),
+        "lat": np.linspace(-1, 1, n), "lon": np.linspace(-3, 3, n),
+        "pc1": x, "pc2": np.sin(x), "pc3": np.cos(x), "pc4": x * x / 16,
+        "raw_score": np.sin(x) + x / 4, "PGS": np.sin(x) + x / 4,
+        "pgs": np.sin(x) + x / 4, "z": np.sin(x), "prev": np.linspace(.1, .9, n),
+        "entry": np.zeros(n), "exit": np.arange(1, n + 1, dtype=float),
+        "event": (np.arange(n) % 3 == 0).astype(float),
+        "case": (np.arange(n) % 2).astype(float), "disease": (np.arange(n) % 2).astype(float),
+        "y": 1 + np.sin(x) + x / 3, "outcome": 1 + np.sin(x),
+        "site": np.resize(["A", "B", "C"], n), "site_id": np.resize(["A", "B"], n),
+        "group": np.resize(["control", "treated"], n), "treatment": np.arange(n) % 2,
+        "sand": np.full(n, .2), "silt": np.full(n, .3), "clay": np.full(n, .5),
+        "nx": np.sin(x), "ny": np.cos(x), "nz": np.zeros(n),
+    })
+    return frame
+
+
+@pytest.fixture(scope="session")
+def python_context():
+    import gamfit
+
+    df = synthetic_data()
+    train = df.copy()
+    test = df.head(4).drop(columns=["y", "outcome", "case", "disease", "event"])
+    model = gamfit.fit(train, "y ~ x")
+    posterior = model.sample(train, samples=20, warmup=20, chains=1, seed=42)
+    x_matrix = train[["x", "x2"]]
+    return {
+        "gamfit": gamfit, "np": np, "pd": pd, "df": df, "data": df,
+        "train": train, "train_df": train, "test": test, "test_df": test,
+        "cal_df": train.head(10), "model": model, "model_a": model, "model_b": model,
+        "loaded": model, "posterior": posterior,
+        "X": x_matrix, "X_train": x_matrix.to_numpy(), "X_test": x_matrix.head(4).to_numpy(),
+        "y": train["y"].to_numpy(),
+        "consume": lambda value: None, "process": lambda value: None,
+    }
+
+
+@pytest.mark.parametrize("path,line,code", list(examples("python")))
+def test_python_documentation_example(path, line, code, python_context, tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    namespace = dict(python_context)
+    compiled = compile(code, f"{path.relative_to(ROOT)}:{line}", "exec")
+    exec(compiled, namespace)
+
+
+def _cli_binary() -> Path:
+    configured = os.environ.get("GAM_CLI_BIN")
+    candidates = [Path(configured)] if configured else []
+    candidates += [ROOT / "target/release/gam", ROOT / "target/debug/gam"]
+    for candidate in candidates:
+        if candidate.is_file():
+            return candidate
+    raise AssertionError("build the CLI first with `cargo build --release -p gam-cli`")
+
+
+def cli_examples():
+    for language in ("bash", "sh"):
+        for parameter in examples(language):
+            # pytest.param stores positional values in ``values``.
+            if parameter.values[2].lstrip().startswith("gam "):
+                yield parameter
+
+
+@pytest.mark.parametrize("path,line,code", list(cli_examples()))
+def test_cli_documentation_example(path, line, code, tmp_path, python_context):
+    frame = python_context["train"]
+    for name in ("train.csv", "data.csv", "new.csv", "new_data.csv", "labelled.csv"):
+        frame.to_csv(tmp_path / name, index=False)
+    for name in ("model.gam", "model.json"):
+        python_context["model"].save(tmp_path / name)
+    np.save(tmp_path / "layer0.npy", np.arange(48, dtype=float).reshape(12, 4))
+    np.save(tmp_path / "layer1.npy", np.arange(48, dtype=float).reshape(12, 4) + 0.1)
+    pd.DataFrame({"id": ["subject-17", "subject-18"], "entry": [0.0, 0.0], "exit": [5.0, 5.0]}).to_csv(
+        tmp_path / "s.csv", index=False
+    )
+    pd.DataFrame({
+        "id": ["subject-17", "subject-17", "subject-18"],
+        "time": [1.0, 4.0, 2.0], "mark": ["relapse", "death", "death"],
+    }).to_csv(tmp_path / "e.csv", index=False)
+    pd.DataFrame({
+        "id": ["subject-17", "subject-18"], "start": [0.0, 0.0], "x": [0.0, 1.0],
+    }).to_csv(tmp_path / "c.csv", index=False)
+    env = os.environ.copy()
+    env["PATH"] = f"{_cli_binary().parent}{os.pathsep}{env.get('PATH', '')}"
+    completed = subprocess.run(
+        code, shell=True, executable="/bin/bash", cwd=tmp_path, env=env,
+        text=True, capture_output=True, timeout=120,
+    )
+    assert completed.returncode == 0, (
+        f"{path.relative_to(ROOT)}:{line}\nstdout:\n{completed.stdout}\nstderr:\n{completed.stderr}"
+    )


### PR DESCRIPTION
### Motivation

- Ensure every runnable code block in `README.md` and `docs/*.md` is actual executable documentation and that the docs stay in sync with the public API and CLI. 
- Catch stale or pseudocode fences early by executing Python examples and shell `gam` snippets as CI-visible tests, while explicitly excluding large external-data or optional-accelerator examples.

### Description

- Add an integration test `tests/test_documentation_examples.py` that enumerates fenced `python`, `bash`, and `sh` blocks in `README.md` and `docs/*.md`, injects a small deterministic synthetic `DataFrame`, and executes every eligible Python snippet as `test_python_documentation_example` and every `gam`-prefixed shell fence as `test_cli_documentation_example` against the built CLI. 
- Reclassify several API-signature pseudocode fences from ```python``` to ```text``` and mark about 20 heavy/optional examples as `python no-exec`, so the collector only runs self-contained examples. 
- Fix small doc problems to make examples concrete and runnable, specifically converting `gam <command> --help` to `gam --help`, replacing `times=[...]` and other ellipses with concrete values, and adding `python no-exec` to SAE/Torch-heavy fences. 
- Commit recorded as `test(docs): execute Python and CLI examples (#0)` and includes the new test plus the documentation edits described above.

### Testing

- Collected the runnable examples with `python -m pytest tests/test_documentation_examples.py --collect-only` which reported `165 tests collected` after the edits. 
- Linted and style-checked the new test with `ruff` which completed with `All checks passed`. 
- Basic repository hygiene checks (`git diff --check`) succeeded with no whitespace errors. 
- Native build steps required to execute all tests end-to-end (`maturin develop` / full `cargo build --workspace --all-targets`) did not finish inside the sandbox (Rust compilation was started but terminated), so examples were only exercised up to Python compilation/exec and CLI test collection rather than full Rust-backed execution. 
- Before the fixes there were five immediate failures: four Python fences invalid as executable Python (API signatures) and one CLI help placeholder (`gam <command> --help`), and those were corrected or reclassified so the example collector is now deterministic.