### PR TITLE
Fix source hygiene blocking the merged GAM build

### DIFF
--- a/bench/measurements/event_history_joint_20260910.txt
+++ b/bench/measurements/event_history_joint_20260910.txt
@@ -1,6 +1,6 @@
-   Compiling gam-event-history v0.3.157 (/projects/standard/hsiehph/sauer354/mdpp/gam/crates/gam-event-history)
+   Compiling gam-event-history v0.3.157 (gam/crates/gam-event-history)
     Finished `test` profile [optimized] target(s) in 1m 02s
-     Running unittests src/lib.rs (/projects/standard/hsiehph/sauer354/targets/gam-mdpp/debug/deps/gam_event_history-1d9bb59d29392367)
+     Running unittests src/lib.rs (target/debug/deps/gam_event_history-1d9bb59d29392367)
 
 running 15 tests
 test joint::tests::measurement_families_are_normalized_and_have_stable_curvature ... ok
@@ -21,4 +21,3 @@ test joint::tests::importance_correction_matches_an_independent_measurement_inte
 test joint::tests::structured_gaussian_limit_integrates_missing_scores_and_large_state_paths ... ok
 
 test result: ok. 15 passed; 0 failed; 0 ignored; 0 measured; 50 filtered out; finished in 1.67s
-

--- a/bench/measurements/issue_2834_2828_20260910.md
+++ b/bench/measurements/issue_2834_2828_20260910.md
@@ -101,9 +101,10 @@ concurrent event-history work on main is outside this validation.
 
 ## Reproduction artifacts
 
-Shared directory: `/projects/standard/hsiehph/sauer354/gam-issues-2834-2828/`.
-Source validation copy: `/scratch.global/sauer354/gam-issues-2834-2828-source`.
-Warm target: `/scratch.global/sauer354/gam-deslop-a2-target`.
+Artifact directory name: `gam-issues-2834-2828`.
+Source validation copy name: `gam-issues-2834-2828-source`.
+Warm target directory name: `gam-deslop-a2-target`.
+Their parent locations are deployment-specific and are not part of the evidence.
 
 - `build_current_crate.py`, `gam_sae_test_argv.json`, `gam_sae_build.log`.
 - `sae_tests_exact_a_probes_2828.log` (nine passing prior/adjoint tests).

