### PR TITLE
fix(math): harden low-level clippy invariants and eliminate large stack arrays

### DIFF
--- a/crates/gam-linalg/src/matrix/mod.rs
+++ b/crates/gam-linalg/src/matrix/mod.rs
@@ -443,6 +443,7 @@ impl<'a> DenseRightProductView<'a> {
         }
     }
 
+    #[must_use]
     pub fn with_factor(mut self, factor: &'a Array2<f64>) -> Self {
         if self.first.is_none() {
             self.first = Some(factor);
@@ -459,6 +460,7 @@ impl<'a> DenseRightProductView<'a> {
         self
     }
 
+    #[must_use]
     pub fn with_optional_factor(self, factor: Option<&'a Array2<f64>>) -> Self {
         match factor {
             Some(factor) => self.with_factor(factor),

--- a/crates/gam-math/src/jet_algebra.rs
+++ b/crates/gam-math/src/jet_algebra.rs
@@ -375,7 +375,8 @@ fn build_partitions(
     if elem == m {
         let mut packed = PackedPartition {
             blocks: [0u8; MAX_SLOTS],
-            n_blocks: n_blocks as u8,
+            n_blocks: u8::try_from(n_blocks)
+                .expect("partition block count must fit the fixed-width representation"),
         };
         packed.blocks[..n_blocks].copy_from_slice(&blocks[..n_blocks]);
         out.push(packed);

--- a/crates/gam-math/src/jet_tower.rs
+++ b/crates/gam-math/src/jet_tower.rs
@@ -434,7 +434,6 @@ impl<const K: usize> Tower4<K> {
         self.compose_unary(ln_gamma_derivative_stack(self.v))
     }
 
-
     /// Contract `t3` with one primary-space direction:
     /// `out[a][b] = Σ_c t3[a][b][c] · dir[c]` — exactly the
     /// `row_third_contracted` shape.
@@ -486,7 +485,6 @@ impl<const K: usize> Tower4<K> {
         }
         out
     }
-
 }
 
 impl<const K: usize> jet_algebra::JetAlgebra<5> for Tower4<K> {
@@ -1147,13 +1145,16 @@ const BERNOULLI_EVEN: [(usize, f64); 10] = [
 
 fn polygamma_recurrence_term(order: usize, x: f64) -> f64 {
     let sign = if order % 2 == 1 { 1.0 } else { -1.0 };
-    sign * factorial(order) / x.powi((order + 1) as i32)
+    sign * factorial(order)
+        / x.powi(i32::try_from(order + 1).expect("supported derivative order fits i32"))
 }
 
 fn digamma_asymptotic(x: f64) -> f64 {
     let mut out = x.ln() - 0.5 / x;
     for (bernoulli_order, bernoulli) in BERNOULLI_EVEN {
-        out -= bernoulli / (bernoulli_order as f64 * x.powi(bernoulli_order as i32));
+        out -= bernoulli
+            / (bernoulli_order as f64
+                * x.powi(i32::try_from(bernoulli_order).expect("Bernoulli order fits i32")));
     }
     out
 }
@@ -1165,15 +1166,20 @@ fn polygamma_asymptotic(order: usize, x: f64) -> f64 {
 
     let order_factorial = factorial(order);
     let leading_sign = if order % 2 == 1 { 1.0 } else { -1.0 };
-    let mut out = leading_sign * factorial(order - 1) / x.powi(order as i32)
-        + leading_sign * order_factorial / (2.0 * x.powi((order + 1) as i32));
+    let mut out = leading_sign * factorial(order - 1)
+        / x.powi(i32::try_from(order).expect("supported derivative order fits i32"))
+        + leading_sign * order_factorial
+            / (2.0
+                * x.powi(i32::try_from(order + 1).expect("supported derivative order fits i32")));
 
     let bernoulli_sign = if order % 2 == 1 { 1.0 } else { -1.0 };
     for (bernoulli_order, bernoulli) in BERNOULLI_EVEN {
         let rising = rising_factorial(bernoulli_order, order);
         out += bernoulli_sign * bernoulli * rising
             / bernoulli_order as f64
-            / x.powi((bernoulli_order + order) as i32);
+            / x.powi(
+                i32::try_from(bernoulli_order + order).expect("combined derivative order fits i32"),
+            );
     }
     out
 }
@@ -1306,7 +1312,7 @@ pub trait RowProgram<const K: usize>: Send + Sync {
     /// uses ONLY [`crate::jet_scalar::JetScalar`] ops and per-row data (response,
     /// censoring, offsets) entering as constants.
     fn eval<S: crate::jet_scalar::JetScalar<K>>(&self, row: usize, p: &[S; K])
-    -> Result<S, String>;
+        -> Result<S, String>;
 }
 
 /// Maximum size of one canonical dense-jet storage object kept on the call
@@ -1950,9 +1956,9 @@ mod tests {
         const TAU: f64 = 1.3; // the link-knot crossing threshold τ
         let g_idx = 1usize;
         let g0 = 0.85_f64; // the slope value b (the g-primary IS the slope)
-        // Stand-in intercept tower a(θ): nonzero value, gradient, Hessian in the
-        // two live axes so a_u and a_uv are both exercised. (In production this
-        // comes from implicit_solve; here we plant known derivatives.)
+                           // Stand-in intercept tower a(θ): nonzero value, gradient, Hessian in the
+                           // two live axes so a_u and a_uv are both exercised. (In production this
+                           // comes from implicit_solve; here we plant known derivatives.)
         let mut a = Tower4::<3>::constant(0.45);
         a.g[0] = 0.7;
         a.g[1] = -0.3;
@@ -2206,7 +2212,6 @@ mod derivative_stack_tests {
             }
         }
     }
-
 }
 
 // ── Contraction-symmetry optimization gate ────────────────────────────────────
@@ -2398,7 +2403,7 @@ mod contraction_symmetry_tests {
     /// randomised order, and reports its own resolution).
     #[test]
     fn contraction_symmetry_speedup_is_reported() {
-        use crate::paired_timing::{SpeedGate, paired_interleaved};
+        use crate::paired_timing::{paired_interleaved, SpeedGate};
 
         const K: usize = 9;
         let mut r = Rng(0xC0FF_EE99_1234_5678);

--- a/crates/gam-math/src/order2_graph.rs
+++ b/crates/gam-math/src/order2_graph.rs
@@ -14,8 +14,8 @@ use std::cell::UnsafeCell;
 use std::mem::MaybeUninit;
 
 use crate::jet_scalar::{
-    Order2, RuntimeJetScalar, SymmetricQuadraticCoefficients, aggregate_shared_source_derivatives,
-    canonical_shared_source_schedule,
+    aggregate_shared_source_derivatives, canonical_shared_source_schedule, Order2,
+    RuntimeJetScalar, SymmetricQuadraticCoefficients,
 };
 
 #[derive(Clone, Copy, Debug)]
@@ -70,6 +70,16 @@ const EMPTY_CURVATURE_EVENT: CurvatureEvent = CurvatureEvent::RankOne {
     input: 0,
     second: 0.0,
 };
+
+#[inline]
+fn packed_index(index: usize) -> u8 {
+    u8::try_from(index).expect("graph index must fit the fixed-capacity tape representation")
+}
+
+#[inline]
+fn packed_offset(offset: usize) -> u16 {
+    u16::try_from(offset).expect("graph offset must fit the fixed-capacity tape representation")
+}
 
 /// Fixed-capacity scalar scratch with only its logical prefix initialized.
 ///
@@ -136,23 +146,34 @@ struct GraphTape {
 }
 
 impl GraphTape {
-    fn new() -> Self {
-        Self {
-            dimension: 0,
-            node_len: 0,
-            edge_len: 0,
-            event_len: 0,
-            diagonal_len: 0,
-            projected_curvature_len: 0,
-            nodes: [EMPTY_NODE; MAX_GRAPH_NODES],
-            gradients: [0.0; MAX_GRAPH_NODES * MAX_PRIMARY_DIMENSION],
-            adjoints: [0.0; MAX_GRAPH_NODES],
-            edge_parents: [0; MAX_GRAPH_EDGES],
-            edge_firsts: [0.0; MAX_GRAPH_EDGES],
-            events: [EMPTY_CURVATURE_EVENT; MAX_GRAPH_NODES],
-            diagonal_inputs: [0; MAX_GRAPH_EDGES],
-            diagonal_seconds: [0.0; MAX_GRAPH_EDGES],
-            projected_curvatures: [0.0; MAX_PROJECTED_CURVATURE_VALUES],
+    fn new_boxed() -> Box<Self> {
+        let mut tape = Box::<Self>::new_uninit();
+        let pointer = tape.as_mut_ptr();
+        // SAFETY: each field is initialized in place before `assume_init`.
+        // In-place initialization is important here: the fixed-capacity tape is
+        // deliberately large and must never be materialized as a stack value.
+        unsafe {
+            std::ptr::addr_of_mut!((*pointer).dimension).write(0);
+            std::ptr::addr_of_mut!((*pointer).node_len).write(0);
+            std::ptr::addr_of_mut!((*pointer).edge_len).write(0);
+            std::ptr::addr_of_mut!((*pointer).event_len).write(0);
+            std::ptr::addr_of_mut!((*pointer).diagonal_len).write(0);
+            std::ptr::addr_of_mut!((*pointer).projected_curvature_len).write(0);
+
+            for node in &mut *std::ptr::addr_of_mut!((*pointer).nodes) {
+                std::ptr::write(node, EMPTY_NODE);
+            }
+            std::ptr::addr_of_mut!((*pointer).gradients).write_bytes(0, 1);
+            std::ptr::addr_of_mut!((*pointer).adjoints).write_bytes(0, 1);
+            std::ptr::addr_of_mut!((*pointer).edge_parents).write_bytes(0, 1);
+            std::ptr::addr_of_mut!((*pointer).edge_firsts).write_bytes(0, 1);
+            for event in &mut *std::ptr::addr_of_mut!((*pointer).events) {
+                std::ptr::write(event, EMPTY_CURVATURE_EVENT);
+            }
+            std::ptr::addr_of_mut!((*pointer).diagonal_inputs).write_bytes(0, 1);
+            std::ptr::addr_of_mut!((*pointer).diagonal_seconds).write_bytes(0, 1);
+            std::ptr::addr_of_mut!((*pointer).projected_curvatures).write_bytes(0, 1);
+            tape.assume_init()
         }
     }
 }
@@ -230,7 +251,7 @@ impl Order2GraphWorkspace {
     #[must_use]
     pub fn new() -> Self {
         Self {
-            tape: UnsafeCell::new(Box::new(GraphTape::new())),
+            tape: UnsafeCell::new(GraphTape::new_boxed()),
         }
     }
 
@@ -287,8 +308,8 @@ impl Order2GraphWorkspace {
         tape.nodes[node] = GraphNode {
             value,
             support,
-            edge_start: edge_start as u16,
-            edge_len: edge_len as u16,
+            edge_start: packed_offset(edge_start),
+            edge_len: packed_offset(edge_len),
             primary_axis: NO_PRIMARY_AXIS,
         };
         tape.gradients[node * K..(node + 1) * K].copy_from_slice(&gradient);
@@ -306,7 +327,7 @@ impl Order2GraphWorkspace {
             parent < tape.node_len,
             "compiled graph edge parent must name an existing node"
         );
-        tape.edge_parents[tape.edge_len] = parent as u8;
+        tape.edge_parents[tape.edge_len] = packed_index(parent);
         tape.edge_firsts[tape.edge_len] = first;
         tape.edge_len += 1;
     }
@@ -331,7 +352,7 @@ impl Order2GraphWorkspace {
             input < tape.node_len,
             "compiled graph diagonal input must name an existing node"
         );
-        tape.diagonal_inputs[tape.diagonal_len] = input as u8;
+        tape.diagonal_inputs[tape.diagonal_len] = packed_index(input);
         tape.diagonal_seconds[tape.diagonal_len] = second;
         tape.diagonal_len += 1;
     }
@@ -560,8 +581,8 @@ impl<'arena, const K: usize> Order2Graph<'arena, K> {
         Order2GraphWorkspace::push_event(
             tape,
             CurvatureEvent::RankOne {
-                owner: owner as u8,
-                input: self.node as u8,
+                owner: packed_index(owner),
+                input: packed_index(self.node),
                 second,
             },
         );
@@ -594,7 +615,7 @@ impl<'arena, const K: usize> RuntimeJetScalar<'arena> for Order2Graph<'arena, K>
         let tape = workspace.tape_mut();
         let edge_start = tape.edge_len;
         let node = Order2GraphWorkspace::push(tape, x, 1_u16 << axis, gradient, edge_start);
-        tape.nodes[node].primary_axis = axis as u8;
+        tape.nodes[node].primary_axis = packed_index(axis);
         Self { workspace, node }
     }
 
@@ -781,8 +802,8 @@ impl<'arena, const K: usize> RuntimeJetScalar<'arena> for Order2Graph<'arena, K>
         Order2GraphWorkspace::push_event(
             tape,
             CurvatureEvent::Projected {
-                owner: owner as u8,
-                curvature_start: curvature_start as u16,
+                owner: packed_index(owner),
+                curvature_start: packed_offset(curvature_start),
                 support,
             },
         );
@@ -855,9 +876,9 @@ impl<'arena, const K: usize> RuntimeJetScalar<'arena> for Order2Graph<'arena, K>
         Order2GraphWorkspace::push_event(
             tape,
             CurvatureEvent::Cross {
-                owner: owner as u8,
-                left: self.node as u8,
-                right: right.node as u8,
+                owner: packed_index(owner),
+                left: packed_index(self.node),
+                right: packed_index(right.node),
             },
         );
         let node = Order2GraphWorkspace::push(tape, value, support, gradient, edge_start);
@@ -901,9 +922,9 @@ impl<'arena, const K: usize> RuntimeJetScalar<'arena> for Order2Graph<'arena, K>
         Order2GraphWorkspace::push_event(
             tape,
             CurvatureEvent::Diagonal {
-                owner: owner as u8,
-                term_start: term_start as u16,
-                len: inputs.len() as u16,
+                owner: packed_index(owner),
+                term_start: packed_offset(term_start),
+                len: packed_offset(inputs.len()),
             },
         );
         let node = Order2GraphWorkspace::push(tape, value, support, gradient, edge_start);
@@ -969,9 +990,9 @@ impl<'arena, const K: usize> RuntimeJetScalar<'arena> for Order2Graph<'arena, K>
         Order2GraphWorkspace::push_event(
             tape,
             CurvatureEvent::Diagonal {
-                owner: owner as u8,
-                term_start: term_start as u16,
-                len: inputs.len() as u16,
+                owner: packed_index(owner),
+                term_start: packed_offset(term_start),
+                len: packed_offset(inputs.len()),
             },
         );
         let node = Order2GraphWorkspace::push(tape, value, support, gradient, edge_start);
@@ -1140,8 +1161,8 @@ impl<'arena, const K: usize> RuntimeJetScalar<'arena> for Order2Graph<'arena, K>
         Order2GraphWorkspace::push_event(
             tape,
             CurvatureEvent::Projected {
-                owner: owner as u8,
-                curvature_start: curvature_start as u16,
+                owner: packed_index(owner),
+                curvature_start: packed_offset(curvature_start),
                 support,
             },
         );
@@ -1220,9 +1241,9 @@ impl<'arena, const K: usize> RuntimeJetScalar<'arena> for Order2Graph<'arena, K>
         Order2GraphWorkspace::push_event(
             tape,
             CurvatureEvent::Cross {
-                owner: owner as u8,
-                left: self.node as u8,
-                right: other.node as u8,
+                owner: packed_index(owner),
+                left: packed_index(self.node),
+                right: packed_index(other.node),
             },
         );
         let node = Order2GraphWorkspace::push(
@@ -1506,8 +1527,7 @@ mod tests {
         vars: &[S; 5],
         workspace: &'arena S::Workspace,
     ) -> S {
-        let right =
-            vars[4].affine_compose(1.2, -0.1, [0.7, -1.2, 0.45, 0.0, 0.0]);
+        let right = vars[4].affine_compose(1.2, -0.1, [0.7, -1.2, 0.45, 0.0, 0.0]);
         let derived_left = vars[2].multiply_add(&vars[3], &vars[0]);
         let addend = S::linear_combination(vars, &[0.3, -0.8, 0.5, 1.1, -0.4], 5, workspace);
         S::shared_multiply_add_affine_composed_sum(

--- a/crates/gam-spec/src/lib.rs
+++ b/crates/gam-spec/src/lib.rs
@@ -2637,6 +2637,7 @@ impl GlmLikelihoodSpec {
     /// the spec. The shape only takes effect for Gamma families; for other
     /// families the scale metadata is left untouched.
     #[inline]
+    #[must_use]
     pub fn with_gamma_shape(mut self, shape: f64) -> Self {
         self.scale = match self.scale {
             LikelihoodScaleMetadata::FixedGammaShape { .. } => {
@@ -2661,6 +2662,7 @@ impl GlmLikelihoodSpec {
     /// from the working residuals, so the IRLS weights `Var(y)=mu(1-mu)/(1+phi)`
     /// reflect the true precision rather than the `phi=1` seed (issue #567).
     #[inline]
+    #[must_use]
     pub fn with_beta_phi(mut self, phi: f64) -> Self {
         if let ResponseFamily::Beta { phi: family_phi } = &mut self.spec.response {
             *family_phi = phi;
@@ -2677,6 +2679,7 @@ impl GlmLikelihoodSpec {
     /// weight / covariance expression. No-op for non-Tweedie families (issue
     /// #771).
     #[inline]
+    #[must_use]
     pub fn with_tweedie_phi(mut self, phi: f64) -> Self {
         if matches!(self.spec.response, ResponseFamily::Tweedie { .. }) {
             self.scale = LikelihoodScaleMetadata::EstimatedTweediePhi { phi };
@@ -2700,6 +2703,7 @@ impl GlmLikelihoodSpec {
     /// PIRLS refresh gate (`negbin_theta_is_estimated()`) already skips the
     /// call, this enforces the same invariant at the data itself.
     #[inline]
+    #[must_use]
     pub fn with_negbin_theta(mut self, theta: f64) -> Self {
         if let ResponseFamily::NegativeBinomial {
             theta: family_theta,
@@ -2742,6 +2746,7 @@ impl GlmLikelihoodSpec {
     /// (the `refine_dispersion_at_converged_eta = true` accept-fit). No-op for
     /// non-Tweedie families and for a user-fixed `phi`.
     #[inline]
+    #[must_use]
     pub fn with_tweedie_phi_frozen_for_search(mut self, phi: f64) -> Self {
         if matches!(self.spec.response, ResponseFamily::Tweedie { .. })
             && self.scale.tweedie_phi_is_estimated()
@@ -2773,6 +2778,7 @@ impl GlmLikelihoodSpec {
     /// not inside the λ search; mgcv likewise"). No-op for non-NB families and
     /// for an already user-fixed θ.
     #[inline]
+    #[must_use]
     pub fn with_negbin_theta_frozen_for_search(mut self, theta: f64) -> Self {
         if let ResponseFamily::NegativeBinomial {
             theta: family_theta,
@@ -2820,6 +2826,7 @@ impl GlmLikelihoodSpec {
     /// reported dispersion / SEs remain the converged-η estimate. No-op for
     /// non-Gamma families and for a user-fixed shape.
     #[inline]
+    #[must_use]
     pub fn with_gamma_shape_frozen_for_search(mut self, shape: f64) -> Self {
         if matches!(self.spec.response, ResponseFamily::Gamma)
             && self.scale.gamma_shape_is_estimated()
@@ -2860,6 +2867,7 @@ impl GlmLikelihoodSpec {
     /// precision / SEs remain the converged-η estimate. No-op for non-Beta
     /// families and for an already-fixed `phi`.
     #[inline]
+    #[must_use]
     pub fn with_beta_phi_frozen_for_search(mut self, phi: f64) -> Self {
         if let ResponseFamily::Beta { phi: family_phi } = &mut self.spec.response
             && self.scale.beta_phi_is_estimated()


### PR DESCRIPTION
### Motivation
- Reduce actionable Clippy findings in the low-level math/graph code by removing unsafe implicit narrowing and eliminating large stack materializations that risk stack overflows. 
- Keep behaviour bit-identical while making fixed-capacity tape/packed-index invariants explicit and checked. 
- Add obvious `#[must_use]` annotations to builder-like consuming methods to avoid silently discarded updates.

### Description
- Replace stack construction of the large fixed-capacity `GraphTape` with an in-place heap initialization and introduce `GraphTape::new_boxed()` to avoid large stack arrays; instantiate the workspace with the boxed initializer instead of creating the tape on the stack (file: `crates/gam-math/src/order2_graph.rs`).
- Add checked packed conversions `packed_index` and `packed_offset` and use them instead of unchecked `usize as u8/u16` casts for graph indices/offsets and event fields (file: `crates/gam-math/src/order2_graph.rs`).
- Replace unchecked narrowing casts for partition counts and `powi` exponents with `try_from(...).expect(...)` and invariant messages to document and harden assumptions (files: `crates/gam-math/src/jet_algebra.rs`, `crates/gam-math/src/jet_tower.rs`).
- Mark consuming/builder-style methods that return `Self` with `#[must_use]` to prevent callers from dropping mutated specs/views: `DenseRightProductView::with_factor` / `with_optional_factor` (file: `crates/gam-linalg/src/matrix/mod.rs`) and several `with_*` methods on `GlmLikelihoodSpec` (file: `crates/gam-spec/src/lib.rs`).
- Keep all changes behavior-preserving; added checks use `expect` with clear invariant messages so runtime panics indicate contract violations rather than silent truncation.

### Testing
- Ran the targeted test suites with `cargo test -p gam-data -p gam-spec -p gam-linalg -p gam-geometry -p gam-math -p gam-row-macros --all-targets` and observed unchanged results: combined runs show `968 passed; 0 failed` across those crates. 
- Ran `cargo check -p gam-math` which completed successfully after the changes. 
- Ran `cargo clippy` on the targeted crates before and after; diagnostics summary for the targeted crates: before `total diagnostics = 770` (35 lint kinds) and after `total diagnostics = 733` (34 lint kinds). Notable reductions: `large_stack_arrays` from 3 → 0 and `cast_possible_truncation` from 36 → 7, while `float_cmp` findings were intentionally left unchanged due to semantic requirements. 
- Attempted full workspace `cargo build --workspace --all-targets`; this failed on unrelated, pre-existing `-D warnings` issues in `gam-sae` (dead-code diagnostics), so a complete workspace build could not be verified here.