### PR TITLE
Certify weak posterior curvature and enforce CTN posterior-mean prediction

### DIFF
--- a/crates/gam-cli/src/main/model_build.rs
+++ b/crates/gam-cli/src/main/model_build.rs
@@ -166,7 +166,7 @@ pub(crate) fn build_transformation_normal_saved_model(
     fit_result: UnifiedFitResult,
     family: &gam::families::transformation_normal::TransformationNormalFamily,
     score_calibration: gam::inference::model::TransformationScoreCalibration,
-) -> SavedModel {
+) -> Result<SavedModel, String> {
     // Thin adapter over the shared core assembler; the CLI supplies per-feature
     // training ranges and no offset columns. See
     // `assemble_transformation_normal_payload`.
@@ -186,7 +186,7 @@ pub(crate) fn build_transformation_normal_saved_model(
             noise_offset_column: None,
         },
     );
-    SavedModel::from_payload(payload)
+    Ok(SavedModel::from_payload(payload?))
 }
 
 pub(crate) fn core_saved_fit_result(

--- a/crates/gam-cli/src/main/run_fit.rs
+++ b/crates/gam-cli/src/main/run_fit.rs
@@ -1141,7 +1141,7 @@ pub(crate) fn run_fit_transformation_normal(
             solved.fit,
             &solved.family,
             solved.score_calibration,
-        );
+        )?;
         model.offset_column = args.offset_column.clone();
         model.noise_offset_column = args.noise_offset_column.clone();
         write_model_json(out, &model)?;

--- a/crates/gam-custom-family/src/covariance.rs
+++ b/crates/gam-custom-family/src/covariance.rs
@@ -1513,54 +1513,16 @@ pub(crate) fn materialize_owned_terminal_unpenalized_hessian<
 /// zero variance in every constraint-normal direction.
 fn spd_covariance_from_precision(
     precision: &Array2<f64>,
-    dim_for_tol: usize,
     face: &str,
 ) -> Result<Array2<f64>, CustomFamilyError> {
-    let p = precision.nrows();
-    let (evals, evecs) = FaerEigh::eigh(precision, Side::Lower).map_err(|e| {
-        format!("joint posterior-precision eigendecomposition failed on the {face}: {e}")
-    })?;
-    let max_abs_eval = evals.iter().fold(0.0_f64, |acc, &ev| acc.max(ev.abs()));
-    let eps_np = f64::EPSILON * (dim_for_tol as f64) * (dim_for_tol as f64);
-    let tol = (10.0 * eps_np * max_abs_eval).max(100.0 * f64::EPSILON);
-    if let Some(&min_eval) = evals
-        .iter()
-        .filter(|&&ev| ev < -tol)
-        .min_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal))
-    {
-        let below = evals.iter().filter(|&&ev| ev < -tol).count();
-        return Err(CustomFamilyError::trial_point(format!(
-            "joint posterior precision H + S_λ is non-PD at the converged optimum on the \
-             {face} ({below} eigenvalue(s) below -tol, min(λ)={min_eval:.6e}, \
-             max|λ|={max_abs_eval:.6e}, tol={tol:.6e}); the mode is not a strict posterior \
-             maximum, so the reported covariance would be meaningless — fit-quality failure \
-             surfaced instead of δ-ridge masking (gam#748)"
-        )));
-    }
-    let flat = evals.iter().filter(|&&ev| ev <= tol).count();
-    if flat > 0 {
-        return Err(CustomFamilyError::trial_point(format!(
-            "joint posterior precision H + S_λ is singular at the converged optimum on the \
-             {face}: {flat} flat direction(s) (max|λ|={max_abs_eval:.6e}, tol={tol:.6e}). The \
-             posterior is improper along a flat direction — its variance is unbounded, so no \
-             finite covariance entry is honest there (a pseudo-inverse would claim zero \
-             variance, a δ-ridge an arbitrary finite one). Identify the direction via a \
-             constraint, penalty, or canonicalisation instead"
-        )));
-    }
-    // Strictly SPD: exact inverse through the eigenbasis, Σ = V diag(1/λ) Vᵀ.
-    let mut cov = Array2::<f64>::zeros((p, p));
-    for (k, &ev) in evals.iter().enumerate() {
-        let inv_ev = 1.0 / ev;
-        for i in 0..p {
-            let vi = evecs[[i, k]];
-            for j in 0..p {
-                cov[[i, j]] += inv_ev * vi * evecs[[j, k]];
-            }
-        }
-    }
-    symmetrize_dense_in_place(&mut cov);
-    Ok(cov)
+    // Small positive curvature is not a structural null: its units depend on
+    // the coefficient chart. Use the existing strict, unjittered Cholesky
+    // and inverse backward-error certificate, not a spectral rank cutoff.
+    gam_linalg::utils::certified_spd_inverse(precision, face)
+        .map(|certified| certified.into_inverse())
+        .map_err(|error| CustomFamilyError::trial_point(format!(
+            "joint posterior precision is non-PD at the converged optimum or its inverse could not be certified on the {face}: {error}"
+        )))
 }
 
 /// `Debug` is derived because the assembly is named in test panic messages that
