### PR TITLE
test(reproducibility): pin fits across Rayon thread counts (Rust + Python)

### DIFF
--- a/tests/test_thread_count_reproducibility.py
+++ b/tests/test_thread_count_reproducibility.py
@@ -1,0 +1,55 @@
+"""The thin Python API preserves Rust's bit-reproducible fit contract."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+
+
+def test_python_fits_are_bit_identical_across_rayon_thread_counts_and_runs() -> None:
+    program = r'''
+import json, math
+import gamfit
+
+def frame(kind):
+    out = {"x": []}
+    out.update({"time": [], "event": []} if kind == "survival" else {"y": []})
+    for i in range(240):
+        x = -2.4 + 4.8 * i / 239.0
+        wave = math.sin(2.1 * x) + 0.15 * math.cos(5.3 * x)
+        out["x"].append(x)
+        if kind == "gaussian": out["y"].append(wave + 0.07 * ((i * 37 % 17) - 8.0))
+        elif kind == "binomial": out["y"].append(float((i * 53 % 101) / 101.0 < 1.0 / (1.0 + math.exp(-wave))))
+        else:
+            latent = math.exp(1.3 - 0.45 * x + 0.12 * wave)
+            censor = 5.0 + (i * 29 % 31) / 5.0
+            out["time"].append(min(latent, censor)); out["event"].append(float(latent <= censor))
+    return out
+
+kind = __import__('os').environ['GAM_REPRO_KIND']
+if kind == "survival":
+    model = gamfit.fit(frame(kind), "Surv(time, event) ~ s(x, k=8)",
+                       survival_likelihood="transformation")
+else:
+    model = gamfit.fit(frame(kind), "y ~ s(x, k=10)", family=kind)
+summary = model.summary()
+coef = summary.coefficients_frame()["estimate"].tolist()
+print("RESULT " + json.dumps({"coefficients": [v.hex() for v in coef],
+    "lambdas": [v.hex() for v in summary.lambdas],
+    "log_likelihood": summary.log_likelihood.hex()}, sort_keys=True))
+'''
+    for kind in ("gaussian", "binomial", "survival"):
+        expected = None
+        for threads in (1, 2, 8):
+            for _run in range(2):
+                env = os.environ.copy()
+                env.update(RAYON_NUM_THREADS=str(threads), GAM_REPRO_KIND=kind)
+                completed = subprocess.run(
+                    [sys.executable, "-c", program], env=env, text=True,
+                    capture_output=True, check=True,
+                )
+                result = next(line for line in completed.stdout.splitlines() if line.startswith("RESULT "))
+                if expected is None:
+                    expected = result
+                assert result == expected, f"{kind} changed with RAYON_NUM_THREADS={threads}"

--- a/tests/thread_count_reproducibility.rs
+++ b/tests/thread_count_reproducibility.rs
@@ -1,0 +1,134 @@
+//! End-to-end determinism contract for the public Rust fitting API.
+//!
+//! Rayon owns one process-global pool, so the parent test launches this test
+//! binary afresh for every thread count.  The child prints the exact IEEE-754
+//! words of the user-visible fitted coefficients, smoothing parameters, and
+//! log-likelihood; comparing text therefore compares bits, not a tolerance.
+
+use std::process::Command;
+
+use csv::StringRecord;
+use gam::{FitConfig, FitResult, encode_recordswith_inferred_schema, fit_from_formula};
+
+fn data(kind: &str) -> gam::data::EncodedDataset {
+    let headers = if kind == "survival" {
+        vec!["time", "event", "x"]
+    } else {
+        vec!["y", "x"]
+    }
+    .into_iter()
+    .map(str::to_owned)
+    .collect();
+    let rows = (0..240)
+        .map(|i| {
+            let x = -2.4 + 4.8 * i as f64 / 239.0;
+            let wave = (2.1 * x).sin() + 0.15 * (5.3 * x).cos();
+            let values = match kind {
+                "gaussian" => vec![wave + 0.07 * ((i * 37 % 17) as f64 - 8.0), x],
+                "binomial" => vec![
+                    ((i * 53 % 101) as f64 / 101.0 < 1.0 / (1.0 + (-wave).exp())) as u8 as f64,
+                    x,
+                ],
+                "survival" => {
+                    let latent = (1.3 - 0.45 * x + 0.12 * wave).exp();
+                    let censor = 5.0 + (i * 29 % 31) as f64 / 5.0;
+                    vec![latent.min(censor), (latent <= censor) as u8 as f64, x]
+                }
+                _ => unreachable!(),
+            };
+            StringRecord::from(
+                values
+                    .into_iter()
+                    .map(|v| format!("{v:.17e}"))
+                    .collect::<Vec<_>>(),
+            )
+        })
+        .collect();
+    encode_recordswith_inferred_schema(headers, rows).expect("encode deterministic fixture")
+}
+
+fn words(values: impl IntoIterator<Item = f64>) -> String {
+    values
+        .into_iter()
+        .map(|v| format!("{:016x}", v.to_bits()))
+        .collect::<Vec<_>>()
+        .join(",")
+}
+
+#[test]
+fn thread_count_fit_child() {
+    let Some(kind) = std::env::var_os("GAM_REPRO_CHILD") else {
+        return;
+    };
+    let kind = kind.to_string_lossy();
+    gam::init_parallelism();
+    let mut config = FitConfig::default();
+    let formula = match kind.as_ref() {
+        "gaussian" => {
+            config.family = Some("gaussian".into());
+            "y ~ s(x, k=10)"
+        }
+        "binomial" => {
+            config.family = Some("binomial".into());
+            "y ~ s(x, k=10)"
+        }
+        "survival" => {
+            config.survival_likelihood = Some("transformation".into());
+            config.time_basis = "ispline".into();
+            config.time_num_internal_knots = 2;
+            "Surv(time, event) ~ s(x, k=8) + survmodel(spec=net)"
+        }
+        _ => panic!("unknown child fixture"),
+    };
+    let result = fit_from_formula(formula, &data(&kind), &config).expect("fit must converge");
+    let fit = match &result {
+        FitResult::Standard(result) => &result.fit,
+        FitResult::SurvivalTransformation(result) => &result.fit,
+        _ => panic!("unexpected fit result"),
+    };
+    let coefficients = fit
+        .blocks
+        .iter()
+        .flat_map(|block| block.beta.iter().copied());
+    println!(
+        "RESULT coefficients={} lambdas={} log_likelihood={:016x}",
+        words(coefficients),
+        words(fit.lambdas.iter().copied()),
+        fit.log_likelihood.to_bits()
+    );
+}
+
+#[test]
+fn fits_are_bit_identical_across_rayon_thread_counts_and_runs() {
+    let exe = std::env::current_exe().expect("current test binary");
+    for kind in ["gaussian", "binomial", "survival"] {
+        let mut baseline = None;
+        for threads in [1, 2, 8] {
+            for run in 0..2 {
+                let output = Command::new(&exe)
+                    .args(["--exact", "thread_count_fit_child", "--nocapture"])
+                    .env("RAYON_NUM_THREADS", threads.to_string())
+                    .env("GAM_REPRO_CHILD", kind)
+                    .output()
+                    .expect("launch isolated fit process");
+                assert!(
+                    output.status.success(),
+                    "{kind}, threads={threads}, run={run}: {}",
+                    String::from_utf8_lossy(&output.stderr)
+                );
+                let stdout = String::from_utf8(output.stdout).expect("UTF-8 child output");
+                let result = stdout
+                    .lines()
+                    .find(|line| line.starts_with("RESULT "))
+                    .expect("child result");
+                match &baseline {
+                    None => baseline = Some(result.to_owned()),
+                    Some(expected) => assert_eq!(
+                        result, expected,
+                        "{kind} fit changed at threads={threads}, run={run}"
+                    ),
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Motivation
- Add an end-to-end regression that ensures fits are bit-identical when the process-global Rayon pool size changes, because Rayon initializes process-wide and thread-count invariance must be exercised in isolated processes. 
- Cover the common model families that exercise different solver paths: a Gaussian smooth, a binomial smooth, and a transformation-survival model.

### Description
- Add `tests/thread_count_reproducibility.rs`, a Rust integration test that spawns the test binary as subprocesses with `RAYON_NUM_THREADS=1,2,8`, fits each model, and prints exact IEEE-754 words of coefficients, smoothing parameters, and log-likelihood for bit-for-bit comparison; child entry is `thread_count_fit_child` and parent is `fits_are_bit_identical_across_rayon_thread_counts_and_runs`.
- Add `tests/test_thread_count_reproducibility.py`, a thin Python pytest that drives the public Python API (`gamfit.fit`) for the same three model kinds and compares `float.hex()` output across runs and thread counts.
- Tests compare textual IEEE-754 representations (hex / bit words) so failures indicate real nondeterministic reductions rather than numerical tolerance slips.
- No production solver logic or numerical algorithm was changed in this PR; the change is purely test additions to pin the reproducibility contract.

### Testing
- Ran `rustfmt --edition 2024 tests/thread_count_reproducibility.rs` and `python -m py_compile tests/test_thread_count_reproducibility.py`, both passed (syntax / formatting checks succeeded).
- Attempted `cargo test --test thread_count_reproducibility fits_are_bit_identical_across_rayon_thread_counts_and_runs -- --nocapture` but the workspace compilation failed due to pre-existing `gam-sae` warnings-as-errors (dead-code) which prevented running the new Rust test; no new assertions were executed.
- Attempted `pytest -q tests/test_thread_count_reproducibility.py` but execution could not proceed because the Python environment in this sandbox lacked the built `gamfit._rust` extension and `numpy`, so the test did not run.
- Started a workspace `cargo build --workspace --all-targets` to satisfy Python extension build and run the Rust tests, but the full workspace build did not complete inside the sandbox time budget and was interrupted; therefore end-to-end test execution remains unverified in this environment.

Commands run (high level) and results:
- `rustfmt --edition 2024 tests/thread_count_reproducibility.rs` — succeeded.
- `python -m py_compile tests/test_thread_count_reproducibility.py` — succeeded.
- `cargo test --test thread_count_reproducibility ...` — failed at compile due to existing `gam-sae` dead-code errors (prevented tests from running).
- `python -m pytest -q tests/test_thread_count_reproducibility.py` — did not run due to missing `gamfit._rust` and `numpy` in the environment.
- `cargo build --workspace --all-targets` — started but did not finish within sandbox time.

Notes / recommended follow-ups
- Fix the pre-existing `gam-sae` dead-code/linters so `cargo test` can complete and then exercise the new Rust test.
- Build the Python extension (e.g. via `maturin develop` / workspace build) and install `numpy` in the test environment to run the new pytest.
- If either test flags a non-deterministic outcome, trace the first failing (model, thread-count, run) back to the reduction that introduced nondeterminism (unordered collect / non-deterministic fold / hash iteration) and make that reduction deterministic without changing numerical semantics.