--- a/crates/gam-event-history/src/joint/category_prior.rs
+++ b/crates/gam-event-history/src/joint/category_prior.rs
@@ -4,7 +4,7 @@
 use super::*;
 
 pub(super) struct CategoryPriors {
-    channels: Vec<(usize, Range<usize>)>,
+    pub(super) channels: Vec<(usize, Range<usize>)>,
 }
 
 struct ChannelEvaluation {
@@ -121,33 +121,9 @@ impl CategoryEvaluation {
 }
 
 #[cfg(test)]
-pub(super) mod tests {
+mod tests {
     use super::*;
-    pub(in crate::joint::function_prior) fn oracle<S: JetField>(
-        prior: &CategoryPriors,
-        theta: &[S],
-    ) -> S {
-        let mut total = theta[0].constant_like(0.0);
-        for (intercept, gaps) in &prior.channels {
-            let cuts = gaps.len() + 1;
-            total = add_real(
-                &total,
-                (1..=cuts).map(|j| (j as f64).ln()).sum::<f64>()
-                    - 0.5 * cuts as f64 * (2.0 * std::f64::consts::PI).ln(),
-            );
-            let mut cut = theta[0].constant_like(0.0);
-            for j in 0..cuts {
-                if j > 0 {
-                    let q = &theta[gaps.start + j - 1];
-                    cut = cut.add(&emission::softplus(q));
-                    total = total.sub(&emission::softplus(&q.neg()));
-                }
-                let z = cut.sub(&theta[*intercept]);
-                total = total.sub(&z.mul(&z).scale(0.5));
-            }
-        }
-        total
-    }
+    use super::super::test_support::category_oracle as oracle;
 
     #[test]
     fn probit_category_base_measure_is_uniform_on_its_probability_simplex() {

--- a/crates/gam-event-history/src/joint/coefficient_integral.rs
+++ b/crates/gam-event-history/src/joint/coefficient_integral.rs
@@ -96,9 +96,12 @@ fn moments(weights: &[f64], values: impl Iterator<Item = f64> + Clone) -> (f64, 
         .iter()
         .enumerate()
         .max_by(|a, b| a.1.total_cmp(b.1))
-        .unwrap()
+        .expect("coefficient moment weights are nonempty")
         .0;
-    let pivot = values.clone().nth(pivot_index).unwrap();
+    let pivot = values
+        .clone()
+        .nth(pivot_index)
+        .expect("coefficient moment values match the weights");
     let mean = pivot
         + sum(weights
             .iter()

--- a/crates/gam-event-history/src/joint/function_prior.rs
+++ b/crates/gam-event-history/src/joint/function_prior.rs
@@ -662,7 +662,12 @@ impl FunctionPriorEvaluation<'_, '_> {
 }
 
 #[cfg(test)]
+#[path = "function_prior_tests.rs"]
+mod test_support;
+
+#[cfg(test)]
 mod tests {
+    use super::test_support::{category_oracle, structural_oracle};
     use super::*;
     use crate::scalar::Mixed;
 
@@ -786,10 +791,10 @@ mod tests {
             let total = rho[prior.decoder_strengths + prior.gaussian.len()].add(&log_level);
             value = value.add(&total).sub(&exp(&total));
         }
-        value = value.add(&category::tests::oracle(&prior.category, theta));
+        value = value.add(&category_oracle(&prior.category, theta));
         for (index, functions) in prior.structural.iter().enumerate() {
             for function in functions {
-                value = value.add(&structural::tests::oracle(
+                value = value.add(&structural_oracle(
                     function,
                     theta,
                     &rho[prior.decoder_strengths + prior.gaussian.len() + 1 + index],

--- a/crates/gam-event-history/src/joint/function_prior_tests.rs
+++ b/crates/gam-event-history/src/joint/function_prior_tests.rs
@@ -1,0 +1,79 @@
+//! Shared independent AD oracles, available only to function-prior tests.
+use super::*;
+
+pub(super) fn category_oracle<S: JetField>(prior: &CategoryPriors, theta: &[S]) -> S {
+    let mut total = theta[0].constant_like(0.0);
+    for (intercept, gaps) in &prior.channels {
+        let cuts = gaps.len() + 1;
+        total = add_real(
+            &total,
+            (1..=cuts).map(|j| (j as f64).ln()).sum::<f64>()
+                - 0.5 * cuts as f64 * (2.0 * std::f64::consts::PI).ln(),
+        );
+        let mut cut = theta[0].constant_like(0.0);
+        for j in 0..cuts {
+            if j > 0 {
+                let q = &theta[gaps.start + j - 1];
+                cut = cut.add(&emission::softplus(q));
+                total = total.sub(&emission::softplus(&q.neg()));
+            }
+            let z = cut.sub(&theta[*intercept]);
+            total = total.sub(&z.mul(&z).scale(0.5));
+        }
+    }
+    total
+}
+
+pub(super) fn structural_oracle<S: JetField>(
+    function: &StructuralFunction,
+    theta: &[S],
+    rho: &S,
+) -> S {
+    let (log_value, log_jacobian, shape, log_gamma) = match *function {
+        StructuralFunction::CountMean { coordinate } => (
+            theta[coordinate].clone(),
+            theta[coordinate].clone(),
+            1.0,
+            0.0,
+        ),
+        StructuralFunction::TemporalVariation {
+            coordinate,
+            log_time,
+        } => {
+            let q = &theta[coordinate];
+            (
+                add_real(&ln(&emission::softplus(q)), log_time),
+                add_real(&emission::softplus(&q.neg()).neg(), log_time),
+                1.0,
+                0.0,
+            )
+        }
+        StructuralFunction::MeasurementPrecision { coordinate } => {
+            let v = theta[coordinate].scale(-2.0);
+            (v.clone(), add_real(&v, 2.0_f64.ln()), 3.0, 2.0_f64.ln())
+        }
+        StructuralFunction::InverseSoftplus {
+            coordinate,
+            log_multiplier,
+        } => {
+            let q = &theta[coordinate];
+            let s = ln(&emission::softplus(q));
+            (
+                add_real(&s.neg(), log_multiplier),
+                add_real(
+                    &emission::softplus(&q.neg()).neg().sub(&s.scale(2.0)),
+                    log_multiplier,
+                ),
+                5.0,
+                24.0_f64.ln(),
+            )
+        }
+    };
+    add_real(
+        &rho.scale(shape)
+            .add(&log_value.scale(shape - 1.0))
+            .add(&log_jacobian)
+            .sub(&exp(&rho.add(&log_value))),
+        -log_gamma,
+    )
+}

--- a/crates/gam-event-history/src/joint/structural_prior.rs
+++ b/crates/gam-event-history/src/joint/structural_prior.rs
@@ -243,63 +243,11 @@ impl JointFunctionPriors<'_> {
 }
 
 #[cfg(test)]
-pub(super) mod tests {
+mod tests {
     use super::*;
     use crate::scalar::Mixed;
 
-    pub(in crate::joint::function_prior) fn oracle<S: JetField>(
-        function: &StructuralFunction,
-        theta: &[S],
-        rho: &S,
-    ) -> S {
-        let (log_value, log_jacobian, shape, log_gamma) = match *function {
-            StructuralFunction::CountMean { coordinate } => (
-                theta[coordinate].clone(),
-                theta[coordinate].clone(),
-                1.0,
-                0.0,
-            ),
-            StructuralFunction::TemporalVariation {
-                coordinate,
-                log_time,
-            } => {
-                let q = &theta[coordinate];
-                (
-                    add_real(&ln(&emission::softplus(q)), log_time),
-                    add_real(&emission::softplus(&q.neg()).neg(), log_time),
-                    1.0,
-                    0.0,
-                )
-            }
-            StructuralFunction::MeasurementPrecision { coordinate } => {
-                let v = theta[coordinate].scale(-2.0);
-                (v.clone(), add_real(&v, 2.0_f64.ln()), 3.0, 2.0_f64.ln())
-            }
-            StructuralFunction::InverseSoftplus {
-                coordinate,
-                log_multiplier,
-            } => {
-                let q = &theta[coordinate];
-                let s = ln(&emission::softplus(q));
-                (
-                    add_real(&s.neg(), log_multiplier),
-                    add_real(
-                        &emission::softplus(&q.neg()).neg().sub(&s.scale(2.0)),
-                        log_multiplier,
-                    ),
-                    5.0,
-                    24.0_f64.ln(),
-                )
-            }
-        };
-        add_real(
-            &rho.scale(shape)
-                .add(&log_value.scale(shape - 1.0))
-                .add(&log_jacobian)
-                .sub(&exp(&rho.add(&log_value))),
-            -log_gamma,
-        )
-    }
+    use super::super::test_support::structural_oracle as oracle;
 
     #[test]
     fn physical_shape_priors_include_exact_normalizers_and_chart_curvature() {

--- a/docs/public-api-census-changes.json
+++ b/docs/public-api-census-changes.json
@@ -1,5 +1,14 @@
 [
   {
+    "base": "4249f82e62ffb0949bed239248006e68994a3242",
+    "removed": {
+      "crates/gam-event-history/src/joint/category_prior.rs::oracle": 1,
+      "crates/gam-event-history/src/joint/structural_prior.rs::oracle": 1
+    },
+    "reason": "Move the two test-only AD reference functions into a shared private test module so sibling tests do not require exported test modules. No production API or equation is removed.",
+    "evidence": "function_prior_tests.rs contains the same oracle bodies as category_oracle and structural_oracle. Category, structural, and combined function-prior tests call these replacements; all original test cases remain."
+  },
+  {
     "base": "e29e4da1b4ca349ee734a01e630d988b1b9c127d",
     "removed": {
       "crates/gam-custom-family/src/tests/inner_solver_numerics.rs::strict_solve_spd_falls_back_to_eigen_floor_on_indefinite_matrix": 1,

--- a/docs/source-removal-changes.json
+++ b/docs/source-removal-changes.json
@@ -2,8 +2,7 @@
   {
     "base": "4249f82e62ffb0949bed239248006e68994a3242",
     "items": [
-      "crates/gam-event-history/src/joint/category_prior.rs:fn:oracle",
-      "crates/gam-event-history/src/joint/structural_prior.rs:fn:oracle"
+      "crates/gam-event-history/src/joint/category_prior.rs:fn:oracle"
     ],
     "reason": "Move the independent AD oracles to a private test-support module shared by the prior test modules; preserve their equations and every original test case.",
     "evidence": "function_prior_tests.rs supplies category_oracle and structural_oracle. The category, structural, and combined prior tests now call those same reference equations without exporting a test module."

--- a/docs/source-removal-changes.json
+++ b/docs/source-removal-changes.json
@@ -1,5 +1,14 @@
 [
   {
+    "base": "4249f82e62ffb0949bed239248006e68994a3242",
+    "items": [
+      "crates/gam-event-history/src/joint/category_prior.rs:fn:oracle",
+      "crates/gam-event-history/src/joint/structural_prior.rs:fn:oracle"
+    ],
+    "reason": "Move the independent AD oracles to a private test-support module shared by the prior test modules; preserve their equations and every original test case.",
+    "evidence": "function_prior_tests.rs supplies category_oracle and structural_oracle. The category, structural, and combined prior tests now call those same reference equations without exporting a test module."
+  },
+  {
     "base": "e29e4da1b4ca349ee734a01e630d988b1b9c127d",
     "items": [
       "crates/gam-cli/src/main/cli_args.rs:enum:PredictModeArg",

--- a/experiments/event_history_scanner.rs
+++ b/experiments/event_history_scanner.rs
@@ -78,6 +78,6 @@ fn main() {
     let before = run(old);
     let after = run(new);
     assert_eq!(before.0, after.0);
-    println!("{comparisons} exhaustive Unicode/overlap comparisons; equal hit counts {}", before.0);
-    println!("old {:?}; new {:?}; speedup {:.2}", before.1, after.1, before.1.as_secs_f64()/after.1.as_secs_f64());
+    eprintln!("{comparisons} exhaustive Unicode/overlap comparisons; equal hit counts {}", before.0);
+    eprintln!("old {:?}; new {:?}; speedup {:.2}", before.1, after.1, before.1.as_secs_f64()/after.1.as_secs_f64());
 }

--- a/experiments/event_history_scanner.rs
+++ b/experiments/event_history_scanner.rs
@@ -79,5 +79,5 @@ fn main() {
     let after = run(new);
     assert_eq!(before.0, after.0);
     eprintln!("{comparisons} exhaustive Unicode/overlap comparisons; equal hit counts {}", before.0);
-    eprintln!("old {:?}; new {:?}; speedup {:.2}", before.1, after.1, before.1.as_secs_f64()/after.1.as_secs_f64());
+    eprintln!("old {:.6}s; new {:.6}s; speedup {:.2}", before.1.as_secs_f64(), after.1.as_secs_f64(), before.1.as_secs_f64()/after.1.as_secs_f64());
 }


### PR DESCRIPTION
The merged tree fails its build checks on machine paths in evidence artifacts, exported test modules, unchecked moment invariants, and experiment output. Normalize the artifact paths, put the independent prior oracles in a shared private test module, state the moment invariants explicitly, and print experiment timings as seconds on stderr. Preserve the prior equations, test cases, timing results, and numerical evidence.

Validation: the Linux CPython-compatible wheel builds successfully on MSI. Source-removal and public-function integrity checks pass against the PR's immutable commits. The targeted event-prior test build exhausted its 120-second dependency-compilation budget before tests ran. No build checks or test floors are weakened. The CI census is already below its recorded floor on the base (1,403 versus 1,435 gam-models tests); this PR does not remove those tests.

Separately, the AoU acceptance exercise completed all three CTN transformations and save/load checks with a bounded response basis; its survival fit timed out at 90 seconds. This hygiene repair does not claim to fix that numerical/performance problem. No local compilation or model execution was performed.
