### PR TITLE
Remove coefficient-pilot tracing that blocks runtime builds

### DIFF
--- a/crates/gam-event-history/src/joint/coefficient_pilot.rs
+++ b/crates/gam-event-history/src/joint/coefficient_pilot.rs
@@ -91,20 +91,7 @@ impl JointCohortIntegration<'_, '_> {
         }
         let last_rejected = std::cell::RefCell::new(None);
         let needs_refinement = std::cell::RefCell::new(None);
-        #[cfg(test)]
-        let trace = (std::time::Instant::now(), std::cell::Cell::new(0_usize));
         let objective = opt::FusedObjective::new(|theta: &Array1<f64>| {
-            #[cfg(test)]
-            {
-                let count = trace.1.get() + 1;
-                trace.1.set(count);
-                if count.is_power_of_two() {
-                    eprintln!(
-                        "coefficient pilot evaluation {count}: elapsed {:?}",
-                        trace.0.elapsed()
-                    );
-                }
-            }
             let theta = theta.to_vec();
             let value = self
                 .score_with_function_priors(&theta, priors, log_strengths, accuracy)


### PR DESCRIPTION
The runtime build stops in the repository ban scanner because coefficient_pilot contains two test-only tracing blocks inside production code. Remove the unused timing and evaluation-count diagnostics. The optimizer and tests are unchanged. Validation: the pinned runtime workflow will run the repository scanner before compiling; no local code was executed.