### PR TITLE
data: reject degenerate / non-finite columns at shared fit boundary (typed errors)

### DIFF
--- a/crates/gam-cli/tests/suite/fit_data_boundary.rs
+++ b/crates/gam-cli/tests/suite/fit_data_boundary.rs
@@ -1,0 +1,59 @@
+use std::{fs, process::Command};
+
+#[test]
+fn cli_fit_reports_degenerate_inputs_at_the_shared_boundary() {
+    let cases = [
+        ("y,x\n0,0\n1,NaN\n2,1\n", "column 'x'", "non-finite"),
+        ("y,x\n0,0\n1,inf\n2,1\n", "column 'x'", "non-finite"),
+        ("y,x\n0,0\n1,-inf\n2,1\n", "column 'x'", "non-finite"),
+        ("y,x\n0,4\n1,4\n2,4\n", "column 'x'", "constant"),
+        (
+            "y,x\n0,NA\n1,4\n2,NA\n",
+            "column 'x'",
+            "only one non-missing value",
+        ),
+        (
+            "y,g\n0,only\n1,only\n2,only\n",
+            "column 'g'",
+            "fewer than two levels",
+        ),
+        ("y,x,x\n0,0,1\n1,1,0\n2,2,1\n", "column 'x'", "duplicate"),
+    ];
+    for (csv, column, problem) in cases {
+        let dir = tempfile::tempdir().unwrap();
+        let input = dir.path().join("data.csv");
+        fs::write(&input, csv).unwrap();
+        let output = Command::new(gam_test_support::gam_binary!())
+            .args([
+                "fit",
+                input.to_str().unwrap(),
+                "y ~ x",
+                "--family",
+                "gaussian",
+            ])
+            .output()
+            .unwrap();
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            !output.status.success(),
+            "degenerate input minted a fit: {csv}"
+        );
+        assert!(
+            stderr.contains(column) && stderr.contains(problem),
+            "{stderr}"
+        );
+    }
+}
+
+#[test]
+fn cli_fit_reports_empty_frame_without_panicking() {
+    let dir = tempfile::tempdir().unwrap();
+    let input = dir.path().join("data.csv");
+    fs::write(&input, "y,x\n").unwrap();
+    let output = Command::new(gam_test_support::gam_binary!())
+        .args(["fit", input.to_str().unwrap(), "y ~ x"])
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+    assert!(String::from_utf8_lossy(&output.stderr).contains("no rows"));
+}

--- a/crates/gam-cli/tests/suite/main.rs
+++ b/crates/gam-cli/tests/suite/main.rs
@@ -9,6 +9,7 @@ mod bug_hunt_explicit_family_emits_wrong_inferred_family_note;
 mod bug_hunt_predict_uncertainty_shifts_point_mean_for_curved_link;
 mod bug_hunt_sas_link_finalize_inner_cap_leak;
 mod bug_hunt_sas_link_outer_inner_cap_guard;
+mod fit_data_boundary;
 mod frontend_payload_parity_2470;
 mod regression_bspline_nonzero_anchor_pin_2297;
 mod regression_predict_cli_surfaces_covariance_provenance;

--- a/crates/gam-data/src/lib.rs
+++ b/crates/gam-data/src/lib.rs
@@ -187,6 +187,10 @@ pub enum DataError {
     /// A cell value cannot be used as a feature: non-finite float, Arrow null,
     /// or an unsupported Arrow data type for the column.
     InvalidValue { reason: String },
+    /// A complete table reached the fitting boundary but one of its columns
+    /// cannot identify a model effect. Unlike `InvalidValue`, this retains
+    /// both pieces of machine-readable context for front ends.
+    DegenerateColumn { column: String, problem: String },
     /// A formula or call site references a column name that is not present in
     /// the input data. Structured so the FFI boundary can raise a typed
     /// Python exception (`gamfit.ColumnNotFoundError`) carrying the missing
@@ -228,6 +232,7 @@ impl DataError {
             | Self::EncodingFailure { .. }
             | Self::EmptyInput { .. }
             | Self::InvalidValue { .. }
+            | Self::DegenerateColumn { .. }
             | Self::ColumnNotFound { .. } => None,
         }
     }
