### PR TITLE
Make CTN rank auditing and smoothing seeds independent of penalty units

### DIFF
--- a/crates/gam-identifiability/src/audit.rs
+++ b/crates/gam-identifiability/src/audit.rs
@@ -2746,7 +2746,7 @@ pub fn audit_identifiability_channel_aware(
 /// route exclusively through the channel-aware audit, so without this they
 /// never benefit from the `[J; S]` augmentation the flat path already applies.
 ///
-/// `S_blockdiag` is the unit-weight STRUCTURAL sum of each block's penalty
+/// `S_blockdiag` is the normalized STRUCTURAL sum of each block's penalty
 /// matrices (the same ρ-invariant `block_structural_penalty_dense` the flat
 /// audit uses): only `∩_m ker(S_m)` matters for the rank verdict, independent
 /// of the fitted λ values. Blocks with no penalty contribute no rows, so for an
@@ -2855,7 +2855,7 @@ fn channel_aware_penalty_aware_joint_rank(
     }
 
     // Per-block structural penalties, parallel to `specs` (None ⇒ no penalty
-    // rows for that block). Reuses the exact unit-weight sum the flat audit
+    // rows for that block). Reuses the same normalized sum the flat audit
     // uses so the two paths agree on the ρ-invariant penalty geometry.
     let block_penalties: Vec<Option<Array2<f64>>> =
         specs.iter().map(block_structural_penalty_dense).collect();
@@ -3370,9 +3370,9 @@ fn locate_block_column(
     )))
 }
 
-/// Structural (λ-invariant) penalty for a block: the unit-weight sum of its
-/// penalty matrices, materialised dense (`p_block × p_block`), or `None` when
-/// the block carries no penalty.
+/// Structural (λ-invariant) penalty for a block: the sum of its independently
+/// normalized penalty matrices, materialised dense (`p_block × p_block`), or
+/// `None` when the block carries no penalty.
 ///
 /// Identifiability of a PENALIZED block is governed by `H + S`, not the raw
 /// design `H` alone: a direction killed by the data design but COVERED by the
