### PR TITLE
Test CTN rejection of artifacts with declined posterior moments

### DIFF
--- a/tests/test_ctn_predictor_native.py
+++ b/tests/test_ctn_predictor_native.py
@@ -21,6 +21,19 @@ def test_standalone_ctn_schema_uses_fit_request(tmp_path, mode):
     assert np.isfinite(model.transformation_score(data)).all()
     posterior = json.loads(model.dumps())["payload"]["unified"]["geometry"]["constrained_posterior"]
     assert posterior["moment_status"] == "Available"
+    declined = json.loads(model.dumps())
+    for key in ("unified", "fit_result"):
+        fit = declined["payload"][key]
+        geometry = fit["geometry"]["constrained_posterior"]
+        geometry["moment_status"] = {"Declined": {
+            "ambient_precision_failure": "regression fixture",
+            "properness": {"CertificationFailed": {"reason": "regression fixture"}}}}
+        geometry["unconstrained_center"] = None
+        geometry["correction"] = None
+        fit["covariance_conditional"] = None
+        fit["covariance_corrected"] = None
+    with pytest.raises(gamfit.GamError, match="posterior-mean"):
+        gamfit.loads(json.dumps(declined).encode()).transformation_score(data)
 
 
 def test_native_ctn_chain_save_load_and_batches(tmp_path):


### PR DESCRIPTION
Exercise the native posterior-mean guard on a saved CTN with an explicitly declined moment calculation, covering both supported standalone request forms. The old e6b2b975 runtime failed both new assertions by returning scores; the corrected 3130f60c runtime passes all three native acceptance tests on MSI in 13.71 seconds. This is a test-only change; no rebuild is needed to establish the result.