@@ -1858,7 +1820,6 @@ pub(crate) fn compute_joint_posterior<F: CustomFamily + Clone + Send + Sync + 's
                 .then(|| {
                     spd_covariance_from_precision(
                         &precision,
-                        p,
                         "full posterior precision H + S_λ + H_Φ + H_completion",
                     )
                 })
@@ -1892,7 +1853,6 @@ pub(crate) fn compute_joint_posterior<F: CustomFamily + Clone + Send + Sync + 's
             // beats a silent wrong number.
             let ambient = match spd_covariance_from_precision(
                 &precision,
-                p,
                 "ambient constrained-posterior precision H + S_λ + H_Φ + H_completion",
             ) {
                 Ok(ambient) => ambient,
@@ -2373,6 +2333,19 @@ mod required_covariance_tests {
     //! knife-edge), so the assertion is deterministic and load-independent.
     use super::*;
     use ndarray::array;
+
+    #[test]
+    fn posterior_inverse_preserves_small_positive_curvature() {
+        let precision = array![[1.0e-12, 2.0e-7], [2.0e-7, 1.0]];
+        let covariance = spd_covariance_from_precision(&precision, "small score units").unwrap();
+        let expected = array![[1.0e12, -2.0e5], [-2.0e5, 1.0]] / 0.96;
+        for (&actual, &expected) in covariance.iter().zip(expected.iter()) {
+            assert!((actual - expected).abs() <= 1e-12 * expected.abs());
+        }
+        for precision in [array![[1., 1.], [1., 1.]], array![[1., 2.], [2., 1.]]] {
+            assert!(spd_covariance_from_precision(&precision, "invalid precision").is_err());
+        }
+    }
 
     #[derive(Clone)]
     struct TrivialFamily;

--- a/crates/gam-models/src/inference/model_payload_builders.rs
+++ b/crates/gam-models/src/inference/model_payload_builders.rs
@@ -944,7 +944,7 @@ pub struct TransformationNormalInputs<'a> {
 pub fn assemble_transformation_normal_payload(
     inputs: TransformationNormalInputs<'_>,
     source: SavedModelSourceMetadata,
-) -> FittedModelPayload {
+) -> Result<FittedModelPayload, String> {
     let TransformationNormalInputs {
         formula,
         data_schema,
@@ -953,6 +953,9 @@ pub fn assemble_transformation_normal_payload(
         family,
         score_calibration,
     } = inputs;
+
+    fit_result.require_posterior_mean("transformation-normal saved-model assembly")
+        .map_err(|error| error.to_string())?;
 
     let mut payload = FittedModelPayload::new(
         MODEL_PAYLOAD_VERSION,
@@ -994,7 +997,7 @@ pub fn assemble_transformation_normal_payload(
     payload.transformation_cone_carrier = Some(cone_carrier.iter().copied().collect());
     payload.transformation_score_calibration = Some(score_calibration);
     source.apply_to(&mut payload);
-    payload
+    Ok(payload)
 }
 
 /// Snapshot the direct-α CTN geometry (gam#2306) a saved model needs to replay
@@ -1988,7 +1991,7 @@ fn payload_for_transformation_normal(
     // Thin adapter over the shared core assembler; the FFI freezes the
     // covariate spec from its design and reads the offset column from the
     // FitConfig. See `assemble_transformation_normal_payload`.
-    Ok(assemble_transformation_normal_payload(
+    assemble_transformation_normal_payload(
         TransformationNormalInputs {
             formula,
             data_schema: dataset.schema.clone(),
@@ -2003,7 +2006,7 @@ fn payload_for_transformation_normal(
             offset_column: fit_config.offset_column.clone(),
             noise_offset_column: None,
         },
-    ))
+    )
 }
 
 fn payload_for_bernoulli_marginal_slope(

--- a/crates/gam-models/src/inference/predict_input.rs
+++ b/crates/gam-models/src/inference/predict_input.rs
@@ -385,6 +385,8 @@ impl SavedCtnChart {
             .ok_or_else(|| PredictInputError::MissingMetadata {
                 reason: "saved transformation-normal model missing unified fit".to_string(),
             })?;
+        fit_saved.require_posterior_mean("transformation-normal prediction")
+            .map_err(|error| PredictInputError::InvalidInput { reason: error.to_string() })?;
         let beta = &fit_saved.blocks[0].beta;
         if beta.len() != self.p_resp * p_cov {
             return Err(PredictInputError::DimensionMismatch {

--- a/tests/test_ctn_predictor_native.py
+++ b/tests/test_ctn_predictor_native.py
@@ -1,4 +1,5 @@
 """Bound this native acceptance test externally; no xfail or convergence bypass."""
+import json
 import numpy as np
 import pandas as pd
 import gamfit
@@ -18,6 +19,8 @@ def test_standalone_ctn_schema_uses_fit_request(tmp_path, mode):
     model = gamfit.fit(data, "pgs ~ x", config=config, **kwargs,
                        persistent_warm_start_root=tmp_path / "warm")
     assert np.isfinite(model.transformation_score(data)).all()
+    posterior = json.loads(model.dumps())["payload"]["unified"]["geometry"]["constrained_posterior"]
+    assert posterior["moment_status"] == "Available"
 
 
 def test_native_ctn_chain_save_load_and_batches(tmp_path):
@@ -48,7 +51,6 @@ def test_native_ctn_chain_save_load_and_batches(tmp_path):
     np.testing.assert_allclose(restored.predict(test), before, rtol=1e-8, atol=1e-10)
     np.testing.assert_allclose(restored.predict(test.iloc[::-1]), before[::-1], rtol=1e-8, atol=1e-10)
     np.testing.assert_allclose(restored.predict(test.iloc[[3]]), before[[3]], rtol=1e-8, atol=1e-10)
-    import json
     payload = json.loads(restored.dumps())
     transform_payload = payload["payload"]["score_transform"]
     payload["payload"]["score_transform"] = None


### PR DESCRIPTION
A public-reference CTN fit completed but its posterior gate classified seven small positive eigenvalues as flat and retained a constrained mode. CTN's payload and observed-score paths then consumed that mode without enforcing the posterior-mean contract.

Use the existing strict, unjittered Cholesky inverse and backward-error certificate for custom-family posterior precision. No ridge, eigenvalue clipping, active-face substitution or optimizer tolerance change is introduced. Require posterior-mean availability at shared CTN model assembly and prediction, propagating errors through CLI and Python. Add a small-curvature inverse regression and assert posterior moments in native CTN acceptance.

Validation in progress on MSI with warm caches and bounded jobs. The reference fit's mode-only artifact is not approved for AoU training; publication remains stopped.