### PR TITLE
Reuse batched survival pullbacks for higher information derivatives

### DIFF
--- a/crates/gam-models/src/survival/marginal_slope/information_third.rs
+++ b/crates/gam-models/src/survival/marginal_slope/information_third.rs
@@ -163,14 +163,7 @@ impl<const P: usize, G: SlopeRowGeometry<P>> SurvivalMarginalSlopeRowKernel<P, G
                 "survival third information derivative requires finite directions of length {p}"
             ));
         }
-        let identity = Array2::<f64>::eye(p);
-        let jacobians = self
-            .jacobian_action_matrix(identity.view())
-            .ok_or("survival third information derivative requires row Jacobians")?;
-        if jacobians.dim() != (self.family.n, P * p) {
-            return Err("survival third information row Jacobian shape mismatch".into());
-        }
-        let mut axes = vec![Array2::<f64>::zeros((p, p)); p];
+        let mut tensors = Vec::with_capacity(self.family.n);
         for row in 0..self.family.n {
             let inputs = rigid_row_inputs(
                 &self.family,
@@ -195,20 +188,9 @@ impl<const P: usize, G: SlopeRowGeometry<P>> SurvivalMarginalSlopeRowKernel<P, G
                     }
                 }
             }
-            for axis in 0..p {
-                let mut primary_hessian = [[0.0; P]; P];
-                for a in 0..P {
-                    for b in 0..P {
-                        for c in 0..P {
-                            primary_hessian[a][b] +=
-                                tensor[a][b][c] * jacobians[[row, c * p + axis]];
-                        }
-                    }
-                }
-                self.add_pullback_hessian(row, &primary_hessian, &mut axes[axis]);
-            }
+            tensors.push(tensor);
         }
-        Ok(axes)
+        self.all_axes_primary_tensor_pullback(&tensors)
     }
 }
 

--- a/crates/gam-models/src/survival/marginal_slope/row_kernel.rs
+++ b/crates/gam-models/src/survival/marginal_slope/row_kernel.rs
@@ -312,26 +312,6 @@ impl<const K: usize, const LIN: u32> SparseTower4<K, LIN> {
         }
     }
 
-    /// Contract `t4` with two primary-space directions —
-    /// `out[a][b] = Σ_{c,d} t4[a][b][c][d]·u[c]·w[d]` — in the EXACT accumulation
-    /// order of [`gam_math::jet_tower::Tower4::fourth_contracted`] (k outer, l
-    /// inner), so the second-directional consumer is bit-identical.
-    #[inline]
-    pub(crate) fn fourth_contracted(&self, u: &[f64; K], w: &[f64; K]) -> [[f64; K]; K] {
-        let mut out = [[0.0; K]; K];
-        for i in 0..K {
-            for j in 0..K {
-                let mut acc = 0.0;
-                for k in 0..K {
-                    for l in 0..K {
-                        acc += self.t4[i][j][k][l] * u[k] * w[l];
-                    }
-                }
-                out[i][j] = acc;
-            }
-        }
-        out
-    }
 }
 
 impl<const K: usize, const LIN: u32> JetScalar<K> for SparseTower4<K, LIN> {

--- a/crates/gam-models/src/survival/marginal_slope/row_kernel.rs
+++ b/crates/gam-models/src/survival/marginal_slope/row_kernel.rs
@@ -1649,17 +1649,9 @@ impl<const P: usize, G: SlopeRowGeometry<P>> RowKernel<P>
     /// expensive (closed-form probit/log-pdf composition over four primaries),
     /// so this is the #979 inner-Newton Jeffreys/Firth hot path.
     ///
-    /// This override builds each row's `t3` tensor ONCE (the swept axis enters
-    /// only through the cheap primary projection `dir_a = Jᵢ·e_a` and the linear
-    /// `t3.third_contracted(dir_a)`), then closes every axis off that single
-    /// build. Crucially it reuses the kernel's OWN `jacobian_action`,
-    /// `Tower4::third_contracted`, and `add_pullback_hessian` in the EXACT SAME
-    /// `ARROW_ROW_CHUNK`-chunked reduction order as the generic per-axis path
-    /// (`par_try_reduce_fold(RowSet::All)`): the cached `t3[row]` is bit-for-bit
-    /// the tensor a fresh `program_full_tower(row)` would produce (a deterministic
-    /// pure function of the row), and every float op downstream is identical, so
-    /// axis `a` matches `row_kernel_directional_derivative(self, All, e_a)`
-    /// bit-for-bit. Only the redundant `(p−1)·n` tower rebuilds are removed.
+    /// Build each row's `t3` once and assemble the pullbacks as weighted Grams.
+    /// This preserves the derivatives, with floating-point reassociation of
+    /// the row sums checked against the scalar per-axis implementation.
     ///
     /// Claims only the full-data unit-weight `RowSet::All` case; otherwise
     /// returns `None` so the generic per-axis Horvitz-Thompson sweep runs.
@@ -1678,7 +1670,7 @@ impl<const P: usize, G: SlopeRowGeometry<P>> RowKernel<P>
         if !matches!(rows, crate::row_kernel::RowSet::All) {
             return None;
         }
-        Some(self.directional_derivative_all_axes_build_once(p))
+        Some(self.directional_derivative_all_axes_build_once())
     }
 
     /// Batched all-axes SECOND directional derivative of the joint Hessian for
