### PR TITLE
Persist cross-fitted CTN predictors and freeze the score scale

### DIFF
--- a/crates/gam-config/src/fit_request_document.rs
+++ b/crates/gam-config/src/fit_request_document.rs
@@ -88,6 +88,8 @@ pub struct FitRequestConfigDocument {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ctn_stage1: Option<CtnStage1Document>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub transformation_normal_config: Option<CtnStage1ConfigDocument>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub expectile_tau: Option<f64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub family: Option<String>,
@@ -200,6 +202,9 @@ pub struct FitRequestConfigDocument {
     pub weights: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub z_column: Option<String>,
+    /// The supplied z column is already transformed by a frozen external model.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub frozen_score: Option<bool>,
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]

--- a/crates/gam-config/src/lib.rs
+++ b/crates/gam-config/src/lib.rs
@@ -38,46 +38,52 @@ const DEFAULT_LEARNED_FRAILTY_SCALE: FrailtyScale = FrailtyScale::Learned { init
 
 impl CtnStage1Document {
     fn into_recipe(self) -> Result<CtnStage1Recipe, String> {
-        let mut config = TransformationNormalConfig::default();
-        if let Some(overrides) = self.config {
-            if let Some(value) = overrides.response_degree {
-                config.response_degree = value;
-            }
-            if let Some(value) = overrides.response_num_internal_knots {
-                config.response_num_internal_knots = value;
-            }
-            if let Some(value) = overrides.response_penalty_order {
-                config.response_penalty_order = value;
-            }
-            if let Some(value) = overrides.response_extra_penalty_orders {
-                config.response_extra_penalty_orders = value;
-            }
-            if let Some(value) = overrides.double_penalty {
-                config.double_penalty = value;
-            }
-        }
-        if config.response_degree == 0 {
-            return Err("ctn_stage1.config.response_degree must be >= 1".to_string());
-        }
-        if config.response_num_internal_knots < 2 {
-            return Err("ctn_stage1.config.response_num_internal_knots must be >= 2".to_string());
-        }
-        if config.response_penalty_order == 0
-            || config
-                .response_extra_penalty_orders
-                .iter()
-                .any(|order| *order == 0)
-        {
-            return Err("ctn_stage1 response penalty orders must be >= 1".to_string());
-        }
         CtnStage1Recipe::new(
             &self.response_column,
             &self.covariate_formula_rhs,
-            config,
+            resolve_ctn_config(self.config)?,
             self.weight_column.as_deref(),
             self.offset_column.as_deref(),
         )
     }
+}
+
+fn resolve_ctn_config(
+    overrides: Option<CtnStage1ConfigDocument>,
+) -> Result<TransformationNormalConfig, String> {
+    let mut config = TransformationNormalConfig::default();
+    if let Some(overrides) = overrides {
+        if let Some(value) = overrides.response_degree {
+            config.response_degree = value;
+        }
+        if let Some(value) = overrides.response_num_internal_knots {
+            config.response_num_internal_knots = value;
+        }
+        if let Some(value) = overrides.response_penalty_order {
+            config.response_penalty_order = value;
+        }
+        if let Some(value) = overrides.response_extra_penalty_orders {
+            config.response_extra_penalty_orders = value;
+        }
+        if let Some(value) = overrides.double_penalty {
+            config.double_penalty = value;
+        }
+    }
+    if config.response_degree == 0 {
+        return Err("ctn_stage1.config.response_degree must be >= 1".to_string());
+    }
+    if config.response_num_internal_knots < 2 {
+        return Err("ctn_stage1.config.response_num_internal_knots must be >= 2".to_string());
+    }
+    if config.response_penalty_order == 0
+        || config
+            .response_extra_penalty_orders
+            .iter()
+            .any(|order| *order == 0)
+    {
+        return Err("ctn_stage1 response penalty orders must be >= 1".to_string());
+    }
+    Ok(config)
 }
 
 #[derive(Clone, Debug)]
@@ -211,6 +217,10 @@ pub fn resolve_fit_request_config(
         fit_config.slope_time_degree = value;
     }
     fit_config.z_column = json_config.z_column;
+    fit_config.frozen_score = json_config.frozen_score.unwrap_or(false);
+    if let Some(config) = json_config.transformation_normal_config {
+        fit_config.transformation_normal_config = Some(resolve_ctn_config(Some(config))?);
+    }
     if let Some(formula) = json_config.slope_formula {
         fit_config.slope_formula = Some(formula);
     }

--- a/crates/gam-event-history/src/joint/emission.rs
+++ b/crates/gam-event-history/src/joint/emission.rs
@@ -432,6 +432,16 @@ mod tests {
         ];
         for (family, y, shape) in cases {
             let seeded: Vec<_> = shape.iter().map(|&v| Mixed::seed(v, 0.0, 0.0)).collect();
+            // The fast path must agree with the independent AD reference.
+            // Check outside the timed loops so the benchmark still measures
+            // each implementation separately, without hardware speed gates.
+            for eta in [-2.75, 0.75, 2.25] {
+                let analytic = location_derivatives(&family, y, eta, &shape).unwrap();
+                let reference = log_density(&family, y, &Mixed::seed(eta, 1.0, 1.0), &seeded)
+                    .unwrap();
+                assert!((analytic.0 - reference.u).abs() < 2e-11 * (1.0 + reference.u.abs()));
+                assert!((analytic.1 - reference.uv).abs() < 2e-11 * (1.0 + reference.uv.abs()));
+            }
             let mut analytic_time = f64::INFINITY;
             let mut ad_time = f64::INFINITY;
             for _ in 0..3 {

--- a/crates/gam-models/src/fit_orchestration/fit_config.rs
+++ b/crates/gam-models/src/fit_orchestration/fit_config.rs
@@ -81,6 +81,14 @@ pub fn validate_survival_baseline_config(
 }
 
 impl FitConfig {
+    pub(crate) fn marginal_slope_latent_policy(&self) -> crate::bms::LatentZPolicy {
+        let mut policy = crate::bms::LatentZPolicy::default();
+        if self.frozen_score {
+            policy.latent_measure = crate::bms::LatentMeasureSpec::StandardNormal;
+        }
+        policy
+    }
+
     /// Opt in to cross-process warm starts at the exact supplied root.
     ///
     /// The path is neither canonicalized nor relocated through temp/cache
@@ -116,6 +124,19 @@ impl FitConfig {
             normalize_optional_column(self.noise_offset_column, "noise_offset_column")?;
         self.weight_column = normalize_optional_column(self.weight_column, "weight_column")?;
         self.z_column = normalize_optional_column(self.z_column, "z_column")?;
+        if self.transformation_normal_config.is_some()
+            && !(self.transformation_normal || self.family.as_deref() == Some("transformation-normal"))
+        {
+            return Err("transformation_normal_config requires a transformation-normal fit".to_string());
+        }
+        if self.frozen_score
+            && (self.z_column.is_none()
+                || self.ctn_stage1.is_some()
+                || !(self.survival_likelihood.as_deref() == Some("marginal-slope")
+                    || self.family.as_deref() == Some("bernoulli-marginal-slope")))
+        {
+            return Err("frozen_score requires a marginal-slope fit with an explicit z_column and no integrated CTN recipe".to_string());
+        }
         if self
             .persistent_warm_start_store
             .as_ref()

--- a/crates/gam-models/src/fit_orchestration/materialize/marginal_slope.rs
+++ b/crates/gam-models/src/fit_orchestration/materialize/marginal_slope.rs
@@ -224,7 +224,7 @@ pub(crate) fn materialize_bernoulli_marginal_slope<'a>(
         frailty: config.frailty.clone(),
         score_warp: routing.score_warp,
         link_dev: routing.link_dev,
-        latent_z_policy: Default::default(),
+        latent_z_policy: config.marginal_slope_latent_policy(),
         score_influence_jacobian,
     };
 

--- a/crates/gam-models/src/fit_orchestration/materialize/survival.rs
+++ b/crates/gam-models/src/fit_orchestration/materialize/survival.rs
@@ -1047,7 +1047,7 @@ pub(crate) fn materialize_survival<'a>(
                 slope_offset: log_sigma_offset.clone(),
                 score_warp: marginal_slope_score_warp.clone(),
                 link_dev: marginal_slope_link_dev.clone(),
-                latent_z_policy: Default::default(),
+                latent_z_policy: config.marginal_slope_latent_policy(),
                 score_influence_jacobian: marginal_slope_jac_oof.clone(),
             },
             options: BlockwiseFitOptions {

--- a/crates/gam-models/src/fit_orchestration/materialize/transformation.rs
+++ b/crates/gam-models/src/fit_orchestration/materialize/transformation.rs
@@ -59,7 +59,7 @@ pub(crate) fn materialize_transformation_normal<'a>(
             weights,
             offset,
             covariate_spec,
-            config: TransformationNormalConfig::default(),
+            config: config.transformation_normal_config.clone().unwrap_or_default(),
             options: BlockwiseFitOptions {
                 persistent_warm_start_store: config.persistent_warm_start_store.clone(),
                 ..BlockwiseFitOptions::default()

--- a/crates/gam-models/src/fit_orchestration/request.rs
+++ b/crates/gam-models/src/fit_orchestration/request.rs
@@ -573,6 +573,11 @@ pub struct FitConfig {
     pub slope_formula: Option<String>,
     /// Column name for the z (exposure/dose) variable in marginal-slope models.
     pub z_column: Option<String>,
+    /// Consume an externally fitted latent score without fitting another
+    /// conditional or rank-based transform. Distribution checks remain on.
+    pub frozen_score: bool,
+    /// Standalone CTN response-basis options, also used by predictive cross-fitting.
+    pub transformation_normal_config: Option<TransformationNormalConfig>,
     /// Optional non-negative per-row training weights column.
     pub weight_column: Option<String>,
     /// Expectile asymmetry `τ ∈ (0, 1)` for `family = "expectile"`.
@@ -764,6 +769,8 @@ impl Default for FitConfig {
             noise_formula: None,
             slope_formula: None,
             z_column: None,
+            frozen_score: false,
+            transformation_normal_config: None,
             weight_column: None,
             expectile_tau: None,
             ctn_stage1: None,

--- a/docs/marginal-slope.md
+++ b/docs/marginal-slope.md
@@ -47,11 +47,17 @@ When the score must be conditioned on covariates to reach the latent
 `N(0, 1)` scale, supply a Stage-1 transformation-normal recipe with
 `transformation_normal_stage1=`. This is the single calibrated
 marginal-slope entry: it fits the conditional transformation
-`h(score | covariates) ~ N(0, 1)`, cross-fits it out-of-fold, and absorbs
-the Stage-1 score-influence directions so the fitted slope surface
-`β(x)` is insensitive to Stage-1 calibration error (Neyman-orthogonal
-cross-fitting). You do not materialise or pass a `z_column` yourself — the
-conditioned score is produced and cross-fitted inside the one fit.
+`h(score | covariates) ~ N(0, 1)` in each fold's training complement. An
+ordinary penalized marginal-slope outcome uses those OOF scores, with no
+influence absorber or second normalization. A separate full-training CTN is
+saved together with the outcome in `CtnMarginalSlopeModel`. Prediction replays
+that frozen transform on raw scores. Cross-fitting alone establishes neither
+Neyman orthogonality nor outcome calibration.
+
+Supply explicit fold labels or a group column. Group assignment is seeded and
+independent of row order; supplied folds are checked for group separation when
+both columns are present. All fitting data must belong to the outer training
+sample. Fold-local knots and geometry never use the outer test sample.
 
 ```python
 model = gamfit.fit(
@@ -62,11 +68,14 @@ model = gamfit.fit(
     transformation_normal_stage1=gamfit.CtnStage1(
         response="raw_score",
         covariates="duchon(pc1, pc2, pc3, pc4, centers=20)",
+        group_column="family_id", folds=2, seed=20260910,
     ),
     scale_dimensions=True,
 )
 
-probs = model.predict(test_df, return_type="dict")["mean"]
+probs = model.predict(test_df)
+model.save("predictor.gamfit")
+probs_reloaded = gamfit.load("predictor.gamfit").predict(test_df)
 ```
 
 By default, Bernoulli marginal-slope prediction returns a 1-D NumPy
@@ -84,8 +93,12 @@ symmetric about `linear_predictor` on the link scale.
 - `transformation_normal_stage1=gamfit.CtnStage1(response=..., covariates=...)`
   is the Stage-1 recipe: `response` is the raw score column to condition,
   `covariates` is the covariate-side formula right-hand side used to fit
-  `h(score | covariates) ~ N(0, 1)`. Supplying it *is* the request for the
-  orthogonalized chain — there is no separate boolean.
+  `h(score | covariates) ~ N(0, 1)`. `fold_column` supplies explicit labels;
+  `group_column` assigns entire families together. Failed folds raise an error.
+- Saved `transform` and `outcome` components are available for manual replay.
+  Outcome intervals are conditional on the fitted CTN, not full two-stage
+  uncertainty estimates. The experimental Rust influence path is separate
+  from this Python prediction API.
 - The base link is fixed to probit. The Python `link=` keyword is not
   needed for marginal-slope fits.
 
@@ -93,6 +106,13 @@ The main formula controls the baseline risk; `slope_formula` controls
 the strength of the score effect at each point in covariate space.
 
 The same recipe drives the survival likelihood:
+
+For prospective net survival, the saved chain also exposes
+`model.survival_at(baseline_df, [1., 3., 5.])`. It supplies the requested
+times and zero event indicators internally, without reading observed outcome
+times. `entry_time=a0` conditions the curve on a common event-free entry time;
+use absolute times `a0 + horizon` in that case. Competing-risk incidence needs
+separate cause components and a CIF, not one minus disease-only net survival.
 
 ```python
 model = gamfit.fit(
@@ -103,6 +123,7 @@ model = gamfit.fit(
     transformation_normal_stage1=gamfit.CtnStage1(
         response="raw_score",
         covariates="s(bmi) + s(hba1c)",
+        group_column="family_id", folds=2,
     ),
 )
 
@@ -212,9 +233,11 @@ standardised score produced outside this pipeline — pass it directly with
 `z_column=` and omit the Stage-1 recipe. This raw-`z` path uses the
 free-warp `score_warp` fallback for shape miscalibration, and the
 automatic latent-measure gate described below for conditional
-miscalibration; prefer the calibrated chain above when the score's
-Stage-1 model is itself part of what you want the fit to be orthogonal
-to.
+miscalibration. Use `config={"frozen_score": True}` when an external
+transformation already supplies the declared conditional standard-normal
+measure and must not be normalized again. This asserts a score-distribution
+assumption; it does not prove it. Prefer the CTN chain when the fitted
+transformation should travel with the outcome predictor.
 
 ```python
 model = gamfit.fit(
@@ -394,6 +417,7 @@ gamfit.fit(df,
     slope_formula="s(age)",
     transformation_normal_stage1=gamfit.CtnStage1(
         response="raw_score", covariates="s(age)",
+        group_column="family_id", folds=2,
     ),
     frailty_kind="gaussian-shift",
     frailty_sd=0.3,
@@ -442,9 +466,10 @@ df = pd.DataFrame({
     "pc3":  rng.normal(0, 1, n),
 })
 df["disease"] = (rng.uniform(0, 1, n) < 0.25).astype(float)
+df["family_id"] = np.arange(n)  # This illustrative sample is unrelated.
 
 # Condition the score on the PCs and fit the slope surface in one
-# cross-fitted, orthogonalized call.
+# cross-fitted predictive call.
 model = gamfit.fit(
     df,
     "disease ~ matern(pc1, pc2, pc3, centers=20)",
@@ -453,10 +478,11 @@ model = gamfit.fit(
     transformation_normal_stage1=gamfit.CtnStage1(
         response="PGS",
         covariates="matern(pc1, pc2, pc3, centers=20)",
+        group_column="family_id", folds=2,
     ),
     scale_dimensions=True,
 )
 
 test = df.head(50).copy()
-probs = model.predict(test, return_type="dict")["mean"]
+probs = model.predict(test)
 ```

--- a/gamfit/__init__.py
+++ b/gamfit/__init__.py
@@ -37,6 +37,7 @@ from pathlib import Path
 from ._api import (
     SUPPORT_SAE_SCHEMA,
     CtnStage1,
+    CtnMarginalSlopeModel,
     SharedPrecisionGroup,
     bspline_basis,
     bspline_basis_derivative,

--- a/gamfit/_api.py
+++ b/gamfit/_api.py
@@ -13,6 +13,7 @@ from typing import Any, NamedTuple, overload
 
 from ._binding import RustExtensionUnavailableError, extension_status, rust_module
 from ._calibrated_slope import CtnStage1, normalize_ctn_stage1
+from ._ctn_model import CtnMarginalSlopeModel, fit_ctn_chain
 from ._cuda import cuda_diagnostics as _cuda_diagnostics
 from ._cuda import cuda_subprocess_env as _cuda_subprocess_env
 from ._cuda import cuda_subprocess_library_dirs as _cuda_subprocess_library_dirs
@@ -288,12 +289,14 @@ def _build_fit_payload(
         "offset": offset,
         "weights": weights,
     }
-    ctn_stage1_recipe = normalize_ctn_stage1(transformation_normal_stage1)
+    if transformation_normal_stage1 is not None:
+        raise ValueError("CtnStage1 uses gamfit.fit with labelled data; it is not a native payload option")
+    if config and "ctn_stage1" in config:
+        raise ValueError("the experimental Rust influence path is not a Python prediction API; use CtnStage1")
     kwarg_items: dict[str, Any] = {
         "negative_binomial_theta": negative_binomial_theta,
         "expectile_tau": expectile_tau,
         "transformation_normal": transformation_normal,
-        "ctn_stage1": ctn_stage1_recipe.to_rust_recipe() if ctn_stage1_recipe else None,
         "survival_likelihood": survival_likelihood,
         "survival_time_anchor": survival_time_anchor,
         "baseline_target": baseline_target,
@@ -896,20 +899,12 @@ def fit(
         Fit a conditional transformation-normal model (``h(Y|x) ~ N(0,1))``).
         Corresponds to ``--transformation-normal``.
     transformation_normal_stage1:
-        Stage-1 CTN recipe for a *calibrated* marginal-slope chain
-        (:class:`gamfit.CtnStage1`, or a mapping of its fields). Supply it on a
-        marginal-slope model (``family="bernoulli-marginal-slope"`` or a
-        survival ``survival_likelihood="marginal-slope"``) to auto-enable the
-        cross-fitted, Neyman-orthogonal score calibration of #461: the Rust core
-        fits the CTN ``h(Y|x) ~ N(0,1)`` per fold, derives an out-of-fold latent
-        score ``z`` that replaces the in-sample one, and absorbs the Stage-1
-        score-influence directions so the fitted slope surface ``β(x)`` is
-        insensitive to Stage-1 calibration error. There is no boolean to toggle
-        orthogonalization — supplying this recipe *is* the request (magic by
-        default). A raw ``z_column`` selects the free-warp ``score_warp`` path.
-        All numerics stay in Rust; this only marshals the recipe. The Stage-1
-        ``response`` column must exist in ``data`` alongside the Stage-2
-        response and covariates.
+        CTN recipe with explicit fold or group columns. Returns a
+        :class:`CtnMarginalSlopeModel` containing a full-training CTN and an
+        ordinary marginal-slope outcome fitted on OOF transformed scores.
+        Prediction replays the saved CTN on the raw score. No influence
+        absorber or second score normalization is applied. Cross-fitting
+        alone supplies no orthogonality or outcome-calibration guarantee.
     survival_likelihood:
         Survival likelihood formulation. One of ``"transformation"``,
         ``"weibull"``, ``"location-scale"``, ``"marginal-slope"``,
@@ -1106,6 +1101,14 @@ def fit(
         Rust engine errors are mapped into the typed gamfit exception
         hierarchy.
     """
+    if transformation_normal_stage1 is not None:
+        options = {name: value for name, value in locals().items()
+                   if name in inspect.signature(fit).parameters
+                   and name not in {"data", "formula", "transformation_normal_stage1"}}
+        if response_geometry is not None:
+            raise ValueError("CtnStage1 does not support response_geometry")
+        return fit_ctn_chain(fit, data, formula,
+                             normalize_ctn_stage1(transformation_normal_stage1), options)
     if constraints:
         # Alias normalization, smooth-term scanning, and the `shape=` rewrite all
         # live in Rust (`gam::terms::smooth::apply_shape_constraints_to_formula`);
@@ -1530,6 +1533,8 @@ def loads(model_bytes: bytes) -> Model:
     # `Model` archive nor a multinomial payload, so detect them first by the
     # schema tag and reconstruct a `ResponseGeometryModel`.
     head = model_bytes[:256].lstrip()
+    if head.startswith(b"{") and b"gamfit.CtnMarginalSlopeModel" in model_bytes[:256]:
+        return CtnMarginalSlopeModel.from_payload(json.loads(model_bytes))
     if head.startswith(b"{") and b"gamfit.ResponseGeometryModel" in model_bytes[:512]:
         payload = json.loads(model_bytes.decode("utf-8"))
         if str(payload.get("schema", "")).startswith("gamfit.ResponseGeometryModel/"):

--- a/gamfit/_calibrated_slope.py
+++ b/gamfit/_calibrated_slope.py
@@ -1,75 +1,31 @@
-"""Calibrated marginal-slope chain: the CTN Stage-1 → marginal-slope Stage-2
-cross-fitted, Neyman-orthogonal score-calibration workflow (closes #461).
-
-This module is a *thin* marshaller. It carries the Stage-1 conditional
-transformation-normal (CTN) recipe from a user's :func:`gamfit.fit` call down
-to the Rust core as a single ``ctn_stage1`` JSON object on the existing
-``fit_table`` payload. ALL numerics — fitting Stage-1 per fold, computing the
-out-of-fold latent score ``z``, the score-influence Jacobian ``∂z/∂θ₁``, and the
-absorbed leakage-projection block — live in Rust
-(``gam::solver::workflow::crossfit_score_calibration`` and
-``gam::families::marginal_slope_orthogonal``). Nothing here computes a transform,
-a fold split, or a Jacobian; supplying the recipe is the sole, magic-by-default
-auto-enable signal for the orthogonalized path (design §5).
-
-The Stage-2 model (``family="bernoulli-marginal-slope"`` or a survival
-marginal-slope ``survival_likelihood="marginal-slope"``) is requested exactly as
-before. When the recipe is present, the Rust materializer refits the CTN on each
-fold's complement, evaluates the held-out ``z`` and ``J``, replaces the in-sample
-score with its out-of-fold value, and installs the realized leakage-projection
-block — so the fitted slope surface ``β(x)`` is insensitive to Stage-1
-calibration error.
-"""
-
+"""Recipes for cross-fitted score prediction; no influence-absorber claim."""
 from __future__ import annotations
 
 from collections.abc import Mapping
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
 from typing import Any
 
 
 @dataclass(frozen=True, slots=True)
 class CtnStage1:
-    """Stage-1 conditional transformation-normal recipe for a calibrated
-    marginal-slope chain.
+    """Conditional score transform fitted inside the supplied training sample.
 
-    Passing this to :func:`gamfit.fit` on a marginal-slope model (Bernoulli or
-    survival) auto-enables the cross-fitted, Neyman-orthogonal score
-    calibration of #461: the Rust core fits the CTN ``h(Y|x) ~ N(0,1)`` per
-    fold, produces an out-of-fold latent score ``z = Φ⁻¹(PIT)`` that replaces the
-    raw in-sample score, and absorbs the Stage-1 score-influence directions so
-    the estimated slope surface ``β(x)`` does not inherit Stage-1 miscalibration.
+    Supply ``fold_column`` with explicit fold labels, or ``group_column`` to
+    assign whole groups reproducibly. If both are supplied, family separation
+    is checked. ``folds`` and ``seed`` govern generated group folds only.
+    Each fold learns its own response knots and covariate geometry. The saved
+    predictor uses a separate CTN fitted on the complete training sample.
 
-    There is no separate boolean to "turn on" orthogonalization — supplying the
-    recipe *is* the request (magic by default). Supplying a raw ``z_column``
-    selects the free-warp ``score_warp`` path, which can only defend the x-free
-    leakage column.
-
-    Parameters
-    ----------
-    response:
-        Stage-1 response column name — the raw score column the CTN conditions
-        on the covariates and transforms into the latent score.
-    covariates:
-        Stage-1 covariate-side formula right-hand side (e.g.
-        ``"s(pc1) + s(pc2)"``). Built into the CTN covariate basis so each
-        per-fold refit reproduces the same Stage-1 covariate geometry. Pass the
-        right-hand side only — no ``~`` and no response symbol.
-    response_degree, response_num_internal_knots, response_penalty_order,
-    response_extra_penalty_orders, double_penalty:
-        Optional overrides for the CTN response-direction basis / penalty.
-        Leave as ``None`` to use the Rust ``TransformationNormalConfig``
-        defaults (degree 3, 10 interior knots, 2nd-derivative penalty, extra
-        order ``[1]``, double penalty on). Any subset may be set; unset fields
-        fall back to the Rust default.
-    weights:
-        Optional Stage-1 observation-weight column name.
-    offset:
-        Optional Stage-1 offset column name.
+    Response-basis options retain the engine's affine-null shape penalties.
+    Cross-fitting does not imply outcome calibration or Neyman orthogonality.
     """
 
     response: str
     covariates: str
+    fold_column: str | None = None
+    group_column: str | None = None
+    folds: int = 5
+    seed: int = 0
     response_degree: int | None = None
     response_num_internal_knots: int | None = None
     response_penalty_order: int | None = None
@@ -78,77 +34,39 @@ class CtnStage1:
     weights: str | None = None
     offset: str | None = None
 
-    def __post_init__(self) -> None:
-        if not isinstance(self.response, str) or not self.response.strip():
-            raise ValueError("CtnStage1.response must be a non-empty column name")
-        if not isinstance(self.covariates, str) or not self.covariates.strip():
-            raise ValueError(
-                "CtnStage1.covariates must be a non-empty covariate formula right-hand side"
-            )
+    def __post_init__(self):
+        for name in ("response", "covariates"):
+            if not isinstance(getattr(self, name), str) or not getattr(self, name).strip():
+                raise ValueError(f"CtnStage1.{name} must be a nonempty string")
         if "~" in self.covariates:
-            raise ValueError(
-                "CtnStage1.covariates is a right-hand side only; pass 's(pc1) + s(pc2)', "
-                "not 'score ~ s(pc1) + s(pc2)'"
-            )
-
-    def to_rust_recipe(self) -> dict[str, Any]:
-        """Serialize to the ``ctn_stage1`` JSON object consumed by the Rust
-        ``PyFitConfig`` deserializer (a one-to-one mirror of the core
-        ``CtnStage1Recipe`` struct). Only set CTN-config overrides are emitted;
-        omitted ones let the Rust ``TransformationNormalConfig`` default fill in.
-        """
-
-        config: dict[str, Any] = {}
-        if self.response_degree is not None:
-            config["response_degree"] = int(self.response_degree)
-        if self.response_num_internal_knots is not None:
-            config["response_num_internal_knots"] = int(self.response_num_internal_knots)
-        if self.response_penalty_order is not None:
-            config["response_penalty_order"] = int(self.response_penalty_order)
+            raise ValueError("CtnStage1.covariates must be a formula right-hand side")
+        if self.fold_column is None and self.group_column is None:
+            raise ValueError("CtnStage1 requires fold_column or group_column")
+        for name in ("fold_column", "group_column", "weights", "offset"):
+            value = getattr(self, name)
+            if value is not None and (not isinstance(value, str) or not value.strip()):
+                raise ValueError(f"CtnStage1.{name} must name a column")
+        if type(self.folds) is not int or self.folds < 2 or type(self.seed) is not int:
+            raise ValueError("CtnStage1 requires folds >= 2 and an integer seed")
+        for name in ("response_degree", "response_num_internal_knots", "response_penalty_order"):
+            value = getattr(self, name)
+            minimum = 2 if name == "response_num_internal_knots" else 1
+            if value is not None and (type(value) is not int or value < minimum):
+                raise ValueError(f"CtnStage1.{name} must be an integer >= {minimum}")
         if self.response_extra_penalty_orders is not None:
-            config["response_extra_penalty_orders"] = [
-                int(order) for order in self.response_extra_penalty_orders
-            ]
-        if self.double_penalty is not None:
-            config["double_penalty"] = bool(self.double_penalty)
+            if any(type(x) is not int or x < 1 for x in self.response_extra_penalty_orders):
+                raise ValueError("response_extra_penalty_orders must be positive integers")
+        if self.double_penalty is not None and type(self.double_penalty) is not bool:
+            raise ValueError("double_penalty must be boolean")
 
-        recipe: dict[str, Any] = {
-            "response_column": self.response.strip(),
-            "covariate_formula_rhs": self.covariates.strip(),
-        }
-        if config:
-            recipe["config"] = config
-        if self.weights is not None:
-            recipe["weight_column"] = self.weights
-        if self.offset is not None:
-            recipe["offset_column"] = self.offset
-        return recipe
+    def response_config(self):
+        return {key: value for key, value in asdict(self).items()
+                if (key.startswith("response_") or key == "double_penalty") and value is not None}
 
 
 def normalize_ctn_stage1(value: Any) -> CtnStage1 | None:
-    """Coerce the ``transformation_normal_stage1`` argument to a
-    :class:`CtnStage1` (or ``None``).
-
-    Accepts a :class:`CtnStage1` directly, or a mapping with ``response`` /
-    ``covariates`` keys (plus any optional CTN-config / weights / offset keys)
-    for callers who prefer a plain dict. Anything else is a type error.
-    """
-
-    if value is None:
-        return None
-    if isinstance(value, CtnStage1):
+    if value is None or isinstance(value, CtnStage1):
         return value
     if isinstance(value, Mapping):
-        # Build directly; CtnStage1.__post_init__ validates required keys.
-        try:
-            return CtnStage1(**value)
-        except TypeError as exc:
-            raise TypeError(
-                "transformation_normal_stage1 mapping has unexpected keys; "
-                "supported keys are 'response', 'covariates', 'response_degree', "
-                "'response_num_internal_knots', 'response_penalty_order', "
-                "'response_extra_penalty_orders', 'double_penalty', 'weights', 'offset'"
-            ) from exc
-    raise TypeError(
-        "transformation_normal_stage1 must be a gamfit.CtnStage1 or a mapping of its fields"
-    )
+        return CtnStage1(**value)
+    raise TypeError("transformation_normal_stage1 must be CtnStage1 or a mapping")

--- a/gamfit/_ctn_model.py
+++ b/gamfit/_ctn_model.py
@@ -1,0 +1,230 @@
+"""A saved CTN plus an ordinary marginal-slope predictor.
+
+Only O(n) generated scores are retained during cross-fitting. No influence
+Jacobian or fitted-and-discarded mean term is constructed by this path.
+"""
+from __future__ import annotations
+
+import base64
+from dataclasses import asdict
+import hashlib
+import json
+from pathlib import Path
+import re
+
+import numpy as np
+
+from ._calibrated_slope import CtnStage1
+from ._tables import _table_column_views
+
+_SCHEMA = "gamfit.CtnMarginalSlopeModel/v1"
+_SCORE = "__gamfit_ctn_score"
+
+
+def _slice(data, rows):
+    columns, kind = _table_column_views(data)
+    if kind == "pandas":
+        return data.iloc[rows].reset_index(drop=True)
+    if kind == "polars":
+        return data[rows.tolist()]
+    if kind == "pyarrow":
+        return data.take(rows)
+    return {key: np.asarray(value)[rows] for key, value in columns.items()}
+
+
+def _with_columns(data, added):
+    columns, kind = _table_column_views(data)
+    if kind == "pandas":
+        return data.assign(**added)
+    if kind == "polars":
+        import polars as pl
+        return data.with_columns([pl.Series(name, values) for name, values in added.items()])
+    if kind == "pyarrow":
+        import pyarrow as pa
+        for name, values in added.items():
+            index = data.schema.get_field_index(name)
+            data = (data.set_column(index, name, pa.array(values)) if index >= 0
+                    else data.append_column(name, pa.array(values)))
+        return data
+    return {**columns, **added}
+
+
+def _with_score(data, scores, score_column=_SCORE):
+    columns, _ = _table_column_views(data)
+    if score_column in columns:
+        raise ValueError(f"reserved generated-score column: {score_column}")
+    return _with_columns(data, {score_column: scores})
+
+
+def _labels(columns, name, n):
+    if name not in columns:
+        raise ValueError(f"missing cross-fit column {name!r}")
+    labels = []
+    for value in columns[name]:
+        if hasattr(value, "as_py"):
+            value = value.as_py()
+        if isinstance(value, np.generic):
+            value = value.item()
+        if not isinstance(value, (str, int, float)) or isinstance(value, bool):
+            raise ValueError(f"{name} must contain nonmissing string or numeric labels")
+        if value == "" or isinstance(value, float) and not np.isfinite(value):
+            raise ValueError(f"{name} contains an empty or nonfinite label")
+        labels.append(json.dumps(value, allow_nan=False))
+    if len(labels) != n:
+        raise ValueError("cross-fit column length differs from response")
+    return labels
+
+
+def crossfit_assignment(data, recipe):
+    """Return validated row-aligned folds; group assignment ignores row order."""
+    columns, _ = _table_column_views(data)
+    if recipe.response not in columns:
+        raise ValueError(f"missing score response {recipe.response!r}")
+    n = len(columns[recipe.response])
+    groups = _labels(columns, recipe.group_column, n) if recipe.group_column else None
+    if recipe.fold_column:
+        labels = _labels(columns, recipe.fold_column, n)
+        levels = sorted(set(labels))
+        if len(levels) < 2:
+            raise ValueError("cross-fitting requires at least two nonempty folds")
+        mapping = {label: i for i, label in enumerate(levels)}
+        folds = np.array([mapping[label] for label in labels], dtype=np.int64)
+    else:
+        levels = sorted(set(groups), key=lambda g: hashlib.sha256(
+            f"{recipe.seed}:{g}".encode()).digest())
+        if len(levels) < recipe.folds:
+            raise ValueError("fewer independent groups than requested folds")
+        mapping = {group: i % recipe.folds for i, group in enumerate(levels)}
+        folds = np.array([mapping[group] for group in groups], dtype=np.int64)
+    if groups is not None:
+        assigned = {}
+        for group, fold in zip(groups, folds):
+            if group in assigned and assigned[group] != fold:
+                raise ValueError("a group crosses CTN fold boundaries")
+            assigned[group] = fold
+    if any(np.count_nonzero(folds != fold) < 2 for fold in np.unique(folds)):
+        raise ValueError("every CTN fold needs at least two training observations")
+    return folds
+
+
+def _scores(model, data):
+    columns, _ = _table_column_views(data)
+    z = np.asarray(model.transformation_score(data), dtype=float)
+    if z.shape != (len(next(iter(columns.values()))),) or not np.isfinite(z).all():
+        raise ValueError("CTN produced invalid transformed scores")
+    return z
+
+
+class CtnMarginalSlopeModel:
+    """One deployable predictor with a frozen full-training score transform.
+
+    ``transform`` and ``outcome`` expose the two fitted components for audits.
+    Prediction uncertainty, when requested, is conditional on the fitted CTN;
+    it does not include nuisance-model estimation or model-selection uncertainty.
+    """
+
+    def __init__(self, transform, outcome, recipe, fold_digest, *, score_column=_SCORE):
+        self.transform, self.outcome = transform, outcome
+        self.recipe, self.fold_digest = recipe, fold_digest
+        if not isinstance(score_column, str) or not score_column:
+            raise ValueError("score_column must name the outcome's frozen latent-score column")
+        self.score_column = score_column
+
+    def transformation_score(self, data):
+        return _scores(self.transform, data)
+
+    def predict(self, data, **kwargs):
+        return self.outcome.predict(_with_score(data, self.transformation_score(data), self.score_column), **kwargs)
+
+    def survival_at(self, data, times, *, entry_time=0.0):
+        """Prospective net survival conditional on event-free scalar entry time.
+
+        Consumes raw PGS and baseline predictors only. ``times`` are absolute
+        analysis times, not observed exit times. For time since recruitment,
+        entry is zero. Disease-before-death incidence still requires a CIF.
+        """
+        times = np.asarray(times, dtype=float)
+        if (times.ndim != 1 or not len(times) or not np.isfinite(times).all()
+                or not np.isfinite(entry_time) or entry_time < 0
+                or (times < entry_time).any() or (np.diff(times) <= 0).any()
+                or times[-1] <= entry_time):
+            raise ValueError("times must increase from entry and include a future horizon")
+        response = self.outcome.formula.split("~", 1)[0].strip()
+        match = re.fullmatch(r"Surv\(\s*([^()]+)\s*\)", response)
+        if match is None:
+            raise ValueError("survival_at requires a Surv outcome")
+        names = [name.strip() for name in match.group(1).split(",")]
+        if len(names) not in (2, 3) or any(not re.fullmatch(r"[A-Za-z_]\w*|0", name) for name in names):
+            raise ValueError("survival_at requires named Surv columns with optional literal zero entry")
+        columns, _ = _table_column_views(data)
+        n = len(next(iter(columns.values())))
+        added = {names[-2]: np.full(n, times[-1]), names[-1]: np.zeros(n)}
+        if len(names) == 3 and names[0] != "0":
+            added[names[0]] = np.full(n, entry_time)
+        prediction = self.predict(_with_columns(data, added))
+        cumulative = np.asarray(prediction.cumulative_hazard_at(times))
+        at_entry = np.asarray(prediction.cumulative_hazard_at([entry_time]))
+        return np.exp(-(cumulative - at_entry))
+
+    def summary(self):
+        return {"score_transform": self.transform.summary(), "outcome": self.outcome.summary(),
+                "uncertainty": "conditional on fitted CTN", "fold_digest": self.fold_digest}
+
+    def dumps(self):
+        return json.dumps({"schema": _SCHEMA, "recipe": asdict(self.recipe),
+                           "fold_digest": self.fold_digest,
+                           "score_column": self.score_column,
+                           "transform": base64.b64encode(self.transform.dumps()).decode("ascii"),
+                           "outcome": base64.b64encode(self.outcome.dumps()).decode("ascii")},
+                          allow_nan=False).encode("utf-8")
+
+    def save(self, path):
+        Path(path).write_bytes(self.dumps())
+
+    @classmethod
+    def from_payload(cls, payload):
+        from ._api import loads
+        if set(payload) != {"schema", "recipe", "fold_digest", "score_column", "transform", "outcome"} or payload["schema"] != _SCHEMA:
+            raise ValueError("invalid CTN predictor archive")
+        return cls(loads(base64.b64decode(payload["transform"], validate=True)),
+                   loads(base64.b64decode(payload["outcome"], validate=True)),
+                   CtnStage1(**payload["recipe"]), payload["fold_digest"], score_column=payload["score_column"])
+
+
+def fit_ctn_chain(fit, data, formula, recipe, options):
+    """Fit fold-local transforms, ordinary Stage 2, and a deployment CTN."""
+    if options.get("z_column") is not None:
+        raise ValueError("CTN and external z_column are mutually exclusive score inputs")
+    if not (options.get("family") == "bernoulli-marginal-slope" or
+            options.get("survival_likelihood") == "marginal-slope"):
+        raise ValueError("CtnStage1 requires a marginal-slope outcome")
+    config = dict(options.get("config") or {})
+    if "ctn_stage1" in config or "frozen_score" in config:
+        raise ValueError("the CTN chain owns the score transformation configuration")
+    if options.get("fisher_rao_w") is not None:
+        raise ValueError("CTN chain does not support fisher_rao_w")
+    columns, _ = _table_column_views(data)
+    if _SCORE in columns:
+        raise ValueError(f"reserved generated-score column: {_SCORE}")
+    folds = crossfit_assignment(data, recipe)
+    z = np.empty(len(folds))
+    stage = {"transformation_normal": True, "weights": recipe.weights,
+             "offset": recipe.offset,
+             "config": {"transformation_normal_config": recipe.response_config()}}
+    warm = options.get("persistent_warm_start_root")
+    for fold in np.unique(folds):
+        train, held = np.flatnonzero(folds != fold), np.flatnonzero(folds == fold)
+        stage["persistent_warm_start_root"] = Path(warm) / f"ctn-fold-{fold}" if warm else None
+        try:
+            transform = fit(_slice(data, train), f"{recipe.response} ~ {recipe.covariates}", **stage)
+            z[held] = _scores(transform, _slice(data, held))
+        except Exception as exc:
+            raise RuntimeError(f"CTN fold {fold} failed; no in-sample replacement was used") from exc
+    config["frozen_score"] = True
+    outcome_options = {**options, "config": config, "z_column": _SCORE}
+    outcome_options["persistent_warm_start_root"] = Path(warm) / "outcome" if warm else None
+    outcome = fit(_with_score(data, z), formula, **outcome_options)
+    stage["persistent_warm_start_root"] = Path(warm) / "ctn-deployment" if warm else None
+    transform = fit(data, f"{recipe.response} ~ {recipe.covariates}", **stage)
+    return CtnMarginalSlopeModel(transform, outcome, recipe,
+                                 hashlib.sha256(folds.astype("<i8").tobytes()).hexdigest())

--- a/tests/test_ctn_predictor.py
+++ b/tests/test_ctn_predictor.py
@@ -1,0 +1,139 @@
+"""Prediction-chain contracts. Native numerical acceptance is a separate test."""
+import json
+from pathlib import Path
+import tempfile
+import unittest
+from unittest.mock import patch
+
+import numpy as np
+import pandas as pd
+
+import gamfit
+from gamfit._ctn_model import (CtnMarginalSlopeModel, _SCORE, crossfit_assignment,
+                               fit_ctn_chain)
+
+
+class Transform:
+    def __init__(self, center):
+        self.center = center
+
+    def transformation_score(self, data):
+        return np.asarray(data["pgs"]) - self.center
+
+    def predict(self, data, **kwargs):
+        raise AssertionError("CTN predict is a conditional mean, not a score")
+
+    def dumps(self):
+        return json.dumps({"center": self.center}).encode()
+
+
+class Outcome:
+    def predict(self, data, **kwargs):
+        return .1 + .03 * np.asarray(data[_SCORE]) + .02 * np.asarray(data["x"])
+
+    def dumps(self):
+        return b'{"outcome":true}'
+
+
+class CtnPredictorContracts(unittest.TestCase):
+    def setUp(self):
+        self.data = pd.DataFrame({"pgs": np.arange(12.), "x": np.linspace(-1, 1, 12),
+                                  "y": np.arange(12) % 2, "family_id": np.arange(12) // 2,
+                                  "fold": np.repeat(np.arange(3), 4)})
+        self.recipe = gamfit.CtnStage1("pgs", "x", fold_column="fold", group_column="family_id")
+
+    def test_explicit_groups_and_permutation(self):
+        recipe = gamfit.CtnStage1("pgs", "x", group_column="family_id", folds=3, seed=72)
+        folds = crossfit_assignment(self.data, recipe)
+        order = np.random.default_rng(2).permutation(12)
+        np.testing.assert_array_equal(crossfit_assignment(self.data.iloc[order], recipe), folds[order])
+        self.assertTrue(np.all(folds[::2] == folds[1::2]))
+        bad = self.data.copy()
+        bad.loc[0, "fold"] = 1
+        with self.assertRaisesRegex(ValueError, "group crosses"):
+            crossfit_assignment(bad, self.recipe)
+        with self.assertRaisesRegex(ValueError, "fold_column or group_column"):
+            gamfit.CtnStage1("pgs", "x")
+
+    def test_fold_local_fits_oof_scores_and_full_training_deployment(self):
+        fits = []
+
+        def fit(data, formula, **options):
+            fits.append((data.copy(), formula, options))
+            return Transform(float(data.pgs.mean())) if options.get("transformation_normal") else Outcome()
+
+        model = fit_ctn_chain(fit, self.data, "y ~ x", self.recipe,
+                              {"family": "bernoulli-marginal-slope", "slope_formula": "1"})
+        self.assertEqual(len(fits), 5)
+        for fold, (data, _, options) in enumerate(fits[:3]):
+            self.assertFalse((data.fold == fold).any())
+            self.assertNotIn("ctn_stage1", options["config"])
+        outcome_data, _, options = fits[3]
+        expected = np.concatenate([self.data.loc[self.data.fold == f, "pgs"].to_numpy() -
+                                   self.data.loc[self.data.fold != f, "pgs"].mean() for f in range(3)])
+        np.testing.assert_array_equal(outcome_data[_SCORE], expected)
+        self.assertEqual(options["config"], {"frozen_score": True})
+        self.assertEqual(len(fits[-1][0]), len(self.data))
+        self.assertEqual(model.transform.center, self.data.pgs.mean())
+        self.assertNotIn(_SCORE, self.data)
+
+    def test_failed_fold_is_not_replaced(self):
+        with self.assertRaisesRegex(RuntimeError, "fold 0 failed"):
+            fit_ctn_chain(lambda *a, **k: (_ for _ in ()).throw(ValueError("bad fit")),
+                          self.data, "y ~ x", self.recipe,
+                          {"family": "bernoulli-marginal-slope"})
+
+    def test_raw_score_prediction_save_load_and_batch_contract(self):
+        model = CtnMarginalSlopeModel(Transform(4.5), Outcome(), self.recipe, "fold-hash")
+        test = self.data[["pgs", "x"]]
+        expected = model.predict(test)
+        np.testing.assert_array_equal(model.predict(test.iloc[::-1]), expected[::-1])
+        np.testing.assert_array_equal(model.predict(test.iloc[[2]]), expected[[2]])
+        explicit = model.outcome.predict(test.assign(**{_SCORE: model.transformation_score(test)}))
+        np.testing.assert_array_equal(expected, explicit)
+        real_loads = gamfit.loads
+
+        def load_component(raw):
+            payload = json.loads(raw)
+            if "center" in payload:
+                return Transform(payload["center"])
+            if "outcome" in payload and "schema" not in payload:
+                return Outcome()
+            return real_loads(raw)
+
+        with tempfile.TemporaryDirectory() as directory, patch("gamfit._api.loads", side_effect=load_component):
+            path = Path(directory) / "model.gamfit"
+            model.save(path)
+            loaded = gamfit.load(path)
+            np.testing.assert_array_equal(loaded.predict(test), expected)
+        np.testing.assert_array_equal(model.predict(test.assign(y=1e9, fold=-1)), expected)
+
+    def test_public_fit_dispatches_without_native_influence_payload(self):
+        with patch("gamfit._api.fit_ctn_chain", return_value="chain") as chain:
+            fitted = gamfit.fit(self.data, "y ~ x", family="bernoulli-marginal-slope",
+                                slope_formula="1", transformation_normal_stage1=self.recipe)
+        self.assertEqual(fitted, "chain")
+        self.assertNotIn("transformation_normal_stage1", chain.call_args.args[-1])
+
+    def test_requested_survival_horizons_ignore_observed_exit_and_event(self):
+        class Surface:
+            def cumulative_hazard_at(self, times):
+                return np.tile(.2 * np.asarray(times), (12, 1))
+
+        class SurvivalOutcome:
+            formula = "Surv(entry, exit, event) ~ x"
+
+            def predict(inner_self, data, **kwargs):
+                np.testing.assert_array_equal(data["exit"], np.full(12, 5.))
+                np.testing.assert_array_equal(data["entry"], np.full(12, 2.))
+                np.testing.assert_array_equal(data["event"], np.zeros(12))
+                return Surface()
+
+        model = CtnMarginalSlopeModel(Transform(0), SurvivalOutcome(), self.recipe, "fold-hash")
+        supplied = self.data.assign(exit=1000, event=1, entry=-20)
+        result = model.survival_at(supplied, [2., 3., 5.], entry_time=2.)
+        np.testing.assert_allclose(result[0], np.exp(-.2 * np.array([0, 1, 3])))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_ctn_predictor_native.py
+++ b/tests/test_ctn_predictor_native.py
@@ -1,0 +1,36 @@
+"""Bound this native acceptance test externally; no xfail or convergence bypass."""
+import numpy as np
+import pandas as pd
+import gamfit
+
+
+def test_native_ctn_chain_save_load_and_batches(tmp_path):
+    rng = np.random.default_rng(714)
+    n = 160
+    x = rng.uniform(-1, 1, n)
+    z = rng.normal(size=n)
+    data = pd.DataFrame({"pgs": 2 + .4 * x + z, "x": x,
+                         "y": (rng.normal(size=n) < -.2 + .3 * x + .5 * z).astype(int),
+                         "group": np.arange(n)})
+    model = gamfit.fit(
+        data, "y ~ x", family="bernoulli-marginal-slope", slope_formula="1",
+        transformation_normal_stage1=gamfit.CtnStage1(
+            "pgs", "x", group_column="group", folds=2,
+            response_num_internal_knots=2),
+        persistent_warm_start_root=tmp_path / "warm")
+    test = data[["pgs", "x"]].iloc[:8].copy()
+    before = np.asarray(model.predict(test))
+    assert np.isfinite(before).all() and ((before >= 0) & (before <= 1)).all()
+    model.save(tmp_path / "chain.gamfit")
+    restored = gamfit.load(tmp_path / "chain.gamfit")
+    np.testing.assert_allclose(restored.predict(test), before, rtol=1e-8, atol=1e-10)
+    np.testing.assert_allclose(restored.predict(test.iloc[::-1]), before[::-1], rtol=1e-8, atol=1e-10)
+    np.testing.assert_allclose(restored.predict(test.iloc[[3]]), before[[3]], rtol=1e-8, atol=1e-10)
+    from gamfit._ctn_model import _with_score
+    manual = restored.outcome.predict(_with_score(test, restored.transform.transformation_score(test)))
+    np.testing.assert_allclose(manual, before, rtol=1e-8, atol=1e-10)
+    for payload in (model.outcome.dumps(), restored.outcome.dumps()):
+        import json
+        saved = json.loads(payload)["payload"]
+        assert saved.get("latent_z_rank_int_calibration") is None
+        assert saved.get("latent_z_conditional_calibration") is None

--- a/tests/test_survival_marginal_slope_clustered_pc_808.py
+++ b/tests/test_survival_marginal_slope_clustered_pc_808.py
@@ -13,15 +13,10 @@ This test reconstructs that repro deterministically (it was lost once when the
 ad-hoc ``repro_surv.py`` was deleted) so the bug can never silently regress and
 the reproducer is preserved in-tree.
 
-Status: #808 is OPEN. The v2 "W-aware operating-point identifiability
-reduction" landed but does NOT fix it: on this design the priority-ordered
-Gram-Schmidt selector drops the *entire* slope block (``slope N -> 0``,
-because time+marginal already span its W-metric directions) yet the frozen
-residual lives in the *time* block (``block_grad_inf ~= [159, 19, 2]``), so the
-stall persists. The test therefore asserts the DESIRED post-fix contract
-(the fit converges to a usable model) and is marked ``xfail(strict=True)``.
-When #808 is genuinely fixed this test will XPASS; flip it to a hard assertion
-at that point and delete the xfail marker.
+This is a hard numerical acceptance test, not an issue-status record. A closed
+issue or an old convergence comment is not evidence that the current build
+passes. Predictions must be finite, nonconstant and monotone on the requested
+time grid, and score contrasts must not vanish through block removal.
 
 The fit is run in a child process under a hard wall timeout so a stalled
 solve cannot hang CI; a timeout is treated as "did not converge" (the bug).
@@ -92,16 +87,22 @@ _CHILD = textwrap.dedent(
     # "outer optimization did not converge"). Sanity-check the fit is usable:
     # predict must produce finite, non-constant survival probabilities.
     pred = model.predict(d)
+    grid = np.linspace(40., 60., 41)
+    survival = np.asarray(pred.survival_at(grid))
+    assert np.isfinite(survival).all()
+    assert ((survival >= 0) & (survival <= 1)).all()
+    assert (np.diff(survival, axis=1) <= 1e-9).all()
+    low, high = d.copy(), d.copy()
+    low['PGS_z'], high['PGS_z'] = -1., 1.
+    contrast = (model.predict(high).survival_at(grid)
+                - model.predict(low).survival_at(grid))
+    assert np.max(np.abs(contrast)) > 1e-6, 'score-effect block was lost'
     sys.stdout.write("CONVERGED\\n")
     """
 )
 
 
-# #1512 / SPEC.md (xfail is never allowed): this stands FAILING as the signal of
-# the open #808 bug — clustered-PC survival marginal-slope inner solve stalls
-# (residual ~3.7e8 >> tol, frozen |g|=1.863); v2 W-aware reduction drops the
-# whole slope block but the residual lives in the time block, so the outer
-# REML never converges. Fix #808 to green this.
+# No xfail or relaxed convergence escape: numerical failure stays visible.
 def test_survival_marginal_slope_clustered_pc_converges_808() -> None:
     env = dict(os.environ)
     env.setdefault("OMP_NUM_THREADS", "1")


### PR DESCRIPTION
The documented `CtnStage1` entry produced OOF scores for training but did not save a deployable CTN; payload construction still required `z_column`. This change routes Python CTN prediction through fold-local score fits, an ordinary frozen-score marginal-slope outcome, and a full-training CTN saved with that outcome.

Explicit fold/group columns replace implicit row-block partitioning in this predictive path. There is no influence Jacobian, fitted-and-discarded absorber, or second score normalization. The existing Rust influence construction remains separate from the Python prediction API. CTN response-basis options reuse the existing affine-null penalty implementation.

The saved object supports raw-score prediction, component inspection, save/load, and prospective survival at requested times. The clustered-PC regression now asserts finite monotone survival and a nonzero score contrast instead of treating a successful `predict()` call as that evidence.

Validation: six prediction-chain contract tests pass on MSI; changed Rust sources pass rustfmt parsing. These tests use numerical test doubles for orchestration and are not native fit results. Native CTN-chain and clustered-PC acceptance remain outstanding. Bounded builds using the existing MSI cache exposed slow dependency/cache I/O, so this PR stays draft until those numerical checks run. No local builds or model fits were used.

The source-integrity run exposed an existing assertion-free measurement timing test. It now compares the analytic derivatives with the independent AD reference outside its timing loops. That detector passes. The remaining census failure is inherited from the base: both base and PR have 1,403 gam-models tests against a recorded floor of 1,435. This PR does not remove those tests or lower that floor. The automatically triggered five-hour Python inventory was cancelled in favor of bounded targeted validation.

Breaking API change: `CtnStage1` requires explicit fold or group columns and no longer promises automatic Neyman orthogonality. Outcome intervals remain conditional on the fitted CTN.
