### PR TITLE
docs(api): enable `missing_docs` and document public Rust library surface

### DIFF
--- a/crates/gam-model-api/src/families/custom_family/family_trait.rs
+++ b/crates/gam-model-api/src/families/custom_family/family_trait.rs
@@ -36,12 +36,17 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 /// Family evaluation over all parameter blocks.
 #[derive(Clone, Debug)]
 pub struct FamilyEvaluation {
+    /// Sum of the family log likelihood over all observations.
     pub log_likelihood: f64,
+    /// IRLS working response and weight information, one entry per block.
     pub blockworking_sets: Vec<BlockWorkingSet>,
 }
 
+/// Exact log likelihood and coefficient gradient returned by a joint workspace.
 pub struct ExactNewtonJointGradientEvaluation {
+    /// Sum of the family log likelihood over all observations.
     pub log_likelihood: f64,
+    /// Gradient in flattened coefficient-block order.
     pub gradient: Array1<f64>,
 }
 
@@ -76,6 +81,10 @@ pub struct BatchedOuterHessianTerms {
     pub outer_hessian: gam_problem::HessianValue,
 }
 
+/// Batched contributions used to assemble the profiled REML/LAML gradient.
+///
+/// Each vector uses the unified outer-coordinate order (smoothing coordinates
+/// followed by family hyperparameters) and must therefore have the same length.
 pub struct BatchedOuterGradientTerms {
     /// Explicit ∂J/∂θ_j contributions evaluated at the converged β̂ holding
     /// β fixed (i.e. the part that does NOT flow through H or S):
@@ -113,6 +122,11 @@ pub struct OuterDerivativePilotSchedule {
 }
 
 impl OuterDerivativePilotSchedule {
+    /// Create a pilot/exact-phase schedule around a shared evaluation counter.
+    ///
+    /// `sampled_phase_budget` is the largest counter value belonging to the
+    /// sampled phase. The constructor is infallible; callers must share this
+    /// same counter with the family evaluation that increments it.
     pub fn new(phase_counter: Arc<AtomicUsize>, sampled_phase_budget: usize) -> Self {
         Self {
             phase_counter,
@@ -1160,6 +1174,11 @@ pub trait CustomFamily {
         false
     }
 
+    /// Whether the joint workspace returns the exact flattened coefficient gradient.
+    ///
+    /// `specs` must be a valid block layout. The default validates it and
+    /// returns `false`; implementations returning `true` must also return
+    /// `Some` from the workspace gradient evaluation.
     fn inner_joint_workspace_gradient_available(&self, specs: &[ParameterBlockSpec]) -> bool {
         assert_valid_blockspecs(specs, "inner joint workspace gradient availability");
         false
@@ -1198,6 +1217,11 @@ pub trait CustomFamily {
         false
     }
 
+    /// Whether the joint workspace returns the exact current log likelihood.
+    ///
+    /// `specs` must be a valid block layout. The default validates it and
+    /// returns `false`; implementations returning `true` must also return
+    /// `Some` from the workspace log-likelihood evaluation.
     fn inner_joint_workspace_log_likelihood_available(&self, specs: &[ParameterBlockSpec]) -> bool {
         assert_valid_blockspecs(specs, "inner joint workspace log-likelihood availability");
         false
@@ -2540,7 +2564,10 @@ pub enum EvalScope {
 /// this prevents.
 #[derive(Clone, Debug)]
 pub struct OuterEvalContext {
+    /// Current log smoothing parameters in penalty order.
     pub rho: Arc<Array1<f64>>,
+    /// Monotonically increasing identifier for the outer evaluation.
     pub eval_id: usize,
+    /// Whether this evaluation is an outer derivative or inner coefficient trial.
     pub scope: EvalScope,
 }

--- a/crates/gam-model-api/src/families/custom_family/options.rs
+++ b/crates/gam-model-api/src/families/custom_family/options.rs
@@ -254,6 +254,12 @@ pub(crate) fn validate_hessian_workspace_ready(
     Ok(())
 }
 
+/// Declare second-order outer calculus after validating the coefficient blocks.
+///
+/// `specs` must form a valid custom-family block layout. `coefficient_cost` is
+/// retained for API compatibility and diagnostics; analytic capability is not
+/// demoted on cost. Invalid specifications panic in the common contract
+/// validator.
 pub fn exact_outer_order_from_capability(
     specs: &[ParameterBlockSpec],
     coefficient_cost: u64,
@@ -531,6 +537,10 @@ pub fn block_offsets_from_specs(specs: &[ParameterBlockSpec]) -> Arc<[Range<usiz
 /// magnitude while still bounding pathological probes.
 pub const FIRST_ORDER_BFGS_LOGLAMBDA_STEP_CAP: f64 = 5.0;
 
+/// Report whether a family exposes the strict pseudo-Laplace geometry needed
+/// by the analytic second-order outer solver.
+///
+/// This query is infallible and does not evaluate the likelihood.
 pub fn exact_newton_outer_geometry_supports_second_order_solver<F: CustomFamily + ?Sized>(
     family: &F,
 ) -> bool {
@@ -540,9 +550,13 @@ pub fn exact_newton_outer_geometry_supports_second_order_solver<F: CustomFamily 
 /// Stable public API for installing outer-score subsampling.
 #[derive(Clone)]
 pub struct BlockwiseFitOptions {
+    /// Maximum coefficient-optimizer cycles allowed before non-convergence is returned.
     pub inner_max_cycles: usize,
+    /// Absolute coefficient stationarity tolerance; must be finite and positive.
     pub inner_tol: f64,
+    /// Maximum REML/LAML outer iterations allowed before non-convergence is returned.
     pub outer_max_iter: usize,
+    /// Absolute outer stationarity tolerance; must be finite and positive.
     pub outer_tol: f64,
     /// Optional override for the OUTER smoothing optimizer's
     /// *relative-cost-decrease* convergence stop, decoupled from `outer_tol`.
@@ -747,6 +761,7 @@ pub struct BlockwiseFitOptions {
     pub seed_screening: bool,
 }
 
+/// Default maximum coefficient cycles for a custom-family fit.
 pub const DEFAULT_CUSTOM_FAMILY_INNER_MAX_CYCLES: usize = 1200;
 
 impl Default for BlockwiseFitOptions {

--- a/crates/gam-model-api/src/families/custom_family/psi_design.rs
+++ b/crates/gam-model-api/src/families/custom_family/psi_design.rs
@@ -18,6 +18,11 @@ pub use gam_problem::{
     MaterializablePsiDerivativeOperator, MaterializationIntent, SharedCustomFamilyHyperLayout,
 };
 
+/// Family-owned exact coefficient-Hessian workspace for joint Newton fitting.
+///
+/// Implementations may expose dense matrices, matrix-free products, or both.
+/// `Ok(None)` means a representation is unavailable; `Err` reports failure to
+/// evaluate the family at the workspace's current coefficient state.
 pub trait ExactNewtonJointHessianWorkspace: Send + Sync {
     /// Pre-build any per-row jet caches the workspace will hand to the
     /// outer-eval directional-derivative path. Called once when the
@@ -53,6 +58,10 @@ pub trait ExactNewtonJointHessianWorkspace: Send + Sync {
     /// directional caches implement this explicitly as a mode-exhaustive no-op.
     fn warm_up_outer_caches_for_mode(&self, eval_mode: EvalMode) -> Result<(), String>;
 
+    /// Return the dense coefficient Hessian when the workspace exposes one.
+    ///
+    /// The matrix is square in flattened coefficient order. `Ok(None)` selects
+    /// another representation; `Err` reports an evaluation or assembly error.
     fn hessian_dense(&self) -> Result<Option<Array2<f64>>, String> {
         Ok(None)
     }
@@ -99,10 +108,17 @@ pub trait ExactNewtonJointHessianWorkspace: Send + Sync {
         self.hessian_dense()
     }
 
+    /// Return the joint log likelihood cached at this workspace state.
+    ///
+    /// `Ok(None)` means it was not computed; `Err` reports evaluation failure.
     fn joint_log_likelihood_evaluation(&self) -> Result<Option<f64>, String> {
         Ok(None)
     }
 
+    /// Return the cached joint log likelihood and exact coefficient gradient.
+    ///
+    /// `Ok(None)` means the workspace does not expose this payload; `Err`
+    /// reports evaluation failure.
     fn joint_gradient_evaluation(
         &self,
     ) -> Result<Option<ExactNewtonJointGradientEvaluation>, String> {
@@ -123,6 +139,11 @@ pub trait ExactNewtonJointHessianWorkspace: Send + Sync {
         false
     }
 
+    /// Apply the coefficient Hessian to one flattened coefficient direction.
+    ///
+    /// The input must have the workspace coefficient dimension and contain no
+    /// NaNs. `Ok(None)` means matrix-free application is unavailable; `Err`
+    /// reports a family evaluation or dimension error.
     fn hessian_matvec(&self, arr: &Array1<f64>) -> Result<Option<Array1<f64>>, String> {
         assert!(arr.iter().all(|v| !v.is_nan()));
         Ok(None)
@@ -201,6 +222,10 @@ pub trait ExactNewtonJointHessianWorkspace: Send + Sync {
         Ok(true)
     }
 
+    /// Return the coefficient-Hessian diagonal in flattened block order.
+    ///
+    /// `Ok(None)` means the diagonal is unavailable without materialization;
+    /// `Err` reports evaluation failure.
     fn hessian_diagonal(&self) -> Result<Option<Array1<f64>>, String> {
         Ok(None)
     }
@@ -225,6 +250,11 @@ pub trait ExactNewtonJointHessianWorkspace: Send + Sync {
         Ok(None)
     }
 
+    /// Differentiate the coefficient Hessian along `d_beta_flat`.
+    ///
+    /// The direction must match the flattened coefficient dimension. Returns
+    /// `Ok(None)` when a dense derivative is unavailable and `Err` when the
+    /// family cannot evaluate the requested direction.
     fn directional_derivative(
         &self,
         d_beta_flat: &Array1<f64>,
@@ -235,12 +265,14 @@ pub trait ExactNewtonJointHessianWorkspace: Send + Sync {
     /// owning a shared row/derivative cache override this so consumers such as
     /// the accepted-mode Jeffreys certificate do not reconstruct the family
     /// state or rebuild direction-independent row towers once per axis.
-    fn directional_derivative_all_axes(
-        &self,
-    ) -> Result<Option<Vec<Array2<f64>>>, String> {
+    fn directional_derivative_all_axes(&self) -> Result<Option<Vec<Array2<f64>>>, String> {
         Ok(None)
     }
 
+    /// Differentiate the coefficient Hessian along one direction as an operator.
+    ///
+    /// The default wraps [`Self::directional_derivative`] in a dense operator.
+    /// `Ok(None)` and `Err` preserve that method's unavailable/error meanings.
     fn directional_derivative_operator(
         &self,
         d_beta_flat: &Array1<f64>,
@@ -250,6 +282,10 @@ pub trait ExactNewtonJointHessianWorkspace: Send + Sync {
             .map(|matrix| Arc::new(DenseMatrixHyperOperator { matrix }) as Arc<dyn HyperOperator>))
     }
 
+    /// Evaluate first Hessian derivatives for a batch of coefficient directions.
+    ///
+    /// Results preserve input order. The first error aborts the batch; an
+    /// individual `None` denotes an unavailable derivative representation.
     fn directional_derivative_operators(
         &self,
         d_beta_flats: &[Array1<f64>],
@@ -260,6 +296,10 @@ pub trait ExactNewtonJointHessianWorkspace: Send + Sync {
             .collect()
     }
 
+    /// Evaluate the mixed second Hessian derivative along two directions.
+    ///
+    /// Both vectors must match the flattened coefficient dimension and contain
+    /// no NaNs. `Ok(None)` means unsupported; `Err` reports evaluation failure.
     fn second_directional_derivative(
         &self,
         arr: &Array1<f64>,
@@ -270,6 +310,10 @@ pub trait ExactNewtonJointHessianWorkspace: Send + Sync {
         Ok(None)
     }
 
+    /// Evaluate a mixed second Hessian derivative as an operator.
+    ///
+    /// The default wraps [`Self::second_directional_derivative`] in a dense
+    /// operator and preserves its unavailable/error semantics.
     fn second_directional_derivative_operator(
         &self,
         d_beta_u: &Array1<f64>,
@@ -280,6 +324,10 @@ pub trait ExactNewtonJointHessianWorkspace: Send + Sync {
             .map(|matrix| Arc::new(DenseMatrixHyperOperator { matrix }) as Arc<dyn HyperOperator>))
     }
 
+    /// Evaluate mixed second Hessian derivatives for a batch of direction pairs.
+    ///
+    /// Results preserve pair order. The first error aborts the batch; an
+    /// individual `None` denotes an unsupported derivative.
     fn second_directional_derivative_operators(
         &self,
         d_beta_pairs: &[(Array1<f64>, Array1<f64>)],

--- a/crates/gam-model-api/src/lib.rs
+++ b/crates/gam-model-api/src/lib.rs
@@ -2,11 +2,19 @@
 //! (`FamilyEvaluation`, joint-gradient/batched-term carriers) and the eval-scope /
 //! outer-eval-context enums that parameterize trait calls.
 
+#![warn(missing_docs)]
+
+/// Contracts implemented by likelihood families.
 pub mod families {
+    /// Public interfaces for user-defined, multi-parameter likelihood families.
     pub mod custom_family {
+        /// The custom-family trait and its evaluation payloads.
         pub mod family_trait;
+        /// Default analytic joint-Newton constructions used by trait methods.
         pub mod joint_newton_defaults;
+        /// Fit and derivative-policy configuration for custom families.
         pub mod options;
+        /// Hyperparameter-design and exact-Hessian workspace contracts.
         pub mod psi_design;
 
         pub use family_trait::*;
@@ -27,6 +35,7 @@ pub use gam_problem::joint_penalty::{JointPenaltyBundle, JointPenaltyError, Join
 pub use gam_problem::outer_subsample::{OuterScoreSubsample, RowSet, WeightedOuterRow};
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+/// Maximum derivative order requested from an outer REML/LAML evaluation.
 pub enum OuterEvalOrder {
     /// Compute only the objective value.
     Value,

--- a/docs/rust-library-surface.md
+++ b/docs/rust-library-surface.md
@@ -1,62 +1,106 @@
-# Rust library surface and removal decisions
+# Getting started with the Rust library
 
-The Rust library is a product, alongside the CLI and Python extension. A public
-item reachable through an exported Rust module, re-export, public type, or trait
-implementation is a source-graph root in every supported configuration. Its
-absence from a CLI or extension symbol table does not make it unused. Generic
-instantiation, inlining, and LTO do not change that rule.
+The `gam` crate is the supported in-process interface to the same formula
+materializer, REML/LAML optimizer, and prediction implementation used by the
+CLI and Python package. A successful call returns a fit whose inner and outer
+optimizations have already supplied convergence evidence; non-convergence is a
+`WorkflowError`, never a partially fitted model.
 
-The maintained high-level API is `gam::fit_from_formula` for formula/data input,
-`gam::materialize` followed by `gam::fit_model` for typed requests, and
-`gam::predict` for prediction. These route to the same production model owners
-used by the CLI and Python wrapper. Domain crates also expose their documented
-numerical and model-building contracts directly; consumers do not have to link
-either executable to use them.
+## Fit a Gaussian smooth and predict with uncertainty
 
-Rust's `dead_code` analysis operates on source definitions and visibility,
-including generic bodies and re-exports. The workspace's deny-warnings production
-builds retain exported library items and reject unreferenced private production
-items. Test targets must also compile: test helpers stay under `#[cfg(test)]`
-and are evaluated within their test source graph. A private production helper
-used only by tests is a candidate to move into test scope, not a reason to delete
-the tests. Compiler acceptance establishes source validity, not whether a public
-contract is valuable; removing a public contract still requires a semantic
-decision and review of its callers and documentation.
+This example builds an encoded data set, fits a penalized smooth with smoothing
+selected by REML, predicts the training means, and propagates coefficient
+uncertainty into response-scale standard errors. It is also compiled and run as
+the `gam::getting_started` doctest, so changes to the public API cannot silently
+make this page stale.
 
-There is no compatibility obligation to recreate deleted convenience names.
-Keep one current API per behavior, and use explicit model inputs where defaults
-would silently choose geometry. An exported name with no internal caller can
-still be useful; an abandoned configuration/report carrier with no callable
-producer is not a substitute for an implemented public contract.
+```rust
+use csv::StringRecord;
+use gam::{
+    FitConfig, FitResult, encode_recordswith_inferred_schema, fit_from_formula,
+    predict::{PredictUncertaintyOptions, predict_gamwith_uncertainty},
+};
 
-## Decisions for the concrete #2829 cases
+# fn main() -> Result<(), Box<dyn std::error::Error>> {
+let headers = vec!["x".to_owned(), "y".to_owned()];
+let rows = (0..32)
+    .map(|i| {
+        let x = -1.0 + 2.0 * f64::from(i) / 31.0;
+        // A reproducible nonlinear signal with a small, nonzero residual.
+        let y = 0.4 + 1.2 * x + 0.7 * x * x + 0.02 * f64::from(i % 3);
+        StringRecord::from(vec![x.to_string(), y.to_string()])
+    })
+    .collect();
+let data = encode_recordswith_inferred_schema(headers, rows)?;
+let config = FitConfig {
+    family: Some("gaussian".to_owned()),
+    ..FitConfig::default()
+};
 
-| Historical item | Current contract and decision |
-| --- | --- |
-| `fit_gam` | Maintain `gam::fit_model` / `gam::fit_from_formula` as the unified model front doors and `gam_solve::estimate::fit_gam_with_penalty_specs` as the explicit external-design API. The generic owned/borrowed design contract is exercised by `public_library_surface_2829.rs`. Recreating an alias that only supplies defaults is unnecessary. |
-| `canonicalize_for_identifiability` | Maintain `gam_identifiability::canonical::canonicalize_for_identifiability_with_operating_scalars`. `None` explicitly requests the zero-state audit; supplied scalars audit the actual family operating point. `canonical_recovery.rs` exercises this public route. |
-| `under_identified_subspace` | Maintain `gam_solve::estimate::reml::jeffreys_subspace::under_identified_subspace_in_metric`. The caller supplies the model's metric; an identity-metric convenience must not hide a coordinate convention. The public integration target tests both identity coordinates and congruent nonorthogonal coordinates. |
-| `arrow_log_det_from_cache` | The public `ArrowSchurCache::arrow_log_det` reads the recorded undamped criterion value. `compute_undamped_arrow_log_det` and `undamped_arrow_log_det_with_schur` own its construction. Do not duplicate this with an evidence-module accessor. |
-| `matrix_free_arrow_evidence_log_det` | Maintain `matrix_free_arrow_evidence_log_det_surrogate`, with an explicit rational-lane state for a differentiable frozen criterion and `None` for value-only SLQ. Internal documentation now names this actual public entry point. |
-| `coordinate_block_log_det`, `criterion_as_atoms` | The current exact-A criterion assembles `log_det` and `log_det_tt` from the same observed information and uses `rank_adjusted_quasi_laplace_complexity`. The removed majorizer convenience is not the ranked coordinate term. Independent adjoint/criterion acceptance is tracked by #2333 and #2828. |
-| `Dual2::{seed_directional,from_channels,seed_inner,seed_outer}` | Maintain the public `Dual2` value/first/second fields, `constant`, `variable`, and `Dual22::channels`. The analytic polynomial channel-order test in `gam-math` verifies the actual representation; redundant setters and getter/setter roundtrips are not separate product behavior. |
-| `enable_outer_gradient_fd_capture` | Maintain `enable_outer_gradient_fd_capture_over_theta`; it arms the complete current diagnostic and owns its typed sink. Consumers now document that actual function. |
-| `triangle_cocycle_defect`, `triangle_sign_product` | Consumers compose the public `ChartTransition` rotations/signs. The restored `local_chart_recovery_tests.rs` independently checks the composition on plane, sphere-band, and Swiss-roll fixtures; no duplicate arithmetic wrapper is required. |
-| `LocalAtlas::co_collapse_candidates` | **Unresolved.** The three historical #2280 co-collapse contracts have no verified replacement. Public transition composition does not establish duplicate-chart detection. #2280 must resolve this behavior explicitly. |
-| `cofit_block_and_curved`, `cofit_linear_via_arrow`, `cofit_composed_via_arrow` | **Unresolved.** Their modules currently retain configuration/report types but no callable producer. `tiered::fit_tiered` is the active fitting route; its fixed-point and stationarity contracts must be compared to the five historical #2023 pins before the old bridge is retired. |
+let FitResult::Standard(fitted) =
+    fit_from_formula("y ~ smooth(x, k=8)", &data, &config)?
+else {
+    unreachable!("a Gaussian formula produces a standard fit")
+};
 
-This is a decision record for the issue's concrete examples, not a claim that all
-1,206 historical public declarations have been audited. Remaining identities must
-be resolved by crate, module/type, and signature; a same-named definition in a
-different owner is not evidence of recovery. #2829 remains open until the
-remaining public behavior decisions and their acceptance evidence are complete.
+let block = fitted.fit.blocks.first().expect("standard fit has one block");
+let family = fitted
+    .fit
+    .likelihood_family
+    .clone()
+    .expect("built-in Gaussian fit records its likelihood");
+let prediction = predict_gamwith_uncertainty(
+    fitted.design.design.clone(),
+    block.beta.view(),
+    fitted.design.affine_offset.view(),
+    family,
+    &fitted.fit,
+    &PredictUncertaintyOptions::default(),
+)?;
 
-The external acceptance targets executed on MSI: two public-library tests, four
-structural-coordinate tests, and four measured-span tests passed. The generic
-fit test instantiates both owned and borrowed designs and verifies the exact
-normal equations including the solver's declared stabilization ridge, with
-bit-identical coefficients across ownership forms. The measured-span shear
-control demonstrates that supplying the wrong metric changes the selected
-dimension. These are compiled external consumers, not symbol-table probes.
-Execution receipts and remaining historical acceptance gaps are recorded in
-[`test-census-2818-recovery.md`](test-census-2818-recovery.md).
+assert_eq!(prediction.mean.len(), 32);
+assert!(prediction.mean_standard_error.iter().all(|se| se.is_finite()));
+
+// REML/LAML diagnostics belong to the converged fit itself.
+let criterion = fitted
+    .fit
+    .reml_score()
+    .expect("this noisy Gaussian data has a finite REML criterion");
+let evidence = fitted.fit.convergence_evidence();
+assert!(criterion.is_finite());
+assert!(fitted.fit.outer_iterations <= config.outer_max_iter);
+println!("REML={criterion:.3}; convergence={evidence:?}");
+# Ok(())
+# }
+```
+
+The design and affine offset above are the *training* design. For new data,
+rebuild from `fitted.resolvedspec` so knots, factor levels, constraints, and
+other fitted term state remain frozen; then pass the rebuilt matrix and offset
+to the same prediction function.
+
+## Reading the result
+
+* `FitResult::Standard` is the ordinary one-linear-predictor GAM result. Other
+  variants make multi-parameter, survival, and large-data representations
+  explicit rather than hiding them behind a lossy common struct.
+* `UnifiedFitResult::convergence_evidence()` is the construction proof carried
+  by every fit. There is no separate boolean callers must remember to check.
+* `UnifiedFitResult::reml_score()` returns the optimized REML/LAML criterion.
+  It returns `None` only at the exact-fit, zero-dispersion Gaussian boundary,
+  where no finite restricted likelihood exists; callers must not substitute a
+  sentinel value when comparing models.
+* `PredictUncertaintyResult::mean` is the posterior-mean response prediction,
+  while `mean_standard_error` contains coefficient-uncertainty standard errors.
+  Prediction errors report incompatible matrix dimensions, missing covariance,
+  or invalid interval options through `EstimationError`.
+
+## Errors and preconditions
+
+`fit_from_formula` rejects malformed formulas, missing or incompatible columns,
+invalid family/link configuration, and any optimizer run that does not converge.
+Input rows must be nonempty and numeric values must be finite. Prediction
+requires one design column per fitted coefficient and one offset per prediction
+row. Keep `FitConfig::default()` unless changing model semantics deliberately:
+smoothing selection remains REML/LAML and prediction remains posterior-mean by
+default.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,6 +41,18 @@
 //! - [`linalg`] — faer ↔ ndarray bridges + numerics helpers
 //! - [`gpu`] — runtime CUDA dispatch for hot linear algebra paths
 
+#![warn(missing_docs)]
+
+/// A compiled copy of the [Rust getting-started guide](crate::getting_started).
+///
+/// Its documentation is sourced from the repository guide so the example is
+/// checked as a rustdoc test; the module also exposes the formula-fit entry
+/// point used by that example.
+#[doc = include_str!("../docs/rust-library-surface.md")]
+pub mod getting_started {
+    pub use gam_models::fit_orchestration::fit_from_formula;
+}
+
 // `config_resolve` was extracted from `src/main/` so the CLI driver and the
 // Python FFI (gam-pyffi) can share the same JSON → FitConfig resolver; pull
 // the current crate in under the `gam` alias so the file can keep using
@@ -168,11 +180,14 @@ pub use gam_solve::rho_uncertainty;
 /// (absent) glob entry with a compat module re-exporting the relocated layer.
 pub mod solver {
     pub use gam_solve::*;
+    /// Compatibility namespace for the high-level fit orchestration API.
     pub mod fit_orchestration {
         pub use gam_models::fit_orchestration::*;
     }
 }
+/// Smooth-term construction plus the sparse-autoencoder term extension.
 pub mod terms {
+    /// Sparse-autoencoder smooth and model-building APIs.
     pub use gam_sae as sae;
     pub use gam_terms::*;
 }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -13,6 +13,9 @@
 //!   custom  → CustomFamilyError
 
 #[macro_export]
+/// Implement `Display`, `Error`, and conversion to `String` for reason-carrying enums.
+///
+/// Every listed variant must have a named `reason` field of type `String`.
 macro_rules! impl_reason_error_boilerplate {
     ($type:ident { $($variant:ident),+ $(,)? }) => {
         impl ::std::fmt::Display for $type {
@@ -34,6 +37,9 @@ macro_rules! impl_reason_error_boilerplate {
 }
 
 #[macro_export]
+/// Return an [`EstimationError::InvalidInput`](crate::model_types::EstimationError::InvalidInput).
+///
+/// Accepts either a `format!`-style literal and arguments or an owned message.
 macro_rules! bail_invalid_estim {
     ($fmt:literal $(, $($arg:tt)*)?) => {
         return Err($crate::model_types::EstimationError::InvalidInput(format!($fmt $(, $($arg)*)?)))
@@ -44,6 +50,9 @@ macro_rules! bail_invalid_estim {
 }
 
 #[macro_export]
+/// Return a [`BasisError::InvalidInput`](crate::terms::basis::BasisError::InvalidInput).
+///
+/// Accepts either a `format!`-style literal and arguments or an owned message.
 macro_rules! bail_invalid_basis {
     ($fmt:literal $(, $($arg:tt)*)?) => {
         return Err($crate::terms::basis::BasisError::InvalidInput(format!($fmt $(, $($arg)*)?)))
@@ -54,6 +63,9 @@ macro_rules! bail_invalid_basis {
 }
 
 #[macro_export]
+/// Return a [`BasisError::DimensionMismatch`](crate::terms::basis::BasisError::DimensionMismatch).
+///
+/// Accepts either a `format!`-style literal and arguments or an owned message.
 macro_rules! bail_dim_basis {
     ($fmt:literal $(, $($arg:tt)*)?) => {
         return Err($crate::terms::basis::BasisError::DimensionMismatch(format!($fmt $(, $($arg)*)?)))
@@ -64,6 +76,9 @@ macro_rules! bail_dim_basis {
 }
 
 #[macro_export]
+/// Return a `GamlssError::InvalidInput` from the current function.
+///
+/// Accepts either a `format!`-style literal and arguments or an owned message.
 macro_rules! bail_invalid_gamlss {
     ($fmt:literal $(, $($arg:tt)*)?) => {
         return Err($crate::families::gamlss::GamlssError::InvalidInput { reason: format!($fmt $(, $($arg)*)?) })
@@ -74,6 +89,9 @@ macro_rules! bail_invalid_gamlss {
 }
 
 #[macro_export]
+/// Return a `GamlssError::DimensionMismatch` from the current function.
+///
+/// Accepts either a `format!`-style literal and arguments or an owned message.
 macro_rules! bail_dim_gamlss {
     ($fmt:literal $(, $($arg:tt)*)?) => {
         return Err($crate::families::gamlss::GamlssError::DimensionMismatch { reason: format!($fmt $(, $($arg)*)?) })
@@ -84,6 +102,9 @@ macro_rules! bail_dim_gamlss {
 }
 
 #[macro_export]
+/// Return a `TransformationNormalError::InvalidInput` from the current function.
+///
+/// Accepts either a `format!`-style literal and arguments or an owned message.
 macro_rules! bail_invalid_tnorm {
     ($fmt:literal $(, $($arg:tt)*)?) => {
         return Err($crate::families::transformation_normal::TransformationNormalError::InvalidInput { reason: format!($fmt $(, $($arg)*)?) })
@@ -94,6 +115,9 @@ macro_rules! bail_invalid_tnorm {
 }
 
 #[macro_export]
+/// Return a `SurvivalError::InvalidInput` from the current function.
+///
+/// Accepts either a `format!`-style literal and arguments or an owned message.
 macro_rules! bail_invalid_surv {
     ($fmt:literal $(, $($arg:tt)*)?) => {
         return Err($crate::families::survival::SurvivalError::InvalidInput { reason: format!($fmt $(, $($arg)*)?) })
@@ -104,6 +128,9 @@ macro_rules! bail_invalid_surv {
 }
 
 #[macro_export]
+/// Return a `SurvivalLocationScaleError::DimensionMismatch` from the current function.
+///
+/// Accepts either a `format!`-style literal and arguments or an owned message.
 macro_rules! bail_dim_sls {
     ($fmt:literal $(, $($arg:tt)*)?) => {
         return Err($crate::families::survival::location_scale::SurvivalLocationScaleError::DimensionMismatch { reason: format!($fmt $(, $($arg)*)?) })
@@ -114,6 +141,9 @@ macro_rules! bail_dim_sls {
 }
 
 #[macro_export]
+/// Return a `CustomFamilyError::DimensionMismatch` from the current function.
+///
+/// Accepts either a `format!`-style literal and arguments or an owned message.
 macro_rules! bail_dim_custom {
     ($fmt:literal $(, $($arg:tt)*)?) => {
         return Err($crate::families::custom_family::CustomFamilyError::DimensionMismatch { reason: format!($fmt $(, $($arg)*)?) })

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,2 +1,6 @@
+//! Small runtime and numerical utility namespaces retained for compatibility.
+
+/// Low-overhead progress reporting for long-running loops.
 pub mod loop_progress;
+/// Quantile and order-statistic helpers.
 pub mod quantile;


### PR DESCRIPTION
### Motivation

- Enforce API quality by enabling `#![warn(missing_docs)]` on the root `gam` crate and `crates/gam-model-api` so rustdoc surfaces cannot silently lose required documentation.  
- Provide clear, runnable user guidance: replace the old decision-record note with a compact getting-started guide that is compiled as a doctest to prevent rot.  
- Surface contract preconditions, error semantics, and capability signals for custom-family and Hessian/workspace APIs so downstream callers know what representations are available and when they must handle `None`/`Err`.

### Description

- Enable `#![warn(missing_docs)]` in `src/lib.rs` (root `gam` crate) and `crates/gam-model-api/src/lib.rs`.  
- Add/complete doc comments for public API items in `crates/gam-model-api`, including `FamilyEvaluation`, `ExactNewtonJointGradientEvaluation`, `BatchedOuterGradientTerms`, `OuterDerivativePilotSchedule`, `OuterEvalContext`, and capability/query helpers for outer-derivative ordering.  
- Expand the `ExactNewtonJointHessianWorkspace` trait docs to explain dense vs matrix-free representations, `hessian_matvec` / `hessian_matvec_into`, directional derivatives (first and second), availability semantics (`Ok(None)` vs `Err`), and preconditions.  
- Document `BlockwiseFitOptions` fields and defaults (e.g. `DEFAULT_CUSTOM_FAMILY_INNER_MAX_CYCLES`) and annotate policy helper functions.  
- Add doc comments for exported crate macros in `src/macros.rs` describing their error variants and argument forms.  
- Replace `docs/rust-library-surface.md` with a real Rust getting-started page that fits a Gaussian smooth, predicts with uncertainty, and inspects the REML/convergence diagnostics, and include that guide into the root crate as a `getting_started` rustdoc module (the module also re-exports `fit_from_formula` used by the example).  
- Small compatibility/clarity edits: add brief module docs and util re-export comments to keep rustdoc warnings quiet and existing public paths stable.

### Testing

- Ran `cargo doc -p gam-model-api --no-deps` and verified the model-api crate documents cleanly with zero `missing documentation` diagnostics. (passed)  
- Ran `RUSTFLAGS='--cap-lints warn' RUSTDOCFLAGS='--cap-lints warn' cargo doc -p gam --no-deps` and verified the root crate documents with zero `missing documentation` diagnostics. (passed)  
- Attempted `cargo test -p gam --doc getting_started` (doctest): doctest compilation entered full dependency compilation and was stopped after the sandbox run became too slow (exceeded available / practical time); the getting-started example remains a compiled rustdoc test in-tree but could not be executed to completion in this environment. (not completed)  
- Attempted `cargo doc --workspace --no-deps` and `cargo build --workspace --all-targets`: workspace-wide doc/build is blocked by pre-existing `gam-sae` dead-code errors (unused-methods promoted to hard errors) and a Cargo output-name collision warning between the `gam` library and `gam-cli` binary; these upstream issues must be resolved before a zero-warning workspace doc/build can be asserted. (blocked)