### PR TITLE
fix(runtime): replace truncating integer casts in runtime bookkeeping

### DIFF
--- a/crates/gam-runtime/src/loop_progress.rs
+++ b/crates/gam-runtime/src/loop_progress.rs
@@ -9,6 +9,10 @@ use std::time::Instant;
 
 pub const DEFAULT_LOOP_PROGRESS_INTERVAL_SECS: u64 = 25;
 
+fn elapsed_nanos(elapsed: std::time::Duration) -> u64 {
+    u64::try_from(elapsed.as_nanos()).unwrap_or(u64::MAX)
+}
+
 pub struct LoopProgress {
     started: Instant,
     last_emit_nanos: AtomicU64,
@@ -39,7 +43,7 @@ impl LoopProgress {
             .progress
             .fetch_add(delta, Ordering::Relaxed)
             .saturating_add(delta);
-        let elapsed = self.started.elapsed().as_nanos() as u64;
+        let elapsed = elapsed_nanos(self.started.elapsed());
         let last = self.last_emit_nanos.load(Ordering::Relaxed);
         if elapsed < last.saturating_add(self.interval_nanos) {
             return;
@@ -120,5 +124,10 @@ mod tests {
             0,
             "zero-delta tick must emit progress 0"
         );
+    }
+
+    #[test]
+    fn elapsed_nanoseconds_saturate_instead_of_truncating() {
+        assert_eq!(elapsed_nanos(std::time::Duration::MAX), u64::MAX);
     }
 }

--- a/crates/gam-runtime/src/resource.rs
+++ b/crates/gam-runtime/src/resource.rs
@@ -953,7 +953,11 @@ impl<K: Eq + Hash + Clone, V: Clone + ResidentBytes> ByteLruCache<K, V> {
         }
         let mut hasher = std::collections::hash_map::DefaultHasher::new();
         key.hash(&mut hasher);
-        &self.shards[(hasher.finish() as usize) % self.shards.len()]
+        let shard_count =
+            u64::try_from(self.shards.len()).expect("shard count must fit in u64");
+        let shard = usize::try_from(hasher.finish() % shard_count)
+            .expect("shard index is bounded by the usize shard count");
+        &self.shards[shard]
     }
 
     pub fn get(&self, key: &K) -> Option<V> {

--- a/crates/gam-runtime/src/warm_start/key.rs
+++ b/crates/gam-runtime/src/warm_start/key.rs
@@ -119,7 +119,8 @@ impl Fingerprinter {
     /// Write one frame header: type discriminator, then length-prefixed tag.
     fn frame(&mut self, code: u8, tag: &[u8]) {
         self.h.update([code]);
-        self.h.update((tag.len() as u32).to_le_bytes());
+        let tag_len = u32::try_from(tag.len()).expect("fingerprint tag length must fit in u32");
+        self.h.update(tag_len.to_le_bytes());
         self.h.update(tag);
     }
 

--- a/crates/gam-runtime/src/warm_start/store.rs
+++ b/crates/gam-runtime/src/warm_start/store.rs
@@ -1230,8 +1230,10 @@ impl WarmStartStore {
         let old_access =
             (meta.accessed_unix_secs as u128) * 1_000_000_000u128 + meta.accessed_nanos as u128;
         let touched = now.max(old_access.saturating_add(1));
-        meta.accessed_unix_secs = (touched / 1_000_000_000u128) as u64;
-        meta.accessed_nanos = (touched % 1_000_000_000u128) as u32;
+        meta.accessed_unix_secs = u64::try_from(touched / 1_000_000_000u128)
+            .expect("warm-start access timestamp seconds must fit in u64");
+        meta.accessed_nanos = u32::try_from(touched % 1_000_000_000u128)
+            .expect("subsecond nanoseconds are less than one billion");
         meta.accessed = true;
         let json = serde_json::to_vec_pretty(&meta)?;
         let tmp = meta_path.with_extension(format!(
@@ -1534,8 +1536,10 @@ impl WarmStartStore {
 
     fn unix_now_parts(&self) -> (u64, u32) {
         let total = nanos_since_epoch().saturating_add(u128::from(self.test_time_offset_ns()));
-        let secs = (total / 1_000_000_000u128) as u64;
-        let nanos = (total % 1_000_000_000u128) as u32;
+        let secs = u64::try_from(total / 1_000_000_000u128)
+            .expect("warm-start timestamp seconds must fit in u64");
+        let nanos = u32::try_from(total % 1_000_000_000u128)
+            .expect("subsecond nanoseconds are less than one billion");
         (secs, nanos)
     }
 


### PR DESCRIPTION
### Motivation

- Eliminate unchecked narrowing casts that could truncate or saturate important runtime bookkeeping values (elapsed wall time, shard selection, warm-start timestamps, fingerprint lengths). 
- These truncations produced Clippy `cast_*` and `needless_pass_by_value` warnings that indicate real correctness or portability risks on some targets (e.g. 32-bit pointers or very long uptimes). 
- Prefer explicit, checked conversions with clear invariants so behaviour remains bit-identical where values fit and fails loudly with a diagnostic where invariants are violated.

### Description

- Replace the `u128 -> u64` truncating conversion of elapsed nanoseconds with a helper `elapsed_nanos` that saturates via `u64::try_from(...).unwrap_or(u64::MAX)` and use that in `LoopProgress::tick`, preserving the emitted seconds value for representable durations and avoiding truncation. 
- Make cache-shard selection robust by computing `hasher.finish() % shard_count` before converting into `usize`, using `u64::try_from`/`usize::try_from` and explicit invariant messages for the conversions in the byte-LRU sharding helper. 
- Stop silent truncation of fingerprint tag lengths by using `u32::try_from(tag.len()).expect(...)` in the `Fingerprinter::frame` header so oversized tags fail with a clear message instead of producing collisions. 
- Replace unchecked narrowing of warm-start access timestamps with `u64::try_from` / `u32::try_from` (and explanatory expect messages) in `WarmStartStore` helpers so on-disk timestamps are computed via checked conversions. 
- Add a unit test `elapsed_nanoseconds_saturate_instead_of_truncating` exercising the new nanosecond helper.

### Testing

- Ran `cargo test -p gam-runtime --all-targets`, and the runtime crate tests passed: `102 passed; 0 failed`. 
- Ran `cargo clippy` for `gam-runtime` before and after the targeted fixes; the clippy invocation initially stopped the workspace at `gam-runtime` with ~`135` clippy diagnostics for that crate, and after the focused fixes the `cast_possible_truncation` occurrences meaningful to production code were reduced (notably `cast_possible_truncation` went `5 -> 3` with remaining instances located in test-only code). 
- Attempted a workspace build and broader clippy runs but the full workspace `--all-targets` build/lint was too large to complete within the sandbox time, so the changes were verified locally for the runtime crate and its tests only.