### PR TITLE
test(linalg): add proptest SPD invariants and enforce derived pivot roundoff guards

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -832,6 +832,15 @@ dependencies = [
 
 [[package]]
 name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec 0.8.0",
+]
+
+[[package]]
+name = "bit-set"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34ddef2995421ab6a5c779542c81ee77c115206f4ad9d5a8e05f4ff49716a3dd"
@@ -844,6 +853,12 @@ name = "bit-vec"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bit-vec"
@@ -1769,7 +1784,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3143,7 +3158,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3719,6 +3734,7 @@ dependencies = [
  "gam-runtime",
  "log",
  "ndarray 0.17.2",
+ "proptest",
  "rayon",
  "serde",
  "thiserror 2.0.19",
@@ -4963,7 +4979,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "525e9ff3e1a4be2fbea1fdf0e98686a6d98b4d8f937e1bf7402245af1909e8c3"
 dependencies = [
  "byteorder-lite",
- "quick-error",
+ "quick-error 2.0.1",
 ]
 
 [[package]]
@@ -6808,6 +6824,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bit-set 0.8.0",
+ "bit-vec 0.8.0",
+ "bitflags 2.13.1",
+ "num-traits",
+ "rand 0.9.5",
+ "rand_chacha 0.9.0",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
 name = "pulp"
 version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6929,6 +6964,12 @@ dependencies = [
 
 [[package]]
 name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
+name = "quick-error"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
@@ -6986,7 +7027,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7148,6 +7189,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.5",
+]
+
+[[package]]
 name = "range-alloc"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7298,7 +7348,7 @@ dependencies = [
  "avif-serialize",
  "imgref",
  "loop9",
- "quick-error",
+ "quick-error 2.0.1",
  "rav1e",
  "rayon",
  "rgb",
@@ -7629,7 +7679,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7673,6 +7723,18 @@ name = "rustversion"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error 1.2.3",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "ryu"
@@ -8421,7 +8483,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8593,7 +8655,7 @@ dependencies = [
  "fax",
  "flate2",
  "half",
- "quick-error",
+ "quick-error 2.0.1",
  "weezl",
  "zune-jpeg",
 ]
@@ -9146,6 +9208,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9337,6 +9405,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d9b2acfb050df409c972a37d3b8e08cdea3bddb0c09db9d53137e504cfabed0"
 dependencies = [
  "utf8parse",
+]
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -9796,7 +9873,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/crates/gam-linalg/Cargo.toml
+++ b/crates/gam-linalg/Cargo.toml
@@ -23,3 +23,4 @@ thiserror = "2.0.18"
 [dev-dependencies]
 # `test_support::fd_checker`'s self-tests compare stencils against closed forms.
 approx = "0.5.1"
+proptest = "1.11.0"

--- a/crates/gam-linalg/src/matrix/symmetric.rs
+++ b/crates/gam-linalg/src/matrix/symmetric.rs
@@ -108,12 +108,26 @@ impl SymmetricMatrix {
                     "Dense SymmetricMatrix strict SPD factorization",
                 )
                 .map_err(|error| error.to_string())?;
-                matrix
-                    .cholesky(faer::Side::Lower)
-                    .map(|factor| Box::new(factor) as Box<dyn FactorizedSystem>)
-                    .map_err(|error| {
-                        format!("Dense SymmetricMatrix strict SPD factorization failed: {error}")
-                    })
+                let factor = matrix.cholesky(faer::Side::Lower).map_err(|error| {
+                    format!("Dense SymmetricMatrix strict SPD factorization failed: {error}")
+                })?;
+                let largest_diagonal = matrix.diag().iter().copied().fold(0.0_f64, f64::max);
+                // A Cholesky pivot is a dot product followed by a subtraction:
+                // at most 2n rounded operations, hence Wilkinson's gamma_(2n).
+                let pivot_band =
+                    crate::roundoff::accumulation_growth(2 * matrix.nrows()) * largest_diagonal;
+                if factor
+                    .diag()
+                    .iter()
+                    .copied()
+                    .any(|diagonal| diagonal * diagonal <= pivot_band)
+                {
+                    return Err(format!(
+                        "Dense SymmetricMatrix strict SPD factorization found a Cholesky pivot \
+                         inside its derived roundoff band {pivot_band:e}"
+                    ));
+                }
+                Ok(Box::new(factor) as Box<dyn FactorizedSystem>)
             }
             Self::Sparse(matrix) => crate::sparse_exact::factorize_sparse_spd_strict(matrix)
                 .map(|factor| Box::new(factor) as Box<dyn FactorizedSystem>)

--- a/crates/gam-linalg/src/sparse_exact.rs
+++ b/crates/gam-linalg/src/sparse_exact.rs
@@ -270,6 +270,24 @@ pub fn factorize_sparse_spd_strict(
         }
     })?;
     let simplicial = factorize_simplicial_canonical_upper(h_upper)?;