@@ -3384,12 +3384,14 @@ fn locate_block_column(
 /// appending any square-root `√S` for the rank/null verdict and avoids a matrix
 /// square root.
 ///
-/// Using the unit-weight STRUCTURAL sum (not a fitted λ) keeps the gate
-/// ρ-invariant: only the penalties' shared null space `∩_m ker(S_m)` matters,
-/// which is independent of the smoothing-parameter values. A block with no
-/// penalty returns `None`, so its augmented design is just `J` — the gate then
-/// reduces EXACTLY to the historical raw-design rank check, leaving every
-/// unpenalized block/family's verdict unchanged.
+/// Only the penalties' shared null space `∩_m ker(S_m)` matters. Positive
+/// scalar weights on PSD penalties preserve that intersection, so divide each
+/// matrix by its largest absolute entry before summing. In particular, response
+/// derivative penalties grow when CTN response units shrink. Summing their raw
+/// magnitudes can bury both the design and other penalties below the QR cutoff,
+/// incorrectly rejecting data-identified affine directions. This normalization
+/// changes only the structural audit, never the fitted penalties or strengths.
+/// A block with no penalty retains the raw-design rank check.
 pub(crate) fn block_structural_penalty_dense(spec: &ParameterBlockSpec) -> Option<Array2<f64>> {
     let p = spec.design.ncols();
     if p == 0 || spec.penalties.is_empty() {
@@ -3400,7 +3402,12 @@ pub(crate) fn block_structural_penalty_dense(spec: &ParameterBlockSpec) -> Optio
     for penalty in &spec.penalties {
         let dense = penalty.to_dense();
         if dense.nrows() == p && dense.ncols() == p {
-            s += &dense;
+            let scale = dense.iter().map(|v| v.abs()).fold(0.0_f64, f64::max);
+            if scale > 0.0 {
+                ndarray::Zip::from(&mut s)
+                    .and(&dense)
+                    .for_each(|sum, &value| *sum += value / scale);
+            }
             any = true;
         }
     }
@@ -3704,6 +3711,42 @@ mod tests {
             return ndarray::Array1::<f64>::zeros(n.max(1));
         }
         ndarray::Array1::linspace(-1.0, 1.0, n)
+    }
+
+    #[test]
+    fn structural_audit_is_invariant_to_independent_penalty_units() {
+        // Data identify the unpenalized location; two distinct PSD penalties
+        // identify the two design-null directions. Their arbitrary units must
+        // not erase either the data direction or the smaller penalty.
+        for (first, second) in [(1.0, 1.0), (1e30, 1e-30), (1e-30, 1e30)] {
+            let mut design = Array2::<f64>::zeros((32, 3));
+            design.column_mut(0).fill(1.0);
+            let mut spec = spec_from_dense("transformation", design);
+            spec.penalties = vec![
+                gam_problem::PenaltyMatrix::Dense(ndarray::arr2(&[
+                    [0.0, 0.0, 0.0],
+                    [0.0, first, 0.0],
+                    [0.0, 0.0, 0.0],
+                ])),
+                gam_problem::PenaltyMatrix::Dense(ndarray::arr2(&[
+                    [0.0, 0.0, 0.0],
+                    [0.0, 0.0, 0.0],
+                    [0.0, 0.0, second],
+                ])),
+            ];
+            let audit = audit_identifiability(&[spec.clone()]).unwrap();
+            assert!(!audit.fatal, "{}", audit.summary);
+            assert_eq!(audit.blocks[0].design_range_rank, 3);
+            assert!(audit.dropped_columns.is_empty());
+
+            // Removing one penalty leaves a real unidentified direction even
+            // at the extreme scale. Normalization must not manufacture rank.
+            spec.penalties.pop();
+            let audit = audit_identifiability(&[spec]).unwrap();
+            assert!(audit.fatal);
+            assert_eq!(audit.blocks[0].design_range_rank, 2);
+            assert_eq!(audit.dropped_columns.len(), 1);
+        }
     }
 
     /// `pair_report_threshold` floors at `REPORT_FLOOR_NEAR_EXACT` and ceilings

--- a/crates/gam-models/src/transformation_normal/config.rs
+++ b/crates/gam-models/src/transformation_normal/config.rs
@@ -127,25 +127,6 @@ pub(crate) const CTN_INNER_MAX_CYCLES_PER_DIM: usize = 2;
 
 pub(crate) const CTN_INNER_MAX_CYCLES_CEILING: usize = 400;
 
-/// Numerical floor on a Gram/penalty diagonal scale before it enters the
-/// `likelihood_scale / penalty_scale` ratio that seeds the outer log-λ search.
-/// A genuinely zero diagonal (an all-zero penalty block, or a degenerate
-/// likelihood Gram) would otherwise produce a `0/0` or `x/0` seed; flooring
-/// both scales at a value far below any meaningful curvature keeps the ratio
-/// finite without perturbing well-posed problems.
-pub(crate) const CTN_SEED_SCALE_FLOOR: f64 = 1.0e-8;
-
-/// Lower bound on the cold-start seed log-λ (i.e. λ ≥ 1). Keeps the outer
-/// optimizer out of the under-regularized regime where the CTN inner solve is
-/// structurally rank-deficient (small-n / p > n); the optimizer is free to step
-/// below this once the data support it. See `ctn_penalty_scale_log_lambdas`.
-pub(crate) const CTN_SEED_LOG_LAMBDA_MIN: f64 = 0.0;
-
-/// Upper bound on the cold-start seed log-λ, matching the outer ρ-bound used
-/// across the location-scale families: λ ≈ e¹² caps the seed in the strongly
-/// over-smoothed regime so a tiny penalty scale cannot seed an absurd λ.
-pub(crate) const CTN_SEED_LOG_LAMBDA_MAX: f64 = 12.0;
-
 /// Floor on the warm-start global residual scale `sqrt(weighted_ss / Σw)`.
 /// Guards the degenerate near-perfect-fit case (residuals collapse to numerical
 /// zero) so the per-residual `residual_floor` below — and the subsequent

--- a/crates/gam-models/src/transformation_normal/family.rs
+++ b/crates/gam-models/src/transformation_normal/family.rs
@@ -634,10 +634,10 @@ impl TransformationNormalFamily {
         let likelihood_diagonal_mean = self
             .x_val_kron
             .weighted_gram_diagonal_mean(self.weights.as_ref(), &policy)?;
-        Ok(ctn_penalty_scale_log_lambdas(
+        ctn_penalty_scale_log_lambdas(
             &self.tensor_penalties,
             likelihood_diagonal_mean,
-        ))
+        )
     }
 
     /// Return the single coefficient block under one explicit smoothing state.

--- a/crates/gam-models/src/transformation_normal/penalty_scaling.rs
+++ b/crates/gam-models/src/transformation_normal/penalty_scaling.rs
@@ -3,28 +3,27 @@ use super::*;
 pub(crate) fn ctn_penalty_scale_log_lambdas(
     penalties: &[PenaltyMatrix],
     likelihood_diagonal_mean: f64,
-) -> Array1<f64> {
+) -> Result<Array1<f64>, String> {
     if penalties.is_empty() {
-        return Array1::zeros(0);
+        return Ok(Array1::zeros(0));
     }
-
-    let likelihood_scale = likelihood_diagonal_mean.max(CTN_SEED_SCALE_FLOOR);
-    Array1::from_iter(penalties.iter().map(|penalty| {
-        let penalty_scale = penalty_diag_scale(penalty).max(CTN_SEED_SCALE_FLOOR);
-        // Lower-bound the SEED log-lambda at 0 (i.e., λ ≥ 1) so we never
-        // start the outer optimizer in the under-regularized regime where
-        // the CTN inner is structurally rank-deficient (small-n / p > n).
-        // The outer BFGS is free to step below 0 when there's enough data
-        // to support it; only the cold-start is constrained. Without this
-        // floor, ratios like n=64, p_resp×p_cov ≈ 200 produce a seed of
-        // log_lambda ≈ -12 (λ ≈ 6e-6), which leaves the inner solve to
-        // pick wild β coefficients and cascade into predict-time monotonicity
-        // violations (h' < 0 on the response grid, observed as -1e15 spikes
-        // in CI synthetic-large-scale tests).
-        (likelihood_scale / penalty_scale)
-            .ln()
-            .clamp(CTN_SEED_LOG_LAMBDA_MIN, CTN_SEED_LOG_LAMBDA_MAX)
-    }))
+    if !likelihood_diagonal_mean.is_finite() || likelihood_diagonal_mean <= 0.0 {
+        return Err("CTN smoothing seed requires a finite positive likelihood scale".to_string());
+    }
+    let mut seed = Array1::zeros(penalties.len());
+    for (index, penalty) in penalties.iter().enumerate() {
+        let scale = penalty_diag_scale(penalty);
+        if !scale.is_finite() || scale <= 0.0 {
+            return Err(format!("CTN smoothing penalty {index} has no finite positive scale"));
+        }
+        // Match the initial effective penalty scale to the likelihood scale.
+        // Clamping log(lambda) at zero makes the starting model depend on the
+        // arbitrary units of S: a small lambda can multiply a very large
+        // response-derivative penalty into appropriate regularization. Compute
+        // in log space so the ratio itself need not be representable.
+        seed[index] = likelihood_diagonal_mean.ln() - scale.ln();
+    }
+    Ok(seed)
 }
 
 pub(crate) fn penalty_diag_scale(penalty: &PenaltyMatrix) -> f64 {

--- a/crates/gam-models/src/transformation_normal/tests.rs
+++ b/crates/gam-models/src/transformation_normal/tests.rs
@@ -110,9 +110,24 @@ pub(crate) fn ctn_penalty_scale_seed_uses_likelihood_to_penalty_ratio() {
         PenaltyMatrix::Dense(array![[2.0, 0.0], [0.0, 2.0]]),
         PenaltyMatrix::Dense(array![[4.0, 0.0], [0.0, 4.0]]),
     ];
-    let rho = ctn_penalty_scale_log_lambdas(&penalties, 8.0);
+    let rho = ctn_penalty_scale_log_lambdas(&penalties, 8.0).unwrap();
     assert!((rho[0] - 4.0_f64.ln()).abs() < 1.0e-12);
     assert!((rho[1] - 2.0_f64.ln()).abs() < 1.0e-12);
+}
+
+#[test]
+fn ctn_penalty_scale_seed_preserves_effective_strength_across_units() {
+    for scale in [1e-30, 1.0, 1e30] {
+        let penalties = vec![PenaltyMatrix::Dense(array![[scale, 0.0], [0.0, scale]])];
+        let rho = ctn_penalty_scale_log_lambdas(&penalties, 8.0).unwrap();
+        assert!((rho[0].exp() * scale / 8.0 - 1.0).abs() < 1e-12);
+    }
+    let zero = vec![PenaltyMatrix::Dense(Array2::zeros((2, 2)))];
+    assert!(ctn_penalty_scale_log_lambdas(&zero, 8.0).is_err());
+    let identity = vec![PenaltyMatrix::Dense(Array2::eye(2))];
+    for scale in [0.0, -1.0, f64::NAN, f64::INFINITY] {
+        assert!(ctn_penalty_scale_log_lambdas(&identity, scale).is_err());
+    }
 }
 
 #[test]

--- a/tests/test_ctn_small_score_units.py
+++ b/tests/test_ctn_small_score_units.py
@@ -1,0 +1,33 @@
+"""Native CTN regression; run under an external wall limit."""
+import numpy as np
+import pandas as pd
+import gamfit
+
+
+def test_ctn_small_score_units_keep_affine_directions(tmp_path):
+    rng = np.random.default_rng(8016)
+    n = 240
+    data = pd.DataFrame({f"PC{i}": rng.normal(size=n) for i in range(1, 7)})
+    data["PGS"] = 1e-5 * (.2 * data.PC1 + rng.normal(size=n))
+    data["age0"] = rng.uniform(40, 70, n)
+    data["sex"] = rng.integers(0, 2, n)
+    model = gamfit.fit(
+        data,
+        "PGS ~ s(age0, k=5) + sex + "
+        "duchon(PC1, PC2, PC3, PC4, PC5, PC6, centers=8, scale_dims=true)",
+        transformation_normal=True,
+        config={"transformation_normal_config": {"response_num_internal_knots": 2}},
+        persistent_warm_start_root=tmp_path / "warm",
+    )
+    # Vary only the observed score to check the frozen conditional transform.
+    held = data.iloc[[0] * 9].copy()
+    held["PGS"] = np.linspace(data.PGS.quantile(.05), data.PGS.quantile(.95), 9)
+    score = np.asarray(model.transformation_score(held))
+    assert np.isfinite(score).all()
+    assert (np.diff(score) > 0).all()
+    model.save(tmp_path / "transform.gamfit")
+    restored = gamfit.load(tmp_path / "transform.gamfit")
+    np.testing.assert_allclose(restored.transformation_score(held), score,
+                               rtol=1e-8, atol=1e-10)
+    np.testing.assert_allclose(restored.transformation_score(held.iloc[[4]]), score[[4]],
+                               rtol=1e-8, atol=1e-10)


### PR DESCRIPTION
CTN fits can be rejected as rank-deficient solely because the raw score uses small units. A six-PC synthetic fit passes at unit score scale, while multiplying only its score by `1e-5` makes the published runtime report rank 52/65. Response derivative penalties become large in those units, and their raw structural sum overwhelms directions identified by the data or other penalties.

Normalize each PSD penalty by its largest absolute entry before assembling the structural audit matrix. Positive scalar weights preserve the penalties' common null space. Fitted penalty matrices and rank tolerances are unchanged.

Also preserve the likelihood-to-penalty scale ratio in CTN smoothing seeds. The former log-lambda clamp forced lambda to be at least one even when response units made the penalty enormous. Compute the ratio in log space, reject invalid scales explicitly, and remove the obsolete clamp and floor constants. This changes initialization, while retaining REML estimation of smoothing strengths.

Validation on MSI: all 65 `gam-identifiability` library tests pass, including a new regression spanning independent penalty scales `1e-30` to `1e30` and a genuinely unidentified control. Two smoothing-seed tests pass in a focused harness compiled from the production implementation and its source tests against warm native dependencies; this is not a full gam-models test run. The native six-PC CTN regression passes with the combined rank and seed fixes in approximately 48 seconds: fitting at small score units, monotonic transformed scores, save/load, and single-row replay. The solver reports that this synthetic fit selected the penalty null space (effective df 15 of 65); this is not evidence of learned nonlinear score shape or outcome accuracy. The rank-only patch had passed the rank gate but failed QP stationarity.

No participant data or workspace configuration is included. This change does not claim completion of the AoU training run or resolution of the separate clustered-PC survival timeout.

CI limitations: the earlier census job reported an existing `gam-models` floor mismatch (1435 recorded versus 1403 measured); the rank-only commit added one Rust test and removed none. The seed change adds another test and leaves the floor untouched. The automatically triggered full Python inventory and the superseded rank-only optimized build were stopped to honor the bounded-compute requirement. The latest commit skips automatic CI. Targeted combined native validation uses existing warm MSI libraries; it is not a release artifact built from the final merged main commit.