@@ -275,6 +280,9 @@ impl fmt::Display for DataError {
             | DataError::EncodingFailure { reason }
             | DataError::EmptyInput { reason }
             | DataError::InvalidValue { reason } => f.write_str(reason),
+            DataError::DegenerateColumn { column, problem } => {
+                write!(f, "column '{column}' {problem}")
+            }
             DataError::ColumnNotFound {
                 name,
                 role,
@@ -378,6 +386,83 @@ pub struct EncodedDataset {
 }
 
 impl EncodedDataset {
+    /// Validate the table at the common formula-fit boundary.
+    ///
+    /// This deliberately lives below formula materialization: library, CLI,
+    /// and Python fits all carry an `EncodedDataset` through that seam, so a
+    /// degenerate design can never acquire frontend-specific behaviour.
+    pub fn validate_fit_boundary(&self) -> Result<(), DataError> {
+        if self.headers.is_empty() {
+            return Err(DataError::DegenerateColumn {
+                column: "<table>".to_string(),
+                problem: "has no columns".to_string(),
+            });
+        }
+        let mut seen = HashSet::with_capacity(self.headers.len());
+        for name in &self.headers {
+            if !seen.insert(name.as_str()) {
+                return Err(DataError::DegenerateColumn {
+                    column: name.clone(),
+                    problem: "has a duplicate name".to_string(),
+                });
+            }
+        }
+        if self.values.nrows() == 0 {
+            return Err(DataError::DegenerateColumn {
+                column: "<table>".to_string(),
+                problem: "has no observations".to_string(),
+            });
+        }
+        if self.values.ncols() != self.headers.len() {
+            return Err(DataError::SchemaMismatch {
+                reason: format!(
+                    "table has {} headers but {} value columns",
+                    self.headers.len(),
+                    self.values.ncols()
+                ),
+            });
+        }
+        for (index, name) in self.headers.iter().enumerate() {
+            if self.column_kinds.get(index) == Some(&ColumnKindTag::Categorical)
+                && self
+                    .schema
+                    .columns
+                    .get(index)
+                    .is_some_and(|column| column.levels.len() < 2)
+            {
+                return Err(DataError::DegenerateColumn {
+                    column: name.clone(),
+                    problem: "is a factor with fewer than two levels".to_string(),
+                });
+            }
+            let column = self.values.column(index);
+            let finite_count = column.iter().filter(|value| value.is_finite()).count();
+            if finite_count == 1 && column.len() > 1 {
+                return Err(DataError::DegenerateColumn {
+                    column: name.clone(),
+                    problem: "has only one non-missing value".to_string(),
+                });
+            }
+            if let Some((row, value)) = column
+                .iter()
+                .enumerate()
+                .find(|(_, value)| !value.is_finite())
+            {
+                return Err(DataError::DegenerateColumn {
+                    column: name.clone(),
+                    problem: format!("has non-finite value {value} at row {}", row + 1),
+                });
+            }
+            if column.len() > 1 && column.iter().all(|value| *value == column[0]) {
+                return Err(DataError::DegenerateColumn {
+                    column: name.clone(),
+                    problem: "is constant".to_string(),
+                });
+            }
+        }
+        Ok(())
+    }
+
     pub fn column_map(&self) -> HashMap<String, usize> {
         self.headers
             .iter()
@@ -3811,6 +3896,95 @@ mod tests {
             let once = canonical_level_bits(v);
             let twice = canonical_level_bits(f64::from_bits(once));
             assert_eq!(once, twice, "value {v}");
+        }
+    }
+    #[test]
+    fn fit_boundary_reports_each_degenerate_column_by_name() {
+        let cases = [
+            (
+                vec![0.0, f64::NAN, 1.0],
+                "has non-finite value NaN at row 2",
+            ),
+            (
+                vec![0.0, f64::INFINITY, 1.0],
+                "has non-finite value inf at row 2",
+            ),
+            (
+                vec![0.0, f64::NEG_INFINITY, 1.0],
+                "has non-finite value -inf at row 2",
+            ),
+            (vec![2.0, 2.0, 2.0], "is constant"),
+            (
+                vec![f64::NAN, 2.0, f64::NAN],
+                "has only one non-missing value",
+            ),
+        ];
+        for (values, expected) in cases {
+            let dataset = EncodedDataset {
+                headers: vec!["temperature".to_string()],
+                values: Array2::from_shape_vec((3, 1), values).unwrap(),
+                schema: DataSchema {
+                    columns: vec![SchemaColumn {
+                        name: "temperature".to_string(),
+                        kind: ColumnKindTag::Continuous,
+                        levels: Vec::new(),
+                    }],
+                },
+                column_kinds: vec![ColumnKindTag::Continuous],
+            };
+            let error = dataset.validate_fit_boundary().unwrap_err();
+            assert!(matches!(error, DataError::DegenerateColumn { .. }));
+            assert_eq!(
+                error.to_string(),
+                format!("column 'temperature' {expected}")
+            );
+        }
+    }
+
+    #[test]
+    fn fit_boundary_rejects_empty_duplicate_and_one_level_factor() {
+        let cases = [
+            EncodedDataset {
+                headers: vec!["x".into()],
+                values: Array2::zeros((0, 1)),
+                schema: DataSchema {
+                    columns: vec![SchemaColumn {
+                        name: "x".into(),
+                        kind: ColumnKindTag::Continuous,
+                        levels: vec![],
+                    }],
+                },
+                column_kinds: vec![ColumnKindTag::Continuous],
+            },
+            EncodedDataset {
+                headers: vec!["x".into(), "x".into()],
+                values: Array2::from_shape_vec((2, 2), vec![0.0, 1.0, 1.0, 0.0]).unwrap(),
+                schema: DataSchema { columns: vec![] },
+                column_kinds: vec![ColumnKindTag::Continuous; 2],
+            },
+            EncodedDataset {
+                headers: vec!["group".into()],
+                values: Array2::zeros((2, 1)),
+                schema: DataSchema {
+                    columns: vec![SchemaColumn {
+                        name: "group".into(),
+                        kind: ColumnKindTag::Categorical,
+                        levels: vec!["only".into()],
+                    }],
+                },
+                column_kinds: vec![ColumnKindTag::Categorical],
+            },
+        ];
+        let expected = [
+            "column '<table>' has no observations",
+            "column 'x' has a duplicate name",
+            "column 'group' is a factor with fewer than two levels",
+        ];
+        for (dataset, expected) in cases.into_iter().zip(expected) {
+            assert_eq!(
+                dataset.validate_fit_boundary().unwrap_err().to_string(),
+                expected
+            );
         }
     }
 }

--- a/crates/gam-models/src/fit_orchestration/entry.rs
+++ b/crates/gam-models/src/fit_orchestration/entry.rs
@@ -2409,6 +2409,7 @@ fn materialize_impl<'a>(
     config: &FitConfig,
     structural_only: bool,
 ) -> Result<MaterializedModel<'a>, WorkflowError> {
+    data.validate_fit_boundary()?;
     let config = config
         .clone()
         .resolve()

--- a/crates/gam-models/src/fit_orchestration/error.rs
+++ b/crates/gam-models/src/fit_orchestration/error.rs
@@ -44,6 +44,8 @@ pub enum WorkflowError {
     /// optimizer / profile-cost evaluation) failed to converge or
     /// produced a non-finite value that downstream code cannot consume.
     IntegrationFailed { reason: String },
+    /// Training data failed the shared fit-boundary contract.
+    InvalidData { column: String, problem: String },
     /// A spatial basis could not be certified at its current resolution and
     /// the next information-bearing expansion could not be fitted. Carries the
     /// attempted resolution and underlying evidence instead of returning the
@@ -82,6 +84,9 @@ impl std::fmt::Display for WorkflowError {
             | WorkflowError::SchemaMismatch { reason }
             | WorkflowError::MissingDependency { reason }
             | WorkflowError::IntegrationFailed { reason } => f.write_str(reason),
+            WorkflowError::InvalidData { column, problem } => {
+                write!(f, "column '{column}' {problem}")
+            }
             WorkflowError::SpatialUnderresolved {
                 term,
                 current_centers,
@@ -141,6 +146,7 @@ impl std::error::Error for WorkflowError {
             | WorkflowError::SchemaMismatch { .. }
             | WorkflowError::MissingDependency { .. }
             | WorkflowError::IntegrationFailed { .. }
+            | WorkflowError::InvalidData { .. }
             | WorkflowError::SpatialUnderresolved { .. }
             | WorkflowError::ColumnNotFound { .. } => None,
         }
@@ -278,6 +284,9 @@ impl From<gam_data::DataError> for WorkflowError {
             | DataError::EncodingFailure { reason }
             | DataError::EmptyInput { reason }
             | DataError::InvalidValue { reason } => Self::InvalidConfig { reason },
+            DataError::DegenerateColumn { column, problem } => {
+                Self::InvalidData { column, problem }
+            }
         }
     }
 }

--- a/crates/gam-models/tests/suite/fit_data_boundary.rs
+++ b/crates/gam-models/tests/suite/fit_data_boundary.rs
@@ -1,0 +1,109 @@
+use gam_data::{ColumnKindTag, DataSchema, EncodedDataset, SchemaColumn};
+use gam_models::fit_orchestration::{FitConfig, WorkflowError, materialize};
+use ndarray::Array2;
+
+fn dataset(values: Vec<f64>, kind: ColumnKindTag, levels: Vec<&str>) -> EncodedDataset {
+    EncodedDataset {
+        headers: vec!["offender".into()],
+        values: Array2::from_shape_vec((values.len(), 1), values).unwrap(),
+        schema: DataSchema {
+            columns: vec![SchemaColumn {
+                name: "offender".into(),
+                kind,
+                levels: levels.into_iter().map(str::to_string).collect(),
+            }],
+        },
+        column_kinds: vec![kind],
+    }
+}
+
+#[test]
+fn public_materializer_returns_typed_data_errors_before_design_construction() {
+    let cases = [
+        (
+            dataset(vec![0.0, f64::NAN, 1.0], ColumnKindTag::Continuous, vec![]),
+            "has non-finite value NaN",
+        ),
+        (
+            dataset(
+                vec![0.0, f64::INFINITY, 1.0],
+                ColumnKindTag::Continuous,
+                vec![],
+            ),
+            "has non-finite value inf",
+        ),
+        (
+            dataset(
+                vec![0.0, f64::NEG_INFINITY, 1.0],
+                ColumnKindTag::Continuous,
+                vec![],
+            ),
+            "has non-finite value -inf",
+        ),
+        (
+            dataset(vec![4.0, 4.0, 4.0], ColumnKindTag::Continuous, vec![]),
+            "is constant",
+        ),
+        (
+            dataset(
+                vec![f64::NAN, 4.0, f64::NAN],
+                ColumnKindTag::Continuous,
+                vec![],
+            ),
+            "has only one non-missing value",
+        ),
+        (
+            dataset(
+                vec![0.0, 0.0, 0.0],
+                ColumnKindTag::Categorical,
+                vec!["only"],
+            ),
+            "is a factor with fewer than two levels",
+        ),
+    ];
+    for (data, problem) in cases {
+        let error = match materialize("offender ~ 1", &data, &FitConfig::default()) {
+            Err(error) => error,
+            Ok(_) => panic!("degenerate data must not materialize a fit request"),
+        };
+        assert!(
+            matches!(&error, WorkflowError::InvalidData { column, .. } if column == "offender")
+        );
+        assert!(error.to_string().contains(problem), "{error}");
+    }
+}
+
+#[test]
+fn public_materializer_types_empty_and_duplicate_column_errors() {
+    let empty = EncodedDataset {
+        headers: vec!["x".into()],
+        values: Array2::zeros((0, 1)),
+        schema: DataSchema {
+            columns: vec![SchemaColumn {
+                name: "x".into(),
+                kind: ColumnKindTag::Continuous,
+                levels: vec![],
+            }],
+        },
+        column_kinds: vec![ColumnKindTag::Continuous],
+    };
+    let duplicate = EncodedDataset {
+        headers: vec!["x".into(), "x".into()],
+        values: Array2::from_shape_vec((2, 2), vec![0.0, 1.0, 1.0, 0.0]).unwrap(),
+        schema: DataSchema { columns: vec![] },
+        column_kinds: vec![ColumnKindTag::Continuous; 2],
+    };
+    for (data, column, problem) in [
+        (empty, "<table>", "no observations"),
+        (duplicate, "x", "duplicate name"),
+    ] {
+        let error = match materialize("x ~ 1", &data, &FitConfig::default()) {
+            Err(error) => error,
+            Ok(_) => panic!("invalid table must not materialize a fit request"),
+        };
+        assert!(
+            matches!(&error, WorkflowError::InvalidData { column: actual, .. } if actual == column)
+        );
+        assert!(error.to_string().contains(problem));
+    }
+}

--- a/crates/gam-models/tests/suite/main.rs
+++ b/crates/gam-models/tests/suite/main.rs
@@ -5,6 +5,7 @@
 mod bspline_nonzero_anchor_affine_2297;
 mod duchon_grid_fit_and_rotation_2319;
 mod exact_gaussian_boundary_2663;
+mod fit_data_boundary;
 mod multinomial_contracted_jeffreys_2612;
 mod multinomial_covariance_mode_2612;
 mod multinomial_jeffreys_outer_gradient_fd_2612;

--- a/crates/gam-pyffi/src/ffi/ffi_errors.rs
+++ b/crates/gam-pyffi/src/ffi/ffi_errors.rs
@@ -869,6 +869,9 @@ pub(crate) fn workflow_error_to_pyerr(py: Python<'_>, err: WorkflowError) -> PyE
         }
         WorkflowError::MissingDependency { reason } => MissingDependencyError::new_err(reason),
         WorkflowError::IntegrationFailed { reason } => IntegrationError::new_err(reason),
+        WorkflowError::InvalidData { column, problem } => {
+            DataError::new_err(format!("column '{column}' {problem}"))
+        }
         WorkflowError::SpatialUnderresolved { .. } => IntegrationError::new_err(err.to_string()),
         WorkflowError::FormulaDsl { .. } => FormulaError::new_err(err.to_string()),
     }

--- a/crates/gam-pyffi/src/model/model_ffi.rs
+++ b/crates/gam-pyffi/src/model/model_ffi.rs
@@ -910,11 +910,7 @@ fn encoded_table_from_columns(
         let column = numeric.column(matrix_column);
         let kind = infer_numeric_array_column_kind(column);
         for (row, value) in column.iter().enumerate() {
-            values[[row, table_column]] = if value.is_finite() {
-                *value
-            } else {
-                f64::NAN
-            };
+            values[[row, table_column]] = *value;
         }
         column_kinds[table_column] = kind;
         schema_columns[table_column] = Some(SchemaColumn {

--- a/crates/gam-terms/src/term_builder.rs
+++ b/crates/gam-terms/src/term_builder.rs
@@ -199,6 +199,9 @@ impl From<DataError> for TermBuilderError {
             | DataError::EncodingFailure { reason }
             | DataError::EmptyInput { reason }
             | DataError::InvalidValue { reason } => Self::MissingColumn { reason },
+            DataError::DegenerateColumn { column, problem } => Self::DegenerateData {
+                reason: format!("column '{column}' {problem}"),
+            },
         }
     }
 }

--- a/gamfit/_tables.py
+++ b/gamfit/_tables.py
@@ -79,12 +79,14 @@ def normalize_table(data: Any) -> tuple[list[str], Any, str]:
     columns, kind = _table_column_views(data)
     headers = list(columns)
     if not headers:
-        raise ValueError("table must have at least one column")
+        from ._exceptions import DataError
+        raise DataError("column '<table>' has no columns")
     reject_duplicate_column_names(headers, kind)
     validate_column_lengths(columns)
     row_count = len(columns[headers[0]])
     if row_count == 0:
-        raise ValueError("table data cannot be empty")
+        from ._exceptions import DataError
+        raise DataError("column '<table>' has no observations")
 
     # Arrow-capable providers hand ownership of a fresh C stream capsule to
     # arrow-rs.  Numeric buffers are then decoded directly from Arrow memory and
@@ -519,11 +521,8 @@ def reject_duplicate_column_names(names: Sequence[str], kind: str) -> None:
         if seen[name] == 2:
             duplicates.append(name)
     if duplicates:
-        listed = ", ".join(repr(name) for name in duplicates)
-        raise ValueError(
-            f"{kind} input has duplicate column names ({listed}); "
-            "every column must have a unique name"
-        )
+        from ._exceptions import DataError
+        raise DataError(f"column {duplicates[0]!r} has a duplicate name")
 
 
 def validate_column_lengths(columns: Mapping[str, Sequence[Any]]) -> None:

--- a/tests/test_fit_data_boundary.py
+++ b/tests/test_fit_data_boundary.py
@@ -1,0 +1,34 @@
+import numpy as np
+import pandas as pd
+import pytest
+
+import gamfit
+
+
+@pytest.mark.parametrize(
+    ("values", "problem"),
+    [
+        ([0.0, np.nan, 1.0], "non-finite value NaN"),
+        ([0.0, np.inf, 1.0], "non-finite value inf"),
+        ([0.0, -np.inf, 1.0], "non-finite value -inf"),
+        ([4.0, 4.0, 4.0], "is constant"),
+        ([np.nan, 4.0, np.nan], "only one non-missing value"),
+    ],
+)
+def test_fit_rejects_numeric_degeneracy_with_typed_column_error(values, problem):
+    frame = pd.DataFrame({"y": [0.0, 1.0, 2.0], "offender": values})
+    with pytest.raises(gamfit.DataError, match="column 'offender'.*" + problem):
+        gamfit.fit(frame, "y ~ offender", family="gaussian")
+
+
+@pytest.mark.parametrize(
+    "frame, column, problem",
+    [
+        (pd.DataFrame({"y": [], "x": []}), "<table>", "no observations"),
+        (pd.DataFrame([[0, 1, 2], [1, 2, 3]], columns=["y", "x", "x"]), "x", "duplicate name"),
+        (pd.DataFrame({"y": [0.0, 1.0, 2.0], "group": pd.Categorical(["only"] * 3)}), "group", "fewer than two levels"),
+    ],
+)
+def test_fit_rejects_structural_degeneracy_with_typed_column_error(frame, column, problem):
+    with pytest.raises(gamfit.DataError, match=f"column '{column}'.*{problem}"):
+        gamfit.fit(frame, "y ~ group" if "group" in frame.columns else "y ~ x", family="gaussian")


### PR DESCRIPTION
### Motivation

- Unify and harden validation when a table reaches the formula→design fit boundary so the Rust library, CLI and Python wrapper all fail at the same place with a typed, actionable error rather than panicking or emitting inconsistent prose.
- Cover common degenerate inputs (NaN, ±Inf, constant column, single non-missing value, empty frame, duplicate column names, one-level factor) that previously slipped into later numerical code or were rejected by different layers with different errors.
- Provide machine-readable error payloads so frontends can raise `gamfit.DataError` / `ColumnNotFoundError` with structured attributes rather than parsing messages.

### Description

- Added `DataError::DegenerateColumn { column, problem }` and implemented `EncodedDataset::validate_fit_boundary()` to detect empty tables, duplicate headers, zero rows, header/value-column count mismatch, one-level factors, columns with only one non-missing value, non-finite cell occurrences, and constant columns. The validator returns a typed `DegenerateColumn` describing the offending column and problem. (crates/gam-data/src/lib.rs)
- Call the new validator from the shared materializer before formula materialization / design construction so the library, CLI, and Python paths all use the single source of truth. (crates/gam-models/src/fit_orchestration/entry.rs)
- Propagate degenerate-boundary failures as a typed workflow variant `WorkflowError::InvalidData { column, problem }` and map it to the public Python `DataError` class in the FFI layer so Python callers receive the same structured exception. (crates/gam-models/src/fit_orchestration/error.rs; crates/gam-pyffi/src/ffi/ffi_errors.rs)
- Preserve numeric values across the Python FFI (stop coercing infinities to NaN at the marshalling site) so the validator can report the real offending payload and row. Also make Python-side pre-normalize checks raise the same typed `gamfit.DataError` for empty frames and duplicate names. Add unit and integration tests exercising all surfaces (Rust library, CLI, Python). (crates/gam-pyffi/src/model/model_ffi.rs; gamfit/_tables.py)

### Testing

- Unit tests added in the data crate: `fit_boundary_reports_each_degenerate_column_by_name` and `fit_boundary_rejects_empty_duplicate_and_one_level_factor` and run with `cargo test -p gam-data fit_boundary`; result: 2 passed, 0 failed. (crates/gam-data/src/lib.rs tests)
- New integration/unit tests added exercising the materializer and error typing: `public_materializer_returns_typed_data_errors_before_design_construction` and `public_materializer_types_empty_and_duplicate_column_errors` and compiled via `cargo check` / unit runs in the `gam-models` test harness; the code compiled under check for the modified crates and the new tests are present (execution of the full gam-models test suite was limited by workspace build time in the sandbox). (crates/gam-models/tests/suite/fit_data_boundary.rs)
- CLI tests added: `cli_fit_reports_degenerate_inputs_at_the_shared_boundary` and `cli_fit_reports_empty_frame_without_panicking`, exercised locally by spawning the `gam` binary on synthetic CSV fixtures; assertions check non-zero exit and typed column messages in stderr. (crates/gam-cli/tests/suite/fit_data_boundary.rs)
- Python-level tests added under `tests/test_fit_data_boundary.py` exercising `gamfit.fit(...)` to assert `gamfit.DataError` is raised with the expected column-oriented message for numeric and structural degeneracies; the test module was syntax-checked and prepared for pytest execution (full pytest run was not completed in the sandbox due to the full workspace build time). (tests/test_fit_data_boundary.py)