@@ -1688,12 +1680,8 @@ impl<const P: usize, G: SlopeRowGeometry<P>> RowKernel<P>
     /// With `d_beta_u` fixed and the second direction sweeping every canonical
     /// axis, the generic per-axis path runs `p` full-data sweeps each evaluating
     /// the per-row two-seed program scalar through `row_fourth_contracted`.
-    /// This override builds each row's `t4` tensor and the fixed-direction
-    /// projection `dir_u = Jᵢ·u` ONCE, then closes every axis with the cheap
-    /// linear `t4.fourth_contracted(dir_u, dir_a)` and the kernel's own
-    /// `add_pullback_hessian`, in the SAME chunked reduction order as
-    /// `row_kernel_second_directional_derivative(self, All, u, e_a)` — bit-for-bit
-    /// identical, only the redundant tower rebuilds removed.
+    /// Contract each row's `t4` with the fixed direction once, then assemble
+    /// every swept axis through the same weighted-Gram path as first order.
     ///
     /// Claims only the full-data unit-weight `RowSet::All` case; otherwise `None`.
     fn second_directional_derivative_all_axes_dense_override(
@@ -1876,15 +1864,27 @@ impl<const P: usize, G: SlopeRowGeometry<P>> SurvivalMarginalSlopeRowKernel<P, G
     /// override docstring. Builds the per-row `t3` towers once, then for each
     /// canonical axis runs the identical chunked pullback reduction the generic
     /// per-axis sweep runs, reusing the cached tower instead of rebuilding it.
-    fn directional_derivative_all_axes_build_once(
-        &self,
-        p: usize,
-    ) -> Result<Vec<Array2<f64>>, String> {
+    fn directional_derivative_all_axes_build_once(&self) -> Result<Vec<Array2<f64>>, String> {
         // #1591: the consumer reads only `third_contracted` (a `t3` contraction),
         // so build the order-≤3 `Tower3<4>` per row — bit-identical on the read
         // channels to the dense `Tower4<4>` but without the discarded `t4` tensor.
         let towers = self.build_row_third_towers()?;
+        let tensors: Vec<_> = towers.into_iter().map(|tower| tower.t3).collect();
+        self.all_axes_primary_tensor_pullback(&tensors)
+    }
 
+    /// Pull back a symmetric primary third tensor along every coefficient axis.
+    /// Higher information derivatives first contract their fixed directions
+    /// into this tensor, so all orders share the same weighted-Gram assembly.
+    pub(super) fn all_axes_primary_tensor_pullback(
+        &self,
+        tensors: &[[[[f64; P]; P]; P]],
+    ) -> Result<Vec<Array2<f64>>, String> {
+        let p = self.n_coefficients();
+        let n = gam_math::jet_tower::RowProgram::n_rows(self);
+        if tensors.len() != n {
+            return Err("survival all-axes primary tensor row count mismatch".into());
+        }
         // This is a genuinely batched dense consumer: materialize the complete
         // row Jacobian J = J·I once through the kernel's structured BLAS-3
         // projection. The former axis loop called `jacobian_action` and
@@ -1906,7 +1906,6 @@ impl<const P: usize, G: SlopeRowGeometry<P>> SurvivalMarginalSlopeRowKernel<P, G
                 "survival marginal-slope all-axes derivative requires a dense J·I projection"
                     .to_string()
             })?;
-        let n = gam_math::jet_tower::RowProgram::n_rows(self);
         let expected = (n, P * p);
         if jacobians.dim() != expected {
             return Err(format!(
@@ -1942,7 +1941,7 @@ impl<const P: usize, G: SlopeRowGeometry<P>> SurvivalMarginalSlopeRowKernel<P, G
                         let weights = Array1::from_shape_fn(n, |row| {
                             let mut weight = 0.0;
                             for direction_primary in 0..P {
-                                weight += towers[row].t3[primary_left][primary_right]
+                                weight += tensors[row][primary_left][primary_right]
                                     [direction_primary]
                                     * jacobian_blocks[direction_primary][[row, axis]];
                             }
@@ -1964,32 +1963,28 @@ impl<const P: usize, G: SlopeRowGeometry<P>> SurvivalMarginalSlopeRowKernel<P, G
             .collect()
     }
 
-    /// gam#979 build-once all-axes SECOND directional derivative — see the trait
-    /// override docstring. Builds the per-row `t4` towers and the fixed-direction
-    /// projection once, then closes every axis from that single build in the
-    /// generic per-axis sweep's reduction order.
+    /// Contract the fixed direction once per row, then use the shared
+    /// weighted-Gram pullback for every swept coefficient axis.
     fn second_directional_derivative_all_axes_from_towers(
         &self,
         d_beta_u: &[f64],
         towers: &[SparseTower4<P, RIGID_LINEAR_MASK>],
     ) -> Result<Vec<Array2<f64>>, String> {
-        let p = self.n_coefficients();
-        (0..p)
-            .into_par_iter()
-            .map(|a| {
-                let mut axis = vec![0.0_f64; p];
-                axis[a] = 1.0;
-                gam_problem::with_nested_parallel(|| {
-                    self.chunked_pullback_reduce(p, |row, acc| {
-                        let dir_u = self.jacobian_action(row, d_beta_u);
-                        let dir_v = self.jacobian_action(row, &axis);
-                        let fourth = towers[row].fourth_contracted(&dir_u, &dir_v);
-                        self.add_pullback_hessian(row, &fourth, acc);
-                        Ok(())
+        let tensors: Vec<_> = towers
+            .iter()
+            .enumerate()
+            .map(|(row, tower)| {
+                let direction = self.jacobian_action(row, d_beta_u);
+                std::array::from_fn(|a| {
+                    std::array::from_fn(|b| {
+                        std::array::from_fn(|c| {
+                            (0..P).map(|d| tower.t4[a][b][d][c] * direction[d]).sum()
+                        })
                     })
                 })
             })
-            .collect()
+            .collect();
+        self.all_axes_primary_tensor_pullback(&tensors)
     }
 
     fn second_directional_derivative_all_axes_build_once(

--- a/crates/gam-models/src/survival/marginal_slope/tests.rs
+++ b/crates/gam-models/src/survival/marginal_slope/tests.rs
@@ -7552,6 +7552,31 @@ fn rigid_survival_all_axes_build_once_equals_per_axis_sweep_979() {
                  diverged from the per-axis sweep by {max_gap:e}"
             );
         }
+
+        // The fifth-order information path contracts its two fixed directions
+        // into a symmetric primary third tensor. Check the shared assembly
+        // against independent row pullbacks with nonconstant, signed tensors.
+        let tensors: Vec<[[[f64; 4]; 4]; 4]> = (0..n).map(|row| {
+            std::array::from_fn(|a| std::array::from_fn(|b| std::array::from_fn(|c| {
+                ((row + 3 * (a + b + c)) as f64 * 0.17).sin()
+            })))
+        }).collect();
+        let assembled = kernel.all_axes_primary_tensor_pullback(&tensors).unwrap();
+        for axis in 0..p {
+            let mut direction = vec![0.0; p];
+            direction[axis] = 1.0;
+            let mut expected = Array2::<f64>::zeros((p, p));
+            for row in 0..n {
+                let projected = kernel.jacobian_action(row, &direction);
+                let hessian = std::array::from_fn(|a| std::array::from_fn(|b| {
+                    (0..4).map(|c| tensors[row][a][b][c] * projected[c]).sum()
+                }));
+                kernel.add_pullback_hessian(row, &hessian, &mut expected);
+            }
+            let scale = expected.iter().fold(1.0_f64, |s, x| s.max(x.abs()));
+            assert!(assembled[axis].iter().zip(&expected)
+                .all(|(actual, expected)| (actual - expected).abs() < 2e-12 * scale));
+        }
     }
 }
 


### PR DESCRIPTION
PC-varying survival fits repeatedly decoded design rows while assembling second and third information derivatives. Contract fixed directions once per row, then reuse the existing weighted-Gram assembly used by the first derivative. Remove the scalar fourth-tensor contraction retired by this change. The likelihood, penalties, posterior target, and convergence criteria are unchanged.

Validation on 7f0c20ae950a739c8f179f94b3407c561f5113ce:
- Focused Rust proof passed both the all-axes scalar oracle and differentiated-fourth-order check: https://github.com/SauersML/gam/actions/runs/34642246797
- Exact runtime build: https://github.com/SauersML/gam/actions/runs/34642249449
- MSI: frozen public-1000G CTN plus synthetic PC-varying survival completed in 98.39 seconds, including save/load, row/batch invariance, unchanged transformed scores, and finite monotone probabilities. The previous runtime timed out on this fixture. This is numerical acceptance, not an AoU outcome result.