+    let largest_diagonal = (0..h_upper.ncols())
+        .filter_map(|column| {
+            (col_ptr[column]..col_ptr[column + 1])
+                .find(|&index| row_idx[index] == column)
+                .map(|index| values[index])
+        })
+        .fold(0.0_f64, f64::max);
+    // Each Schur-complement pivot forms a length-n dot product and subtracts
+    // it: at most 2n rounded operations, hence Wilkinson's gamma_(2n).
+    let pivot_band = crate::roundoff::accumulation_growth(2 * h_upper.ncols()) * largest_diagonal;
+    if (0..simplicial.n).any(|column| {
+        let diagonal = simplicial.l_values[simplicial.l_col_ptr[column]];
+        diagonal * diagonal <= pivot_band
+    }) {
+        return Err(LinalgError::ModelIsIllConditioned {
+            condition_number: f64::INFINITY,
+        });
+    }
     let logdet = simplicial.logdet;
     Ok(SparseExactFactor {
         factor,

--- a/crates/gam-linalg/tests/spd_properties.rs
+++ b/crates/gam-linalg/tests/spd_properties.rs
@@ -1,0 +1,148 @@
+use faer::Side;
+use gam_linalg::faer_ndarray::{fast_ata, strict_symmetric_eigh, FaerCholesky};
+use gam_linalg::matrix::{FactorizedSystem, SymmetricMatrix};
+use gam_linalg::roundoff::accumulation_growth;
+use gam_linalg::sparse_exact::{
+    dense_to_sparse_symmetric_upper, factorize_sparse_spd_strict, logdet_from_factor,
+    solve_sparse_spd,
+};
+use ndarray::{Array1, Array2};
+use proptest::prelude::*;
+
+const MAX_DIMENSION: usize = 6;
+
+fn spd_case() -> impl Strategy<Value = (Array2<f64>, Array1<f64>)> {
+    (
+        1usize..=MAX_DIMENSION,
+        -8i32..=8,
+        prop::collection::vec(-0.25f64..=0.25, MAX_DIMENSION * MAX_DIMENSION),
+        prop::collection::vec(-1.0f64..=1.0, MAX_DIMENSION),
+    )
+        .prop_map(|(n, scale_exponent, coefficients, x)| {
+            let mut lower = Array2::<f64>::zeros((n, n));
+            for row in 0..n {
+                for column in 0..row {
+                    lower[[row, column]] = coefficients[row * MAX_DIMENSION + column];
+                }
+                // Keeping every pivot in [1, 3/2] makes the generated matrices
+                // positive definite by construction without imposing a search box.
+                lower[[row, row]] = 1.25 + coefficients[row * MAX_DIMENSION + row];
+            }
+            let scale = 10.0f64.powi(scale_exponent);
+            let mut matrix = lower.dot(&lower.t());
+            matrix *= scale;
+            (matrix, Array1::from_vec(x[..n].to_vec()))
+        })
+}
+
+fn condition_number(matrix: &Array2<f64>) -> f64 {
+    let (eigenvalues, _) = strict_symmetric_eigh(matrix, Side::Lower).unwrap();
+    let smallest = eigenvalues.iter().copied().fold(f64::INFINITY, f64::min);
+    let largest = eigenvalues.iter().copied().fold(0.0, f64::max);
+    largest / smallest
+}
+
+fn infinity_norm(values: &Array1<f64>) -> f64 {
+    values.iter().copied().map(f64::abs).fold(0.0, f64::max)
+}
+
+proptest! {
+    #[test]
+    fn strict_spd_solve_recovers_x_with_condition_derived_error((matrix, expected) in spd_case()) {
+        let n = matrix.nrows();
+        let rhs = matrix.dot(&expected);
+        let factor = SymmetricMatrix::Dense(matrix.clone()).factorize_spd().unwrap();
+        let actual = factor.solve(&rhs).unwrap();
+        let error = infinity_norm(&(&actual - &expected));
+
+        // Standard floating-point analysis gives gamma_k = k*u/(1-k*u) for k
+        // rounded operations.  Forming A*x costs at most 2n operations per row;
+        // Cholesky costs at most 2n per entry, and its two triangular solves cost
+        // at most 2n each.  Thus gamma_(8n) bounds the combined backward error.
+        // Perturbation of an SPD solve amplifies that error by kappa(A), giving
+        // ||x_hat-x||/||x|| <= kappa*gamma/(1-kappa*gamma).
+        let relative_backward_error = accumulation_growth(8 * n);
+        let amplified = condition_number(&matrix) * relative_backward_error;
+        prop_assume!(amplified < 1.0);
+        let bound = infinity_norm(&expected) * amplified / (1.0 - amplified);
+        prop_assert!(error <= bound, "error {error:e} exceeded derived bound {bound:e}");
+    }
+
+    #[test]
+    fn sparse_logdet_matches_dense_reference_across_scales((matrix, _) in spd_case()) {
+        let n = matrix.nrows();
+        let condition = condition_number(&matrix);
+        let dense_logdet = matrix.cholesky(Side::Lower).unwrap().logdet();
+        let sparse = dense_to_sparse_symmetric_upper(&matrix, 0.0).unwrap();
+        let sparse_factor = factorize_sparse_spd_strict(&sparse).unwrap();
+        let sparse_logdet = logdet_from_factor(&sparse_factor).unwrap();
+
+        // Each factorization has at most gamma_(2n) elementwise backward error.
+        // log(det(.)) has first-order relative-matrix condition at most n*kappa;
+        // adding the two independent errors gives gamma_(4n).  The final n logs
+        // and sum contribute six roundings per diagonal across the two paths:
+        // square root, logarithm, and the final multiplication by two.
+        let perturbation = condition * n as f64 * accumulation_growth(4 * n);
+        prop_assume!(perturbation < 1.0);
+        let factorization_bound = perturbation / (1.0 - perturbation);
+        let log_accumulation_bound =
+            accumulation_growth(6 * n) * (dense_logdet.abs() + n as f64);
+        let bound = factorization_bound + log_accumulation_bound;
+        prop_assert!((sparse_logdet - dense_logdet).abs() <= bound,
+            "sparse {sparse_logdet:e}, dense {dense_logdet:e}, derived bound {bound:e}");
+    }
+
+    #[test]
+    fn gram_of_random_input_is_bitwise_symmetric(
+        rows in 1usize..=MAX_DIMENSION,
+        columns in 1usize..=MAX_DIMENSION,
+        values in prop::collection::vec(-1.0f64..=1.0, MAX_DIMENSION * MAX_DIMENSION),
+    ) {
+        let input = Array2::from_shape_fn((rows, columns), |(row, column)| {
+            values[row * MAX_DIMENSION + column]
+        });
+        let gram = fast_ata(&input);
+        for row in 0..columns {
+            for column in 0..columns {
+                prop_assert_eq!(gram[[row, column]].to_bits(), gram[[column, row]].to_bits());
+            }
+        }
+    }
+
+    #[test]
+    fn rank_deficient_inputs_are_rejected(
+        n in 2usize..=MAX_DIMENSION,
+        values in prop::collection::vec(-1.0f64..=1.0, MAX_DIMENSION * MAX_DIMENSION),
+    ) {
+        let mut matrix = Array2::from_shape_fn((n, n), |(row, column)| {
+            values[row * MAX_DIMENSION + column]
+        });
+        matrix = matrix.t().dot(&matrix);
+        // Make the final row and column exact copies of the first. This gives
+        // the stored floating-point matrix an exact null vector e_last-e_first;
+        // it does not merely rely on a real-arithmetic rank statement that the
+        // preceding Gram accumulation could perturb away.
+        for index in 0..n {
+            matrix[[n - 1, index]] = matrix[[0, index]];
+            matrix[[index, n - 1]] = matrix[[index, 0]];
+        }
+        prop_assert!(SymmetricMatrix::Dense(matrix.clone()).factorize_spd().is_err());
+        let sparse = dense_to_sparse_symmetric_upper(&matrix, 0.0).unwrap();
+        prop_assert!(factorize_sparse_spd_strict(&sparse).is_err());
+    }
+
+    #[test]
+    fn sparse_spd_solve_recovers_x_with_condition_derived_error((matrix, expected) in spd_case()) {
+        let n = matrix.nrows();
+        let rhs = matrix.dot(&expected);
+        let sparse = dense_to_sparse_symmetric_upper(&matrix, 0.0).unwrap();
+        let factor = factorize_sparse_spd_strict(&sparse).unwrap();
+        let actual = solve_sparse_spd(&factor, &rhs).unwrap();
+        let error = infinity_norm(&(&actual - &expected));
+        let relative_backward_error = accumulation_growth(8 * n);
+        let amplified = condition_number(&matrix) * relative_backward_error;
+        prop_assume!(amplified < 1.0);
+        let bound = infinity_norm(&expected) * amplified / (1.0 - amplified);
+        prop_assert!(error <= bound, "error {error:e} exceeded derived bound {bound:e}");
+    }
+}


### PR DESCRIPTION
### Motivation

- Add property-based tests for core SPD linear-algebra invariants (solve recovery, log-determinant parity, bitwise symmetry of Gram, and rank-deficiency rejection) to harden the `gam-linalg` numerics contract. 
- Bounds must be derived from floating-point backward-error analysis (Wilkinson's gamma) rather than tuned constants, and routines must reject rank-deficient inputs instead of returning finite garbage.

### Description

- Added a new proptest-based test suite `crates/gam-linalg/tests/spd_properties.rs` that generates random SPD matrices across scales and verifies: `solve(A, A·x) ≈ x` with a bound derived from condition number × Wilkinson growth, sparse `logdet` matches dense reference with a derived bound including factorization and log accumulation rounding, Gram outputs are bitwise symmetric, and strict factorization rejects rank-deficient inputs.
- Introduced `proptest` as a `dev-dependency` for `gam-linalg` and built the random fixtures to span scales 1e-8..1e8 without hand-tuned clamps. 
- Replaced an ad-hoc `gamma` helper in tests by the library `crate::roundoff::accumulation_growth` and explicitly documented the operation counts used in the derived bounds (e.g. `γ_(2n)`, `γ_(4n)`, `γ_(8n)` etc.).
- Fixed strict-SPD factorization behavior: both the dense `factorize_spd` and the strict sparse path now check that Cholesky pivots lie outside the derived Wilkinson roundoff band (computed from `accumulation_growth` and the largest stored diagonal) and reject matrices with pivots inside that band by returning a clear ill-conditioned / rejection error rather than producing finite but meaningless outputs.

### Testing

- Ran the new property test harness with `cargo test -p gam-linalg --test spd_properties`, and the final run reported `5 passed; 0 failed` (all proptest cases passed). 
- Ran the `gam-linalg` unit test suite with `cargo test -p gam-linalg` and observed all internal unit tests pass (the package test run completed with the library tests and the new property tests passing). 
- Attempted workspace-wide build `cargo build --workspace --all-targets`; this completed compilation of `gam-linalg` but the full workspace build failed later due to unrelated `gam-sae` dead-code errors (warnings-as-errors in that crate), not because of the linalg changes; the `gam-linalg` tests and properties themselves are green. 
- All numerical bounds used by the tests were derived from `accumulation_growth`/Wilkinson analysis and documented inline in test comments rather than tuned.